### PR TITLE
Adds dockerized relay for development purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /Cargo.lock
 .env
 mostro.db*
+
+# Relay data
+/relay/data/*

--- a/README.md
+++ b/README.md
@@ -102,3 +102,15 @@ Before run it you to set `NSEC_PRIVKEY` with the private key of your Mostro, if 
 ```bash
 $ cargo run
 ```
+
+If you want to run with with a private dockerized relay, you must:
+
+```bash
+cd relay
+docker compose up -d
+```
+
+This will spin a new docker container with an instance of [nostr-rs-relay](https://github.com/scsibug/nostr-rs-relay), that will listen at port `7000`.
+
+
+So the relay URL you want to connect to is: `ws://localhost:7000`.

--- a/relay/config.toml
+++ b/relay/config.toml
@@ -1,0 +1,217 @@
+# Nostr-rs-relay configuration
+
+[info]
+# The advertised URL for the Nostr websocket.
+relay_url = "wss://nostr.example.com/"
+
+# Relay information for clients.  Put your unique server name here.
+name = "nostr-rs-relay"
+
+# Description
+description = "A newly created nostr-rs-relay.\n\nCustomize this with your own info."
+
+# Administrative contact pubkey
+#pubkey = "0c2d168a4ae8ca58c9f1ab237b5df682599c6c7ab74307ea8b05684b60405d41"
+
+# Administrative contact URI
+#contact = "mailto:contact@example.com"
+
+# Favicon location.  Relative to the current directory.  Assumes an
+# ICO format.
+#favicon = "favicon.ico"
+
+[diagnostics]
+# Enable tokio tracing (for use with tokio-console)
+#tracing = false
+
+[database]
+# Database engine (sqlite/postgres).  Defaults to sqlite.
+# Support for postgres is currently experimental.
+#engine = "sqlite"
+
+# Directory for SQLite files.  Defaults to the current directory.  Can
+# also be specified (and overriden) with the "--db dirname" command
+# line option.
+#data_directory = "."
+
+# Use an in-memory database instead of 'nostr.db'.
+# Requires sqlite engine.
+# Caution; this will not survive a process restart!
+#in_memory = false
+
+# Database connection pool settings for subscribers:
+
+# Minimum number of SQLite reader connections
+#min_conn = 4
+
+# Maximum number of SQLite reader connections.  Recommend setting this
+# to approx the number of cores.
+#max_conn = 8
+
+# Database connection string.  Required for postgres; not used for
+# sqlite.
+#connection = "postgresql://postgres:nostr@localhost:7500/nostr"
+
+
+[grpc]
+# gRPC interfaces for externalized decisions and other extensions to
+# functionality.
+#
+# Events can be authorized through an external service, by providing
+# the URL below.  In the event the server is not accessible, events
+# will be permitted.  The protobuf3 schema used is available in
+# `proto/nauthz.proto`.
+# event_admission_server = "http://[::1]:50051"
+
+[network]
+# Bind to this network address
+address = "0.0.0.0"
+
+# Listen on this port
+port = 8080
+
+# If present, read this HTTP header for logging client IP addresses.
+# Examples for common proxies, cloudflare:
+#remote_ip_header = "x-forwarded-for"
+#remote_ip_header = "cf-connecting-ip"
+
+# Websocket ping interval in seconds, defaults to 5 minutes
+#ping_interval = 300
+
+[options]
+# Reject events that have timestamps greater than this many seconds in
+# the future.  Recommended to reject anything greater than 30 minutes
+# from the current time, but the default is to allow any date.
+reject_future_seconds = 1800
+
+[limits]
+# Limit events created per second, averaged over one minute.  Must be
+# an integer.  If not set (or set to 0), there is no limit.  Note:
+# this is for the server as a whole, not per-connection.
+#
+# Limiting event creation is highly recommended if your relay is
+# public!
+#
+#messages_per_sec = 5
+
+# Limit client subscriptions created, averaged over one minute.  Must
+# be an integer.  If not set (or set to 0), defaults to unlimited.
+# Strongly recommended to set this to a low value such as 10 to ensure
+# fair service.
+#subscriptions_per_min = 0
+
+# UNIMPLEMENTED...
+# Limit how many concurrent database connections a client can have.
+# This prevents a single client from starting too many expensive
+# database queries.  Must be an integer.  If not set (or set to 0),
+# defaults to unlimited (subject to subscription limits).
+#db_conns_per_client = 0
+
+# Limit blocking threads used for database connections.  Defaults to 16.
+#max_blocking_threads = 16
+
+# Limit the maximum size of an EVENT message.  Defaults to 128 KB.
+# Set to 0 for unlimited.
+#max_event_bytes = 131072
+
+# Maximum WebSocket message in bytes.  Defaults to 128 KB.
+#max_ws_message_bytes = 131072
+
+# Maximum WebSocket frame size in bytes.  Defaults to 128 KB.
+#max_ws_frame_bytes = 131072
+
+# Broadcast buffer size, in number of events.  This prevents slow
+# readers from consuming memory.
+#broadcast_buffer = 16384
+
+# Event persistence buffer size, in number of events.  This provides
+# backpressure to senders if writes are slow.
+#event_persist_buffer = 4096
+
+# Event kind blacklist. Events with these kinds will be discarded.
+#event_kind_blacklist = [
+#    70202,
+#]
+
+# Event kind allowlist. Events other than these kinds will be discarded.
+#event_kind_allowlist = [
+#    0, 1, 2, 3, 7, 40, 41, 42, 43, 44, 30023,
+#]
+
+[authorization]
+# Pubkey addresses in this array are whitelisted for event publishing.
+# Only valid events by these authors will be accepted, if the variable
+# is set.
+#pubkey_whitelist = [
+#  "35d26e4690cbe1a898af61cc3515661eb5fa763b57bd0b42e45099c8b32fd50f",
+#  "887645fef0ce0c3c1218d2f5d8e6132a19304cdc57cd20281d082f38cfea0072",
+#]
+# Enable NIP-42 authentication
+#nip42_auth = false
+# Send DMs events (kind 4) only to their authenticated recipients
+#nip42_dms = false
+
+[verified_users]
+# NIP-05 verification of users.  Can be "enabled" to require NIP-05
+# metadata for event authors, "passive" to perform validation but
+# never block publishing, or "disabled" to do nothing.
+#mode = "disabled"
+
+# Domain names that will be prevented from publishing events.
+#domain_blacklist = ["wellorder.net"]
+
+# Domain names that are allowed to publish events.  If defined, only
+# events NIP-05 verified authors at these domains are persisted.
+#domain_whitelist = ["example.com"]
+
+# Consider an pubkey "verified" if we have a successful validation
+# from the NIP-05 domain within this amount of time.  Note, if the
+# domain provides a successful response that omits the account,
+# verification is immediately revoked.
+#verify_expiration = "1 week"
+
+# How long to wait between verification attempts for a specific author.
+#verify_update_frequency = "24 hours"
+
+# How many consecutive failed checks before we give up on verifying
+# this author.
+#max_consecutive_failures = 20
+
+[pay_to_relay]
+# Enable pay to relay
+#enabled = false
+
+# The cost to be admitted to relay
+#admission_cost = 4200
+
+# The cost in sats per post
+#cost_per_event = 0
+
+# Url of lnbits api
+#node_url = "<node url>"
+
+# LNBits api secret
+#api_secret = "<ln bits api>"
+
+# Terms of service
+#terms_message = """
+#This service (and supporting services) are provided "as is", without warranty of any kind, express or implied.
+#
+#By using this service, you agree:
+#* Not to engage in spam or abuse the relay service
+#* Not to disseminate illegal content
+#* That requests to delete content cannot be guaranteed
+#* To use the service in compliance with all applicable laws
+#* To grant necessary rights to your content for unlimited time
+#* To be of legal age and have capacity to use this service
+#* That the service may be terminated at any time without notice
+#* That the content you publish may be removed at any time without notice
+#* To have your IP address collected to detect abuse or misuse
+#* To cooperate with the relay to combat abuse or misuse
+#* You may be exposed to content that you might find triggering or distasteful
+#* The relay operator is not liable for content produced by users of the relay
+#"""
+
+# Whether or not new sign ups should be allowed
+#sign_ups = false
+#secret_key = "<nostr nsec>"

--- a/relay/docker-compose.yml
+++ b/relay/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  nostr-relay:
+    image: scsibug/nostr-rs-relay
+    container_name: nostr-relay
+    ports:
+      - '7000:8080'
+    volumes:
+      - './data:/usr/src/app/db:Z'
+      - './config.toml:/usr/src/app/config.toml:ro,Z'
+


### PR DESCRIPTION
I also modified the README a bit, with simple instructions on how to run the container. But for this to be complete, the `src/utils.rs` should also be modified to include the local relay URL (`ws://localhost:7000`) when in development mode.

I'm not sure how to do this, so I leave that open to alternatives. There could be logic that selects between two different sets of relays, depending on the execution context. Or maybe that list of relays could be loaded from an external configuration file or environment variables, and we have a different set of these for development and production mode.