### PR TITLE
fix(#490): child order of buy order was not sent to maker, but to taker

### DIFF
--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -219,6 +219,9 @@ async fn handle_child_order(
             _ => {}
         }
 
+        let destination_key = child_order
+            .get_creator_pubkey()
+            .map_err(MostroInternalErr)?;
         child_order.creator_pubkey = next_trade_pubkey.to_string();
         child_order.next_trade_index = None;
         child_order.next_trade_pubkey = None;
@@ -230,7 +233,7 @@ async fn handle_child_order(
             new_order.id,
             Action::NewOrder,
             Some(Payload::Order(new_order)),
-            next_trade_pubkey,
+            destination_key,
             Some(next_trade_index as i64),
         )
         .await;


### PR DESCRIPTION
@Catrya 

this is the fix for #490 .
Tested with a sell order and a buy order - now child order seems correctly sent to makers.

