### PR TITLE
New actions and remove text strings, refactoring

### DIFF
--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -53,12 +53,7 @@ pub async fn add_invoice_action(
     };
     // Only the buyer can add an invoice
     if buyer_pubkey != event.pubkey {
-        send_cant_do_msg(
-            Some(order.id),
-            Some("Not allowed".to_string()),
-            &event.pubkey,
-        )
-        .await;
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
 

--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -107,15 +107,7 @@ pub async fn add_invoice_action(
             return Ok(());
         }
         _ => {
-            send_cant_do_msg(
-                Some(order.id),
-                Some(format!(
-                    "You are not allowed to add an invoice because order Id {} status is {}",
-                    order_status, order.id
-                )),
-                &buyer_pubkey,
-            )
-            .await;
+            send_new_order_msg(Some(order.id), Action::NotAllowedByStatus, None, &event.pubkey).await;
             return Ok(());
         }
     }

--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -71,8 +71,8 @@ pub async fn add_invoice_action(
             .await
             {
                 Ok(_) => payment_request,
-                Err(e) => {
-                    send_cant_do_msg(Some(order.id), Some(e.to_string()), &event.pubkey).await;
+                Err(_) => {
+                    send_new_order_msg(None, Action::IncorrectInvoiceAmount, None, &event.pubkey).await;
                     return Ok(());
                 }
             }

--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -89,16 +89,7 @@ pub async fn add_invoice_action(
         Status::SettledHoldInvoice => {
             order.payment_attempts = 0;
             order.clone().update(pool).await?;
-            send_new_order_msg(
-                Some(order.id),
-                Action::AddInvoice,
-                Some(Content::TextMessage(format!(
-                    "Order Id {}: Invoice updated!",
-                    order.id
-                ))),
-                &buyer_pubkey,
-            )
-            .await;
+            send_new_order_msg(Some(order.id), Action::InvoiceUpdated, None, &buyer_pubkey).await;
             return Ok(());
         }
         _ => {

--- a/src/app/admin_add_solver.rs
+++ b/src/app/admin_add_solver.rs
@@ -31,7 +31,7 @@ pub async fn admin_add_solver_action(
     // Check if the pubkey is Mostro
     if event.pubkey.to_string() != my_keys.public_key().to_string() {
         // We create a Message
-        send_cant_do_msg(None, Some("Not allowed".to_string()), &event.pubkey).await;
+        send_cant_do_msg(None, None, &event.pubkey).await;
         return Ok(());
     }
     let public_key = PublicKey::from_bech32(npubkey)?.to_hex();

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use crate::db::{find_dispute_by_order_id, is_assigned_solver};
 use crate::lightning::LndConnector;
 use crate::nip33::new_event;
-use crate::util::{send_cant_do_msg, send_dm, send_new_order_msg, update_order_event};
+use crate::util::{send_dm, send_new_order_msg, update_order_event};
 use crate::NOSTR_CLIENT;
 
 use anyhow::{Error, Result};
@@ -30,13 +30,7 @@ pub async fn admin_cancel_action(
 
     match is_assigned_solver(pool, &event.pubkey.to_string(), order_id).await {
         Ok(false) => {
-            send_cant_do_msg(
-                None,
-                Some("Dispute not taken by you".to_string()),
-                &event.pubkey,
-            )
-            .await;
-
+            send_new_order_msg(Some(order_id), Action::IsNotYourDispute, None, &event.pubkey).await;
             return Ok(());
         }
         Err(e) => {

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use crate::db::{find_dispute_by_order_id, is_assigned_solver};
 use crate::lightning::LndConnector;
 use crate::nip33::new_event;
-use crate::util::{send_cant_do_msg, send_dm, update_order_event};
+use crate::util::{send_cant_do_msg, send_dm, send_new_order_msg, update_order_event};
 use crate::NOSTR_CLIENT;
 
 use anyhow::{Error, Result};
@@ -69,12 +69,7 @@ pub async fn admin_cancel_action(
     }
 
     if order.status != Status::Dispute.to_string() {
-        let error = format!(
-            "Can't settle an order with status different than {}!",
-            Status::Dispute
-        );
-        send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
-
+        send_new_order_msg(Some(order.id), Action::NotAllowedByStatus, None, &event.pubkey).await;
         return Ok(());
     }
 

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -1,7 +1,7 @@
 use crate::db::{find_dispute_by_order_id, is_assigned_solver};
 use crate::lightning::LndConnector;
 use crate::nip33::new_event;
-use crate::util::{send_cant_do_msg, send_dm, send_new_order_msg, settle_seller_hold_invoice, update_order_event};
+use crate::util::{send_dm, send_new_order_msg, settle_seller_hold_invoice, update_order_event};
 use crate::NOSTR_CLIENT;
 
 use anyhow::{Error, Result};
@@ -31,13 +31,7 @@ pub async fn admin_settle_action(
 
     match is_assigned_solver(pool, &event.pubkey.to_string(), order_id).await {
         Ok(false) => {
-            send_cant_do_msg(
-                None,
-                Some("Dispute not taken by you".to_string()),
-                &event.pubkey,
-            )
-            .await;
-
+            send_new_order_msg(Some(order_id), Action::IsNotYourDispute, None, &event.pubkey).await;
             return Ok(());
         }
         Err(e) => {

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -1,7 +1,7 @@
 use crate::db::{find_dispute_by_order_id, is_assigned_solver};
 use crate::lightning::LndConnector;
 use crate::nip33::new_event;
-use crate::util::{send_cant_do_msg, send_dm, settle_seller_hold_invoice, update_order_event};
+use crate::util::{send_cant_do_msg, send_dm, send_new_order_msg, settle_seller_hold_invoice, update_order_event};
 use crate::NOSTR_CLIENT;
 
 use anyhow::{Error, Result};
@@ -70,12 +70,7 @@ pub async fn admin_settle_action(
     }
 
     if order.status != Status::Dispute.to_string() {
-        let error = format!(
-            "Can't settle an order with status different than {}!",
-            Status::Dispute
-        );
-        send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
-
+        send_new_order_msg(Some(order.id), Action::NotAllowedByStatus, None, &event.pubkey).await;
         return Ok(());
     }
 

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -68,7 +68,7 @@ pub async fn admin_take_dispute_action(
     if let Ok(dispute_status) = Status::from_str(&dispute.status) {
         if !pubkey_event_can_solve(pool, &event.pubkey, dispute_status).await {
             // We create a Message
-            send_cant_do_msg(None, Some("Not allowed".to_string()), &event.pubkey).await;
+            send_cant_do_msg(Some(dispute_id), None, &event.pubkey).await;
             return Ok(());
         }
     } else {

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -1,6 +1,6 @@
 use crate::db::find_solver_pubkey;
 use crate::nip33::new_event;
-use crate::util::{send_cant_do_msg, send_dm};
+use crate::util::{send_cant_do_msg, send_dm, send_new_order_msg};
 use crate::NOSTR_CLIENT;
 
 use anyhow::{Error, Result};
@@ -54,12 +54,7 @@ pub async fn admin_take_dispute_action(
         Some(dispute) => dispute,
         None => {
             // We create a Message
-            send_cant_do_msg(
-                Some(dispute_id),
-                Some("Dispute not found".to_string()),
-                &event.pubkey,
-            )
-            .await;
+            send_new_order_msg(Some(dispute_id), Action::NotFound, None, &event.pubkey).await;
             return Ok(());
         }
     };

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -35,12 +35,7 @@ pub async fn cancel_action(
         // Validates if this user is the order creator
         if user_pubkey != order.creator_pubkey {
             // We create a Message
-            send_cant_do_msg(
-                Some(order_id),
-                Some("Not allowed!".to_string()),
-                &event.pubkey,
-            )
-            .await;
+            send_new_order_msg(Some(order.id), Action::IsNotYourOrder, None, &event.pubkey).await;
         } else {
             // We publish a new replaceable kind nostr event with the status updated
             // and update on local database the status and new event id

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -38,12 +38,7 @@ pub async fn dispute_action(
                 if matches!(st, Status::Active | Status::FiatSent) {
                     order
                 } else {
-                    send_cant_do_msg(
-                        Some(order.id),
-                        Some("Not allowed".to_string()),
-                        &event.pubkey,
-                    )
-                    .await;
+                    send_new_order_msg(Some(order.id), Action::NotAllowedByStatus, None, &event.pubkey).await;
                     return Ok(());
                 }
             } else {

--- a/src/app/fiat_sent.rs
+++ b/src/app/fiat_sent.rs
@@ -29,8 +29,7 @@ pub async fn fiat_sent_action(
     };
     // Send to user a DM with the error
     if order.status != Status::Active.to_string() {
-        let error = format!("Order Id {order_id} wrong status");
-        send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
+        send_new_order_msg(Some(order.id), Action::NotAllowedByStatus, None, &event.pubkey).await;
         return Ok(());
     }
     // Check if the pubkey is the buyer

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -1,9 +1,9 @@
 use crate::cli::settings::Settings;
 use crate::lightning::invoice::decode_invoice;
-use crate::util::{get_bitcoin_price, publish_order, send_cant_do_msg};
+use crate::util::{get_bitcoin_price, publish_order, send_cant_do_msg, send_new_order_msg};
 
 use anyhow::Result;
-use mostro_core::message::Message;
+use mostro_core::message::{Action, Message};
 use nostr_sdk::{Event, Keys};
 use sqlx::{Pool, Sqlite};
 use tracing::error;
@@ -25,9 +25,7 @@ pub async fn order_action(
                 .map(|sats| sats / 1000)
                 .is_some()
             {
-                let error = String::from("Invoice with an amount different from zero receive on new order, please send 0 amount invoice or no invoice at all!");
-                send_cant_do_msg(order.id, Some(error), &event.pubkey).await;
-
+                send_new_order_msg(None, Action::IncorrectInvoiceAmount, None, &event.pubkey).await;
                 return Ok(());
             }
         }

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -39,8 +39,7 @@ pub async fn order_action(
         // in case of single order do like usual
         if let (Some(min), Some(max)) = (order.min_amount, order.max_amount) {
             if min >= max {
-                let msg = "Min amount is greater than max amount".to_string();
-                send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
+                send_cant_do_msg(order.id, None, &event.pubkey).await;
                 return Ok(());
             }
             if order.amount == 0 {

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -74,11 +74,7 @@ pub async fn order_action(
             if quote > mostro_settings.max_order_amount as i64
                 || quote < mostro_settings.min_payment_amount as i64
             {
-                let msg = format!(
-                    "Quote is out of sats boundaries min is {} max is {}",
-                    mostro_settings.min_payment_amount, mostro_settings.max_order_amount
-                );
-                send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
+                send_new_order_msg(None, Action::OutOfRangeSatsAmount, None, &event.pubkey).await;
                 return Ok(());
             }
         }

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -45,8 +45,7 @@ pub async fn order_action(
                 amount_vec.push(min);
                 amount_vec.push(max);
             } else {
-                let msg = "Amount must be 0 in case of range order".to_string();
-                send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
+                send_new_order_msg(None, Action::InvalidSatsAmount, None, &event.pubkey).await;
                 return Ok(());
             }
         }
@@ -68,8 +67,7 @@ pub async fn order_action(
 
             // Check amount is positive - extra safety check
             if quote < 0 {
-                let msg = format!("Amount must be positive {} is not valid", order.amount);
-                send_cant_do_msg(order.id, Some(msg), &event.pubkey).await;
+                send_new_order_msg(None, Action::InvalidSatsAmount, None, &event.pubkey).await;
                 return Ok(());
             }
 

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -93,7 +93,7 @@ pub async fn release_action(
         && current_status != Status::FiatSent
         && current_status != Status::Dispute
     {
-        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
+        send_new_order_msg(Some(order.id), Action::NotAllowedByStatus, None, &event.pubkey).await;
         return Ok(());
     }
 

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -98,12 +98,7 @@ pub async fn release_action(
     }
 
     if &seller_pubkey.to_string() != seller_pubkey_hex {
-        send_cant_do_msg(
-            Some(order.id),
-            Some("You are not allowed to release funds for this order!".to_string()),
-            &event.pubkey,
-        )
-        .await;
+        send_cant_do_msg(Some(order.id), None, &event.pubkey).await;
         return Ok(());
     }
 

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -53,11 +53,7 @@ pub async fn take_buy_action(
     if let Some(am) = get_fiat_amount_requested(&order, &msg) {
         order.fiat_amount = am;
     } else {
-        let error = format!(
-            "Amount requested is not correct, probably out of range min {:#?} - max {:#?}",
-            order.min_amount, order.max_amount
-        );
-        send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
+        send_new_order_msg(Some(order.id), Action::OutOfRangeFiatAmount, None, &event.pubkey).await;
         return Ok(());
     }
 

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -4,7 +4,7 @@ use crate::util::{
 };
 
 use anyhow::{Error, Result};
-use mostro_core::message::{Action, Content, Message};
+use mostro_core::message::{Action, Message};
 use mostro_core::order::{Kind, Order, Status};
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
@@ -85,15 +85,7 @@ pub async fn take_buy_action(
     // Seller can take pending orders only
     if order_status != Status::Pending {
         // We create a Message
-        send_new_order_msg(
-            Some(order.id),
-            Action::FiatSent,
-            Some(Content::TextMessage(format!(
-                "Order Id {order_id} was already taken!"
-            ))),
-            &seller_pubkey,
-        )
-        .await;
+        send_new_order_msg(Some(order.id), Action::NotAllowedByStatus, None, &seller_pubkey).await;
         return Ok(());
     }
 

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -37,11 +37,7 @@ pub async fn take_sell_action(
     if let Some(am) = get_fiat_amount_requested(&order, &msg) {
         order.fiat_amount = am;
     } else {
-        let error = format!(
-            "Amount requested is not correct, probably out of range min {:#?} - max {:#?}",
-            order.min_amount, order.max_amount
-        );
-        send_cant_do_msg(Some(order.id), Some(error), &event.pubkey).await;
+        send_new_order_msg(Some(order.id), Action::OutOfRangeFiatAmount, None, &event.pubkey).await;
         return Ok(());
     }
 


### PR DESCRIPTION
To replace all text strings sent to users with actions https://github.com/MostroP2P/mostro/issues/312
The new actions added are:

IsNotYourOrder
NotAllowedByStatus
PaymentFailed
InvoiceUpdated
NotFound
IsNotYourDispute
OutOfRangeFiatAmount
OutOfRangeSatsAmount
IncorrectInvoiceAmount
InvalidSatsAmount
Some CantDo were kept but all without text strings
The new actions were added to mostro-core library

Have to propose messages that clients can give to users when they receive the actions

This PR has the same content as the #335  but without conflicts with my Main branch :)