### PR TITLE
Restore message for client switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -133,29 +133,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
 name = "argon2"
@@ -182,28 +182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,7 +189,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -274,49 +252,21 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
+ "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.7.3",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -326,73 +276,9 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
-dependencies = [
- "axum-core 0.5.2",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit 0.8.4",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 1.0.2",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -406,15 +292,16 @@ checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -479,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.6"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
+checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
  "bech32",
@@ -686,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "shlex",
 ]
@@ -756,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -766,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -778,14 +665,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -802,7 +689,7 @@ checksum = "85a8ab73a1c02b0c15597b22e09c7dc36e63b2f601f9d1e83ac0c3decd38b1ae"
 dependencies = [
  "nix",
  "terminfo",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "which",
  "windows-sys 0.59.0",
 ]
@@ -970,7 +857,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1065,29 +952,22 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-tonic-lnd"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df03ca33b5116de3051c1e233fe341e23b04c4913c7b16042497924559bc2a2e"
+checksum = "374d7b804191264442b33656b9d1e2800c38f8431c64644bb0f4419f3c7be4bc"
 dependencies = [
  "hex",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "prost 0.12.6",
- "rustls 0.21.12",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "prost 0.13.5",
+ "rustls 0.23.31",
  "rustls-pemfile",
  "tokio",
  "tokio-stream",
- "tonic 0.10.2",
- "tonic-build 0.10.2",
- "tower 0.4.13",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -1214,7 +1094,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1311,35 +1191,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.10.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http",
  "indexmap 2.10.0",
  "slab",
  "tokio",
@@ -1365,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hashlink"
@@ -1440,17 +1301,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -1462,23 +1312,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -1489,8 +1328,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1508,30 +1347,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -1539,9 +1354,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.11",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -1553,28 +1368,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -1583,23 +1384,11 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1614,7 +1403,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1633,9 +1422,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -1796,7 +1585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1856,15 +1645,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1905,15 +1685,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -2000,9 +1780,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 
 [[package]]
 name = "matchers"
@@ -2012,12 +1792,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -2097,7 +1871,7 @@ name = "mostro"
 version = "0.14.2"
 dependencies = [
  "argon2",
- "axum 0.7.9",
+ "axum",
  "bech32",
  "bitcoin",
  "chrono",
@@ -2112,7 +1886,7 @@ dependencies = [
  "nostr-sdk",
  "once_cell",
  "openssl",
- "prost 0.13.5",
+ "prost 0.14.1",
  "reqwest",
  "rpassword",
  "secrecy",
@@ -2122,8 +1896,9 @@ dependencies = [
  "sqlx-crud",
  "tokio",
  "toml",
- "tonic 0.13.1",
- "tonic-build 0.13.1",
+ "tonic 0.14.1",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2132,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.6.45"
+version = "0.6.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ec264b8ec6be14ad8055392dad10afb88a38a981b103bd8e0eb74bb618e8d0"
+checksum = "108a32cdb4e0a8952e30a9cac2335aec5cf19ba5256b71f34a5ce6bdbec724a2"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -2180,12 +1955,6 @@ dependencies = [
 
 [[package]]
 name = "negentropy"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e664971378a3987224f7a0e10059782035e89899ae403718ee07de85bec42afe"
-
-[[package]]
-name = "negentropy"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
@@ -2214,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95d3f2f0d564cce3ebe09bb1343af67d88c60108cedc518a307dfdf6e3f503b6"
+checksum = "f30e6dcb36d88017587b0b5578d1ed3398afe8e4f45fdb910e48b8675aaf6f68"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -2227,7 +1996,6 @@ dependencies = [
  "chacha20poly1305",
  "getrandom 0.2.16",
  "instant",
- "regex",
  "scrypt",
  "secp256k1",
  "serde",
@@ -2238,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-database"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6dc456a11d26f99a932b6531d94c20cb2e274ada6eab1d2438e2fb9c944af5"
+checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
 dependencies = [
  "lru",
  "nostr",
@@ -2249,16 +2017,15 @@ dependencies = [
 
 [[package]]
 name = "nostr-relay-pool"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23994b7a613540de50d0b6ac5fcdfeb65d814b0dc5630875d3e1d3e8f05e8c7c"
+checksum = "265d9b44771ed15db93b183a0c93dbb703b2b0d0b74dffb5c2a081be52373a5a"
 dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
  "lru",
- "negentropy 0.3.1",
- "negentropy 0.5.0",
+ "negentropy",
  "nostr",
  "nostr-database",
  "tokio",
@@ -2267,16 +2034,15 @@ dependencies = [
 
 [[package]]
 name = "nostr-sdk"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d201c49818ef560a67f9c26c415007da38b007943e7d1644ac55aa98c55a42"
+checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
 dependencies = [
  "async-utility",
  "nostr",
  "nostr-database",
  "nostr-relay-pool",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2354,7 +2120,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2365,9 +2131,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.1+3.5.1"
+version = "300.5.2+3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
+checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
 dependencies = [
  "cc",
 ]
@@ -2440,7 +2206,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.15",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2480,21 +2246,11 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
-dependencies = [
- "fixedbitset 0.4.2",
- "indexmap 2.10.0",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
- "fixedbitset 0.5.7",
+ "fixedbitset",
  "indexmap 2.10.0",
 ]
 
@@ -2553,7 +2309,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2610,26 +2366,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
 ]
 
 [[package]]
@@ -2643,24 +2389,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.12.6"
+name = "prost"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
- "heck 0.5.0",
- "itertools 0.12.1",
- "log",
- "multimap",
- "once_cell",
- "petgraph 0.6.5",
- "prettyplease",
- "prost 0.12.6",
- "prost-types 0.12.6",
- "regex",
- "syn 2.0.104",
- "tempfile",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
@@ -2670,30 +2405,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "once_cell",
- "petgraph 0.7.1",
+ "petgraph",
  "prettyplease",
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.104",
+ "syn 2.0.105",
  "tempfile",
 ]
 
 [[package]]
-name = "prost-derive"
-version = "0.12.6"
+name = "prost-build"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "heck 0.5.0",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.105",
+ "tempfile",
 ]
 
 [[package]]
@@ -2703,19 +2447,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
-name = "prost-types"
-version = "0.12.6"
+name = "prost-derive"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
- "prost 0.12.6",
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2725,6 +2473,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost 0.14.1",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags 2.9.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b6a0769a491a08b31ea5c62494a8f144ee0987d86d670a8af4df1e1b7cde75"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -2812,22 +2589,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
 ]
 
 [[package]]
@@ -2876,20 +2653,20 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.11",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-rustls 0.27.7",
+ "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -2902,10 +2679,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -2966,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
@@ -3009,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring 0.17.14",
@@ -3062,9 +2839,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -3188,14 +2965,14 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -3215,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -3313,9 +3090,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -3328,9 +3105,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
@@ -3474,7 +3251,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3552,20 +3329,14 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -3584,7 +3355,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3644,11 +3415,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -3659,18 +3430,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3709,9 +3480,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3722,19 +3493,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
-dependencies = [
- "pin-project-lite",
- "tokio",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3745,7 +3506,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3771,21 +3532,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -3820,7 +3571,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -3830,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3843,74 +3594,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
 
 [[package]]
-name = "tonic"
-version = "0.10.2"
+name = "toml_parser"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.21.7",
- "bytes",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout 0.4.1",
- "percent-encoding",
- "pin-project",
- "prost 0.12.6",
- "rustls 0.21.12",
- "rustls-pemfile",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
+ "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
@@ -3919,15 +3638,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "axum 0.8.4",
+ "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.11",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
- "hyper-timeout 0.5.2",
+ "hyper",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
@@ -3935,23 +3654,39 @@ dependencies = [
  "socket2 0.5.10",
  "tokio",
  "tokio-stream",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.10.2"
+name = "tonic"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d021fc044c18582b9a2408cd0dd05b1596e3ecdb5c4df822bb0183545683889"
+checksum = "67ac5a8627ada0968acec063a4746bf79588aa03ccb66db2f75d7dce26722a40"
 dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build 0.12.6",
- "quote",
- "syn 2.0.104",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.0",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3965,27 +3700,46 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "tonic-build"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "49e323d8bba3be30833707e36d046deabf10a35ae8ad3cae576943ea8933e25d"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.105",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c511b9a96d40cb12b7d5d00464446acf3b9105fd3ce25437cfe41c92b1c87d"
+dependencies = [
+ "bytes",
+ "prost 0.14.1",
+ "tonic 0.14.1",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ef298fcd01b15e135440c4b8c974460ceca4e6a5af7f1c933b08e4d2875efa1"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.14.1",
+ "prost-types 0.14.1",
+ "quote",
+ "syn 2.0.105",
+ "tempfile",
+ "tonic-build 0.14.1",
 ]
 
 [[package]]
@@ -3999,7 +3753,7 @@ dependencies = [
  "indexmap 2.10.0",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -4016,11 +3770,11 @@ dependencies = [
  "bitflags 2.9.1",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -4057,7 +3811,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4113,14 +3867,14 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http",
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls 0.23.29",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "utf-8",
 ]
 
@@ -4129,6 +3883,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
@@ -4242,9 +4002,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -4256,13 +4016,13 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b682e8c381995ea03130e381928e0e005b7c9eb483c6c8682f50e07b33c2b7"
+checksum = "22b7ad00068276db5fea436dba78daa7891b8d60db76e4f51cbdefbdecdab97e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4329,7 +4089,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -4364,7 +4124,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4485,7 +4245,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4496,7 +4256,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4558,7 +4318,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -4579,10 +4339,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -4694,9 +4455,6 @@ name = "winnow"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winsafe"
@@ -4739,7 +4497,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure",
 ]
 
@@ -4760,7 +4518,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -4780,7 +4538,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
  "synstructure",
 ]
 
@@ -4803,9 +4561,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4820,5 +4578,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.105",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,8 +1908,6 @@ dependencies = [
 [[package]]
 name = "mostro-core"
 version = "0.6.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "108a32cdb4e0a8952e30a9cac2335aec5cf19ba5256b71f34a5ce6bdbec724a2"
 dependencies = [
  "argon2",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,7 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.6.46"
+version = "0.6.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9d544be1429816a4c0acf199a12c1d7c759b8d89fa8bc7e9933e2c6f2de69b"
 dependencies = [
  "argon2",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,6 @@ bech32 = "0.11.0"
 
 [build-dependencies]
 tonic-prost-build = "0.14.1"
+
+[patch.crates-io]
+mostro-core = { path = "../mostro-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ sqlx = { version = "0.6.2", features = [
   "offline",
 ] }
 sqlx-crud = { version = "0.4.0", features = ["runtime-tokio-rustls"] }
-tokio = { version = "1.40.0", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full"] }
 fedimint-tonic-lnd = "0.3.0"
 uuid = { version = "1.17.0", features = [
   "v4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ prost = "0.14.1"
 tonic-prost = "0.14.1"
 
 [dev-dependencies]
-tokio = { version = "1.47.0", features = ["full", "test-util", "macros"] }
+tokio = { version = "1.47.1", features = ["full", "test-util", "macros"] }
 axum = "0.8.4"
 tower-http = { version = "0.6.6", features = ["cors"] }
 bech32 = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,16 +33,18 @@ sign-tag = true
 allow-branch = ["main"]
 # Git cliff to generate the changelog
 pre-release-hook = [
-  "sh", "-c", "git cliff --unreleased --github-repo MostroP2P/mostro -o CHANGELOG.md --tag {{version}} && if [ \"$DRY_RUN\" != \"true\" ]; then git diff --quiet CHANGELOG.md || git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; else echo \"DRY RUN: Skip git add and commit\"; fi"
+  "sh",
+  "-c",
+  "git cliff --unreleased --github-repo MostroP2P/mostro -o CHANGELOG.md --tag {{version}} && if [ \"$DRY_RUN\" != \"true\" ]; then git diff --quiet CHANGELOG.md || git add CHANGELOG.md && git commit -m \"Update CHANGELOG for version {{version}}\"; else echo \"DRY RUN: Skip git add and commit\"; fi",
 ]
 
 [dependencies]
 chrono = "0.4.35"
 easy-hasher = "2.2.1"
 lightning-invoice = { version = "0.33.1", features = ["std"] }
-nostr-sdk = { version = "0.41.0", features = ["nip59"] }
+nostr-sdk = { version = "0.43.0", features = ["nip59"] }
 serde = { version = "1.0.210" }
-toml = "0.8.22"
+toml = "0.9.5"
 serde_json = "1.0.128"
 sqlx = { version = "0.6.2", features = [
   "runtime-tokio-rustls",
@@ -54,18 +56,18 @@ sqlx = { version = "0.6.2", features = [
 ] }
 sqlx-crud = { version = "0.4.0", features = ["runtime-tokio-rustls"] }
 tokio = { version = "1.40.0", features = ["full"] }
-fedimint-tonic-lnd = "0.2.0"
+fedimint-tonic-lnd = "0.3.0"
 uuid = { version = "1.17.0", features = [
   "v4",
   "fast-rng",
   "macro-diagnostics",
   "serde",
 ] }
-reqwest = { version = "0.12.1", features = ["json"] }
-mostro-core = { version = "0.6.45", features = ["sqlx"] }
+reqwest = { version = "0.12.23", features = ["json"] }
+mostro-core = { version = "0.6.46", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-clap = { version = "4.5.39", features = ["derive"] }
+clap = { version = "4.5.45", features = ["derive"] }
 lnurl-rs = "0.9.0"
 openssl = { version = "0.10.66", features = ["vendored"] }
 once_cell = "1.20.2"
@@ -75,14 +77,15 @@ argon2 = "0.5"
 secrecy = "0.10.0"
 dirs = "6.0.0"
 clearscreen = "4.0.1"
-tonic = "0.13.1"
-prost = "0.13.5"
+tonic = "0.14.1"
+prost = "0.14.1"
+tonic-prost = "0.14.1"
 
 [dev-dependencies]
-tokio = { version = "1.40.0", features = ["full", "test-util", "macros"] }
-axum = "0.7.4"
+tokio = { version = "1.47.0", features = ["full", "test-util", "macros"] }
+axum = "0.8.4"
 tower-http = { version = "0.6.6", features = ["cors"] }
 bech32 = "0.11.0"
 
 [build-dependencies]
-tonic-build = "0.13.1"
+tonic-prost-build = "0.14.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ uuid = { version = "1.17.0", features = [
   "serde",
 ] }
 reqwest = { version = "0.12.23", features = ["json"] }
-mostro-core = { version = "0.6.46", features = ["sqlx"] }
+mostro-core = { version = "0.6.47", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.45", features = ["derive"] }
@@ -89,6 +89,3 @@ bech32 = "0.11.0"
 
 [build-dependencies]
 tonic-prost-build = "0.14.1"
-
-[patch.crates-io]
-mostro-core = { path = "../mostro-core" }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,7 @@
 use std::process::Command;
 fn main() {
     // Compile protobuf definitions
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&["proto/admin.proto"], &["proto"])
         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ pub mod release; // Release of held funds
 pub mod restore_session; // Restore session action
 pub mod take_buy; // Taking buy orders
 pub mod take_sell; // Taking sell orders
-pub mod trade_pubkey; // Trade pubkey action // Restore session action
+pub mod trade_pubkey; // Trade pubkey action
 
 // Import action handlers from submodules
 use crate::app::add_invoice::add_invoice_action;

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ pub mod fiat_sent; // Fiat payment confirmation
 pub mod order; // Order creation and management
 pub mod rate_user; // User reputation system
 pub mod release; // Release of held funds
-pub mod restore_session;
+pub mod restore_session; // Restore session action
 pub mod take_buy; // Taking buy orders
 pub mod take_sell; // Taking sell orders
 pub mod trade_pubkey; // Trade pubkey action // Restore session action

--- a/src/app.rs
+++ b/src/app.rs
@@ -13,9 +13,10 @@ pub mod fiat_sent; // Fiat payment confirmation
 pub mod order; // Order creation and management
 pub mod rate_user; // User reputation system
 pub mod release; // Release of held funds
+pub mod restore_session;
 pub mod take_buy; // Taking buy orders
 pub mod take_sell; // Taking sell orders
-pub mod trade_pubkey; // Trade pubkey action
+pub mod trade_pubkey; // Trade pubkey action // Restore session action
 
 // Import action handlers from submodules
 use crate::app::add_invoice::add_invoice_action;
@@ -29,6 +30,7 @@ use crate::app::fiat_sent::fiat_sent_action;
 use crate::app::order::order_action;
 use crate::app::rate_user::update_user_reputation_action;
 use crate::app::release::release_action;
+use crate::app::restore_session::restore_session_action;
 use crate::app::take_buy::take_buy_action;
 use crate::app::take_sell::take_sell_action;
 use crate::app::trade_pubkey::trade_pubkey_action;
@@ -255,6 +257,9 @@ async fn handle_message_action(
             .await
             .map_err(|e| e.into()),
         Action::TradePubkey => trade_pubkey_action(msg, event, pool)
+            .await
+            .map_err(|e| e.into()),
+        Action::RestoreSession => restore_session_action(event, pool)
             .await
             .map_err(|e| e.into()),
 

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -1,0 +1,120 @@
+use crate::util::enqueue_order_msg;
+use crate::{db::RestoreSessionManager, util::enqueue_restore_session_msg};
+use mostro_core::prelude::*;
+use nostr::nips::nip59::UnwrappedGift;
+use nostr_sdk::prelude::*;
+use sqlx::{Pool, Sqlite};
+
+/// Handle restore session action
+/// This function starts a background task to process the restore session
+/// and immediately returns, avoiding blocking the main application
+pub async fn restore_session_action(
+    event: &UnwrappedGift,
+    pool: &Pool<Sqlite>,
+) -> Result<(), MostroError> {
+    // Get user master key from the event sender
+    let master_key = event.sender.to_string();
+
+    // Validate the master key format
+    if !master_key.chars().all(|c| c.is_ascii_hexdigit()) || master_key.len() != 64 {
+        return Err(MostroCantDo(CantDoReason::InvalidPubkey));
+    }
+
+    tracing::info!(
+        "Starting background restore session for master key: {}",
+        master_key
+    );
+
+    // Create a new manager for this specific restore session
+    let manager = RestoreSessionManager::new();
+    let pool_clone = pool.clone();
+
+    // Start the background processing
+    manager
+        .start_restore_session(pool_clone, master_key.clone())
+        .await?;
+
+    // Start a background task to handle the results
+    tokio::spawn(async move {
+        handle_restore_session_results(manager, master_key).await;
+    });
+
+    Ok(())
+}
+
+/// Handle restore session results in the background
+async fn handle_restore_session_results(mut manager: RestoreSessionManager, master_key: String) {
+    // Wait for the result with a timeout
+    let timeout = tokio::time::Duration::from_secs(60); // 60 second timeout
+
+    match tokio::time::timeout(timeout, manager.wait_for_result()).await {
+        Ok(Some(result)) => {
+            // Send the restore session response
+            if let Err(e) = send_restore_session_response(
+                &master_key,
+                result.restore_orders,
+                result.restore_disputes,
+            )
+            .await
+            {
+                tracing::error!("Failed to send restore session response: {}", e);
+            }
+        }
+        Ok(None) => {
+            tracing::error!("Restore session result channel closed unexpectedly");
+        }
+        Err(_) => {
+            tracing::error!("Restore session timed out after 60 seconds");
+            // Send timeout message to user
+            if let Err(e) = send_restore_session_timeout(&master_key).await {
+                tracing::error!("Failed to send timeout message: {}", e);
+            }
+        }
+    }
+}
+
+/// Send restore session response to the user
+async fn send_restore_session_response(
+    master_key: &str,
+    orders: Vec<RestoredOrdersInfo>,
+    disputes: Vec<RestoredDisputesInfo>,
+) -> Result<(), MostroError> {
+    // Convert master_key string to PublicKey
+    let master_pubkey =
+        PublicKey::from_hex(master_key).map_err(|_| MostroCantDo(CantDoReason::InvalidPubkey))?;
+
+    // Send the order data using the flat structure
+    enqueue_restore_session_msg(
+        Some(Payload::RestoreData(RestoreSessionInfo {
+            restore_orders: orders,
+            restore_disputes: disputes,
+        })),
+        master_pubkey,
+    )
+    .await;
+
+    tracing::info!("Restore session response sent to user {}", master_key,);
+
+    Ok(())
+}
+
+/// Send timeout message to user
+async fn send_restore_session_timeout(master_key: &str) -> Result<(), MostroError> {
+    let master_pubkey =
+        PublicKey::from_hex(master_key).map_err(|_| MostroCantDo(CantDoReason::InvalidPubkey))?;
+
+    // Send timeout message without payload since Text doesn't exist
+    enqueue_order_msg(
+        None,
+        None,
+        Action::RestoreSession,
+        None,
+        master_pubkey,
+        None,
+    )
+    .await;
+
+    tracing::warn!("Restore session timed out for user: {}", master_key);
+
+    Ok(())
+}

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -1,4 +1,3 @@
-use crate::util::enqueue_order_msg;
 use crate::{db::RestoreSessionManager, util::enqueue_restore_session_msg};
 use mostro_core::prelude::*;
 use nostr::nips::nip59::UnwrappedGift;
@@ -104,15 +103,7 @@ async fn send_restore_session_timeout(master_key: &str) -> Result<(), MostroErro
         PublicKey::from_hex(master_key).map_err(|_| MostroCantDo(CantDoReason::InvalidPubkey))?;
 
     // Send timeout message without payload since Text doesn't exist
-    enqueue_order_msg(
-        None,
-        None,
-        Action::RestoreSession,
-        None,
-        master_pubkey,
-        None,
-    )
-    .await;
+    enqueue_restore_session_msg(None, master_pubkey).await;
 
     tracing::warn!("Restore session timed out for user: {}", master_key);
 

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -44,7 +44,7 @@ pub async fn restore_session_action(
 /// Handle restore session results in the background
 async fn handle_restore_session_results(mut manager: RestoreSessionManager, master_key: String) {
     // Wait for the result with a timeout
-    let timeout = tokio::time::Duration::from_secs(60); // 60 second timeout
+    let timeout = tokio::time::Duration::from_secs(60 * 10); // 10 minute timeout
 
     match tokio::time::timeout(timeout, manager.wait_for_result()).await {
         Ok(Some(result)) => {
@@ -63,7 +63,7 @@ async fn handle_restore_session_results(mut manager: RestoreSessionManager, mast
             tracing::error!("Restore session result channel closed unexpectedly");
         }
         Err(_) => {
-            tracing::error!("Restore session timed out after 60 seconds");
+            tracing::error!("Restore session timed out after 10 minutes");
             // Send timeout message to user
             if let Err(e) = send_restore_session_timeout(&master_key).await {
                 tracing::error!("Failed to send timeout message: {}", e);

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -44,7 +44,7 @@ pub async fn restore_session_action(
 /// Handle restore session results in the background
 async fn handle_restore_session_results(mut manager: RestoreSessionManager, master_key: String) {
     // Wait for the result with a timeout
-    let timeout = tokio::time::Duration::from_secs(60 * 10); // 10 minute timeout
+    let timeout = tokio::time::Duration::from_secs(60 * 60); // 1 hour timeout
 
     match tokio::time::timeout(timeout, manager.wait_for_result()).await {
         Ok(Some(result)) => {
@@ -63,7 +63,7 @@ async fn handle_restore_session_results(mut manager: RestoreSessionManager, mast
             tracing::error!("Restore session result channel closed unexpectedly");
         }
         Err(_) => {
-            tracing::error!("Restore session timed out after 10 minutes");
+            tracing::error!("Restore session timed out after 1 hour");
             // Send timeout message to user
             if let Err(e) = send_restore_session_timeout(&master_key).await {
                 tracing::error!("Failed to send timeout message: {}", e);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -36,7 +36,7 @@ pub static MOSTRO_DB_PASSWORD: OnceLock<SecretString> = OnceLock::new();
 /// - `queue_order_rate`: Holds events related to user rates.
 /// - `queue_restore_session_msg`: Holds messages related to restore session.
 ///
-/// Each queue is wrapped in an `Arc<Mutex<>>` to allow safe concurrent access across threads.
+/// Each queue is wrapped in an `Arc<RwLock<>>` to allow safe concurrent access across tasks.
 #[derive(Debug, Clone, Default)]
 pub struct MessageQueues {
     pub queue_order_msg: Arc<RwLock<Vec<(Message, PublicKey)>>>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -34,6 +34,7 @@ pub static MOSTRO_DB_PASSWORD: OnceLock<SecretString> = OnceLock::new();
 /// - `queue_order_msg`: Holds messages related to orders.
 /// - `queue_order_cantdo`: Holds messages that cannot be processed.
 /// - `queue_order_rate`: Holds events related to user rates.
+/// - `queue_restore_session_msg`: Holds messages related to restore session.
 ///
 /// Each queue is wrapped in an `Arc<Mutex<>>` to allow safe concurrent access across threads.
 #[derive(Debug, Clone, Default)]
@@ -41,6 +42,7 @@ pub struct MessageQueues {
     pub queue_order_msg: Arc<RwLock<Vec<(Message, PublicKey)>>>,
     pub queue_order_cantdo: Arc<RwLock<Vec<(Message, PublicKey)>>>,
     pub queue_order_rate: Arc<RwLock<Vec<Event>>>,
+    pub queue_restore_session_msg: Arc<RwLock<Vec<(Message, PublicKey)>>>,
 }
 
 pub static MESSAGE_QUEUES: LazyLock<MessageQueues> = LazyLock::new(MessageQueues::default);

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -2,21 +2,8 @@ use super::{DB_POOL, MOSTRO_CONFIG};
 use crate::config::types::{
     DatabaseSettings, LightningSettings, MostroSettings, NostrSettings, RpcSettings,
 };
-use mostro_core::prelude::*;
-use nostr_sdk::prelude::*;
 use serde::Deserialize;
-use std::sync::{Arc, Mutex};
-
-/// Message queues for Mostro:
-/// - `queue_order_msg`: Holds messages related to orders.
-/// - `queue_order_cantdo`: Holds messages that cannot be processed.
-/// - `queue_order_rate`: Holds events related to user rates.
-#[derive(Debug, Clone, Default)]
-pub struct MessageQueues {
-    pub queue_order_msg: Arc<Mutex<Vec<(Message, PublicKey)>>>,
-    pub queue_order_cantdo: Arc<Mutex<Vec<(Message, PublicKey)>>>,
-    pub queue_order_rate: Arc<Mutex<Vec<Event>>>,
-}
+use std::sync::Arc;
 
 // Mostro configuration settings struct
 #[derive(Debug, Deserialize, Clone)]

--- a/src/db.rs
+++ b/src/db.rs
@@ -1225,10 +1225,9 @@ impl RestoreSessionManager {
         let sender = self.sender.clone();
 
         // Use spawn_blocking for CPU-intensive decryption work
+        let handle = tokio::runtime::Handle::current();
         tokio::task::spawn_blocking(move || {
-            // Run the async restore work to completion on this blocking thread
-            let rt = tokio::runtime::Handle::current();
-            match rt.block_on(process_restore_session_work(pool, master_key)) {
+            match handle.block_on(process_restore_session_work(pool, master_key)) {
                 Ok(restore_data) => {
                     // No need for an async context just to send; this is a blocking thread.
                     let _ = sender.blocking_send(restore_data);

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,8 +22,7 @@ use uuid::Uuid;
 
 // Constants for excluded statuses used across restore session functions
 const EXCLUDED_ORDER_STATUSES: &str = "'expired','success','canceled','dispute','canceledbyadmin','completedbyadmin','settledbyadmin','cooperativelycanceled'";
-const EXCLUDED_DISPUTE_STATUSES: &str = "'initiated','in-progress'";
-
+const ACTIVE_DISPUTE_STATUSES: &str = "'initiated','in-progress'";
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -1007,8 +1007,6 @@ pub async fn find_user_orders_by_master_key(
                     trade_index: involved_key,
                     status: order.status,
                 });
-            } else {
-                tracing::info!("No trade index found for order: {}", order.id);
             }
         }
 
@@ -1103,8 +1101,6 @@ pub async fn find_user_disputes_by_master_key(
                     trade_index: involved_key,
                     status: dispute.dispute_status,
                 });
-            } else {
-                tracing::info!("No trade index found for dispute: {}", dispute.dispute_id);
             }
         }
         Ok(matching_disputes)

--- a/src/db.rs
+++ b/src/db.rs
@@ -1200,7 +1200,12 @@ impl RestoreSessionManager {
             match handle.block_on(process_restore_session_work(pool, master_key)) {
                 Ok(restore_data) => {
                     // No need for an async context just to send; this is a blocking thread.
-                    let _ = sender.blocking_send(restore_data);
+                    if let Err(e) = sender.blocking_send(restore_data) {
+                        tracing::warn!(
+                            "RestoreSessionManager: receiver dropped before sending result: {}",
+                            e
+                        );
+                    }
                 }
                 Err(e) => {
                     tracing::error!("Failed to process restore session work: {}", e);

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -285,7 +285,7 @@ mod tests {
     #[tokio::test]
     async fn test_zero_amount_invoice() {
         init_settings_test();
-        let payment_request = "lnbc1p52xk52pp53crvcz8x52sqvjwrryhuspqgtjfveuut2hvw8ftu0gazcd6l3hasdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp5sqkze6ay30rmv4w52pk7cku9pl7xmhr9neytpstseka4spa0yxps9qxpqysgql66l5vh4dsdj4awunq8t83v3ayjynrrlx7tsh5npvsz87gk0wsczxgrtmgh499p6nzum8dywekajq5h8lhtp6xlpvm0a8jmu750usyspe3vqz0".to_string();
+        let payment_request = "lnbc1p52fjqxpp5h4g2avnvudp73e7yjw2fx4sytv3r7nze56yx7r7hnh432lfsquxqdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp53jcfq55zd8k5ruqqcu8puvs76t36kv4ghgxdtnpkassxtqf99wcs9qxpqysgqszmr5khv07fkemakrhdrf8shqf4dtv70nle5rtzcrj8d0z7jdx28xgfkkev360vka56ssgv9e6hna8tf4cclnqas60k2uwq0fu5chncqtu95ay".to_string();
         let zero_amount_err = is_valid_invoice(payment_request, Some(100), None);
         assert_eq!(Ok(()), zero_amount_err.await);
     }

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -285,7 +285,7 @@ mod tests {
     #[tokio::test]
     async fn test_zero_amount_invoice() {
         init_settings_test();
-        let payment_request = "lnbc1p5fr5rppp57geae89p9quvwgedaul0x3gpedhrmnh9uwxdwdtja5t9dteaqphqcqzyssp5aftk78kzcnej33f7eydgta9x5wup3v6m26hu4upgvr7709fg0mxq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdqqmqz9gxqyjw5qrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glclludlw6z8nzdzcqqqqlgqqqqqeqqjqsatwvdm6hcwgmxx5pjz0wl6m6s9f8rrupeh97vesnt54exasemxk7a4knjgc6xhy9qrc3e78y70yxenaymykyw0crkwgerhf3y7zpfqqd8wnvl".to_string();
+        let payment_request = "lnbc1p52xk52pp53crvcz8x52sqvjwrryhuspqgtjfveuut2hvw8ftu0gazcd6l3hasdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp5sqkze6ay30rmv4w52pk7cku9pl7xmhr9neytpstseka4spa0yxps9qxpqysgql66l5vh4dsdj4awunq8t83v3ayjynrrlx7tsh5npvsz87gk0wsczxgrtmgh499p6nzum8dywekajq5h8lhtp6xlpvm0a8jmu750usyspe3vqz0".to_string();
         let zero_amount_err = is_valid_invoice(payment_request, Some(100), None);
         assert_eq!(Ok(()), zero_amount_err.await);
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -39,6 +39,8 @@ async fn job_flush_messages_queue() {
     let order_msg_list = MESSAGE_QUEUES.queue_order_msg.clone();
     // Clone for closure owning with Arc
     let cantdo_msg_list = MESSAGE_QUEUES.queue_order_cantdo.clone();
+    // Clone for closure owning with Arc
+    let restore_session_msg_list = MESSAGE_QUEUES.queue_restore_session_msg.clone();
     let sender_keys = match get_keys() {
         Ok(keys) => keys,
         Err(e) => return error!("{e}"),
@@ -75,6 +77,7 @@ async fn job_flush_messages_queue() {
     tokio::spawn(async move {
         let mut retries_messages = 0;
         let mut retries_cantdo_messages = 0;
+        let mut retries_restore_session_messages = 0;
 
         loop {
             send_messages(
@@ -87,6 +90,12 @@ async fn job_flush_messages_queue() {
                 cantdo_msg_list.clone(),
                 sender_keys.clone(),
                 &mut retries_cantdo_messages,
+            )
+            .await;
+            send_messages(
+                restore_session_msg_list.clone(),
+                sender_keys.clone(),
+                &mut retries_restore_session_messages,
             )
             .await;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -609,7 +609,7 @@ pub async fn connect_nostr() -> Result<Client, MostroError> {
     // So we increase the limits for those events
     limits.messages.max_size = Some(6_000);
     limits.events.max_size = Some(6_500);
-    let opts = Options::new().relay_limits(limits);
+    let opts = ClientOptions::new().relay_limits(limits);
 
     // Create new client
     let client = ClientBuilder::default().opts(opts).build();
@@ -908,6 +908,16 @@ pub async fn enqueue_cant_do_msg(
     let message = Message::cant_do(order_id, request_id, Some(Payload::CantDo(Some(reason))));
     MESSAGE_QUEUES
         .queue_order_cantdo
+        .write()
+        .await
+        .push((message, destination_key));
+}
+
+pub async fn enqueue_restore_session_msg(payload: Option<Payload>, destination_key: PublicKey) {
+    // Send message to event creator
+    let message = Message::new_restore(payload);
+    MESSAGE_QUEUES
+        .queue_restore_session_msg
         .write()
         .await
         .push((message, destination_key));


### PR DESCRIPTION
@grunch @Catrya 

First testable release of **mostrod** with the **restore session** message — you can request it now from the terminal with ```mostro-cli restore```.

- **What’s included**
  - Many small **version bumps** and alignment fixes across the codebase.
  - New **restore** command that lets a client recover/change state without losing current orders and disputes. See the message specification: [Restore session spec](https://mostro.network/protocol/restore_session.html).

- **How to try it**
  - From your terminal run:
    - ```mostro-cli restore```
  - Observe the restore-session exchange in the logs / CLI output and verify that orders/disputes remain intact.

- **Technical note (database search & performance)**
  - The restore flow requires searching the database for matching records. In the plaintext case the queries are fast, but with very large datasets (e.g., ~1M pending orders) they can take noticeable time.
  - The tricky case is **database encryption**: we must attempt decryption with the master key to find matches, which is CPU/time intensive.
  - To avoid blocking the main service (```mostro```), I spawn a dedicated **blocking thread** to perform the database search/decryption. This keeps the main event loop responsive while the (relatively rare) heavy work runs in the background.
  - Summary:
    - Plaintext searches: quick.
    - Encrypted DB searches: potentially slow — handled in a dedicated blocking thread to preserve responsiveness.

- **Next steps / requests**
  - Feedback on the threading approach and any concerns about resource usage or edge cases would be appreciated.
  - Ping me or @coderabbitai for questions or to request more detailed traces.

Thanks — looking forward to your reviews and suggestions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Restore-session flow to recover past orders and disputes by master key; results delivered asynchronously or a timeout notification sent.

- **User-visible Integrations**
  - Restore-session messages are enqueued and delivered via the messaging pipeline; scheduler now flushes and retries these messages like other message types.

- **Chores**
  - Upgraded multiple dependencies and replaced protobuf/build tooling; minor release-config formatting tweaks.

- **Tests**
  - Updated invoice test data (BOLT11 invoice string).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->