### PR TITLE
added maker rating on new order creation

### DIFF
--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -55,12 +55,12 @@ pub async fn order_action(
                 _ => order.amount,
             };
 
-        // Check amount is positive - extra safety check
-        if quote < 0 {
-            let msg = format!("Amount must be positive {} is not valid", order.amount);
-            send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
-            return Ok(());
-        }
+            // Check amount is positive - extra safety check
+            if quote < 0 {
+                let msg = format!("Amount must be positive {} is not valid", order.amount);
+                send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
+                return Ok(());
+            }
 
             if quote > mostro_settings.max_order_amount as i64
                 || quote < mostro_settings.min_payment_amount as i64

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -19,7 +19,7 @@ use tracing::error;
 const MAX_RATING: u8 = 5;
 const MIN_RATING: u8 = 1;
 
-pub async fn get_counterpart_reputation(user: &str, my_keys: &Keys) -> Result<Option<Rating>> {
+pub async fn get_user_reputation(user: &str, my_keys: &Keys) -> Result<Option<Rating>> {
     // Request NIP33 of the counterparts
     let filters = Filter::new()
         .author(my_keys.public_key())
@@ -124,7 +124,7 @@ pub async fn update_user_reputation_action(
     }
 
     // Ask counterpart reputation
-    let rep = get_counterpart_reputation(&counterpart, my_keys).await?;
+    let rep = get_user_reputation(&counterpart, my_keys).await?;
     // Here we have to update values of the review of the counterpart
     let mut reputation;
 

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -251,7 +251,7 @@ async fn payment_success(
                         // CRUD order creation
                         new_order.clone().create(&pool).await?;
                         // We transform the order fields to tags to use in the event
-                        let tags = crate::nip33::order_to_tags(&new_order);
+                        let tags = crate::nip33::order_to_tags(&new_order, None);
 
                         info!("range order tags to be republished: {:#?}", tags);
                         // nip33 kind with order fields as tags and order id as identifier
@@ -278,7 +278,7 @@ async fn payment_success(
                         // CRUD order creation
                         new_order.clone().create(&pool).await?;
                         // We transform the order fields to tags to use in the event
-                        let tags = crate::nip33::order_to_tags(&new_order);
+                        let tags = crate::nip33::order_to_tags(&new_order, None);
 
                         info!("range order tags to be republished: {:#?}", tags);
                         // nip33 kind with order fields as tags and order id as identifier

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1,6 +1,7 @@
 use crate::Settings;
 use chrono::Duration;
 use mostro_core::order::{Order, Status};
+use mostro_core::rating::Rating;
 use mostro_core::NOSTR_REPLACEABLE_EVENT_KIND;
 use nostr::event::builder::Error;
 use nostr_sdk::prelude::*;
@@ -51,13 +52,22 @@ fn create_fiat_amt_string(order: &Order) -> String {
         order.fiat_amount.to_string()
     }
 }
+
+fn create_rating_string(rating: Option<Rating>) -> String {
+    if rating.is_some() {
+        format!("{:?}", rating.unwrap(),)
+    } else {
+        "No user reputation received".to_string()
+    }
+}
+
 /// Transform an order fields to tags
 ///
 /// # Arguments
 ///
 /// * `order` - The order to transform
 ///
-pub fn order_to_tags(order: &Order) -> Vec<(String, String)> {
+pub fn order_to_tags(order: &Order, reputation: Option<Rating>) -> Vec<(String, String)> {
     let tags = vec![
         // kind (k) - The order kind (buy or sell)
         ("k".to_string(), order.kind.to_string()),
@@ -73,6 +83,8 @@ pub fn order_to_tags(order: &Order) -> Vec<(String, String)> {
         ("pm".to_string(), order.payment_method.to_string()),
         // premium (premium) - The premium
         ("premium".to_string(), order.premium.to_string()),
+        // User rating
+        ("Rating".to_string(), create_rating_string(reputation)),
         // Label to identify this is a Mostro's order
         ("y".to_string(), "mostrop2p".to_string()),
         // Table name

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use crate::app::rate_user::get_user_reputation;
 use crate::cli::settings::Settings;
 use crate::db;
 use crate::error::MostroError;
@@ -196,9 +197,12 @@ pub async fn publish_order(
     // CRUD order creation
     let mut order = new_order_db.clone().create(pool).await?;
     let order_id = order.id;
+    // Get user reputation
+    let reputation = get_user_reputation(initiator_pubkey, keys).await?;
+
     info!("New order saved Id: {}", order_id);
     // We transform the order fields to tags to use in the event
-    let tags = order_to_tags(&new_order_db);
+    let tags = order_to_tags(&new_order_db, reputation);
 
     info!("order tags to be published: {:#?}", tags);
     // nip33 kind with order fields as tags and order id as identifier
@@ -292,7 +296,7 @@ pub async fn update_order_event(keys: &Keys, status: Status, order: &Order) -> R
     // update order.status with new status
     order_updated.status = status.to_string();
     // We transform the order fields to tags to use in the event
-    let tags = order_to_tags(&order_updated);
+    let tags = order_to_tags(&order_updated, None);
     // nip33 kind with order id as identifier and order fields as tags
     let event = new_event(keys, "", order.id.to_string(), tags)?;
     let order_id = order.id.to_string();


### PR DESCRIPTION
Hi @grunch ,

quick add to fix issue #284, now just inserted user rating in new order creation. Maker rating should be added with new fn:

```Rust
fn create_rating_string(rating: Option<Rating>) -> String {
    if rating.is_some() {
        format!("{:?}", rating.unwrap(),)
    } else {
        "No user reputation received".to_string()
    }
}
```
