### PR TITLE
No currency exchange rate

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum MostroError {
     MinAmountError,
     WrongAmountError,
     NoAPIResponse,
+    NoCurrency,
 }
 
 impl std::error::Error for MostroError {}
@@ -23,6 +24,7 @@ impl fmt::Display for MostroError {
             MostroError::MinAmountError => write!(f, "Minimal payment amount"),
             MostroError::WrongAmountError => write!(f, "The amount on this invoice is wrong"),
             MostroError::NoAPIResponse => write!(f, "Price API not answered - retry"),
+            MostroError::NoCurrency => write!(f, "Currency requested is not present in the exchange list, please specify a fixed rate"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ pub enum MostroError {
     WrongAmountError,
     NoAPIResponse,
     NoCurrency,
+    MalformedAPIRes,
 }
 
 impl std::error::Error for MostroError {}
@@ -25,6 +26,7 @@ impl fmt::Display for MostroError {
             MostroError::WrongAmountError => write!(f, "The amount on this invoice is wrong"),
             MostroError::NoAPIResponse => write!(f, "Price API not answered - retry"),
             MostroError::NoCurrency => write!(f, "Currency requested is not present in the exchange list, please specify a fixed rate"),
+            MostroError::MalformedAPIRes => write!(f, "Malformed answer from exchange quoting request"),
         }
     }
 }


### PR DESCRIPTION
Hi @grunch @bilthon ,

did some refactoring for error messages on `Yadio` request, should be better now:

- If 4 retries are over we get: 
```Rust
MostroError::NoAPIResponse => write!(f, "Price API not answered - retry")
```

-  No currency exchange on Yadio list:
```Rust
MostroError::NoCurrency => write!(f, "Currency requested is not present in the exchange list, please specify a fixed rate"),
```
-  Malformed answer from Yadio
```Rust
MostroError::MalformedAPIRes => write!(f, "Malformed answer from exchange quoting request")
```