### PR TITLE
Config file dir

### DIFF
--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -15,7 +15,7 @@ pub async fn order_action(
     pool: &Pool<Sqlite>,
 ) -> Result<()> {
     if let Some(order) = msg.get_order() {
-        let mostro_settings = Settings::get_mostro()?;
+        let mostro_settings = Settings::get_mostro();
         let quote = get_market_quote(&order.fiat_amount, &order.fiat_code, &0).await?;
         if quote > mostro_settings.max_order_amount as i64 {
             let message = Message::new(0, order.id, None, Action::CantDo, None);

--- a/src/db.rs
+++ b/src/db.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use crate::settings::Settings;
 
 pub async fn connect() -> Result<Pool<Sqlite>, sqlx::Error> {
-    let db_settings = Settings::get_db().unwrap();
+    let db_settings = Settings::get_db();
     let db_url = db_settings.url;
     if !Sqlite::database_exists(&db_url).await.unwrap_or(false) {
         panic!("Not database found, please create a new one first!");
@@ -208,7 +208,7 @@ pub async fn update_order_event_id_status(
     amount: i64,
 ) -> anyhow::Result<bool> {
     let mut conn = pool.acquire().await?;
-    let mostro_settings = Settings::get_mostro()?;
+    let mostro_settings = Settings::get_mostro();
     let status = status.to_string();
     // We calculate the bot fee
     let fee = mostro_settings.fee / 2.0;
@@ -315,7 +315,7 @@ pub async fn find_order_by_hash(pool: &SqlitePool, hash: &str) -> anyhow::Result
 }
 
 pub async fn find_order_by_date(pool: &SqlitePool) -> anyhow::Result<Vec<Order>> {
-    let mostro_settings = Settings::get_mostro()?;
+    let mostro_settings = Settings::get_mostro();
     let exp_hours = mostro_settings.expiration_hours as u64;
     let expire_time = Timestamp::now() - (3600 * exp_hours);
     let order = sqlx::query_as::<_, Order>(
@@ -333,7 +333,7 @@ pub async fn find_order_by_date(pool: &SqlitePool) -> anyhow::Result<Vec<Order>>
 }
 
 pub async fn find_order_by_seconds(pool: &SqlitePool) -> anyhow::Result<Vec<Order>> {
-    let mostro_settings = Settings::get_mostro()?;
+    let mostro_settings = Settings::get_mostro();
     let exp_seconds = mostro_settings.expiration_seconds as u64;
     let expire_time = Timestamp::now() - exp_seconds;
     let order = sqlx::query_as::<_, Order>(

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -65,7 +65,7 @@ pub async fn hold_invoice_paid(hash: &str) {
             .unwrap();
         status = Status::Active;
     } else {
-        let mostro_settings = Settings::get_mostro().unwrap();
+        let mostro_settings = Settings::get_mostro();
         let sub_fee = mostro_settings.fee * order_data.amount as f64;
         let rounded_fee = sub_fee.round();
         let new_amount = order_data.amount - rounded_fee as i64;

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -20,8 +20,8 @@ pub fn is_valid_invoice(
     fee: Option<u64>,
 ) -> Result<Invoice, MostroError> {
     let invoice = Invoice::from_str(payment_request)?;
-    let mostro_settings = Settings::get_mostro().unwrap();
-    let ln_settings = Settings::get_ln().unwrap();
+    let mostro_settings = Settings::get_mostro();
+    let ln_settings = Settings::get_ln();
 
     let amount_msat = invoice.amount_milli_satoshis().unwrap_or(0) / 1000;
     let fee = fee.unwrap_or(0);

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -35,7 +35,7 @@ pub struct PaymentMessage {
 
 impl LndConnector {
     pub async fn new() -> Self {
-        let ln_settings = Settings::get_ln().unwrap();
+        let ln_settings = Settings::get_ln();
 
         // Connecting to LND requires only host, port, cert file, and macaroon file
         let client = tonic_openssl_lnd::connect(
@@ -58,7 +58,7 @@ impl LndConnector {
         let mut preimage = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut preimage);
         let hash = raw_sha256(preimage.to_vec());
-        let ln_settings = Settings::get_ln().unwrap();
+        let ln_settings = Settings::get_ln();
         let cltv_expiry = ln_settings.hold_invoice_cltv_delta as u64;
 
         let invoice = AddHoldInvoiceRequest {
@@ -159,7 +159,7 @@ impl LndConnector {
         let payment_hash = invoice.payment_hash();
         let payment_hash = payment_hash.to_vec();
         let hash = payment_hash.to_hex();
-        let mostro_settings = Settings::get_mostro().unwrap();
+        let mostro_settings = Settings::get_mostro();
 
         // We need to set a max fee amount
         // If the amount is small we use a different max routing fee

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,9 @@ use anyhow::Result;
 use lightning::LndConnector;
 use nostr_sdk::prelude::*;
 use scheduler::start_scheduler;
-use settings::init_default_dir;
-use std::env::args;
+use settings::Settings;
+use settings::{init_default_dir, init_global_settings};
+use std::{env::args, path::PathBuf};
 use tokio::sync::Mutex;
 
 #[macro_use]
@@ -23,55 +24,56 @@ extern crate lazy_static;
 
 lazy_static! {
     static ref RATE_EVENT_LIST: Mutex<Vec<Event>> = Mutex::new(vec![]);
+    // Global var
+    static ref MOSTRO_CONFIG : std::sync::Mutex<Settings> = std::sync::Mutex::new(Settings { database: Default::default(), nostr: Default::default(), mostro: Default::default(), lightning: Default::default() });
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     pretty_env_logger::init();
-    // Connect to database
-    // let pool = db::connect().await?;
-    // // Connect to relays
-    // let client = util::connect_nostr().await?;
-    // let my_keys = util::get_keys()?;
-    let mut config_path = String::new();
+
+    // File settings path
+    let mut config_path = PathBuf::new();
 
     let args: Vec<String> = args().collect();
     // Create install path string
     match args.len() {
         1 => {
             // No dir parameter on cli
-            init_default_dir(None, &mut config_path);
-        },
-        2 => {
-            if args[1] == "dir" {
-                init_default_dir(Some(&args[2]), &mut config_path);
+            config_path = init_default_dir(None)?;
+        }
+        3 => {
+            if args[1] == "--dir" {
+                config_path = init_default_dir(Some(&args[2]))?;
             }
-        },
+        }
         _ => {
             println!("Can't get what you're sayin! Run mostro or mostro --dir /path/to_config_file")
         }
     }
 
-    println!("{:?}", config_path);
-    Ok(())
+    // Create config global var
+    init_global_settings(Settings::new(config_path)?);
 
-    //println!("Default dir : {:?}",settings_dir_default);
+    // Connect to database
+    let pool = db::connect().await?;
+    // // Connect to relays
+    let client = util::connect_nostr().await?;
+    let my_keys = util::get_keys()?;
 
     // println!("pub {}", my_keys.public_key().to_bech32().unwrap());
 
-    // Ok(())
+    let subscription = Filter::new()
+        .pubkey(my_keys.public_key())
+        .since(Timestamp::now());
 
-    // let subscription = Filter::new()
-    //     .pubkey(my_keys.public_key())
-    //     .since(Timestamp::now());
+    client.subscribe(vec![subscription]).await;
+    let mut ln_client = LndConnector::new().await;
 
-    // client.subscribe(vec![subscription]).await;
-    // let mut ln_client = LndConnector::new().await;
+    // Start scheduler for tasks
+    start_scheduler().await.unwrap().start().await?;
 
-    // // Start scheduler for tasks
-    // start_scheduler().await.unwrap().start().await?;
-
-    // run(my_keys, client, &mut ln_client, pool).await
+    run(my_keys, client, &mut ln_client, pool).await
 }
 
 #[cfg(test)]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -68,7 +68,7 @@ pub async fn cron_scheduler(sched: &JobScheduler) -> Result<(), anyhow::Error> {
             let client = crate::util::connect_nostr().await.unwrap();
             let keys = crate::util::get_keys().unwrap();
             let mut ln_client = LndConnector::new().await;
-            let mostro_settings = Settings::get_mostro().unwrap();
+            let mostro_settings = Settings::get_mostro();
             let exp_seconds = mostro_settings.expiration_seconds;
 
             info!("Check for order to republish for late actions of users");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,17 @@
-use anyhow::Error;
+use anyhow::{Error, Result};
 use config::{Config, ConfigError, Environment, File};
 use serde::Deserialize;
 use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{stdin, stdout, BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::process;
+
+lazy_static! {
+    static ref CONFIG_PATH: PathBuf = PathBuf::new();
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Database {
     pub url: String,
@@ -97,6 +107,20 @@ impl Settings {
         s.try_deserialize()
     }
 
+    pub fn set_val() -> Result<Self, ConfigError> {
+        // let run_mode = env::var("RUN_MODE").unwrap_or_else(|_| "dev".into());
+        let file_name = format!("settings.toml");
+        let s = Config::builder()
+            .add_source(File::with_name(&file_name).required(true))
+            // Add in settings from the environment (with a prefix of APP)
+            // Eg.. `APP_DEBUG=1 ./target/app` would set the `debug` key
+            .set_override("database.config_path", "/.mostro")?
+            .build()?;
+
+        // You can deserialize the entire configuration as
+        s.try_deserialize()
+    }
+
     pub fn get_ln() -> Result<Lightning, Error> {
         let settings = Settings::new()?;
 
@@ -119,5 +143,74 @@ impl Settings {
         let settings = Settings::new()?;
 
         Ok(settings.nostr)
+    }
+}
+
+pub fn init_default_dir(config_path: Option<&String>, final_path : &mut String) -> Result<()> {
+    // Dir prefix
+    let home_dir;
+    // Complete path to file variable
+    let mut settings_dir_default = std::path::PathBuf::new();
+
+    if config_path.is_none() {
+        // Get $HOME from env
+        home_dir = std::env::var("HOME").unwrap();
+        // Create default path with default .mostro value
+        settings_dir_default.push(home_dir);
+        settings_dir_default.push(".mostro");
+    } else {
+        home_dir = config_path.unwrap().to_string();
+        // Create default path from custom path
+        settings_dir_default.push(home_dir);
+    }
+
+    // Check if default folder exists
+    let folder_default = settings_dir_default.is_dir();
+
+    // If settings dir is not existing
+    if !folder_default {
+        println!(
+            "Creating .mostro default settings dir {:?}",
+            settings_dir_default
+        );
+        print!("Are you sure? (Y/n) > ");
+
+        // Ask user confirm for default folder
+        let mut user_input = String::new();
+        let _input = stdin();
+
+        stdout().flush()?;
+
+        let mut answer = stdin().lock();
+        answer.read_line(&mut user_input)?;
+
+        match user_input.to_lowercase().as_str().trim_end() {
+            "y" | "" => {
+                fs::create_dir(settings_dir_default.clone())?;
+                println!("Ok you have created the folder for settings file");
+                println!("Copy the settings.toml file with template in {:?} folder than edit field with correct values",settings_dir_default);
+                process::exit(0);
+            }
+            "n" => {
+                println!("Ok try again with another folder...");
+                process::exit(0);
+            }
+            &_ => {
+                println!("Can't get what you're sayin!");
+                process::exit(0);
+            }
+        };
+    } else {
+        // Get kind of config file from .env var
+        let run_mode = env::var("RUN_MODE").unwrap_or_else(|_| "dev".into());
+        let file_name = format!("settings.{}.toml", run_mode);
+        settings_dir_default.push(file_name);
+        // Check file existence
+        if settings_dir_default.exists() {
+            Ok(settings_dir_default)
+        } else {
+            println!("Settings file is not present in the requested path {:?} check file and copy it inside folder",settings_dir_default);
+            std::process::exit(0)
+        }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -173,7 +173,7 @@ pub async fn send_dm(
 }
 
 pub fn get_keys() -> Result<Keys> {
-    let nostr_settings = Settings::get_nostr()?;
+    let nostr_settings = Settings::get_nostr();
     // nostr private key
     let my_keys = Keys::from_sk_str(&nostr_settings.nsec_privkey)?;
 
@@ -258,13 +258,13 @@ pub async fn update_order_event(
 
 pub async fn connect_nostr() -> Result<Client> {
     let my_keys = crate::util::get_keys()?;
-    let nostr_settings = Settings::get_nostr()?;
+    let nostr_settings = Settings::get_nostr();
     // Create new client
     let client = Client::new(&my_keys);
-    let relays = nostr_settings.relays;
+    let relays = &nostr_settings.relays;
 
     // Add relays
-    for r in relays.into_iter() {
+    for r in relays.iter() {
         client.add_relay(r, None).await?;
     }
 
@@ -284,7 +284,7 @@ pub async fn show_hold_invoice(
     order: &Order,
 ) -> anyhow::Result<()> {
     let mut ln_client = lightning::LndConnector::new().await;
-    let mostro_settings = Settings::get_mostro()?;
+    let mostro_settings = Settings::get_mostro();
     // Add fee of seller to hold invoice
     let seller_fee = mostro_settings.fee / 2.0;
     let add_fee = seller_fee * order.amount as f64;
@@ -385,7 +385,7 @@ pub async fn set_market_order_sats_amount(
     pool: &SqlitePool,
     client: &Client,
 ) -> Result<i64> {
-    let mostro_settings = Settings::get_mostro()?;
+    let mostro_settings = Settings::get_mostro();
     // Update amount order
     let new_sats_amount =
         get_market_quote(&order.fiat_amount, &order.fiat_code, &order.premium).await?;


### PR DESCRIPTION
Finally I am here @grunch !

Ok this is a first working idea of config dir command. What's that?

- You can use mostro command alone and it will search if $HOME/.mostro folder exits and than ask to user for creation, the it asks to copy your config file inside, if it's correct next time you run mostro it will run.
- You can use mostro command with --dir /path/to/config and it will search if /path/to/config / folder exits and than ask to user for creation, the it asks to copy your config file inside, if it's correct next time you run mostro it will run.

Config is set at startup in lazy static so just read file one shot at start.

Things to improve...

- Path to file: check if with final slash and without works correctly ( tested only on Linux now , so also OS is to be tested).
- Adding clap for commands, if eventually with add other cli command it's realy better than manual management.
- Behaviour of custom command dir : now you have to launch mostro alway with --dir command if you want custom dir, so mostro does not remind where is special dir after first time you set it. If you launch mostro with no --dir param it will search on $HOME/.mostro dir. To be improved...

