### PR TITLE
Reduced verbosity of nostr-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,5 @@ reqwest = { version = "0.11", features = ["json"] }
 mostro-core = "0.2.7"
 tokio-cron-scheduler = "*"
 tracing = "0.1.37"
-tracing-subscriber = "0.3.16"
+tracing-subscriber = { version = "0.3.16", features =["env-filter"] }
 config = "0.13.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,15 +16,23 @@ use nostr_sdk::prelude::*;
 use scheduler::start_scheduler;
 use settings::Settings;
 use settings::{init_default_dir, init_global_settings};
+use std::env;
 use std::sync::Arc;
 use std::{env::args, path::PathBuf, sync::OnceLock};
 use tokio::sync::Mutex;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 static MOSTRO_CONFIG: OnceLock<Settings> = OnceLock::new();
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    pretty_env_logger::init();
+    env::set_var("RUST_LOG", "none,mostro=info");
+
+    // Tracing using RUST_LOG
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::from_default_env())
+        .init();
 
     let rate_list: Arc<Mutex<Vec<Event>>> = Arc::new(Mutex::new(vec![]));
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -10,16 +10,11 @@ use std::error::Error;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio_cron_scheduler::{Job, JobScheduler};
-use tracing::{info, warn, Level};
-use tracing_subscriber::FmtSubscriber;
+use tracing::{info, warn};
 
 pub async fn start_scheduler(
     rate_list: Arc<Mutex<Vec<Event>>>,
 ) -> Result<JobScheduler, Box<dyn Error>> {
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::INFO)
-        .finish();
-    tracing::subscriber::set_global_default(subscriber).expect("Setting default subscriber failed");
     info!("Creating scheduler");
     let sched = JobScheduler::new().await?;
     cron_scheduler(&sched, rate_list).await?;


### PR DESCRIPTION
Modified some init in main to print out just `INFO` from `Mostro` and avoid other logs from dependencies.

