### PR TITLE
Support to set local relay port through environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ mostro.db*
 
 # Relay data
 /relay/data/*
+
+# IDE's
+.idea
+.vscode

--- a/relay/.env.example
+++ b/relay/.env.example
@@ -1,0 +1,2 @@
+# Port for local relay
+MOSTRO_RELAY_LOCAL_PORT=7000

--- a/relay/docker-compose.yml
+++ b/relay/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: scsibug/nostr-rs-relay
     container_name: nostr-relay
     ports:
-      - '7000:8080'
+      - '${MOSTRO_RELAY_LOCAL_PORT:-7000}:8080'
     volumes:
       - './data:/usr/src/app/db:Z'
       - './config.toml:/usr/src/app/config.toml:ro,Z'


### PR DESCRIPTION
Relay local port variable through environment variable.
If not set will default to `7000`