### PR TITLE
Includes buyer & seller pubkeys and order creation time upon order transition to Active state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ uuid = { version = "1.3.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.11", features = ["json"] }
-mostro-core = "0.4.5"
+mostro-core = { git = "https://github.com/bilthon/mostro-core.git", branch = "feat_pubkeys_to_smallorder" }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 config = "0.13.3"

--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -134,7 +134,9 @@ pub async fn add_invoice_action(
             order.buyer_pubkey.as_ref().cloned(),
             order.seller_pubkey.as_ref().cloned(),
             None,
-            None,
+            Some(order.created_at),
+            order.buyer_pubkey.clone(),
+            order.seller_pubkey.clone(),
         );
         // We publish a new replaceable kind nostr event with the status updated
         // and update on local database the status and new event id

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -52,7 +52,9 @@ pub async fn hold_invoice_paid(hash: &str) {
         None,
         None,
         None,
-        None,
+        Some(order.created_at),
+        order.buyer_pubkey.clone(),
+        order.seller_pubkey.clone(),
     );
     let status;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -417,7 +417,9 @@ pub async fn set_market_order_sats_amount(
         None,
         None,
         None,
+        Some(order.created_at),
         None,
+        None
     );
     // We create a Message
     let message = Message::new_order(


### PR DESCRIPTION
With the seller as the maker, the information about each trade party's real public keys should be sent upon the hodl invoice confirmation with the `buyer_pubkey ` & `seller_pubkey ` as per the [documentation](https://mostro.network/messages/seller_pay_hold_invoice.html). This however was not happening. Another thing that was missing was the order creation time.

Please note that for this to work the dependencies must be updated as I'm using a modified `mostro-core` with modifications that can be seen [here](https://github.com/bilthon/mostro-core/commit/f594e32782d2b9f67afa5d662435ab7e3177d259). Basically just adding these two fields to the `SmallOrder` struct.