### PR TITLE
Some improvements on config file and db file

### DIFF
--- a/init_db.sh
+++ b/init_db.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo "Reading database URL from settings.toml..."
-DATABASE_URL=$(awk -F'"' '/url *= */ {print $2}' settings.toml)
+DATABASE_URL=$(awk -F'"' '/url *= */ {print $2}' settings.tpl.toml)
 export DATABASE_URL
 echo "Database URL is: $DATABASE_URL"
 if ls mostro.db* 1> /dev/null 2>&1; then

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -56,11 +56,14 @@ pub fn is_valid_invoice(
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
     use std::env::set_var;
+    use std::path::PathBuf;
 
     use super::is_valid_invoice;
-    use crate::{error::MostroError, settings::{init_global_settings, Settings}};
+    use crate::{
+        error::MostroError,
+        settings::{init_global_settings, Settings},
+    };
 
     #[test]
     fn test_wrong_amount_invoice() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,16 +16,16 @@ use nostr_sdk::prelude::*;
 use scheduler::start_scheduler;
 use settings::Settings;
 use settings::{init_default_dir, init_global_settings};
-use std::{env::args, path::PathBuf};
+use std::{env::args, path::PathBuf, sync::OnceLock};
 use tokio::sync::Mutex;
+
+static MOSTRO_CONFIG: OnceLock<Settings> = OnceLock::new();
 
 #[macro_use]
 extern crate lazy_static;
 
 lazy_static! {
     static ref RATE_EVENT_LIST: Mutex<Vec<Event>> = Mutex::new(vec![]);
-    // Global var
-    static ref MOSTRO_CONFIG : std::sync::Mutex<Settings> = std::sync::Mutex::new(Settings { database: Default::default(), nostr: Default::default(), mostro: Default::default(), lightning: Default::default() });
 }
 
 #[tokio::main]


### PR DESCRIPTION
Hi @grunch @bilthon !

Some improvements on config files and db file:

- Switched `MOSTRO_CONFIG` variable from `lazy_static` to `OnceLock` which is included in [std lib](https://github.com/rust-lang/rust/pull/105587) now. Maybe you could have to update to latest Rust. Next time I will try to use `OnceCell` to remove also variable of `RATE_EVENT_LIST` from lazy static so we can remove the not maintained crate.
- I changed `settings.toml` to `settings.tpl.toml` in .init_db.sh for compatibility and made config path the one in which db file is searched at startup.

Now what is happening is that user will launch in root folder the db init then launches mostro that creates path for settings and db file, then will print out to copy both file in the folder.
Maybe we could improve in some way that file copy and db creation are automated, but I don't if it's a good idea...

Waiting for advice... ;)