### PR TITLE
docs(README): add missing dependency for mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Before running it you need to set `nsec_privkey` in the `[nostr]` section of the
 
 When you run mostro for first time it will create a .mostro directory in /home/user/ and copy the settings.toml and mostro.db files inside.
 
+Every time you make a change in the settings.toml file of the project, you need to update those changes in /home/user/.mostro/settings.toml file
+
 Finnaly run it:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To compile on Mac, then use brew:
 
 ```bash
 brew update
-brew install cmake pkg-config openssl sqlite3
+brew install cmake pkg-config openssl sqlite3 protobuf
 ```
 
 ## Install


### PR DESCRIPTION
### Context
In mac it was necessary to have protobuf in order that the setup worked.  Also added a reminder to update the settings.toml in the .mostro path every time a change is made in the settings.toml of


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the macOS installation instructions to include an additional dependency ("protobuf") needed for setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->