### PR TITLE
Correct full privacy mode check when orders arrives

### DIFF
--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -105,8 +105,7 @@ pub async fn order_action(
             request_id,
             msg.get_inner_message_kind().trade_index,
         )
-        .await
-        .map_err(|_| MostroError::MostroInternalErr(ServiceError::InvalidOrderId))?;
+        .await?
     }
     Ok(())
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -163,6 +163,33 @@ pub fn get_expiration_date(expire: Option<i64>) -> i64 {
     }
     expire_date
 }
+/// Check if the order is full privacy or normal and return the tags accordingly
+pub async fn check_full_privacy_order(
+    new_order_db: &Order,
+    pool: &SqlitePool,
+    identity_pubkey: &PublicKey,
+    trade_pubkey: &PublicKey,
+) -> Result<Tags, MostroError> {
+    let tags = match is_user_present(pool, identity_pubkey.to_string()).await {
+        Ok(user) => {
+            // We transform the order fields to tags to use in the event
+            order_to_tags(
+                new_order_db,
+                Some((user.total_rating, user.total_reviews, user.created_at)),
+            )
+        }
+        Err(_) => {
+            // We transform the order fields to tags to use in the event
+            if identity_pubkey == trade_pubkey {
+                order_to_tags(new_order_db, None)
+            } else {
+                return Err(MostroInternalErr(ServiceError::InvalidPubkey));
+            }
+        }
+    };
+
+    Ok(tags)
+}
 
 #[allow(clippy::too_many_arguments)]
 pub async fn publish_order(
@@ -200,17 +227,13 @@ pub async fn publish_order(
     let order_id = order.id;
     info!("New order saved Id: {}", order_id);
     // Get user reputation
-    let user = is_user_present(pool, identity_pubkey.to_string())
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-    // We transform the order fields to tags to use in the event
-    let tags = order_to_tags(
-        &new_order_db,
-        Some((user.total_rating, user.total_reviews, user.created_at)),
-    );
+
+    let tags =
+        check_full_privacy_order(&new_order_db, pool, &identity_pubkey, &trade_pubkey).await?;
     // nip33 kind with order fields as tags and order id as identifier
     let event = new_event(keys, "", order_id.to_string(), tags)
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+
     info!("Order event to be published: {event:#?}");
     let event_id = event.id.to_string();
     info!("Publishing Event Id: {event_id} for Order Id: {order_id}");

--- a/src/util.rs
+++ b/src/util.rs
@@ -164,7 +164,7 @@ pub fn get_expiration_date(expire: Option<i64>) -> i64 {
     expire_date
 }
 /// Check if the order is full privacy or normal and return the tags accordingly
-pub async fn check_full_privacy_order(
+pub async fn get_tags_for_new_order(
     new_order_db: &Order,
     pool: &SqlitePool,
     identity_pubkey: &PublicKey,
@@ -228,8 +228,7 @@ pub async fn publish_order(
     info!("New order saved Id: {}", order_id);
     // Get user reputation
 
-    let tags =
-        check_full_privacy_order(&new_order_db, pool, &identity_pubkey, &trade_pubkey).await?;
+    let tags = get_tags_for_new_order(&new_order_db, pool, &identity_pubkey, &trade_pubkey).await?;
     // nip33 kind with order fields as tags and order id as identifier
     let event = new_event(keys, "", order_id.to_string(), tags)
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -226,8 +226,7 @@ pub async fn publish_order(
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
     let order_id = order.id;
     info!("New order saved Id: {}", order_id);
-    // Get user reputation
-
+    // Get tags for new order in case of full privacy or normal order
     let tags = get_tags_for_new_order(&new_order_db, pool, &identity_pubkey, &trade_pubkey).await?;
     // nip33 kind with order fields as tags and order id as identifier
     let event = new_event(keys, "", order_id.to_string(), tags)


### PR DESCRIPTION
@grunch @Catrya 

fix for full privacy order coming in mostrod, now events are published also if order is in full privacy.

Removed an useless map_err call which was creating not precise error message remapping again a `MostroError` coming from below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to streamline the generation of tags for orders based on user privacy status, enhancing the order processing experience.

- **Refactor**
	- Simplified error management during order publication for more consistent and reliable processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->