### PR TITLE
bumped some deps and removed two unwraps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 anyhow = "1.0.81"
 chrono = "0.4.35"
 easy-hasher = "2.2.1"
-lightning-invoice = "0.29.0"
-nostr-sdk = "0.29.0"
+lightning-invoice = "0.30.0"
+nostr-sdk = "0.30.0"
 serde = { version = "1.0.197" }
 serde_json = "1.0.114"
 sqlx = { version = "0.6.2", features = [
@@ -41,5 +41,5 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 config = "0.14.0"
 clap = { version = "4.5.3", features = ["derive"] }
-lnurl-rs = "0.4.0"
+lnurl-rs = "0.5.0"
 openssl = { version = "0.10", features = ["vendored"] }

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -140,7 +140,7 @@ pub async fn update_user_reputation_action(
         reputation.last_rating = rating;
         reputation.total_reviews += 1;
         // Format with two decimals
-        let new_rating = format!("{:.2}", new_rating).parse::<f64>().unwrap();
+        let new_rating = format!("{:.2}", new_rating).parse::<f64>()?;
 
         // Assing new total rating to review
         reputation.total_rating = new_rating;

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -182,7 +182,7 @@ pub fn init_default_dir(config_path: Option<String>) -> Result<PathBuf> {
         settings_dir_default.push(home_dir);
     } else {
         // Get $HOME from env
-        let tmp = std::env::var("HOME").unwrap();
+        let tmp = std::env::var("HOME")?;
         // Os String
         home_dir = tmp.into();
         // Create default path with default .mostro value

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -8,9 +8,9 @@ use crate::util::bytes_to_string;
 
 use anyhow::Result;
 use easy_hasher::easy_hasher::*;
-use nostr_sdk::hashes::Hash;
 use nostr_sdk::nostr::hashes::hex::FromHex;
 use nostr_sdk::nostr::secp256k1::rand::{self, RngCore};
+use nostr_sdk::secp256k1::hashes::Hash;
 use tokio::sync::mpsc::Sender;
 use tonic_openssl_lnd::invoicesrpc::{
     AddHoldInvoiceRequest, AddHoldInvoiceResp, CancelInvoiceMsg, CancelInvoiceResp,

--- a/src/util.rs
+++ b/src/util.rs
@@ -318,8 +318,8 @@ pub async fn connect_nostr() -> Result<Client> {
     let nostr_settings = Settings::get_nostr();
 
     let mut limits = RelayLimits::default();
-    limits.messages.max_size = 3_000;
-    limits.events.max_size = 2_000;
+    limits.messages.max_size = Some(3_000);
+    limits.events.max_size = Some(2_000);
     let opts = Options::new().relay_limits(limits);
 
     // Create new client


### PR DESCRIPTION
Hi @grunch,

just updated some deps and compiled, seems ok apart that on win10 ( my work pc ) i had this error related to Openssl ( i supposed you introduced dep for cross compile ):

```
error: failed to run custom build command for `openssl-sys v0.9.102`

Caused by:
  process didn't exit successfully: `C:\Rust_prj\mostro\target\debug\build\openssl-sys-36a8d81941f24bd0\build-script-main` (exit code: 101)
  --- stdout
  cargo:rerun-if-env-changed=X86_64_PC_WINDOWS_MSVC_OPENSSL_NO_VENDOR
  X86_64_PC_WINDOWS_MSVC_OPENSSL_NO_VENDOR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_VENDOR
  OPENSSL_NO_VENDOR unset
  running "perl" "./Configure" "--prefix=C:/Rust_prj/mostro/target/debug/build/openssl-sys-4bafe812c17faca5/out/openssl-build/install" "--openssldir=SYS$MANAGER:[OPENSSL]" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "no-capieng" "no-asm" "VC-WIN64A"
```

Maybe someone else can try to reprduce on windows? 