### PR TITLE
Removed lazy static crate, refactored some code in user rate send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mostro"
-version = "0.7.9"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["Francisco Calderón <negrunch@grunch.dev>"]
@@ -38,5 +38,4 @@ mostro-core = "0.2.7"
 tokio-cron-scheduler = "*"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
-lazy_static = "1.4.0"
 config = "0.13.3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,15 +17,17 @@ use crate::app::cancel::cancel_action;
 use crate::app::dispute::dispute_action;
 use crate::app::fiat_sent::fiat_sent_action;
 use crate::app::order::order_action;
-use crate::app::rate_user::update_user_reputation_action;
+use crate::app::rate_user::{send_user_rates, update_user_reputation_action};
 use crate::app::release::release_action;
 use crate::app::take_buy::take_buy_action;
 use crate::app::take_sell::take_sell_action;
 use crate::lightning::LndConnector;
+use crate::CLEAR_USER_VEC;
 use anyhow::Result;
 use mostro_core::{Action, Message};
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
+use std::sync::atomic::Ordering;
 
 pub async fn run(
     my_keys: Keys,
@@ -35,6 +37,15 @@ pub async fn run(
 ) -> Result<()> {
     loop {
         let mut notifications = client.notifications();
+
+        let mut rate_list: Vec<Event> = vec![];
+
+        // Check if we can send user rates updates
+        if CLEAR_USER_VEC.load(Ordering::Relaxed) {
+            send_user_rates(&rate_list, &client).await?;
+            CLEAR_USER_VEC.store(false, Ordering::Relaxed);
+            rate_list.clear();
+        }
 
         while let Ok(notification) = notifications.recv().await {
             if let RelayPoolNotification::Event(_, event) = notification {
@@ -85,7 +96,12 @@ pub async fn run(
                                     Action::PayInvoice => todo!(),
                                     Action::RateUser => {
                                         update_user_reputation_action(
-                                            msg, &event, &my_keys, &client, &pool,
+                                            msg,
+                                            &event,
+                                            &my_keys,
+                                            &client,
+                                            &pool,
+                                            &mut rate_list,
                                         )
                                         .await?;
                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,17 +16,11 @@ use nostr_sdk::prelude::*;
 use scheduler::start_scheduler;
 use settings::Settings;
 use settings::{init_default_dir, init_global_settings};
+use std::sync::atomic::AtomicBool;
 use std::{env::args, path::PathBuf, sync::OnceLock};
-use tokio::sync::Mutex;
 
+static CLEAR_USER_VEC: AtomicBool = AtomicBool::new(false);
 static MOSTRO_CONFIG: OnceLock<Settings> = OnceLock::new();
-
-#[macro_use]
-extern crate lazy_static;
-
-lazy_static! {
-    static ref RATE_EVENT_LIST: Mutex<Vec<Event>> = Mutex::new(vec![]);
-}
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@ use crate::lightning::LndConnector;
 use crate::messages;
 use crate::models::Yadio;
 use crate::settings::Settings;
-use crate::{db, flow, RATE_EVENT_LIST};
+use crate::{db, flow};
 
 use anyhow::{Context, Result};
 use log::{error, info};
@@ -188,6 +188,7 @@ pub async fn update_user_rating_event(
     order_id: Uuid,
     keys: &Keys,
     pool: &SqlitePool,
+    rate_list: &mut Vec<Event>,
 ) -> Result<()> {
     // let reputation = reput
     // nip33 kind and d tag
@@ -204,7 +205,7 @@ pub async fn update_user_rating_event(
     }
 
     // Add event message to global list
-    RATE_EVENT_LIST.lock().await.push(event);
+    rate_list.push(event);
 
     Ok(())
 }


### PR DESCRIPTION
Hi @grunch ,

removed lazy static crate here, refactored a bit the user send rate logic to avoid complexity in global vector management.
Now we have an atomic flag set by the scheduler that triggers user rate event send.

Waiting for comments...