### PR TITLE
admin-settle-add-validation

### DIFF
--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -1,4 +1,4 @@
-use crate::db::{find_dispute_by_order_id, is_assigned_solver, find_solver_pubkey};
+use crate::db::{find_dispute_by_order_id, find_solver_pubkey, is_assigned_solver};
 use crate::lightning::LndConnector;
 use crate::nip33::new_event;
 use crate::util::{send_cant_do_msg, send_dm, settle_seller_hold_invoice, update_order_event};
@@ -16,14 +16,10 @@ use tracing::error;
 
 use super::release::do_payment;
 
-pub async fn pubkey_event_can_solve(
-    pool: &Pool<Sqlite>,
-    ev_pubkey: &PublicKey,
-) -> bool {
+pub async fn pubkey_event_can_solve(pool: &Pool<Sqlite>, ev_pubkey: &PublicKey) -> bool {
     if let Ok(my_keys) = crate::util::get_keys() {
         // Is mostro admin taking dispute?
-        if ev_pubkey.to_string() == my_keys.public_key().to_string()
-        {
+        if ev_pubkey.to_string() == my_keys.public_key().to_string() {
             return true;
         }
     }
@@ -60,10 +56,10 @@ pub async fn admin_settle_action(
     };
 
     // Check if the pubkey is a solver or admin
-        if !pubkey_event_can_solve(pool, &event.pubkey).await {            
-            send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
-            return Ok(());
-        }    
+    if !pubkey_event_can_solve(pool, &event.pubkey).await {
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
+        return Ok(());
+    }
 
     // Was orde cooperatively cancelled?
     if order.status == Status::CooperativelyCanceled.to_string() {
@@ -106,7 +102,6 @@ pub async fn admin_settle_action(
         }
         _ => {}
     }
-
 
     settle_seller_hold_invoice(event, ln_client, Action::AdminSettled, true, &order).await?;
 


### PR DESCRIPTION
Now if someone who is not a solver or admin tries to settle an order, they will get CantDo. If they are a solver or admin and the order is not in dispute, mostro will notified that they cannot do because of the status, and if it is in dispute but they did not taken it, will notified correctly.

The way Mostro has been working until now, if a user tries to settle an order regardless of its status and regardless of whether they are an admin or not they will see the message `Dispute not taken by you`, (except if it was cooperatively canceled). 

I haven't yet incorporated the the new actions without text strings

@grunch @arkanoider please test it :)
