### PR TITLE
Fix: Set event expiration time to 24 hours, improved time to check or…

### DIFF
--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -94,7 +94,7 @@ fn create_status_tags(order: &Order) -> Result<(bool, Status), MostroError> {
     match status {
         Status::WaitingBuyerInvoice => Ok((order.is_sell_order().is_ok(), Status::InProgress)),
         Status::WaitingPayment => Ok((order.is_buy_order().is_ok(), Status::InProgress)),
-        Status::Canceled | Status::CanceledByAdmin | Status::CooperativelyCanceled => {
+        Status::Canceled | Status::CanceledByAdmin | Status::CooperativelyCanceled | Status::Expired=> {
             Ok((true, Status::Canceled))
         }
         Status::Success | Status::CompletedByAdmin => Ok((true, status)),
@@ -162,7 +162,7 @@ pub fn order_to_tags(
             ),
             Tag::custom(
                 TagKind::Custom(Cow::Borrowed("expiration")),
-                vec![order.expires_at.to_string()],
+                vec![(order.expires_at + Duration::hours(12).num_seconds()).to_string()],
             ),
             Tag::custom(
                 TagKind::Custom(Cow::Borrowed("y")),

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1,6 +1,7 @@
 use crate::config::settings::Settings;
 use crate::lightning::LnStatus;
 use crate::LN_STATUS;
+use chrono::Duration;
 use mostro_core::prelude::*;
 use nostr::event::builder::Error;
 use nostr_sdk::prelude::*;

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1,7 +1,6 @@
 use crate::config::settings::Settings;
 use crate::lightning::LnStatus;
 use crate::LN_STATUS;
-use chrono::Duration;
 use mostro_core::prelude::*;
 use nostr::event::builder::Error;
 use nostr_sdk::prelude::*;
@@ -163,7 +162,7 @@ pub fn order_to_tags(
             ),
             Tag::custom(
                 TagKind::Custom(Cow::Borrowed("expiration")),
-                vec![(order.expires_at + Duration::hours(12).num_seconds()).to_string()],
+                vec![order.expires_at.to_string()],
             ),
             Tag::custom(
                 TagKind::Custom(Cow::Borrowed("y")),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -372,7 +372,7 @@ async fn job_cancel_orders() {
                     next_tick.format("%a %b %e %T %Y")
                 );
             }
-            tokio::time::sleep(tokio::time::Duration::from_secs(exp_seconds as u64)).await;
+            tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
         }
     });
 }


### PR DESCRIPTION
…ders to be canceled

fix #506 

- Now the kind 38383 event of a pending order has a duration of 24 hours, not 36.
- Now `job_cancel_orders()` is executed every 1 minute, so that orders do not accumulate for 15 minutes to be processed all at once, and there is greater consistency in the time of an order in status `waiting-buyer-invoice` or `waiting-payment`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted order status handling to treat expired orders as canceled.
  * Modified the order cancellation job to run every 60 seconds for consistent timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->