### PR TITLE
Added the check on min sats allowed in a new order

### DIFF
--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -50,10 +50,12 @@ pub async fn order_action(
             return Ok(());
         }
 
-        if quote > mostro_settings.max_order_amount as i64 {
+        if quote > mostro_settings.max_order_amount as i64
+            || quote < mostro_settings.min_payment_amount as i64
+        {
             let msg = format!(
-                "Quote too high, max is {}",
-                mostro_settings.max_order_amount
+                "Quote is out of sats boundaries min is {} max is {}",
+                mostro_settings.min_payment_amount, mostro_settings.max_order_amount
             );
             send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
             return Ok(());

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -154,7 +154,13 @@ pub async fn update_user_reputation_action(
         .await?;
 
         // Send confirmation message to user that rated
-        send_new_order_msg(Some(order.id), Action::RateReceived, Some(Content::RatingUser(rating)), &event.pubkey).await;
+        send_new_order_msg(
+            Some(order.id),
+            Action::RateReceived,
+            Some(Content::RatingUser(rating)),
+            &event.pubkey,
+        )
+        .await;
     }
 
     Ok(())


### PR DESCRIPTION
Hi @grunch ,

as pointed out yesterday by @Catrya , when creating a new order user is allowed to make sats amount lower than minimum ( we checked only maximum ).

Then order is publishe and if someone takes it it's not allowed to do, but I think at this point is more meaningful to refuse new order with sats amout lower than minimum of settings.

Give a look, just a simple check added.