### PR TITLE
fix for buy order flow with message to maker

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -989,7 +989,9 @@ pub async fn notify_taker_reputation(
                     order.get_seller_pubkey().map_err(MostroInternalErr)?,
                 )
             } else {
-                return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+                //FIX for the case of a buy order and maker is adding invoice
+                // just return ok
+                return Ok(());
             }
         }
         Status::WaitingPayment => {


### PR DESCRIPTION
@grunch ,

small fix i've found during working on encoding to have the buy order working fine.
Merge this before, and i will open encryption PR.

@Catrya 

do a test on your side as we said today

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where adding an invoice to a buy order in a specific status would incorrectly return an error. This action will now succeed silently as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->