### PR TITLE
Handle next trade on fiatsent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09cc9a5dc67cbdda958e53f72fe6c8a7e3a036d31b84d54f79ae06e28fb0fa2"
+checksum = "e6a7c10b8900e96717edc31b621e1d07204a18b001c22d128fd3573a9f882585"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ uuid = { version = "1.8.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.12.1", features = ["json"] }
-mostro-core = { version = "0.6.24", features = ["sqlx"] }
+mostro-core = { version = "0.6.25", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 config = "0.15.4"

--- a/migrations/20221222153301_orders.sql
+++ b/migrations/20221222153301_orders.sql
@@ -37,5 +37,7 @@ CREATE TABLE IF NOT EXISTS orders (
   failed_payment integer default 0,
   expires_at integer not null,
   trade_index_seller integer default 0,
-  trade_index_buyer integer default 0
+  trade_index_buyer integer default 0,
+  next_trade_pubkey char(64),
+  next_trade_index integer default 0
 );

--- a/src/app/fiat_sent.rs
+++ b/src/app/fiat_sent.rs
@@ -97,7 +97,8 @@ pub async fn fiat_sent_action(
     )
     .await;
 
-    // If the buyer is the maker and we received the next trade field data, we save it
+    // Update next trade fields only when the buyer is the maker of a range order
+    // These fields will be used to create the next child order in the range
     if order.creator_pubkey == event.rumor.pubkey.to_string() && next_trade.is_some() {
         if let Some((pubkey, index)) = next_trade {
             order.next_trade_pubkey = Some(pubkey.clone());

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -196,7 +196,7 @@ async fn handle_child_order(
             &next_trade_pubkey,
             child_order
                 .trade_index_buyer
-                .or(child_order.trade_index_buyer),
+                .or(child_order.trade_index_seller),
         )
         .await;
         child_order.clone().update(pool).await?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -33,12 +33,13 @@ pub async fn connect() -> Result<Pool<Sqlite>> {
         })?;
         match SqlitePool::connect(&db_url).await {
             Ok(pool) => {
-                tracing::info!(
-                    "Successfully created Mostro database file at {}",
-                    db_path.display(),
-                );
                 match sqlx::migrate!().run(&pool).await {
-                    Ok(_) => (),
+                    Ok(_) => {
+                        tracing::info!(
+                            "Successfully created Mostro database file at {}",
+                            db_path.display(),
+                        );
+                    }
                     Err(e) => {
                         // Clean up the created file on migration failure
                         if let Err(cleanup_err) = std::fs::remove_file(db_path) {


### PR DESCRIPTION
Add next_trade_pubkey and next_trade_index fields to order table, this fields should be sent when the maker of a range order is a buyer, mostrod needs these fields to create the new child order

Implement logic of saving next trade fields after fiat-sent action by buyer

Code refactoring to optimize some parts of the code

Add logic on release to use next trade fields in order when the maker of the range order is the buyer

Update mostro-core version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Dependencies**
  - Updated `mostro-core` dependency to version 0.6.25

- **Database**
  - Enhanced orders table schema with new columns for trade tracking
    - Added `next_trade_pubkey`
    - Added `next_trade_index`

- **Improvements**
  - Refined error handling and control flow in order management processes
  - Improved database migration logging to reflect actual setup success
  - Introduced a new helper function for managing child orders
<!-- end of auto-generated comment: release notes by coderabbit.ai -->