### PR TITLE
Uses awk instead of grep in the init script, making it more robust

### DIFF
--- a/init_db.sh
+++ b/init_db.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Reading database URL from settings.toml..."
-DATABASE_URL=$(grep -oP 'url\s*=\s*"\K[^"]+' settings.toml)
+DATABASE_URL=$(awk -F'"' '/url *= */ {print $2}' settings.toml)
 export DATABASE_URL
 echo "Database URL is: $DATABASE_URL"
 if ls mostro.db* 1> /dev/null 2>&1; then


### PR DESCRIPTION
This is an improvement over the last commit.

The problem there was with older versions of `grep`, like the BSD version included with macOS, lack the `-P` option. So it would work in Linux, where it was tested, but fail on a Mac. 

This version uses `awk` instead, which is more universally compatible across different Unix-like systems.