### PR TITLE
Range order fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,7 @@ dependencies = [
  "lnurl-rs",
  "mostro-core",
  "nostr-sdk",
+ "openssl",
  "reqwest",
  "serde",
  "serde_json",
@@ -1859,7 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.5.12"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6925018b57b54d0b049ce6596d0bd818b685b266c6ac37e3cb7e9deab7f17fc4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2118,6 +2121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.2.3+3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2137,7 @@ checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,6 @@ dependencies = [
  "lnurl-rs",
  "mostro-core",
  "nostr-sdk",
- "openssl",
  "reqwest",
  "serde",
  "serde_json",
@@ -1860,9 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72951dc9f95702763a9d90fc94d9709a611fe12ae75a6658ff019d3c0ec6bd56"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2121,15 +2118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "300.2.3+3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,7 +2125,6 @@ checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ uuid = { version = "1.8.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.12.1", features = ["json"] }
-mostro-core = { version = "0.5.8", features = ["sqlx"] }
+mostro-core = { version = "0.5.12", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 config = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ uuid = { version = "1.8.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.12.1", features = ["json"] }
-mostro-core = { version = "0.5.12", features = ["sqlx"] }
+mostro-core = { version = "0.5.13", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 config = "0.14.0"

--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -111,8 +111,7 @@ pub async fn add_invoice_action(
                 Some(order.id),
                 Some(format!(
                     "You are not allowed to add an invoice because order Id {} status is {}",
-                    order_status.to_string(),
-                    order.id
+                    order_status, order.id
                 )),
                 &buyer_pubkey,
             )
@@ -134,6 +133,8 @@ pub async fn add_invoice_action(
             Some(Status::Active),
             order.amount,
             order.fiat_code.clone(),
+            order.min_amount,
+            order.max_amount,
             order.fiat_amount,
             order.payment_method.clone(),
             order.premium,

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -57,7 +57,7 @@ pub async fn admin_cancel_action(
     if order.status != Status::Dispute.to_string() {
         let error = format!(
             "Can't settle an order with status different than {}!",
-            Status::Dispute.to_string()
+            Status::Dispute
         );
         send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
 

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -58,7 +58,7 @@ pub async fn admin_settle_action(
     if order.status != Status::Dispute.to_string() {
         let error = format!(
             "Can't settle an order with status different than {}!",
-            Status::Dispute.to_string()
+            Status::Dispute
         );
         send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
 

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -81,8 +81,12 @@ pub async fn admin_take_dispute_action(
     };
 
     let mut new_order = order.as_new_order();
-    new_order.master_buyer_pubkey = order.master_buyer_pubkey.clone();
-    new_order.master_seller_pubkey = order.master_seller_pubkey.clone();
+    new_order
+        .master_buyer_pubkey
+        .clone_from(&order.master_buyer_pubkey);
+    new_order
+        .master_seller_pubkey
+        .clone_from(&order.master_seller_pubkey);
 
     // Update dispute fields
     dispute.status = Status::InProgress.to_string();

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -243,6 +243,7 @@ async fn payment_success(
                         let mut new_order = order.clone();
                         new_order.max_amount = None;
                         new_order.min_amount = None;
+                        new_order.amount = 0;
                         new_order.fiat_amount = new_max;
                         new_order.status = Status::Pending.to_string();
                         new_order.id = uuid::Uuid::new_v4();
@@ -271,6 +272,7 @@ async fn payment_success(
                         let mut new_order = order.clone();
                         new_order.max_amount = Some(new_max);
                         new_order.range_parent_id = Some(order.id);
+                        new_order.amount = 0;
                         new_order.id = uuid::Uuid::new_v4();
                         new_order.status = Status::Pending.to_string();
                         // CRUD order creation

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -6,6 +6,7 @@ use crate::util::{
     get_keys, rate_counterpart, send_cant_do_msg, send_new_order_msg, settle_seller_hold_invoice,
     update_order_event,
 };
+use crate::NOSTR_CLIENT;
 
 use anyhow::{Error, Result};
 use lnurl::lightning_address::LightningAddress;
@@ -14,6 +15,7 @@ use mostro_core::order::{Order, Status};
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
 use sqlx_crud::Crud;
+use std::cmp::Ordering;
 use std::str::FromStr;
 use tokio::sync::mpsc::channel;
 use tonic_openssl_lnd::lnrpc::payment::PaymentStatus;
@@ -131,7 +133,7 @@ pub async fn release_action(
     Ok(())
 }
 
-pub async fn do_payment(order: Order) -> Result<()> {
+pub async fn do_payment(mut order: Order) -> Result<()> {
     // Finally we try to pay buyer's invoice
     let payment_request = match order.buyer_invoice.as_ref() {
         Some(req) => req.to_string(),
@@ -182,9 +184,13 @@ pub async fn do_payment(order: Order) -> Result<()> {
                                 "Order Id {}: Invoice with hash: {} paid!",
                                 order.id, msg.payment.payment_hash
                             );
-                            let _ =
-                                payment_success(&order, &buyer_pubkey, &seller_pubkey, &my_keys)
-                                    .await;
+                            let _ = payment_success(
+                                &mut order,
+                                &buyer_pubkey,
+                                &seller_pubkey,
+                                &my_keys,
+                            )
+                            .await;
                         }
                         PaymentStatus::Failed => {
                             info!(
@@ -211,7 +217,7 @@ pub async fn do_payment(order: Order) -> Result<()> {
 }
 
 async fn payment_success(
-    order: &Order,
+    order: &mut Order,
     buyer_pubkey: &PublicKey,
     seller_pubkey: &PublicKey,
     my_keys: &Keys,
@@ -224,6 +230,73 @@ async fn payment_success(
         buyer_pubkey,
     )
     .await;
+
+    // Check if order is range type
+    // Add parent range id and update max amount
+    if order.max_amount.is_some() && order.min_amount.is_some() {
+        if let Some(max) = order.max_amount {
+            if let Some(new_max) = max.checked_sub(order.fiat_amount) {
+                match new_max.cmp(&order.min_amount.unwrap()) {
+                    Ordering::Equal => {
+                        // Update order in case max == min
+                        let pool = db::connect().await?;
+                        let mut new_order = order.clone();
+                        new_order.max_amount = None;
+                        new_order.min_amount = None;
+                        new_order.fiat_amount = new_max;
+                        new_order.status = Status::Pending.to_string();
+                        new_order.id = uuid::Uuid::new_v4();
+                        new_order.status = Status::Pending.to_string();
+                        // CRUD order creation
+                        new_order.clone().create(&pool).await?;
+                        // We transform the order fields to tags to use in the event
+                        let tags = crate::nip33::order_to_tags(&new_order);
+
+                        info!("range order tags to be republished: {:#?}", tags);
+                        // nip33 kind with order fields as tags and order id as identifier
+                        let event =
+                            crate::nip33::new_event(my_keys, "", new_order.id.to_string(), tags)?;
+
+                        let _ = NOSTR_CLIENT
+                            .get()
+                            .unwrap()
+                            .send_event(event)
+                            .await
+                            .map(|_s| ())
+                            .map_err(|err| err.to_string());
+                    }
+                    Ordering::Greater => {
+                        // Update order in case new max is still greater the min amount
+                        let pool = db::connect().await?;
+                        let mut new_order = order.clone();
+                        new_order.max_amount = Some(new_max);
+                        new_order.range_parent_id = Some(order.id);
+                        new_order.id = uuid::Uuid::new_v4();
+                        new_order.status = Status::Pending.to_string();
+                        // CRUD order creation
+                        new_order.clone().create(&pool).await?;
+                        // We transform the order fields to tags to use in the event
+                        let tags = crate::nip33::order_to_tags(&new_order);
+
+                        info!("range order tags to be republished: {:#?}", tags);
+                        // nip33 kind with order fields as tags and order id as identifier
+                        let event =
+                            crate::nip33::new_event(my_keys, "", new_order.id.to_string(), tags)?;
+
+                        let _ = NOSTR_CLIENT
+                            .get()
+                            .unwrap()
+                            .send_event(event)
+                            .await
+                            .map(|_s| ())
+                            .map_err(|err| err.to_string());
+                    }
+                    // Update order status in case new max is smaller the min amount
+                    Ordering::Less => {}
+                }
+            }
+        }
+    }
 
     // Let's wait 5 secs before publish this new event
     tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -58,6 +58,7 @@ pub async fn take_buy_action(
             order.min_amount, order.max_amount
         );
         send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
+        return Ok(());
     }
 
     let order_status = match Status::from_str(&order.status) {

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -1,5 +1,6 @@
 use crate::util::{
-    get_market_amount_and_fee, send_cant_do_msg, send_new_order_msg, show_hold_invoice,
+    get_fiat_amount_requested, get_market_amount_and_fee, send_cant_do_msg, send_new_order_msg,
+    show_hold_invoice,
 };
 
 use anyhow::{Error, Result};
@@ -48,6 +49,17 @@ pub async fn take_buy_action(
         return Ok(());
     }
 
+    // Get amount request if user requested one for range order - fiat amount will be used below
+    if let Some(am) = get_fiat_amount_requested(&order, &msg) {
+        order.fiat_amount = am;
+    } else {
+        let error = format!(
+            "Amount requested is not correct, probably out of range min {:#?} - max {:#?}",
+            order.min_amount, order.max_amount
+        );
+        send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
+    }
+
     let order_status = match Status::from_str(&order.status) {
         Ok(s) => s,
         Err(e) => {
@@ -67,7 +79,9 @@ pub async fn take_buy_action(
         return Ok(());
     }
     // We update the master pubkey
-    order.master_seller_pubkey = msg.get_inner_message_kind().pubkey.clone();
+    order
+        .master_seller_pubkey
+        .clone_from(&msg.get_inner_message_kind().pubkey);
 
     let seller_pubkey = event.pubkey;
     // Seller can take pending orders only

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -1,7 +1,7 @@
 use crate::lightning::invoice::is_valid_invoice;
 use crate::util::{
-    get_market_amount_and_fee, send_cant_do_msg, send_dm, set_waiting_invoice_status,
-    show_hold_invoice, update_order_event,
+    get_fiat_amount_requested, get_market_amount_and_fee, send_cant_do_msg, send_dm,
+    set_waiting_invoice_status, show_hold_invoice, update_order_event,
 };
 
 use anyhow::{Error, Result};
@@ -32,6 +32,18 @@ pub async fn take_sell_action(
             return Ok(());
         }
     };
+
+    // Get amount request if user requested one for range order - fiat amount will be used below
+    if let Some(am) = get_fiat_amount_requested(&order, &msg) {
+        order.fiat_amount = am;
+    } else {
+        let error = format!(
+            "Amount requested is not correct, probably out of range min {:#?} - max {:#?}",
+            order.min_amount, order.max_amount
+        );
+        send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
+    }
+
     // Maker can't take own order
     if order.creator_pubkey == event.pubkey.to_hex() {
         send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
@@ -99,7 +111,9 @@ pub async fn take_sell_action(
     }
 
     // We update the master pubkey
-    order.master_buyer_pubkey = msg.get_inner_message_kind().pubkey.clone();
+    order
+        .master_buyer_pubkey
+        .clone_from(&msg.get_inner_message_kind().pubkey);
     // Add buyer pubkey to order
     order.buyer_pubkey = Some(buyer_pubkey.to_string());
     // Timestamp take order time

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -41,6 +41,8 @@ pub async fn hold_invoice_paid(hash: &str) -> Result<()> {
         None,
         order.amount,
         order.fiat_code.clone(),
+        order.min_amount,
+        order.max_amount,
         order.fiat_amount,
         order.payment_method.clone(),
         order.premium,

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -25,7 +25,10 @@ pub fn new_event(
 ) -> Result<Event, Error> {
     // This tag (nip33) allows us to change this event in particular in the future
     let mut tags: Vec<Tag> = Vec::with_capacity(1 + extra_tags.len());
-    tags.push(Tag::Identifier(identifier)); // `d` tag
+    //tags.push(Tag::Identifier(identifier)); // `d` tag //Check with Yuki!
+    let tag = Tag::Generic(TagKind::Custom("d".to_string()), vec![identifier]);
+    tags.push(tag);
+
     for (key, value) in extra_tags.into_iter() {
         let tag = Tag::Generic(TagKind::Custom(key), vec![value]);
         tags.push(tag);
@@ -34,6 +37,17 @@ pub fn new_event(
     EventBuilder::new(Kind::Custom(NOSTR_REPLACEABLE_EVENT_KIND), content, tags).to_event(keys)
 }
 
+fn create_fiat_amt_string(order: &Order) -> String {
+    if order.min_amount.is_some() && order.max_amount.is_some() {
+        format!(
+            "{}-{}",
+            order.min_amount.unwrap(),
+            order.max_amount.unwrap()
+        )
+    } else {
+        order.fiat_amount.to_string()
+    }
+}
 /// Transform an order fields to tags
 ///
 /// # Arguments
@@ -51,7 +65,7 @@ pub fn order_to_tags(order: &Order) -> Vec<(String, String)> {
         // amount (amt) - The amount of sats
         ("amt".to_string(), order.amount.to_string()),
         // fiat_amount (fa) - The fiat amount
-        ("fa".to_string(), order.fiat_amount.to_string()),
+        ("fa".to_string(), create_fiat_amt_string(order)),
         // payment_method (pm) - The payment method
         ("pm".to_string(), order.payment_method.to_string()),
         // premium (premium) - The premium

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1,6 +1,6 @@
 use crate::Settings;
 use chrono::Duration;
-use mostro_core::order::Order;
+use mostro_core::order::{Order, Status};
 use mostro_core::NOSTR_REPLACEABLE_EVENT_KIND;
 use nostr::event::builder::Error;
 use nostr_sdk::prelude::*;
@@ -38,7 +38,10 @@ pub fn new_event(
 }
 
 fn create_fiat_amt_string(order: &Order) -> String {
-    if order.min_amount.is_some() && order.max_amount.is_some() {
+    if order.min_amount.is_some()
+        && order.max_amount.is_some()
+        && order.status == Status::Pending.to_string()
+    {
         format!(
             "{}-{}",
             order.min_amount.unwrap(),


### PR DESCRIPTION
Fixes #276 

- Updated `cargo.toml` for mostro-core 5.13
- Removed not null conditions from db file to avoid errors on db entry creation due to `max_amount` and `min_amount` null possible value
- If order is with range now we check if sats amount conversion is inside limit for both values, if order is no range order same logic as before
- Implemented same logic of lnP2P bot to diminish max amount or ranged order and mark it as successful ( this part need to be fully tested and improved in style )

Missing things in my mind:

- `TakeBuy` and `TakeSell` checks if amount received is in the range of order and in case send back a message to user.
- Testing everything