### PR TITLE
hot-fix Prevent release in Active status: only allow in fiat sent or dispute

### DIFF
--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -137,9 +137,8 @@ pub async fn release_action(
         return Err(MostroCantDo(CantDoReason::InvalidPeer));
     }
 
-    // Check if order is active, fiat sent or dispute
-    if order.check_status(Status::Active).is_err()
-        && order.check_status(Status::FiatSent).is_err()
+    // Check if order is in status fiat sent or dispute
+    if order.check_status(Status::FiatSent).is_err()
         && order.check_status(Status::Dispute).is_err()
     {
         return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));


### PR DESCRIPTION
This PR fixes this:

When a seller releases funds on a buy order with range that's still in Active status, this happened:

1. Seller sends release before buyer sends `fiat sent` action
```
2025-06-09T15:31:02.289327Z  WARN mostrod::app: Error in Release with context Error in database access: Error caused by Unexpected error: Next trade buyer pubkey is missing - inner message Error caused by Unexpected error: Next trade buyer pubkey is missing
```
3. Buyer's next trade key is missing (sent with fiat_sent message)  
4. Mostrod cannot assign the child order to anyone
5. Current order remains in Active status and buyer doesn't receive sats, (and seller thinks he done fine their part)
6. Ghost child order gets published in event 38383 but doesn't exist in database
7. Users trying to take the ghost order get errors because it belongs to no one
```
2025-06-09T15:34:40.383957Z  WARN mostrod::app: Error in TakeBuy with context Order id not present in database - inner message No message
```

Restrict seller release validation to only allow FiatSent and Dispute statuses, removing Active status to ensure proper flow:
- Buyer must send fiat_sent (with next trade key) before seller can release
- Prevents orphaned child orders and database inconsistencies