### PR TITLE
Stop sending CantDo message after solver settles dispute

### DIFF
--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -68,15 +68,7 @@ pub async fn admin_settle_action(
         return Ok(());
     }
 
-    settle_seller_hold_invoice(
-        event,
-        my_keys,
-        ln_client,
-        Action::AdminSettled,
-        true,
-        &order,
-    )
-    .await?;
+    settle_seller_hold_invoice(event, ln_client, Action::AdminSettled, true, &order).await?;
 
     let order_updated = update_order_event(my_keys, Status::SettledHoldInvoice, &order).await?;
 

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -1,4 +1,4 @@
-use crate::db::find_solver_npub;
+use crate::db::find_solver_pubkey;
 use crate::nip33::new_event;
 use crate::util::{send_cant_do_msg, send_dm};
 use crate::NOSTR_CLIENT;
@@ -21,7 +21,7 @@ pub async fn pubkey_event_can_solve(pool: &Pool<Sqlite>, ev_pubkey: &PublicKey) 
     }
 
     // Is a solver taking a dispute
-    if let Ok(solver) = find_solver_npub(pool, ev_pubkey.to_string()).await {
+    if let Ok(solver) = find_solver_pubkey(pool, ev_pubkey.to_string()).await {
         if solver.is_solver != 0_i64 {
             return true;
         }

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -90,7 +90,7 @@ pub async fn release_action(
         return Ok(());
     }
 
-    settle_seller_hold_invoice(event, my_keys, ln_client, Action::Released, false, &order).await?;
+    settle_seller_hold_invoice(event, ln_client, Action::Released, false, &order).await?;
 
     let order_updated = update_order_event(my_keys, Status::SettledHoldInvoice, &order).await?;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -281,7 +281,7 @@ pub async fn find_failed_payment(pool: &SqlitePool) -> anyhow::Result<Vec<Order>
     Ok(order)
 }
 
-pub async fn find_solver_npub(pool: &SqlitePool, solver_npub: String) -> anyhow::Result<User> {
+pub async fn find_solver_pubkey(pool: &SqlitePool, solver_npub: String) -> anyhow::Result<User> {
     let user = sqlx::query_as::<_, User>(
         r#"
           SELECT *

--- a/src/util.rs
+++ b/src/util.rs
@@ -501,20 +501,13 @@ pub async fn rate_counterpart(
 #[allow(clippy::too_many_arguments)]
 pub async fn settle_seller_hold_invoice(
     event: &Event,
-    my_keys: &Keys,
     ln_client: &mut LndConnector,
     action: Action,
     is_admin: bool,
     order: &Order,
 ) -> Result<()> {
-    // It can be settle only by a seller or by admin
-    let pubkey = if is_admin {
-        my_keys.public_key().to_string()
-    } else {
-        order.seller_pubkey.as_ref().unwrap().to_string()
-    };
     // Check if the pubkey is right
-    if event.pubkey.to_string() != pubkey {
+    if !is_admin && event.pubkey.to_string() != *order.seller_pubkey.as_ref().unwrap().to_string() {
         send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }


### PR DESCRIPTION
* Renamed function find_solver_npub to find_solver_pubkey
* Fixes validation on settle_seller_hold_invoice()

Fix #258
