### PR TITLE
User rating ack message carries the rating back

### DIFF
--- a/book/src/user_rating.md
+++ b/book/src/user_rating.md
@@ -24,7 +24,7 @@ After a Mostro client receive this message, the user can rate the other party, t
     "pubkey": null,
     "action": "rate-user",
     "content": {
-      "RatingUser": 5 // User input
+      "rating_user": 5 // User input
     }
   }
 }
@@ -41,7 +41,9 @@ If Mostro received the correct message, it will send back a confirmation message
     "id": "7e44aa5d-855a-4b17-865e-8ca3834a91a3",
     "pubkey": null,
     "action": "rate-received",
-    "content": null
+    "content": {
+      "rating_user": 5
+    }
   }
 }
 ```

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -154,7 +154,7 @@ pub async fn update_user_reputation_action(
         .await?;
 
         // Send confirmation message to user that rated
-        send_new_order_msg(Some(order.id), Action::RateReceived, None, &event.pubkey).await;
+        send_new_order_msg(Some(order.id), Action::RateReceived, Some(Content::RatingUser(rating)), &event.pubkey).await;
     }
 
     Ok(())


### PR DESCRIPTION
Just makes mostro reply with the user rating in the ack message. This facilitates updating the UI in case messages come out of order and doesn't represent too much of an overhead.

I'm also updating the docs.