### PR TITLE
added Cross.toml for protoc compiler inside docker sandbox

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,6 @@
+[build]
+pre-build = [
+    "apt update && apt install -y unzip",
+    "curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-linux-x86_64.zip && unzip protoc-28.2-linux-x86_64.zip -d /usr/",
+    "chmod 755 /usr/bin/protoc"
+]


### PR DESCRIPTION
Hi @grunch ,

this `Cross.toml` should be the solution using cross crate.
Take a look!