### PR TITLE
starting idea for resubscribe of invoices held

### DIFF
--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -39,7 +39,7 @@ pub async fn order_action(
         // in case of single order do like usual
         if let (Some(min), Some(max)) = (order.min_amount, order.max_amount) {
             if min >= max {
-                let msg = format!("Min amount is greater than max amount");
+                let msg = "Min amount is greater than max amount".to_string();
                 send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
                 return Ok(());
             }

--- a/src/db.rs
+++ b/src/db.rs
@@ -267,6 +267,20 @@ pub async fn update_order_invoice_held_at_time(
     Ok(rows_affected > 0)
 }
 
+pub async fn find_held_invoices(pool: &SqlitePool) -> anyhow::Result<Vec<Order>> {
+    let order = sqlx::query_as::<_, Order>(
+        r#"
+          SELECT *
+          FROM orders
+          WHERE invoice_held_at !=0 true AND  status == 'active'
+        "#,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    Ok(order)
+}
+
 pub async fn find_failed_payment(pool: &SqlitePool) -> anyhow::Result<Vec<Order>> {
     let order = sqlx::query_as::<_, Order>(
         r#"

--- a/src/util.rs
+++ b/src/util.rs
@@ -400,6 +400,13 @@ pub async fn show_hold_invoice(
     )
     .await;
 
+    let _ = invoice_subscribe(hash).await;
+
+    Ok(())
+}
+
+// Create function to reuse in case of resubscription
+pub async fn invoice_subscribe(hash: Vec<u8>) {
     let mut ln_client_invoices = lightning::LndConnector::new().await;
     let (tx, mut rx) = channel(100);
 
@@ -438,8 +445,6 @@ pub async fn show_hold_invoice(
         }
     };
     tokio::spawn(subs);
-
-    Ok(())
 }
 
 pub async fn get_market_amount_and_fee(


### PR DESCRIPTION
Hi @grunch,

starting idea for ln invoice resubscribe.

Just added a db function to  get orders with held_time set and state is active.

Embedded in a fn invoice stuff to reuse the fn around and called at main level at the moment, still can't see other use cases then at restart of daemon, in case with the scheduler we have to be sure to don't call again resub on the same invoice I suppose. Maybe a field in db could be useful in this case? Or a new order field?

Waiting for comments if I am on the right path.