### PR TITLE
When taking an order, check the status first and then the quantity

### DIFF
--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -73,7 +73,7 @@ pub async fn add_invoice_action(
             {
                 Ok(_) => payment_request,
                 Err(_) => {
-                    send_new_order_msg(None, Action::IncorrectInvoiceAmount, None, &event.sender)
+                    send_new_order_msg(Some(order.id), Action::IncorrectInvoiceAmount, None, &event.sender)
                         .await;
                     return Ok(());
                 }

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -45,20 +45,6 @@ pub async fn take_buy_action(
         return Ok(());
     }
 
-    // Get amount request if user requested one for range order - fiat amount will be used below
-    if let Some(am) = get_fiat_amount_requested(&order, &msg) {
-        order.fiat_amount = am;
-    } else {
-        send_new_order_msg(
-            Some(order.id),
-            Action::OutOfRangeFiatAmount,
-            None,
-            &event.sender,
-        )
-        .await;
-        return Ok(());
-    }
-
     let order_status = match Status::from_str(&order.status) {
         Ok(s) => s,
         Err(e) => {
@@ -90,6 +76,21 @@ pub async fn take_buy_action(
             return Ok(());
         }
     }
+    
+    // Get amount request if user requested one for range order - fiat amount will be used below
+    if let Some(am) = get_fiat_amount_requested(&order, &msg) {
+        order.fiat_amount = am;
+    } else {
+        send_new_order_msg(
+            Some(order.id),
+            Action::OutOfRangeFiatAmount,
+            None,
+            &event.sender,
+        )
+        .await;
+        return Ok(());
+    } 
+    
     // Check market price value in sats - if order was with market price then calculate
     if order.amount == 0 {
         let (new_sats_amount, fee) =

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -34,20 +34,6 @@ pub async fn take_sell_action(
         }
     };
 
-    // Get amount request if user requested one for range order - fiat amount will be used below
-    if let Some(am) = get_fiat_amount_requested(&order, &msg) {
-        order.fiat_amount = am;
-    } else {
-        send_new_order_msg(
-            Some(order.id),
-            Action::OutOfRangeFiatAmount,
-            None,
-            &event.sender,
-        )
-        .await;
-        return Ok(());
-    }
-
     // Maker can't take own order
     if order.creator_pubkey == event.sender.to_hex() {
         send_cant_do_msg(Some(order.id), None, &event.sender).await;
@@ -109,6 +95,20 @@ pub async fn take_sell_action(
             .await;
             return Ok(());
         }
+    }
+    
+    // Get amount request if user requested one for range order - fiat amount will be used below
+    if let Some(am) = get_fiat_amount_requested(&order, &msg) {
+        order.fiat_amount = am;
+    } else {
+        send_new_order_msg(
+            Some(order.id),
+            Action::OutOfRangeFiatAmount,
+            None,
+            &event.sender,
+        )
+        .await;
+        return Ok(());
     }
 
     // Add buyer pubkey to order


### PR DESCRIPTION
fix #349 
Now when someone takes an order Mostro will first check the status of the order and then if it has a range it will check the quantity that was requested to be taken is within the range and not the other way around.