### PR TITLE
fix(docker/compose): specify platform so it runs on mac m1

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -4,3 +4,4 @@ services:
     volumes:
       - ./config:/config  # settings.toml and mostro.db
       - ~/.polar/networks/1/volumes/lnd:/lnd # LND data
+    platform: linux/amd64


### PR DESCRIPTION
When attempting to run the dockerized relay in a mac m1, the following error appears:

```bash
! nostr-relay The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

This can be fixed by just explicitly setting the platform on the compose file