### PR TITLE
Message refactoring

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,7 +36,7 @@ use tokio::sync::Mutex;
 
 pub async fn run(
     my_keys: Keys,
-    client: Client,
+    client: &Client,
     ln_client: &mut LndConnector,
     pool: Pool<Sqlite>,
     rate_list: Arc<Mutex<Vec<Event>>>,
@@ -61,38 +61,28 @@ pub async fn run(
                                 if let Some(action) = msg.inner_action() {
                                     match action {
                                         Action::NewOrder => {
-                                            order_action(msg, &event, &my_keys, &client, &pool)
-                                                .await?;
+                                            order_action(msg, &event, &my_keys, &pool).await?;
                                         }
                                         Action::TakeSell => {
-                                            take_sell_action(msg, &event, &my_keys, &client, &pool)
-                                                .await?;
+                                            take_sell_action(msg, &event, &my_keys, &pool).await?;
                                         }
                                         Action::TakeBuy => {
-                                            take_buy_action(msg, &event, &my_keys, &client, &pool)
-                                                .await?;
+                                            take_buy_action(msg, &event, &my_keys, &pool).await?;
                                         }
                                         Action::FiatSent => {
-                                            fiat_sent_action(msg, &event, &my_keys, &client, &pool)
-                                                .await?;
+                                            fiat_sent_action(msg, &event, &my_keys, &pool).await?;
                                         }
                                         Action::Release => {
-                                            release_action(
-                                                msg, &event, &my_keys, &client, &pool, ln_client,
-                                            )
-                                            .await?;
+                                            release_action(msg, &event, &my_keys, &pool, ln_client)
+                                                .await?;
                                         }
                                         Action::Cancel => {
-                                            cancel_action(
-                                                msg, &event, &my_keys, &client, &pool, ln_client,
-                                            )
-                                            .await?;
+                                            cancel_action(msg, &event, &my_keys, &pool, ln_client)
+                                                .await?;
                                         }
                                         Action::AddInvoice => {
-                                            add_invoice_action(
-                                                msg, &event, &my_keys, &client, &pool,
-                                            )
-                                            .await?;
+                                            add_invoice_action(msg, &event, &my_keys, &pool)
+                                                .await?;
                                         }
                                         Action::PayInvoice => todo!(),
                                         Action::RateUser => {
@@ -100,39 +90,33 @@ pub async fn run(
                                                 msg,
                                                 &event,
                                                 &my_keys,
-                                                &client,
                                                 &pool,
                                                 rate_list.clone(),
                                             )
                                             .await?;
                                         }
                                         Action::Dispute => {
-                                            dispute_action(msg, &event, &my_keys, &client, &pool)
-                                                .await?;
+                                            dispute_action(msg, &event, &my_keys, &pool).await?;
                                         }
                                         Action::AdminCancel => {
                                             admin_cancel_action(
-                                                msg, &event, &my_keys, &client, &pool, ln_client,
+                                                msg, &event, &my_keys, &pool, ln_client,
                                             )
                                             .await?;
                                         }
                                         Action::AdminSettle => {
                                             admin_settle_action(
-                                                msg, &event, &my_keys, &client, &pool, ln_client,
+                                                msg, &event, &my_keys, &pool, ln_client,
                                             )
                                             .await?;
                                         }
                                         Action::AdminAddSolver => {
-                                            admin_add_solver_action(
-                                                msg, &event, &my_keys, &client, &pool,
-                                            )
-                                            .await?;
+                                            admin_add_solver_action(msg, &event, &my_keys, &pool)
+                                                .await?;
                                         }
                                         Action::AdminTakeDispute => {
-                                            admin_take_dispute_action(
-                                                msg, &event, &my_keys, &client, &pool,
-                                            )
-                                            .await?;
+                                            admin_take_dispute_action(msg, &event, &my_keys, &pool)
+                                                .await?;
                                         }
                                         _ => todo!(),
                                     }

--- a/src/app/admin_add_solver.rs
+++ b/src/app/admin_add_solver.rs
@@ -1,4 +1,4 @@
-use crate::util::send_dm;
+use crate::util::{send_cant_do_msg, send_dm};
 
 use anyhow::Result;
 use mostro_core::message::{Action, Content, Message};
@@ -12,7 +12,6 @@ pub async fn admin_add_solver_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
 ) -> Result<()> {
     let inner_message = msg.get_inner_message_kind();
@@ -32,10 +31,7 @@ pub async fn admin_add_solver_action(
     // Check if the pubkey is Mostro
     if event.pubkey.to_string() != my_keys.public_key().to_string() {
         // We create a Message
-        let message = Message::cant_do(None, None, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message).await?;
-
+        send_cant_do_msg(None, Some("Not allowed".to_string()), &event.pubkey).await;
         return Ok(());
     }
     let user = User::new(npubkey.to_string(), 0, 1, 0, 0);
@@ -48,7 +44,7 @@ pub async fn admin_add_solver_action(
     let message = Message::new_dispute(None, None, Action::AdminAddSolver, None);
     let message = message.as_json()?;
     // Send the message
-    send_dm(client, my_keys, &event.pubkey, message).await?;
+    send_dm(&event.pubkey, message).await?;
 
     Ok(())
 }

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -3,7 +3,8 @@ use std::str::FromStr;
 use crate::db::find_dispute_by_order_id;
 use crate::lightning::LndConnector;
 use crate::nip33::new_event;
-use crate::util::{send_dm, update_order_event};
+use crate::util::{send_cant_do_msg, send_dm, update_order_event};
+use crate::NOSTR_CLIENT;
 
 use anyhow::Result;
 use mostro_core::dispute::Status as DisputeStatus;
@@ -18,7 +19,6 @@ pub async fn admin_cancel_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
     ln_client: &mut LndConnector,
 ) -> Result<()> {
@@ -34,10 +34,7 @@ pub async fn admin_cancel_action(
     // Check if the pubkey is Mostro
     if event.pubkey.to_string() != my_keys.public_key().to_string() {
         // We create a Message
-        let message = Message::cant_do(Some(order.id), None, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message).await?;
-
+        send_cant_do_msg(Some(order_id), None, &event.pubkey).await;
         return Ok(());
     }
 
@@ -65,19 +62,18 @@ pub async fn admin_cancel_action(
         // nip33 kind with dispute id as identifier
         let event = new_event(my_keys, "", dispute_id.to_string(), tags)?;
 
-        client.send_event(event).await?;
+        NOSTR_CLIENT.get().unwrap().send_event(event).await?;
     }
 
     // We publish a new replaceable kind nostr event with the status updated
     // and update on local database the status and new event id
-    let order_updated =
-        update_order_event(client, my_keys, Status::CanceledByAdmin, &order).await?;
+    let order_updated = update_order_event(my_keys, Status::CanceledByAdmin, &order).await?;
     order_updated.update(pool).await?;
     // We create a Message
     let message = Message::new_dispute(Some(order.id), None, Action::AdminCancel, None);
     let message = message.as_json()?;
     // Message to admin
-    send_dm(client, my_keys, &event.pubkey, message.clone()).await?;
+    send_dm(&event.pubkey, message.clone()).await?;
     let seller_pubkey = match XOnlyPublicKey::from_str(order.seller_pubkey.as_ref().unwrap()) {
         Ok(pk) => pk,
         Err(e) => {
@@ -85,7 +81,7 @@ pub async fn admin_cancel_action(
             return Ok(());
         }
     };
-    send_dm(client, my_keys, &seller_pubkey, message.clone()).await?;
+    send_dm(&seller_pubkey, message.clone()).await?;
     let buyer_pubkey = match XOnlyPublicKey::from_str(order.buyer_pubkey.as_ref().unwrap()) {
         Ok(pk) => pk,
         Err(e) => {
@@ -93,7 +89,7 @@ pub async fn admin_cancel_action(
             return Ok(());
         }
     };
-    send_dm(client, my_keys, &buyer_pubkey, message.clone()).await?;
+    send_dm(&buyer_pubkey, message.clone()).await?;
 
     Ok(())
 }

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -1,5 +1,6 @@
 use crate::nip33::new_event;
-use crate::util::send_dm;
+use crate::util::{send_cant_do_msg, send_dm};
+use crate::NOSTR_CLIENT;
 
 use anyhow::Result;
 use mostro_core::dispute::{Dispute, Status};
@@ -14,7 +15,6 @@ pub async fn admin_take_dispute_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
 ) -> Result<()> {
     let dispute_id = msg.get_inner_message_kind().id.unwrap();
@@ -22,14 +22,12 @@ pub async fn admin_take_dispute_action(
         Some(dispute) => dispute,
         None => {
             // We create a Message
-            let message = Message::cant_do(
-                None,
-                None,
-                Some(Content::TextMessage("Dispute not found".to_string())),
-            );
-            let message = message.as_json()?;
-            send_dm(client, my_keys, &event.pubkey, message).await?;
-
+            send_cant_do_msg(
+                Some(dispute_id),
+                Some("Dispute not found".to_string()),
+                &event.pubkey,
+            )
+            .await;
             return Ok(());
         }
     };
@@ -42,14 +40,7 @@ pub async fn admin_take_dispute_action(
     // TODO: solvers also can take disputes
     if event.pubkey.to_string() != my_keys.public_key().to_string() {
         // We create a Message
-        let message = Message::cant_do(
-            None,
-            None,
-            Some(Content::TextMessage("Not allowed".to_string())),
-        );
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message).await?;
-
+        send_cant_do_msg(None, Some("Not allowed".to_string()), &event.pubkey).await;
         return Ok(());
     }
 
@@ -69,7 +60,7 @@ pub async fn admin_take_dispute_action(
     );
     let message = message.as_json()?;
     // Send the message
-    send_dm(client, my_keys, &event.pubkey, message.clone()).await?;
+    send_dm(&event.pubkey, message.clone()).await?;
 
     // We create a tag to show status of the dispute
     let tags = vec![
@@ -80,7 +71,7 @@ pub async fn admin_take_dispute_action(
     // nip33 kind with dispute id as identifier
     let event = new_event(my_keys, "", dispute_id.to_string(), tags)?;
     info!("Dispute event to be published: {event:#?}");
-    client.send_event(event).await?;
+    NOSTR_CLIENT.get().unwrap().send_event(event).await?;
 
     Ok(())
 }

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -1,8 +1,8 @@
 use crate::db::{edit_buyer_pubkey_order, edit_seller_pubkey_order, update_order_to_initial_state};
 use crate::lightning::LndConnector;
-use crate::util::{send_dm, update_order_event};
+use crate::util::{send_cant_do_msg, send_new_order_msg, update_order_event};
 use anyhow::Result;
-use mostro_core::message::{Action, Content, Message};
+use mostro_core::message::{Action, Message};
 use mostro_core::order::{Kind as OrderKind, Order, Status};
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
@@ -14,7 +14,6 @@ pub async fn cancel_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
     ln_client: &mut LndConnector,
 ) -> Result<()> {
@@ -31,25 +30,20 @@ pub async fn cancel_action(
         // Validates if this user is the order creator
         if user_pubkey != order.creator_pubkey {
             // We create a Message
-            let message = Message::cant_do(
-                Some(order.id),
-                None,
-                Some(Content::TextMessage("Not allowed!".to_string())),
-            );
-            let message = message.as_json()?;
-            send_dm(client, my_keys, &event.pubkey, message).await?;
+            send_cant_do_msg(
+                Some(order_id),
+                Some("Not allowed!".to_string()),
+                &event.pubkey,
+            )
+            .await;
         } else {
             // We publish a new replaceable kind nostr event with the status updated
             // and update on local database the status and new event id
-            if let Ok(order_updated) =
-                update_order_event(client, my_keys, Status::Canceled, &order).await
-            {
+            if let Ok(order_updated) = update_order_event(my_keys, Status::Canceled, &order).await {
                 let _ = order_updated.update(pool).await;
             }
             // We create a Message for cancel
-            let message = Message::new_order(Some(order.id), None, Action::Cancel, None);
-            let message = message.as_json()?;
-            send_dm(client, my_keys, &event.pubkey, message).await?;
+            send_new_order_msg(Some(order.id), Action::Cancel, None, &event.pubkey).await;
         }
 
         return Ok(());
@@ -58,13 +52,13 @@ pub async fn cancel_action(
     if order.kind == OrderKind::Sell.to_string()
         && order.status == Status::WaitingBuyerInvoice.to_string()
     {
-        cancel_add_invoice(ln_client, &mut order, event, pool, client, my_keys).await?;
+        cancel_add_invoice(ln_client, &mut order, event, pool, my_keys).await?;
     }
 
     if order.kind == OrderKind::Buy.to_string()
         && order.status == Status::WaitingPayment.to_string()
     {
-        cancel_pay_hold_invoice(ln_client, &mut order, event, pool, client, my_keys).await?;
+        cancel_pay_hold_invoice(ln_client, &mut order, event, pool, my_keys).await?;
     }
 
     if order.status == Status::Active.to_string()
@@ -87,10 +81,7 @@ pub async fn cancel_action(
             Some(ref initiator_pubkey) => {
                 if initiator_pubkey == &user_pubkey {
                     // We create a Message
-                    let message = Message::cant_do(Some(order.id), None, None);
-                    let message = message.as_json()?;
-                    send_dm(client, my_keys, &event.pubkey, message).await?;
-
+                    send_cant_do_msg(Some(order_id), None, &event.pubkey).await;
                     return Ok(());
                 } else {
                     if order.hash.is_some() {
@@ -105,19 +96,23 @@ pub async fn cancel_action(
                     order.status = Status::CooperativelyCanceled.to_string();
                     // We publish a new replaceable kind nostr event with the status updated
                     // and update on local database the status and new event id
-                    update_order_event(client, my_keys, Status::CooperativelyCanceled, &order)
-                        .await?;
+                    update_order_event(my_keys, Status::CooperativelyCanceled, &order).await?;
                     // We create a Message for an accepted cooperative cancel and send it to both parties
-                    let message = Message::new_order(
+                    send_new_order_msg(
                         Some(order.id),
-                        None,
                         Action::CooperativeCancelAccepted,
                         None,
-                    );
-                    let message = message.as_json()?;
-                    send_dm(client, my_keys, &event.pubkey, message.clone()).await?;
+                        &event.pubkey,
+                    )
+                    .await;
                     let counterparty_pubkey = XOnlyPublicKey::from_str(&counterparty_pubkey)?;
-                    send_dm(client, my_keys, &counterparty_pubkey, message).await?;
+                    send_new_order_msg(
+                        Some(order.id),
+                        Action::CooperativeCancelAccepted,
+                        None,
+                        &counterparty_pubkey,
+                    )
+                    .await;
                     info!("Cancel: Order Id {order_id} canceled cooperatively!");
                 }
             }
@@ -126,23 +121,21 @@ pub async fn cancel_action(
                 // update db
                 let order = order.update(pool).await?;
                 // We create a Message to start a cooperative cancel and send it to both parties
-                let message = Message::new_order(
+                send_new_order_msg(
                     Some(order.id),
-                    None,
                     Action::CooperativeCancelInitiatedByYou,
                     None,
-                );
-                let message = message.as_json()?;
-                send_dm(client, my_keys, &event.pubkey, message).await?;
-                let message = Message::new_order(
+                    &event.pubkey,
+                )
+                .await;
+                let counterparty_pubkey = XOnlyPublicKey::from_str(&counterparty_pubkey)?;
+                send_new_order_msg(
                     Some(order.id),
-                    None,
                     Action::CooperativeCancelInitiatedByPeer,
                     None,
-                );
-                let message = message.as_json()?;
-                let counterparty_pubkey = XOnlyPublicKey::from_str(&counterparty_pubkey)?;
-                send_dm(client, my_keys, &counterparty_pubkey, message).await?;
+                    &counterparty_pubkey,
+                )
+                .await;
             }
         }
     }
@@ -154,7 +147,6 @@ pub async fn cancel_add_invoice(
     order: &mut Order,
     event: &Event,
     pool: &Pool<Sqlite>,
-    client: &Client,
     my_keys: &Keys,
 ) -> Result<()> {
     if order.hash.is_some() {
@@ -175,22 +167,17 @@ pub async fn cancel_add_invoice(
     };
     if buyer_pubkey != &user_pubkey {
         // We create a Message
-        let message = Message::cant_do(Some(order.id), None, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
 
     if &order.creator_pubkey == buyer_pubkey {
         // We publish a new replaceable kind nostr event with the status updated
         // and update on local database the status and new event id
-        update_order_event(client, my_keys, Status::CooperativelyCanceled, order).await?;
+        update_order_event(my_keys, Status::CooperativelyCanceled, order).await?;
         // We create a Message for cancel
-        let message = Message::new_order(Some(order.id), None, Action::Cancel, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message.clone()).await?;
-        send_dm(client, my_keys, &seller_pubkey, message).await?;
+        send_new_order_msg(Some(order.id), Action::Cancel, None, &event.pubkey).await;
+        send_new_order_msg(Some(order.id), Action::Cancel, None, &seller_pubkey).await;
         Ok(())
     } else {
         // We re-publish the event with Pending status
@@ -201,7 +188,7 @@ pub async fn cancel_add_invoice(
         }
         edit_buyer_pubkey_order(pool, order.id, None).await?;
         update_order_to_initial_state(pool, order.id, order.amount, order.fee).await?;
-        update_order_event(client, my_keys, Status::Pending, order).await?;
+        update_order_event(my_keys, Status::Pending, order).await?;
         info!(
             "{}: Canceled order Id {} republishing order",
             buyer_pubkey, order.id
@@ -215,7 +202,6 @@ pub async fn cancel_pay_hold_invoice(
     order: &mut Order,
     event: &Event,
     pool: &Pool<Sqlite>,
-    client: &Client,
     my_keys: &Keys,
 ) -> Result<()> {
     if order.hash.is_some() {
@@ -236,22 +222,17 @@ pub async fn cancel_pay_hold_invoice(
     };
     if seller_pubkey.to_string() != user_pubkey {
         // We create a Message
-        let message = Message::cant_do(Some(order.id), None, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
 
     if order.creator_pubkey == seller_pubkey.to_string() {
         // We publish a new replaceable kind nostr event with the status updated
         // and update on local database the status and new event id
-        update_order_event(client, my_keys, Status::Canceled, order).await?;
+        update_order_event(my_keys, Status::Canceled, order).await?;
         // We create a Message for cancel
-        let message = Message::new_order(Some(order.id), None, Action::Cancel, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message.clone()).await?;
-        send_dm(client, my_keys, &seller_pubkey, message).await?;
+        send_new_order_msg(Some(order.id), Action::Cancel, None, &event.pubkey).await;
+        send_new_order_msg(Some(order.id), Action::Cancel, None, &seller_pubkey).await;
         Ok(())
     } else {
         // We re-publish the event with Pending status
@@ -262,7 +243,7 @@ pub async fn cancel_pay_hold_invoice(
         }
         edit_seller_pubkey_order(pool, order.id, None).await?;
         update_order_to_initial_state(pool, order.id, order.amount, order.fee).await?;
-        update_order_event(client, my_keys, Status::Pending, order).await?;
+        update_order_event(my_keys, Status::Pending, order).await?;
         info!(
             "{}: Canceled order Id {} republishing order",
             buyer_pubkey, order.id

--- a/src/app/fiat_sent.rs
+++ b/src/app/fiat_sent.rs
@@ -1,4 +1,4 @@
-use crate::util::{send_dm, update_order_event};
+use crate::util::{send_cant_do_msg, send_new_order_msg, update_order_event};
 
 use anyhow::Result;
 use mostro_core::message::{Action, Content, Message, Peer};
@@ -13,7 +13,6 @@ pub async fn fiat_sent_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
 ) -> Result<()> {
     let order_id = msg.get_inner_message_kind().id.unwrap();
@@ -27,22 +26,18 @@ pub async fn fiat_sent_action(
     // Send to user a DM with the error
     if order.status != Status::Active.to_string() {
         let error = format!("Order Id {order_id} wrong status");
-        let message = Message::cant_do(Some(order.id), None, Some(Content::TextMessage(error)));
-        send_dm(client, my_keys, &event.pubkey, message.as_json()?).await?;
-
+        send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
         return Ok(());
     }
     // Check if the pubkey is the buyer
     if Some(event.pubkey.to_string()) != order.buyer_pubkey {
-        let message = Message::cant_do(Some(order.id), None, None);
-        send_dm(client, my_keys, &event.pubkey, message.as_json()?).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
 
     // We publish a new replaceable kind nostr event with the status updated
     // and update on local database the status and new event id
-    if let Ok(order_updated) = update_order_event(client, my_keys, Status::FiatSent, &order).await {
+    if let Ok(order_updated) = update_order_event(my_keys, Status::FiatSent, &order).await {
         let _ = order_updated.update(pool).await;
     }
 
@@ -56,26 +51,24 @@ pub async fn fiat_sent_action(
     let peer = Peer::new(event.pubkey.to_string());
 
     // We create a Message
-    let message = Message::new_order(
+    send_new_order_msg(
         Some(order.id),
-        None,
         Action::FiatSent,
         Some(Content::Peer(peer)),
-    );
-    let message = message.as_json().unwrap();
-    send_dm(client, my_keys, &seller_pubkey, message).await?;
+        &seller_pubkey,
+    )
+    .await;
     // We send a message to buyer to wait
     let peer = Peer::new(seller_pubkey.to_string());
 
     // We create a Message
-    let message = Message::new_order(
+    send_new_order_msg(
         Some(order.id),
-        None,
         Action::FiatSent,
         Some(Content::Peer(peer)),
-    );
-    let message = message.as_json()?;
-    send_dm(client, my_keys, &event.pubkey, message).await?;
+        &event.pubkey,
+    )
+    .await;
 
     Ok(())
 }

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -1,10 +1,10 @@
 use crate::cli::settings::Settings;
 use crate::lightning::invoice::decode_invoice;
-use crate::util::{get_market_quote, publish_order, send_dm};
+use crate::util::{get_market_quote, publish_order, send_cant_do_msg};
 
 use anyhow::Result;
-use mostro_core::message::{Content, Message};
-use nostr_sdk::{Client, Event, Keys};
+use mostro_core::message::Message;
+use nostr_sdk::{Event, Keys};
 use sqlx::{Pool, Sqlite};
 use tracing::error;
 
@@ -12,7 +12,6 @@ pub async fn order_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
 ) -> Result<()> {
     if let Some(order) = msg.get_inner_message_kind().get_order() {
@@ -26,15 +25,9 @@ pub async fn order_action(
                 .map(|sats| sats / 1000)
                 .is_some()
             {
-                let message = Message::cant_do(
-                    order.id,
-                    None,
-                    Some(Content::TextMessage(
-                        String::from("Invoice with an amount different from zero receive on new order, please send 0 amount invoice or no invoice at all!"                  
-                    ))),
-                );
-                let message = message.as_json()?;
-                send_dm(client, my_keys, &event.pubkey, message).await?;
+                let error = String::from("Invoice with an amount different from zero receive on new order, please send 0 amount invoice or no invoice at all!");
+                send_cant_do_msg(order.id, Some(error), &event.pubkey).await;
+
                 return Ok(());
             }
         }
@@ -52,32 +45,17 @@ pub async fn order_action(
 
         // Check amount is positive - extra safety check
         if quote < 0 {
-            let message = Message::cant_do(
-                order.id,
-                None,
-                Some(Content::TextMessage(format!(
-                    "Amount must be positive {} is not valid",
-                    order.amount
-                ))),
-            );
-            let message = message.as_json()?;
-            send_dm(client, my_keys, &event.pubkey, message).await?;
-
+            let msg = format!("Amount must be positive {} is not valid", order.amount);
+            send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
             return Ok(());
         }
 
         if quote > mostro_settings.max_order_amount as i64 {
-            let message = Message::cant_do(
-                order.id,
-                None,
-                Some(Content::TextMessage(format!(
-                    "Quote too high, max is {}",
-                    mostro_settings.max_order_amount
-                ))),
+            let msg = format!(
+                "Quote too high, max is {}",
+                mostro_settings.max_order_amount
             );
-            let message = message.as_json()?;
-            send_dm(client, my_keys, &event.pubkey, message).await?;
-
+            send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
             return Ok(());
         }
 
@@ -86,17 +64,13 @@ pub async fn order_action(
             Some(ref pk) => pk,
             None => {
                 // We create a Message
-                let message = Message::cant_do(order.id, None, None);
-                let message = message.as_json()?;
-                send_dm(client, my_keys, &event.pubkey, message).await?;
-
+                send_cant_do_msg(order.id, None, &event.pubkey).await;
                 return Ok(());
             }
         };
 
         publish_order(
             pool,
-            client,
             my_keys,
             order,
             &initiator_ephemeral_pubkey,

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -1,4 +1,7 @@
-use crate::util::{nostr_tags_to_tuple, send_dm, update_user_rating_event};
+use crate::util::{
+    nostr_tags_to_tuple, send_cant_do_msg, send_new_order_msg, update_user_rating_event,
+};
+use crate::NOSTR_CLIENT;
 
 use anyhow::Result;
 use mostro_core::message::{Action, Content, Message};
@@ -13,11 +16,7 @@ use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::error;
 
-pub async fn get_counterpart_reputation(
-    user: &str,
-    my_keys: &Keys,
-    client: &Client,
-) -> Result<Option<Rating>> {
+pub async fn get_counterpart_reputation(user: &str, my_keys: &Keys) -> Result<Option<Rating>> {
     // Request NIP33 of the counterparts
     let filters = Filter::new()
         .author(my_keys.public_key())
@@ -25,7 +24,9 @@ pub async fn get_counterpart_reputation(
         .custom_tag(Alphabet::Z, vec!["rating"])
         .identifier(user.to_string());
 
-    let mut user_reputation_event = client
+    let mut user_reputation_event = NOSTR_CLIENT
+        .get()
+        .unwrap()
         .get_events_of(vec![filters], Some(Duration::from_secs(10)))
         .await?;
 
@@ -46,7 +47,6 @@ pub async fn update_user_reputation_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
     rate_list: Arc<Mutex<Vec<Event>>>,
 ) -> Result<()> {
@@ -65,11 +65,8 @@ pub async fn update_user_reputation_action(
     let message_sender = event.pubkey.to_string();
 
     if order.status != Status::Success.to_string() {
-        let message = Message::cant_do(Some(order.id), None, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message).await?;
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         error!("Order Id {order_id} wrong status");
-
         return Ok(());
     }
     // Get counterpart pubkey
@@ -89,10 +86,7 @@ pub async fn update_user_reputation_action(
     // Add a check in case of no counterpart found
     if counterpart.is_empty() {
         // We create a Message
-        let message = Message::cant_do(Some(order.id), None, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     };
 
@@ -117,7 +111,7 @@ pub async fn update_user_reputation_action(
     }
 
     // Ask counterpart reputation
-    let rep = get_counterpart_reputation(&counterpart, my_keys, client).await?;
+    let rep = get_counterpart_reputation(&counterpart, my_keys).await?;
     // Here we have to update values of the review of the counterpart
     let mut reputation;
     // min_rate is 1 and max_rate is 5
@@ -160,9 +154,7 @@ pub async fn update_user_reputation_action(
         .await?;
 
         // Send confirmation message to user that rated
-        let message = Message::new_order(Some(order.id), None, Action::RateReceived, None);
-        let message = message.as_json()?;
-        send_dm(client, my_keys, &event.pubkey, message).await?;
+        send_new_order_msg(Some(order.id), Action::RateReceived, None, &event.pubkey).await;
     }
 
     Ok(())

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -3,13 +3,13 @@ use crate::db;
 use crate::lightning::LndConnector;
 use crate::lnurl::resolv_ln_address;
 use crate::util::{
-    connect_nostr, get_keys, rate_counterpart, send_dm, settle_seller_hold_invoice,
+    get_keys, rate_counterpart, send_cant_do_msg, send_new_order_msg, settle_seller_hold_invoice,
     update_order_event,
 };
 
 use anyhow::Result;
 use lnurl::lightning_address::LightningAddress;
-use mostro_core::message::{Action, Content, Message};
+use mostro_core::message::{Action, Message};
 use mostro_core::order::{Order, Status};
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
@@ -28,6 +28,7 @@ pub async fn check_failure_retries(order: &Order) -> Result<Order> {
     // Get max number of retries
     let ln_settings = Settings::get_ln();
     let retries_number = ln_settings.payment_attempts as i64;
+    let time_window = ln_settings.payment_retries_interval * retries_number as u32;
 
     // Mark payment as failed
     if !order.failed_payment {
@@ -36,6 +37,10 @@ pub async fn check_failure_retries(order: &Order) -> Result<Order> {
     } else if order.payment_attempts < retries_number {
         order.payment_attempts += 1;
     }
+    let msg = format!("I tried to send you the sats but the payment of your invoice failed, I will try {} more times in {} minutes window, please check your node/wallet is online",retries_number,time_window);
+    let buyer_key = XOnlyPublicKey::from_str(order.buyer_pubkey.as_ref().unwrap()).unwrap();
+
+    send_cant_do_msg(Some(order.id), Some(msg), &buyer_key).await;
 
     // Update order
     let result = order.update(&pool).await?;
@@ -46,7 +51,6 @@ pub async fn release_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
     ln_client: &mut LndConnector,
 ) -> Result<()> {
@@ -72,56 +76,38 @@ pub async fn release_action(
         && current_status != Status::FiatSent
         && current_status != Status::Dispute
     {
-        let message = Message::cant_do(Some(order.id), None, None);
-        send_dm(client, my_keys, &event.pubkey, message.as_json()?).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
 
     if &seller_pubkey.to_string() != seller_pubkey_hex {
-        let message = Message::cant_do(
+        send_cant_do_msg(
             Some(order.id),
-            None,
-            Some(Content::TextMessage(
-                "You are not allowed to release funds for this order!".to_string(),
-            )),
-        );
-        send_dm(client, my_keys, &event.pubkey, message.as_json()?).await?;
-
+            Some("You are not allowed to release funds for this order!".to_string()),
+            &event.pubkey,
+        )
+        .await;
         return Ok(());
     }
 
-    settle_seller_hold_invoice(
-        event,
-        my_keys,
-        client,
-        ln_client,
-        Action::Release,
-        false,
-        &order,
-    )
-    .await?;
+    settle_seller_hold_invoice(event, my_keys, ln_client, Action::Release, false, &order).await?;
 
     let buyer_pubkey = order.buyer_pubkey.clone().unwrap();
 
-    let order_updated =
-        update_order_event(client, my_keys, Status::SettledHoldInvoice, &order).await?;
+    let order_updated = update_order_event(my_keys, Status::SettledHoldInvoice, &order).await?;
 
     // We send a HoldInvoicePaymentSettled message to seller, the client should
     // indicate *funds released* message to seller
-    let message = Message::new_order(
+    send_new_order_msg(
         Some(order_id),
-        None,
         Action::HoldInvoicePaymentSettled,
         None,
-    );
-
-    send_dm(client, my_keys, &seller_pubkey, message.as_json()?).await?;
+        &seller_pubkey,
+    )
+    .await;
     // We send a message to buyer indicating seller released funds
-    let message = Message::new_order(Some(order_id), None, Action::Release, None);
-    let message = message.as_json()?;
     let buyer_pubkey = XOnlyPublicKey::from_str(&buyer_pubkey)?;
-    send_dm(client, my_keys, &buyer_pubkey, message).await?;
+    send_new_order_msg(Some(order_id), Action::Release, None, &buyer_pubkey).await;
     let _ = do_payment(order_updated).await;
 
     Ok(())
@@ -154,7 +140,6 @@ pub async fn do_payment(order: Order) -> Result<()> {
     let payment = {
         async move {
             // We redeclare vars to use inside this block
-            let client = connect_nostr().await.unwrap();
             let my_keys = get_keys().unwrap();
             let buyer_pubkey =
                 XOnlyPublicKey::from_str(order.buyer_pubkey.as_ref().unwrap()).unwrap();
@@ -169,14 +154,7 @@ pub async fn do_payment(order: Order) -> Result<()> {
                                 "Order Id {}: Invoice with hash: {} paid!",
                                 order.id, msg.payment.payment_hash
                             );
-                            payment_success(
-                                &order,
-                                &buyer_pubkey,
-                                &seller_pubkey,
-                                &my_keys,
-                                &client,
-                            )
-                            .await;
+                            payment_success(&order, &buyer_pubkey, &seller_pubkey, &my_keys).await;
                         }
                         PaymentStatus::Failed => {
                             info!(
@@ -207,24 +185,25 @@ async fn payment_success(
     buyer_pubkey: &XOnlyPublicKey,
     seller_pubkey: &XOnlyPublicKey,
     my_keys: &Keys,
-    client: &Client,
 ) {
     // Purchase completed message to buyer
-    let message = Message::new_order(Some(order.id), None, Action::PurchaseCompleted, None);
-    let message = message.as_json().unwrap();
-    send_dm(client, my_keys, buyer_pubkey, message)
-        .await
-        .unwrap();
+    send_new_order_msg(
+        Some(order.id),
+        Action::PurchaseCompleted,
+        None,
+        buyer_pubkey,
+    )
+    .await;
 
     // Let's wait 5 secs before publish this new event
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
     // We publish a new replaceable kind nostr event with the status updated
     // and update on local database the status and new event id
-    if let Ok(order_updated) = update_order_event(client, my_keys, Status::Success, order).await {
+    if let Ok(order_updated) = update_order_event(my_keys, Status::Success, order).await {
         let pool = db::connect().await.unwrap();
         if let Ok(order_success) = order_updated.update(&pool).await {
             // Adding here rate process
-            rate_counterpart(client, buyer_pubkey, seller_pubkey, my_keys, &order_success)
+            rate_counterpart(buyer_pubkey, seller_pubkey, &order_success)
                 .await
                 .unwrap();
         }

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -1,4 +1,6 @@
-use crate::util::{get_market_amount_and_fee, send_dm, show_hold_invoice};
+use crate::util::{
+    get_market_amount_and_fee, send_cant_do_msg, send_new_order_msg, show_hold_invoice,
+};
 
 use anyhow::Result;
 use mostro_core::message::{Action, Content, Message};
@@ -13,7 +15,6 @@ pub async fn take_buy_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
 ) -> Result<()> {
     // Safe unwrap as we verified the message
@@ -28,17 +29,13 @@ pub async fn take_buy_action(
     // We check if the message have a pubkey
     if msg.get_inner_message_kind().pubkey.is_none() {
         // We create a Message
-        let message = Message::cant_do(Some(order.id), None, None);
-        send_dm(client, my_keys, &event.pubkey, message.as_json()?).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
 
     if order.kind != Kind::Buy.to_string() {
         error!("Order Id {order_id} wrong kind");
-        let message = Message::cant_do(Some(order.id), None, None);
-        send_dm(client, my_keys, &event.pubkey, message.as_json()?).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
 
@@ -57,9 +54,7 @@ pub async fn take_buy_action(
         }
     };
     if buyer_pubkey == event.pubkey {
-        let message = Message::cant_do(Some(order.id), None, None);
-        send_dm(client, my_keys, &event.pubkey, message.as_json()?).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
     // We update the master pubkey
@@ -69,16 +64,15 @@ pub async fn take_buy_action(
     // Seller can take pending orders only
     if order_status != Status::Pending {
         // We create a Message
-        let message = Message::new_order(
+        send_new_order_msg(
             Some(order.id),
-            None,
             Action::FiatSent,
             Some(Content::TextMessage(format!(
                 "Order Id {order_id} was already taken!"
             ))),
-        );
-        send_dm(client, my_keys, &seller_pubkey, message.as_json()?).await?;
-
+            &seller_pubkey,
+        )
+        .await;
         return Ok(());
     }
 
@@ -94,6 +88,6 @@ pub async fn take_buy_action(
     // Timestamp order take time
     order.taken_at = Timestamp::now().as_i64();
 
-    show_hold_invoice(client, my_keys, None, &buyer_pubkey, &seller_pubkey, order).await?;
+    show_hold_invoice(my_keys, None, &buyer_pubkey, &seller_pubkey, order).await?;
     Ok(())
 }

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -1,11 +1,11 @@
 use crate::lightning::invoice::is_valid_invoice;
 use crate::util::{
-    get_market_amount_and_fee, send_dm, set_waiting_invoice_status, show_hold_invoice,
-    update_order_event,
+    get_market_amount_and_fee, send_cant_do_msg, send_dm, set_waiting_invoice_status,
+    show_hold_invoice, update_order_event,
 };
 
 use anyhow::Result;
-use mostro_core::message::{Content, Message};
+use mostro_core::message::Message;
 use mostro_core::order::{Kind, Order, Status};
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
@@ -17,7 +17,6 @@ pub async fn take_sell_action(
     msg: Message,
     event: &Event,
     my_keys: &Keys,
-    client: &Client,
     pool: &Pool<Sqlite>,
 ) -> Result<()> {
     // Safe unwrap as we verified the message
@@ -34,9 +33,7 @@ pub async fn take_sell_action(
     }
     // We check if the message have a pubkey
     if msg.get_inner_message_kind().pubkey.is_none() {
-        let message = Message::cant_do(Some(order.id), None, None);
-        send_dm(client, my_keys, &event.pubkey, message.as_json()?).await?;
-
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
     let buyer_pubkey = event.pubkey;
@@ -62,12 +59,7 @@ pub async fn take_sell_action(
             {
                 Ok(_) => Some(payment_request),
                 Err(e) => {
-                    let message = Message::cant_do(
-                        Some(order.id),
-                        None,
-                        Some(Content::TextMessage(e.to_string())),
-                    );
-                    send_dm(client, my_keys, &buyer_pubkey, message.as_json()?).await?;
+                    send_cant_do_msg(Some(order.id), Some(e.to_string()), &event.pubkey).await;
                     error!("{e}");
                     return Ok(());
                 }
@@ -88,8 +80,6 @@ pub async fn take_sell_action(
         Status::Pending | Status::WaitingBuyerInvoice => {}
         _ => {
             send_dm(
-                client,
-                my_keys,
                 &buyer_pubkey,
                 format!("Order Id {order_id} was already taken!"),
             )
@@ -114,12 +104,11 @@ pub async fn take_sell_action(
         order.fee = fee;
 
         if pr.is_none() {
-            match set_waiting_invoice_status(&mut order, buyer_pubkey, my_keys, client).await {
+            match set_waiting_invoice_status(&mut order, buyer_pubkey).await {
                 Ok(_) => {
                     // Update order status
                     if let Ok(order_updated) =
-                        update_order_event(client, my_keys, Status::WaitingBuyerInvoice, &order)
-                            .await
+                        update_order_event(my_keys, Status::WaitingBuyerInvoice, &order).await
                     {
                         let _ = order_updated.update(pool).await;
                         return Ok(());
@@ -131,14 +120,14 @@ pub async fn take_sell_action(
                 }
             }
         } else {
-            show_hold_invoice(client, my_keys, pr, &buyer_pubkey, &seller_pubkey, order).await?;
+            show_hold_invoice(my_keys, pr, &buyer_pubkey, &seller_pubkey, order).await?;
         }
     } else if pr.is_none() {
-        match set_waiting_invoice_status(&mut order, buyer_pubkey, my_keys, client).await {
+        match set_waiting_invoice_status(&mut order, buyer_pubkey).await {
             Ok(_) => {
                 // Update order status
                 if let Ok(order_updated) =
-                    update_order_event(client, my_keys, Status::WaitingBuyerInvoice, &order).await
+                    update_order_event(my_keys, Status::WaitingBuyerInvoice, &order).await
                 {
                     let _ = order_updated.update(pool).await;
                 }
@@ -149,7 +138,7 @@ pub async fn take_sell_action(
             }
         }
     } else {
-        show_hold_invoice(client, my_keys, pr, &buyer_pubkey, &seller_pubkey, order).await?;
+        show_hold_invoice(my_keys, pr, &buyer_pubkey, &seller_pubkey, order).await?;
     }
 
     Ok(())

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,5 +1,5 @@
-use crate::util::send_dm;
-use mostro_core::message::{Action, Content, Message};
+use crate::util::send_new_order_msg;
+use mostro_core::message::{Action, Content};
 use mostro_core::order::{Kind, SmallOrder, Status};
 use nostr_sdk::prelude::*;
 use sqlx_crud::Crud;
@@ -8,7 +8,6 @@ use tracing::{error, info};
 
 pub async fn hold_invoice_paid(hash: &str) {
     let pool = crate::db::connect().await.unwrap();
-    let client = crate::util::connect_nostr().await.unwrap();
     let order = crate::db::find_order_by_hash(&pool, hash).await.unwrap();
     let my_keys = crate::util::get_keys().unwrap();
     let seller_pubkey = match XOnlyPublicKey::from_str(order.seller_pubkey.as_ref().unwrap()) {
@@ -60,27 +59,21 @@ pub async fn hold_invoice_paid(hash: &str) {
         status = Status::Active;
         order_data.status = Some(status);
         // We send a confirmation message to seller
-        let message = Message::new_order(
+        send_new_order_msg(
             Some(order.id),
-            None,
             Action::BuyerTookOrder,
             Some(Content::Order(order_data.clone())),
-        );
-        let message = message.as_json().unwrap();
-        send_dm(&client, &my_keys, &seller_pubkey, message)
-            .await
-            .unwrap();
+            &seller_pubkey,
+        )
+        .await;
         // We send a message to buyer saying seller paid
-        let message = Message::new_order(
+        send_new_order_msg(
             Some(order.id),
-            None,
             Action::HoldInvoicePaymentAccepted,
             Some(Content::Order(order_data)),
-        );
-        let message = message.as_json().unwrap();
-        send_dm(&client, &my_keys, &buyer_pubkey, message)
-            .await
-            .unwrap();
+            &buyer_pubkey,
+        )
+        .await;
     } else {
         let new_amount = order_data.amount - order.fee;
         order_data.amount = new_amount;
@@ -89,28 +82,26 @@ pub async fn hold_invoice_paid(hash: &str) {
         order_data.master_buyer_pubkey = None;
         order_data.master_seller_pubkey = None;
         // We ask to buyer for a new invoice
-        let message = Message::new_order(
+        send_new_order_msg(
             Some(order.id),
-            None,
             Action::AddInvoice,
             Some(Content::Order(order_data)),
-        );
-        let message = message.as_json().unwrap();
-        send_dm(&client, &my_keys, &buyer_pubkey, message)
-            .await
-            .unwrap();
+            &buyer_pubkey,
+        )
+        .await;
+
         // We send a message to seller we are waiting for buyer invoice
-        let message = Message::new_order(Some(order.id), None, Action::WaitingBuyerInvoice, None);
-        let message = message.as_json().unwrap();
-        send_dm(&client, &my_keys, &seller_pubkey, message)
-            .await
-            .unwrap();
+        send_new_order_msg(
+            Some(order.id),
+            Action::WaitingBuyerInvoice,
+            None,
+            &seller_pubkey,
+        )
+        .await;
     }
     // We publish a new replaceable kind nostr event with the status updated
     // and update on local database the status and new event id
-    if let Ok(updated_order) =
-        crate::util::update_order_event(&client, &my_keys, status, &order).await
-    {
+    if let Ok(updated_order) = crate::util::update_order_event(&my_keys, status, &order).await {
         // Update order on db
         let _ = updated_order.update(&pool).await;
     }


### PR DESCRIPTION
Hi @grunch ,

![immagine](https://github.com/MostroP2P/mostro/assets/113362043/f3c68835-ada5-478c-b362-f045b8e77a3c)

@bilthon meme syndrome got me and in the end i did this shit:

- Create a static global var for client instance, really too much functions using the same parameter.
 ```Rust
static NOSTR_CLIENT: OnceLock<Client> = OnceLock::new();
 ```
This has the advantage to call everywhere, just with import the `client` instance from main.
So we can do this:
```Rust
 NOSTR_CLIENT.get().unwrap().send_event(event).await?;
```
- This lead me to create two new wrapper `send_new_order_msg` and `send_cant_do_msg` to embed all the logic in a function, I think the message part is more clean now, we used a lot of send_dm around creating message...give a look if you like more.

- Also a lot of `my_key` parameters are remove from function, just get it in `send_dm` function, the result function just calls inside the keys like that:
```Rust
pub async fn send_dm(receiver_pubkey: &XOnlyPublicKey, content: String) -> Result<()> {
    info!("DM content: {content:#?}");
    // Get mostro keys
    let sender_keys = crate::util::get_keys().unwrap();

    let event =
        EventBuilder::new_encrypted_direct_msg(&sender_keys, *receiver_pubkey, content, None)?
            .to_event(&sender_keys)?;
    info!("Sending event: {event:#?}");
    NOSTR_CLIENT.get().unwrap().send_event(event).await?;

    Ok(())
}
```

And as meme pointed out this should fix #211 !

I could do the same for the few dispute messages if you approve, I did some quick testing and seems ok, but need some deeper tests.

@Catrya can you hear me??? :smile: 