### PR TITLE
Add previous order state in database for solver message

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ uuid = { version = "1.8.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.12.1", features = ["json"] }
-mostro-core = { version = "0.6.35", features = ["sqlx"] }
+mostro-core = { version = "0.6.36", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 config = "0.15.8"

--- a/migrations/20230928145530_disputes.sql
+++ b/migrations/20230928145530_disputes.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS disputes (
   id char(36) primary key not null,
   order_id char(36) unique not null,
   status varchar(10) not null,
+  order_previous_status varchar(10) not null,
   solver_pubkey char(64),
   created_at integer not null,
   taken_at integer default 0,

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -184,6 +184,9 @@ pub async fn dispute_action(
         Err(cause) => return Err(MostroCantDo(cause)),
     };
 
+    // Create new dispute record and generate security tokens
+    let mut dispute = Dispute::new(order_id, order.status.clone());
+
     // Setup dispute
     if order.setup_dispute(is_buyer_dispute).is_ok() {
         order
@@ -193,8 +196,6 @@ pub async fn dispute_action(
             .map_err(|cause| MostroInternalErr(ServiceError::DbAccessError(cause.to_string())))?;
     }
 
-    // Create new dispute record and generate security tokens
-    let mut dispute = Dispute::new(order_id);
     // Create tokens
     let (initiator_token, counterpart_token) = dispute.create_tokens(is_buyer_dispute);
 


### PR DESCRIPTION
@grunch @Catrya ,

added here the previous order state in database dispute table. It will be sent when admin takes a dispute in the solver message.

In relation to this feature you can you locally this [pull request](https://github.com/MostroP2P/mostro-core/pull/98) of `mostro-core.`

@Catrya 
use as usual in mostrod and mostro-cli the cargo.toml with this modification:

```Rust
[patch.crates-io]
mostro-core ={ path = "catrya/path/mostro-core" }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced dispute processing now records the order’s status at the time a dispute is raised, providing improved context and transparency.
	- This update enriches dispute tracking without altering existing workflows.
- **Database Changes**
	- Added a new column `order_previous_status` to the `disputes` table, which is required for all records. 
- **Dependency Updates**
	- Updated `mostro-core` dependency version from `0.6.35` to `0.6.36`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->