### PR TITLE
Configurable nip40 expiration time via settings.toml

### DIFF
--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -35,6 +35,8 @@ min_payment_amount = 100
 expiration_hours = 24
 # Max expiration days for an order
 max_expiration_days = 15
+# Nip40 expiration days
+nip40_expiration_days = 15
 # Expiration of pending orders
 expiration_seconds = 900
 # User rate events scheduled time interval

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -75,6 +75,7 @@ mod tests {
                                             min_payment_amount = 100
                                             expiration_hours = 24
                                             max_expiration_days = 15
+                                            nip40_expiration_days = 15
                                             expiration_seconds = 900
                                             user_rates_sent_interval_seconds = 3600
                                             publish_relays_interval = 60
@@ -161,6 +162,7 @@ mod tests {
         assert_eq!(mostro_settings.mostro.min_payment_amount, 100);
         assert_eq!(mostro_settings.mostro.expiration_hours, 24);
         assert_eq!(mostro_settings.mostro.max_expiration_days, 15);
+        assert_eq!(mostro_settings.mostro.nip40_expiration_days, 15);
         assert_eq!(mostro_settings.mostro.expiration_seconds, 900);
         assert_eq!(
             mostro_settings.mostro.user_rates_sent_interval_seconds,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -93,6 +93,8 @@ pub struct MostroSettings {
     pub user_rates_sent_interval_seconds: u32,
     /// Maximum expiration days
     pub max_expiration_days: u32,
+    /// Nip40 expiration days
+    pub nip40_expiration_days: u32,
     /// Publish relays interval
     pub publish_relays_interval: u32,
     /// Proof of work required

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -285,7 +285,7 @@ mod tests {
     #[tokio::test]
     async fn test_zero_amount_invoice() {
         init_settings_test();
-        let payment_request = "lnbc1p5fr5rppp57geae89p9quvwgedaul0x3gpedhrmnh9uwxdwdtja5t9dteaqphqcqzyssp5aftk78kzcnej33f7eydgta9x5wup3v6m26hu4upgvr7709fg0mxq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdqqmqz9gxqyjw5qrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glclludlw6z8nzdzcqqqqlgqqqqqeqqjqsatwvdm6hcwgmxx5pjz0wl6m6s9f8rrupeh97vesnt54exasemxk7a4knjgc6xhy9qrc3e78y70yxenaymykyw0crkwgerhf3y7zpfqqd8wnvl".to_string();
+        let payment_request = "lnbc1p52v0v9pp5scdu5kh9gkgp63r7k72pugffkut4uqdv98d7vruvanklt700rmrsdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp5tw8kcvr22mlmdffrtfta6xxhhl5cdtnpg02qygvr2yhm3vva9zas9qxpqysgqecamkem2pcz8savcv8j7p3uj6lxlx5dnecc26ax5uk005aqfdszsdxfuchsph6tej8j08eps3np5ukvv6t6nfldkge76qyn3qs0p23gqy2jj0z".to_string();
         let zero_amount_err = is_valid_invoice(payment_request, Some(100), None);
         assert_eq!(Ok(()), zero_amount_err.await);
     }

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -196,6 +196,8 @@ pub fn order_to_tags(
     let (create_event, status) = create_status_tags(order)?;
     // Create mostro: scheme link in case of pending order creation
     let mostro_link = create_source_tag(order, &Settings::get_nostr().relays)?;
+    // Get mostro settings
+    let mostro_settings = Settings::get_mostro();
 
     // Send just in case the order is pending/in-progress/success/canceled
     if create_event {
@@ -242,7 +244,9 @@ pub fn order_to_tags(
             ),
             Tag::custom(
                 TagKind::Custom(Cow::Borrowed("expiration")),
-                vec![(order.expires_at + Duration::hours(24).num_seconds()).to_string()],
+                vec![(order.expires_at
+                    + Duration::days(mostro_settings.nip40_expiration_days as i64).num_seconds())
+                .to_string()],
             ),
             Tag::custom(
                 TagKind::Custom(Cow::Borrowed("y")),


### PR DESCRIPTION
@grunch ,

since it comes to zero effort, i will drop this PR and let you decide if it is worth to merge it, as I said in tg chat this allow with new config parameter called `nip40_expiration_days` to define the days before nip40 on relay is triggered so now total life time of the order event is:

lifetime = now() + expires_at + nip40_expiration_days 

now nip40_expiration_days is basically hardcoded to 24h.

