### PR TITLE
Idea to catch the great part of the errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "async-stream"
@@ -174,18 +174,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -337,12 +337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
-name = "base64"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
-
-[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,9 +457,9 @@ checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "byte-tools"
@@ -496,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -586,7 +580,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -695,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]
@@ -839,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
  "cfg-if",
 ]
@@ -1024,7 +1018,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -1078,9 +1072,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1109,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -1128,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
 dependencies = [
  "bytes",
  "fnv",
@@ -1335,7 +1329,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.25",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1358,7 +1352,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.4",
+ "h2 0.4.3",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -1815,7 +1809,7 @@ dependencies = [
  "lnurl-rs",
  "mostro-core",
  "nostr-sdk",
- "reqwest 0.12.3",
+ "reqwest 0.12.2",
  "serde",
  "serde_json",
  "sqlx",
@@ -1927,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.29.4"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8efc437bcf8c433887a9897dfb6f99914170f656a2a66398e737b3050c2aa34"
+checksum = "a1b306bc99d49064950a16a06d35c7c19af94d8b4052fad0dfe02e41e529d5d3"
 dependencies = [
  "async-utility",
  "async-wsocket",
@@ -2077,7 +2071,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2203,9 +2197,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2214,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2224,22 +2218,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
 dependencies = [
  "once_cell",
  "pest",
@@ -2283,7 +2277,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -2413,9 +2407,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -2523,7 +2517,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.25",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -2538,7 +2532,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.10",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2554,21 +2548,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.3"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6cc1e89e689536eb5aeede61520e874df5a4707df811cd5da4aa5fbb2aae19"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.4",
+ "h2 0.4.3",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
@@ -2583,7 +2577,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2596,7 +2590,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.52.0",
+ "winreg",
 ]
 
 [[package]]
@@ -2724,16 +2718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
-dependencies = [
- "base64 0.22.0",
- "rustls-pki-types",
 ]
 
 [[package]]
@@ -2888,7 +2872,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3088,7 +3072,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
- "crc 3.2.1",
+ "crc 3.0.1",
  "crossbeam-queue",
  "dotenvy",
  "either",
@@ -3111,7 +3095,7 @@ dependencies = [
  "paste",
  "percent-encoding",
  "rustls 0.20.9",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "serde",
  "sha2 0.10.8",
  "smallvec",
@@ -3146,7 +3130,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3195,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "subtle"
@@ -3218,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3292,7 +3276,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3366,7 +3350,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3523,7 +3507,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.25",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -3660,7 +3644,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3869,7 +3853,7 @@ checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]
@@ -3926,7 +3910,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
  "wasm-bindgen-shared",
 ]
 
@@ -3960,7 +3944,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4218,9 +4202,9 @@ checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.6.6"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c976aaaa0e1f90dbb21e9587cdaf1d9679a1cde8875c0d6bd83ab96a208352"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]
@@ -4230,16 +4214,6 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -4271,7 +4245,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.57",
 ]
 
 [[package]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -62,61 +62,165 @@ pub async fn run(
                                 if let Some(action) = msg.inner_action() {
                                     match action {
                                         Action::NewOrder => {
-                                            order_action(msg, &event, &my_keys, &pool).await?;
+                                            if let Err(e) =
+                                                order_action(msg, &event, &my_keys, &pool).await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::TakeSell => {
-                                            take_sell_action(msg, &event, &my_keys, &pool).await?;
+                                            if let Err(e) =
+                                                take_sell_action(msg, &event, &my_keys, &pool).await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::TakeBuy => {
-                                            take_buy_action(msg, &event, &my_keys, &pool).await?;
+                                            if let Err(e) =
+                                                take_buy_action(msg, &event, &my_keys, &pool).await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::FiatSent => {
-                                            fiat_sent_action(msg, &event, &my_keys, &pool).await?;
+                                            if let Err(e) =
+                                                fiat_sent_action(msg, &event, &my_keys, &pool).await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            };
                                         }
                                         Action::Release => {
-                                            release_action(msg, &event, &my_keys, &pool, ln_client)
-                                                .await?;
+                                            if let Err(e) = release_action(
+                                                msg, &event, &my_keys, &pool, ln_client,
+                                            )
+                                            .await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::Cancel => {
-                                            cancel_action(msg, &event, &my_keys, &pool, ln_client)
-                                                .await?;
+                                            if let Err(e) = cancel_action(
+                                                msg, &event, &my_keys, &pool, ln_client,
+                                            )
+                                            .await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::AddInvoice => {
-                                            add_invoice_action(msg, &event, &my_keys, &pool)
-                                                .await?;
+                                            if let Err(e) =
+                                                add_invoice_action(msg, &event, &my_keys, &pool)
+                                                    .await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::PayInvoice => todo!(),
                                         Action::RateUser => {
-                                            update_user_reputation_action(
+                                            if let Err(e) = update_user_reputation_action(
                                                 msg,
                                                 &event,
                                                 &my_keys,
                                                 &pool,
                                                 rate_list.clone(),
                                             )
-                                            .await?;
+                                            .await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::Dispute => {
-                                            dispute_action(msg, &event, &my_keys, &pool).await?;
+                                            if let Err(e) =
+                                                dispute_action(msg, &event, &my_keys, &pool).await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::AdminCancel => {
-                                            admin_cancel_action(
+                                            if let Err(e) = admin_cancel_action(
                                                 msg, &event, &my_keys, &pool, ln_client,
                                             )
-                                            .await?;
+                                            .await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::AdminSettle => {
-                                            admin_settle_action(
+                                            if let Err(e) = admin_settle_action(
                                                 msg, &event, &my_keys, &pool, ln_client,
                                             )
-                                            .await?;
+                                            .await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::AdminAddSolver => {
-                                            admin_add_solver_action(msg, &event, &my_keys, &pool)
-                                                .await?;
+                                            if let Err(e) = admin_add_solver_action(
+                                                msg, &event, &my_keys, &pool,
+                                            )
+                                            .await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         Action::AdminTakeDispute => {
-                                            admin_take_dispute_action(msg, &event, &pool).await?;
+                                            if let Err(e) =
+                                                admin_take_dispute_action(msg, &event, &pool).await
+                                            {
+                                                tracing::warn!(
+                                                    "Error in {} with context {}",
+                                                    action,
+                                                    e
+                                                );
+                                            }
                                         }
                                         _ => info!("Received message with action {:?}", action),
                                     }


### PR DESCRIPTION
Hi @grunch ,

added some catcher in the loop at the end, I think it's better and as improvement in the next days we could remove some matches in the functions below, cause now all errors are caught in the loop printing a warn message with error.
Example:

```Rust
Action::NewOrder => {
        if let Err(e) =
            order_action(msg, &event, &my_keys, &pool).await
        {
            tracing::warn!(
                "Error in {} with context {}",
                action,
                e
            );
        }
    }
```

Did a quick test with your cli command and it works:
```Rust
2024-04-15T21:07:43.464556Z  INFO mostrod::scheduler: Next tick for removal of older orders is Mon Apr 15 21:08:43 2024
2024-04-15T21:07:43.479253Z  INFO mostrod::scheduler: I run async every 60 minutes - checking for failed lighting payment
2024-04-15T21:08:25.779619Z  WARN mostrod::app: Error in NewOrder with context Incorrect invoice
2024-04-15T21:08:43.465449Z  INFO mostrod::scheduler: Check older orders and mark them Expired - check is done every minute
2024-04-15T21:08:43.466700Z  INFO mostrod::scheduler: Next tick for removal of older orders is Mon Apr 15 21:09:43 2024
```

