### PR TITLE
Includes the dispute id in the initial message sent by mostro to both parties

### DIFF
--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -7,7 +7,7 @@ use crate::NOSTR_CLIENT;
 
 use anyhow::{Error, Result};
 use mostro_core::dispute::Dispute;
-use mostro_core::message::{Action, Message};
+use mostro_core::message::{Action, Content, Message};
 use mostro_core::order::{Order, Status};
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
@@ -114,7 +114,7 @@ pub async fn dispute_action(
     send_new_order_msg(
         Some(order_id),
         Action::DisputeInitiatedByYou,
-        None,
+        Some(Content::Dispute(dispute.id)),
         &initiator_pubkey,
     )
     .await;
@@ -130,7 +130,7 @@ pub async fn dispute_action(
     send_new_order_msg(
         Some(order_id),
         Action::DisputeInitiatedByPeer,
-        None,
+        Some(Content::Dispute(dispute.id)),
         &counterpart_pubkey,
     )
     .await;


### PR DESCRIPTION
This is important because otherwise the client cannot link further dispute updates to a specific order.