### PR TITLE
doc: updates the 'add-invoice' content

### DIFF
--- a/book/src/take_sell.md
+++ b/book/src/take_sell.md
@@ -88,7 +88,7 @@ Mostro updates the nip 33 event with `d` tag `ede61c96-4c13-4519-bf3a-dcf7f1e9d8
 
 ## Buyer sends LN invoice
 
-The buyer sends a nip 04 event to Mostro with the lightning invoice, the action should be the same the buyer just received in the last message from Mostro (`add-invoice`), here the unencrypted content of the event:
+The buyer sends a nip 04 event to Mostro with the lightning invoice, the action should be the same the buyer just received in the last message from Mostro (`add-invoice`), here the unencrypted content of the event for an invoice with no amount:
 
 ```json
 {
@@ -100,12 +100,15 @@ The buyer sends a nip 04 event to Mostro with the lightning invoice, the action 
     "content": {
       "payment_request": [
         null,
-        "lnbcrt78510n1pj59wmepp50677g8tffdqa2p8882y0x6newny5vtz0hjuyngdwv226nanv4uzsdqqcqzzsxqyz5vqsp5skn973360gp4yhlpmefwvul5hs58lkkl3u3ujvt57elmp4zugp4q9qyyssqw4nzlr72w28k4waycf27qvgzc9sp79sqlw83j56txltz4va44j7jda23ydcujj9y5k6k0rn5ms84w8wmcmcyk5g3mhpqepf7envhdccp72nz6e"
+        "lnbcrt1pn9dvx0pp5935mskms2uf8wx90m8dlr60ytwn5vxy0e65ls42h7y7exweyvekqdqqcqzzsxqyz5vqsp5xjmllv4ta7jkuc5nfgqp8qjc3amzfewmlycpkkggr7q2y5mjfldq9qyyssqncpf3vm8hwujutqc99f0vy45zh8es54mn6u99q9t6rwm0q80dxszskzrp24y46lxqkc7ly9p80t6lalc8x8xhsn49yhy70a7wqyygugpv7chqs",
+        3922
       ]
     }
   }
 }
 ```
+
+If the invoice includes an amount, the last element of the `payment_request` array should be set to `null`.
 
 ## Mostro response
 


### PR DESCRIPTION
The documentation is not up to date with the contents of the `add-invoice` message.  A third field was added to the `payment_request` array and if not present the message is rejected.