### PR TITLE
Change tag "y" to mostro

### DIFF
--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -90,7 +90,7 @@ pub async fn admin_cancel_action(
             ),
             Tag::custom(
                 TagKind::Custom(Cow::Borrowed("y")),
-                vec!["mostrop2p".to_string()],
+                vec!["mostro".to_string()],
             ),
             Tag::custom(
                 TagKind::Custom(Cow::Borrowed("z")),

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -90,7 +90,7 @@ pub async fn admin_settle_action(
             ),
             Tag::custom(
                 TagKind::Custom(std::borrow::Cow::Borrowed("y")),
-                vec!["mostrop2p".to_string()],
+                vec!["mostro".to_string()],
             ),
             Tag::custom(
                 TagKind::Custom(std::borrow::Cow::Borrowed("z")),

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -245,7 +245,7 @@ pub async fn admin_take_dispute_action(
         ),
         Tag::custom(
             TagKind::Custom(std::borrow::Cow::Borrowed("y")),
-            vec!["mostrop2p".to_string()],
+            vec!["mostro".to_string()],
         ),
         Tag::custom(
             TagKind::Custom(std::borrow::Cow::Borrowed("z")),

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -37,7 +37,7 @@ async fn publish_dispute_event(dispute: &Dispute, my_keys: &Keys) -> Result<(), 
         // Application identifier tag
         Tag::custom(
             TagKind::Custom(Cow::Borrowed("y")),
-            vec!["mostrop2p".to_string()],
+            vec!["mostro".to_string()],
         ),
         // Event type tag
         Tag::custom(

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -275,7 +275,7 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
         ),
         Tag::custom(
             TagKind::Custom(Cow::Borrowed("y")),
-            vec!["mostrop2p".to_string()],
+            vec!["mostro".to_string()],
         ),
         Tag::custom(
             TagKind::Custom(Cow::Borrowed("z")),


### PR DESCRIPTION
Currently, order events of kind 38383 published by Mostro use the `y` tag as `mostro`, while dispute and information events use `mostrop2p` as the `y` tag.
This small PR updates all `y` tags to `mostro` to ensure consistency across all Mostro events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated application identifier tags in dispute-related events from "mostrop2p" to "mostro" for consistency across the platform. No changes to functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->