### PR TITLE
fixed a missing error check 

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -315,7 +315,9 @@ pub async fn update_order_event(keys: &Keys, status: Status, order: &Order) -> R
         status.to_string()
     );
 
-    NOSTR_CLIENT.get().unwrap().send_event(event).await?;
+    if NOSTR_CLIENT.get().unwrap().send_event(event).await.is_err(){
+        tracing::warn!("order id : {} is expired", order_updated.id)
+    }
 
     println!(
         "Inside update_order_event order_updated status {:?} - order id {:?}",


### PR DESCRIPTION
Hi @grunch ,

looking to your weird case of DM i found a fix to do imo
On await fn if you get an error ( in my case was `sdk` signaling order expired ) the function returns without updating db status which is not good to me.

Take a look! 