### PR TITLE
Pow check of events incoming

### DIFF
--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -41,6 +41,8 @@ expiration_seconds = 900
 user_rates_sent_interval_seconds = 3600
 # Relay list event time interval
 publish_relays_interval = 60
+# Requested POW
+pow = 0
 
 
 

--- a/src/cli/settings.rs
+++ b/src/cli/settings.rs
@@ -101,6 +101,7 @@ pub struct Mostro {
     pub user_rates_sent_interval_seconds: u32,
     pub max_expiration_days: u32,
     pub publish_relays_interval: u32,
+    pub pow: u8,
 }
 
 impl TryFrom<Settings> for Mostro {

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -168,7 +168,7 @@ pub fn info_to_tags(mostro_pubkey: &PublicKey) -> Vec<Tag> {
             vec![mostro_settings.fee.to_string()],
         ),
         Tag::custom(
-            TagKind::Custom(std::borrow::Cow::Borrowed("Pow")),
+            TagKind::Custom(std::borrow::Cow::Borrowed("pow")),
             vec![mostro_settings.pow.to_string()],
         ),
         Tag::custom(

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -168,6 +168,10 @@ pub fn info_to_tags(mostro_pubkey: &PublicKey) -> Vec<Tag> {
             vec![mostro_settings.fee.to_string()],
         ),
         Tag::custom(
+            TagKind::Custom(std::borrow::Cow::Borrowed("Pow")),
+            vec![mostro_settings.pow.to_string()],
+        ),
+        Tag::custom(
             TagKind::Custom(std::borrow::Cow::Borrowed("hold_invoice_expiration_window")),
             vec![ln_settings.hold_invoice_expiration_window.to_string()],
         ),


### PR DESCRIPTION
Hi @grunch ,

`mostrod` now checks the POW of incoming events.
Settings file now in `[mostro]` section has also pow value ( 0 means no pow ).

Added also pow requested by mostro in info event.

