### PR TITLE
fix on admin settle and cosmetic on order.rs

### DIFF
--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -21,19 +21,21 @@ pub async fn order_action(
         // Reject all new invoices in a neworder with amount != 0
         if let Some(invoice) = msg.get_inner_message_kind().get_payment_request() {
             let invoice = decode_invoice(&invoice)?;
-            if let Some(invoice_sats) = invoice.amount_milli_satoshis().map(|sats| sats / 1000) {
-                if invoice_sats !=0 {
-                    let message = Message::cant_do(
-                        order.id,
-                        None,
-                        Some(Content::TextMessage(
-                            String::from("Invoice with an amount different from zero receive on new order, please send 0 amount invoice or no invoice at all!"                  
-                        ))),
-                    );
-                    let message = message.as_json()?;
-                    send_dm(client, my_keys, &event.pubkey, message).await?;
-                    return Ok(());
-                }
+            if invoice
+                .amount_milli_satoshis()
+                .map(|sats| sats / 1000)
+                .is_some()
+            {
+                let message = Message::cant_do(
+                    order.id,
+                    None,
+                    Some(Content::TextMessage(
+                        String::from("Invoice with an amount different from zero receive on new order, please send 0 amount invoice or no invoice at all!"                  
+                    ))),
+                );
+                let message = message.as_json()?;
+                send_dm(client, my_keys, &event.pubkey, message).await?;
+                return Ok(());
             }
         }
 


### PR DESCRIPTION
Hi @grunch ,

did a quick fix on `admin_settle.rs` ( thanks to @Catrya for signaling it ).

Little cosmetics on a useless check in `order.rs`

Not tested, but it's just a filter as you did in `admin_cancel.rs`, so I am quite confident we can merge it, and then @Catrya will make his tests again!