### PR TITLE
added configurable interval for user rate send events

### DIFF
--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -29,6 +29,8 @@ min_payment_amount = 100
 expiration_hours = 24
 # Expiration of pending orders
 expiration_seconds = 900
+# User rate events scheduled time interval
+user_rates_sent_interval_seconds = 3600
 
 [database]
 url = "sqlite://mostro.db"

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -97,6 +97,7 @@ pub struct Mostro {
     pub min_payment_amount: u32,
     pub expiration_hours: u32,
     pub expiration_seconds: u32,
+    pub user_rates_sent_interval_seconds: u32,
 }
 
 impl TryFrom<Settings> for Mostro {


### PR DESCRIPTION
Hi @grunch ,

added configurable interval in seconds to send user rates events to relays.