### PR TITLE
Privacy range order fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,8 +1990,6 @@ dependencies = [
 [[package]]
 name = "mostro-core"
 version = "0.6.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca930bdc9b8fbf585d8f26c994aa2be1a8df7baeca41a6c614e0632e2bb8f8a9"
 dependencies = [
  "anyhow",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ bitcoin = "0.32.5"
 
 [dev-dependencies]
 tokio = { version = "1.40.0", features = ["full", "test-util", "macros"] }
+
+[patch.crates-io]
+mostro-core = { path = "../mostro-core" }

--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -79,7 +79,7 @@ pub async fn add_invoice_action(
                     MostroInternalErr(ServiceError::DbAccessError(cause.to_string()))
                 })?;
                 updated_order
-            },
+            }
             Err(_) => order.clone(), // Fallback to original order if update fails
         };
 


### PR DESCRIPTION
@Catrya @grunch ,

this pull request is related to this [pull request](https://github.com/MostroP2P/mostro-core/pull/97) of `mostro-core`.

I have improved dispute message for solver adding a specific field for full privacy orders and optional fields for the users.

I fixed also #466 , need to be tested a bit more because I introduced this morning an improvement on mostro-core to check full privacy orders.

@Catrya when you can do a round of test, as usal use mostro-core locally with pull request linked above.