### PR TITLE
cancel in waiting-buyer-invoice or waiting-payment

### DIFF
--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -85,16 +85,103 @@ pub async fn cancel_action(
         return Ok(());
     }
 
-    if order.kind == OrderKind::Sell.to_string()
-        && order.status == Status::WaitingBuyerInvoice.to_string()
+    if order.status == Status::WaitingPayment.to_string()
+        || order.status == Status::WaitingBuyerInvoice.to_string()
     {
-        cancel_add_invoice(ln_client, &mut order, event, pool, my_keys, request_id).await?;
-    }
+        let (seller_pubkey, buyer_pubkey) = match (&order.seller_pubkey, &order.buyer_pubkey) {
+            (Some(seller), Some(buyer)) => (seller, buyer),
+            (None, _) => return Err(Error::msg("Missing seller pubkey")),
+            (_, None) => return Err(Error::msg("Missing buyer pubkey")),
+        };
 
-    if order.kind == OrderKind::Buy.to_string()
-        && order.status == Status::WaitingPayment.to_string()
-    {
-        cancel_pay_hold_invoice(ln_client, &mut order, event, pool, my_keys, request_id).await?;
+        let taker_pubkey: String;
+        if seller_pubkey == &order.creator_pubkey {
+            taker_pubkey = buyer_pubkey.to_string();
+        } else {
+            taker_pubkey = seller_pubkey.to_string();
+        }
+
+        if user_pubkey == order.creator_pubkey {
+            if let Ok(order_updated) = update_order_event(my_keys, Status::Canceled, &order).await {
+                let _ = order_updated.update(pool).await;
+            }
+
+            if let Some(hash) = &order.hash {
+                ln_client.cancel_hold_invoice(hash).await?;
+                info!("Order Id {}: Funds returned to seller", &order.id);
+            }
+
+            send_new_order_msg(
+                request_id,
+                Some(order.id),
+                Action::Canceled,
+                None,
+                &event.rumor.pubkey,
+                None,
+            )
+            .await;
+            
+            let taker_pubkey = PublicKey::from_str(&taker_pubkey)?;
+            //We notify the taker that the order was cancelled
+            send_new_order_msg(
+                None,
+                Some(order.id),
+                Action::Canceled,
+                None,
+                &taker_pubkey,
+                None,
+            )
+            .await;
+        } else if user_pubkey == taker_pubkey {
+            if let Ok(order_updated) = update_order_event(my_keys, Status::Pending, &order).await {
+                let _ = order_updated.update(pool).await;
+            }
+            if let Some(hash) = &order.hash {
+                ln_client.cancel_hold_invoice(hash).await?;
+                info!("Order Id {}: Funds returned to seller", &order.id);
+            }
+
+            send_new_order_msg(
+                request_id,
+                Some(order.id),
+                Action::Canceled,
+                None,
+                &event.rumor.pubkey,
+                None,
+            )
+            .await;
+
+            let creator_pubkey = PublicKey::from_str(&order.creator_pubkey)?;
+            //We notify the creator that the order was cancelled only if the taker had already done his part before
+            
+            if order.kind == OrderKind::Buy.to_string()
+                && order.status == Status::WaitingBuyerInvoice.to_string()
+            {
+                send_new_order_msg(
+                    request_id,
+                    Some(order.id),
+                    Action::Canceled,
+                    None,
+                    &creator_pubkey,
+                    None,
+                )
+                .await;
+            }
+            
+            if order.kind == OrderKind::Sell.to_string()
+                && order.status == Status::WaitingPayment.to_string()
+            {
+                send_new_order_msg(
+                    request_id,
+                    Some(order.id),
+                    Action::Canceled,
+                    None,
+                    &creator_pubkey,
+                    None,
+                )
+                .await;
+            }
+        }
     }
 
     if order.status == Status::Active.to_string()


### PR DESCRIPTION
closes #379 

Added:

When the maker cancels an order in status `waiting-buyer-invoice` or `waiting-payment`, the order goes to status `canceled` and the taker will be notified that it was cancelled

When the taker cancels an order in the status `waiting-buyer-invoice` or `waiting-payment`, the order goes to status `pending`. The maker will be notified that it was cancelled only if the maker has already been notified to submit their invoice or pay the hold invoice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced order cancellation process with broader status handling.
  - Improved user role-based cancellation logic.
  - Added comprehensive notifications for order cancellations.

- **Bug Fixes**
  - Streamlined invoice cancellation handling.
  - Refined conditions for order status changes during cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->