### PR TITLE
Error refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ uuid = { version = "1.3.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.11", features = ["json"] }
-mostro-core = "0.3.7"
+mostro-core = "0.3.8"
 #tokio-cron-scheduler = "*"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,8 +1,7 @@
 pub mod settings;
 
-use crate::cli::settings::init_default_dir;
+use crate::cli::settings::{init_default_dir, MostroSettingsError};
 
-use anyhow::Result;
 use clap::Parser;
 use std::path::PathBuf;
 
@@ -30,7 +29,7 @@ pub struct Cli {
     dirsettings: Option<String>,
 }
 
-pub fn settings_init() -> Result<PathBuf> {
+pub fn settings_init() -> Result<PathBuf, MostroSettingsError> {
     let cli = Cli::parse();
 
     if let Some(path) = cli.dirsettings.as_deref() {

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -195,6 +195,7 @@ impl Settings {
         })
     }
 
+    // Getter functions for struct MOSTRO unwrap here should be safe because we yet deserialized it.
     pub fn get_ln() -> Lightning {
         MOSTRO_CONFIG.get().unwrap().lightning.clone()
     }
@@ -226,7 +227,7 @@ pub fn init_default_dir(config_path: Option<String>) -> Result<PathBuf, MostroSe
         settings_dir_default.push(home_dir);
     } else {
         // Get $HOME from env
-        let tmp = std::env::var("HOMEX").map_err(|source| MostroSettingsError {
+        let tmp = std::env::var("HOME").map_err(|source| MostroSettingsError {
             path: None,
             kind: FromConfigErrorKind::Env { source },
         })?;


### PR DESCRIPTION
Hi @grunch ,

putting here as an example of possible refactoring idea based on the blog article I shared on telegram:

https://sabrinajewson.org/blog/errors

I like the idea inside seems more elegant also if it's a required an effort in code and many calls to `map_err` when we can have a `Result`.

Putting here this as draft to share what could be te result, now `settings.rs` has some refactoring i did and results of error are now like this:

```
mostrod.exe -d c:\mostroSettings
Error: error reading `c:\mostroSettings\`

Caused by:
    expected an equals, found a newline at line 18 column 4 in ..\..\..\..\mostroSettings\settings.dev.toml
```

or

```
Error: error reading `H:\.mostro\`

Caused by:
    Forbidden access. (os error 5)
```

The approach is to avoid a big enum file and distribute errors in relative file, creating more specialized ones.

This will remove also `anyhow ` crate.

Let me know what you think about...


