### PR TITLE
update mostro core to ver 5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ uuid = { version = "1.3.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.11", features = ["json"] }
-mostro-core = "0.5.3"
+mostro-core = "0.5.4"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 config = "0.14.0"


### PR DESCRIPTION
Hi @grunch ,

I think we should update toml with latest core version, i saw it's live on `crates.io`.