### PR TITLE
New user or privacy order send same user info with zeros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ uuid = { version = "1.8.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.12.1", features = ["json"] }
-mostro-core = { version = "0.6.35", features = ["sqlx"] }
+mostro-core = { version = "0.6.36", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 config = "0.15.8"

--- a/src/app.rs
+++ b/src/app.rs
@@ -282,7 +282,7 @@ pub async fn run(
                     let event = match nip59::extract_rumor(&my_keys, &event).await {
                         Ok(u) => u,
                         Err(_) => {
-                            println!("Error unwrapping gift");
+                            tracing::warn!("Error unwrapping gift");
                             continue;
                         }
                     };

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -194,7 +194,7 @@ pub async fn dispute_action(
     }
 
     // Create new dispute record and generate security tokens
-    let mut dispute = Dispute::new(order_id);
+    let mut dispute = Dispute::new(order_id, order.status.clone());
     // Create tokens
     let (initiator_token, counterpart_token) = dispute.create_tokens(is_buyer_dispute);
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -587,8 +587,11 @@ pub async fn is_assigned_solver(
     solver_pubkey: &str,
     order_id: Uuid,
 ) -> Result<bool, MostroError> {
-    println!("solver_pubkey: {}", solver_pubkey);
-    println!("order_id: {}", order_id);
+    tracing::info!(
+        "Solver_pubkey: {} assigned to order {}",
+        solver_pubkey,
+        order_id
+    );
     let result = sqlx::query(
         "SELECT EXISTS(SELECT 1 FROM disputes WHERE solver_pubkey = ? AND order_id = ?)",
     )

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -47,14 +47,25 @@ pub fn new_event(
 ///
 /// # Returns a json string
 fn create_rating_tag(reputation_data: Option<(f64, i64, i64)>) -> String {
-    let now = Timestamp::now();
-    let days = (now.as_u64() - reputation_data.map_or(0, |data| data.2) as u64) / 86400;
+    if let Some(data) = reputation_data {
+        const SECONDS_IN_DAY: u64 = 86400;
+        // If operating day is 0, it means the user is new and we don't have a valid reputation data
+        let days = if data.2 != 0 {
+            let now = Timestamp::now();
+            (now.as_u64() - data.2 as u64) / SECONDS_IN_DAY
+        } else {
+            0
+        };
 
-    let json_data = json!([
+        // Create the json string
+        let json_data = json!([
         "rating",
-        {"total_reviews": reputation_data.map_or(0, |data| data.1), "total_rating": reputation_data.map_or(0.0, |data| data.0), "days": days}
-    ]);
-    json_data.to_string()
+            {"total_reviews": data.1, "total_rating": data.0, "days": days}
+        ]);
+        json_data.to_string()
+    } else {
+        "No data in reputation tag".to_string()
+    }
 }
 
 fn create_fiat_amt_array(order: &Order) -> Vec<String> {
@@ -105,6 +116,8 @@ pub fn order_to_tags(
     order: &Order,
     reputation_data: Option<(f64, i64, i64)>,
 ) -> Result<Option<Tags>, MostroError> {
+    // Po
+    const RATING_TAG_INDEX: usize = 7;
     // Check if the order is pending/in-progress/success/canceled
     let (create_event, status) = create_status_tags(order)?;
     // Send just in case the order is pending/in-progress/success/canceled
@@ -165,7 +178,7 @@ pub fn order_to_tags(
         // Add reputation data if available
         if reputation_data.is_some() {
             tags.insert(
-                7,
+                RATING_TAG_INDEX,
                 Tag::custom(
                     TagKind::Custom(Cow::Borrowed("rating")),
                     vec![create_rating_tag(reputation_data)],

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -399,7 +399,11 @@ async fn job_expire_pending_older_orders() {
             info!("Check older orders and mark them Expired - check is done every minute");
             if let Ok(older_orders_list) = crate::db::find_order_by_date(&pool).await {
                 for order in older_orders_list.iter() {
-                    println!("Uid {} - created at {}", order.id, order.created_at);
+                    tracing::info!(
+                        "Order id {} - created at {} is expired",
+                        order.id,
+                        order.created_at
+                    );
                     // We update the order id with the new event_id
                     if let Ok(order_updated) =
                         crate::util::update_order_event(&keys, Status::Expired, order).await

--- a/src/util.rs
+++ b/src/util.rs
@@ -230,7 +230,7 @@ pub async fn get_tags_for_new_order(
         Err(_) => {
             // We transform the order fields to tags to use in the event
             if identity_pubkey == trade_pubkey {
-                order_to_tags(new_order_db, None)
+                order_to_tags(new_order_db, Some((0.0, 0, 0)))
             } else {
                 Err(MostroInternalErr(ServiceError::InvalidPubkey))
             }


### PR DESCRIPTION
@Catrya ,

this should be quite easy, when you are available please test.

Now new order event from a new user or a privacy order should have the same ratings values filled with zeros.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced order processing to better handle cases where user details are missing by applying consistent default parameters. This update improves the stability and reliability of order tagging, ensuring smoother operations when associated user data is not available.

- **New Features**
  - Improved error logging throughout the application for better monitoring and debugging.
  - Enhanced clarity in logging messages related to order assignments and expirations.
  - Added contextual information to dispute handling by including order status in dispute creation.

- **Refactor**
  - Updated the handling of reputation data to ensure accurate JSON output and improved maintainability by using constants for indexing.
  - Improved logging mechanisms across various functions for structured and clear log messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->