### PR TITLE
add payment failed info: attempts and retries interval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ uuid = { version = "1.17.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.12.1", features = ["json"] }
-mostro-core = { version = "0.6.42", features = ["sqlx"] }
+mostro-core = { version = "0.6.43", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.39", features = ["derive"] }

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -39,7 +39,7 @@ pub async fn check_failure_retries(
     let ln_settings = Settings::get_ln();
     let retries_number = ln_settings.payment_attempts as i64;
 
-    let is_first_failure = !order.failed_payment;
+    let is_first_failure = order.payment_attempts == 0;
 
     // Count payment retries up to limit
     order.count_failed_payment(retries_number);
@@ -50,7 +50,7 @@ pub async fn check_failure_retries(
     if is_first_failure {
         // Create payment failed payload with retry configuration
         let payment_failed_info = PaymentFailedInfo {
-            payment_attempts: ln_settings.payment_attempts,
+            payment_attempts: ln_settings.payment_attempts.saturating_sub(1),
             payment_retries_interval: ln_settings.payment_retries_interval,
         };
 


### PR DESCRIPTION
fix #474 

Now, when an invoice payment fails:
- Mostro will tell the buyer the first time it fails, payment_attempts and payment_retries_interval
- For the remaining failures, it won't tell them anything, so the user isn't bombarded with failed payment spam.
- If the maximum number of failures is reached, Mostro will prompt the user to add an invoice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved payment failure notifications to only send detailed alerts on the first failure and when retry limits are reached, reducing unnecessary notifications during intermediate failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->