### PR TITLE
refactor: remove deprecated token columns from disputes table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,9 @@ dependencies = [
 [[package]]
 name = "bitcoin"
 version = "0.32.7"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
@@ -1781,7 +1783,9 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "lru"
 version = "0.16.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 
 [[package]]
@@ -1907,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.6.47"
+version = "0.6.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9d544be1429816a4c0acf199a12c1d7c759b8d89fa8bc7e9933e2c6f2de69b"
+checksum = "628171bedc33fbc0b5b7c783566047541954155776ff2e41cbbea517657cf9c5"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -1983,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.43.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30e6dcb36d88017587b0b5578d1ed3398afe8e4f45fdb910e48b8675aaf6f68"
+checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -2007,7 +2011,9 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.43.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
 checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
 dependencies = [
  "lru",
@@ -2018,13 +2024,16 @@ dependencies = [
 [[package]]
 name = "nostr-relay-pool"
 version = "0.43.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "265d9b44771ed15db93b183a0c93dbb703b2b0d0b74dffb5c2a081be52373a5a"
 checksum = "265d9b44771ed15db93b183a0c93dbb703b2b0d0b74dffb5c2a081be52373a5a"
 dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
  "lru",
+ "negentropy",
  "negentropy",
  "nostr",
  "nostr-database",
@@ -2035,7 +2044,9 @@ dependencies = [
 [[package]]
 name = "nostr-sdk"
 version = "0.43.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
 checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
 dependencies = [
  "async-utility",
@@ -2970,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -4002,9 +4013,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -4016,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b7ad00068276db5fea436dba78daa7891b8d60db76e4f51cbdefbdecdab97e"
+checksum = "d9384a660318abfbd7f8932c34d67e4d1ec511095f95972ddc01e19d7ba8413f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,13 +183,13 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -367,9 +367,7 @@ dependencies = [
 [[package]]
 name = "bitcoin"
 version = "0.32.7"
-version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
@@ -469,9 +467,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "blake2"
@@ -575,18 +573,19 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -645,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc0e74a703892159f5ae7d3aac52c8e6c392f5ae5f359c70b5881d60aaac318"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -655,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.44"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -667,14 +666,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -691,7 +690,7 @@ checksum = "85a8ab73a1c02b0c15597b22e09c7dc36e63b2f601f9d1e83ac0c3decd38b1ae"
 dependencies = [
  "nix",
  "terminfo",
- "thiserror 2.0.14",
+ "thiserror 2.0.16",
  "which",
  "windows-sys 0.59.0",
 ]
@@ -859,7 +858,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -972,6 +971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+
+[[package]]
 name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,9 +1027,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -1096,7 +1101,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1170,7 +1175,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.3+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1203,7 +1208,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1349,13 +1354,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
@@ -1363,6 +1369,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1551,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1582,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.5",
@@ -1614,11 +1621,11 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -1697,7 +1704,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "libc",
 ]
 
@@ -1776,25 +1783,23 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
 version = "0.16.0"
-version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -1900,7 +1905,7 @@ dependencies = [
  "sqlx-crud",
  "tokio",
  "toml",
- "tonic 0.14.1",
+ "tonic 0.14.2",
  "tonic-prost",
  "tonic-prost-build",
  "tower-http",
@@ -1969,7 +1974,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2011,9 +2016,7 @@ dependencies = [
 [[package]]
 name = "nostr-database"
 version = "0.43.0"
-version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
 checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
 dependencies = [
  "lru",
@@ -2024,16 +2027,13 @@ dependencies = [
 [[package]]
 name = "nostr-relay-pool"
 version = "0.43.0"
-version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265d9b44771ed15db93b183a0c93dbb703b2b0d0b74dffb5c2a081be52373a5a"
 checksum = "265d9b44771ed15db93b183a0c93dbb703b2b0d0b74dffb5c2a081be52373a5a"
 dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
  "lru",
- "negentropy",
  "negentropy",
  "nostr",
  "nostr-database",
@@ -2044,9 +2044,7 @@ dependencies = [
 [[package]]
 name = "nostr-sdk"
 version = "0.43.0"
-version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
 checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
 dependencies = [
  "async-utility",
@@ -2058,12 +2056,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2114,7 +2111,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2131,7 +2128,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2167,12 +2164,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -2251,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -2262,7 +2253,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
 ]
 
 [[package]]
@@ -2320,7 +2311,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2354,9 +2345,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
@@ -2372,19 +2363,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.97"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -2425,7 +2416,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.105",
+ "syn 2.0.106",
  "tempfile",
 ]
 
@@ -2447,7 +2438,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.105",
+ "syn 2.0.106",
  "tempfile",
 ]
 
@@ -2461,7 +2452,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2474,7 +2465,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2501,7 +2492,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "memchr",
  "unicase",
 ]
@@ -2604,7 +2595,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -2615,52 +2606,37 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.14",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.1.10"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -2764,7 +2740,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2942,7 +2918,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2976,7 +2952,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3262,7 +3238,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3340,9 +3316,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.105"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3366,7 +3342,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3375,7 +3351,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3392,15 +3368,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3426,11 +3402,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.14"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.14",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -3441,18 +3417,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.14"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3476,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3517,7 +3493,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3609,7 +3585,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3673,9 +3649,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac5a8627ada0968acec063a4746bf79588aa03ccb66db2f75d7dce26722a40"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
  "axum",
@@ -3711,46 +3687,46 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e323d8bba3be30833707e36d046deabf10a35ae8ad3cae576943ea8933e25d"
+checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c511b9a96d40cb12b7d5d00464446acf3b9105fd3ce25437cfe41c92b1c87d"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
  "prost 0.14.1",
- "tonic 0.14.1",
+ "tonic 0.14.2",
 ]
 
 [[package]]
 name = "tonic-prost-build"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ef298fcd01b15e135440c4b8c974460ceca4e6a5af7f1c933b08e4d2875efa1"
+checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
 dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build 0.14.1",
  "prost-types 0.14.1",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "tempfile",
- "tonic-build 0.14.1",
+ "tonic-build 0.14.2",
 ]
 
 [[package]]
@@ -3761,7 +3737,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.10.0",
+ "indexmap 2.11.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -3778,7 +3754,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
  "http",
@@ -3822,7 +3798,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3848,14 +3824,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -3885,7 +3861,7 @@ dependencies = [
  "rustls 0.23.31",
  "rustls-pki-types",
  "sha1 0.10.6",
- "thiserror 2.0.14",
+ "thiserror 2.0.16",
  "utf-8",
 ]
 
@@ -3983,9 +3959,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4033,7 +4009,7 @@ checksum = "d9384a660318abfbd7f8932c34d67e4d1ec511095f95972ddc01e19d7ba8413f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4071,11 +4047,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.3+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -4100,7 +4076,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
@@ -4135,7 +4111,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4256,7 +4232,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4267,7 +4243,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4463,9 +4439,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 
 [[package]]
 name = "winsafe"
@@ -4474,13 +4450,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.1",
-]
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "writeable"
@@ -4508,7 +4481,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -4529,7 +4502,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4549,7 +4522,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -4589,5 +4562,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.105",
+ "syn 2.0.106",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,8 @@ uuid = { version = "1.17.0", features = [
   "macro-diagnostics",
   "serde",
 ] }
-reqwest = { version = "0.12.23", features = ["json"] }
-mostro-core = { version = "0.6.47", features = ["sqlx"] }
+reqwest = { version = "0.12.1", features = ["json"] }
+mostro-core = { version = "0.6.49", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.45", features = ["derive"] }

--- a/migrations/20230928145530_disputes.sql
+++ b/migrations/20230928145530_disputes.sql
@@ -5,7 +5,5 @@ CREATE TABLE IF NOT EXISTS disputes (
   order_previous_status varchar(10) not null,
   solver_pubkey char(64),
   created_at integer not null,
-  taken_at integer default 0,
-  buyer_token integer not null,
-  seller_token integer not null
+  taken_at integer default 0
 );

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -170,7 +170,7 @@ pub async fn admin_take_dispute_action(
         request_id,
         None,
         Action::AdminTookDispute,
-        Some(Payload::Dispute(dispute.id, None, Some(dispute_info))),
+        Some(Payload::Dispute(dispute.id, Some(dispute_info))),
     );
     let message = message
         .as_json()

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -101,8 +101,6 @@ async fn notify_dispute_to_users(
     dispute: &Dispute,
     msg: &Message,
     order_id: Uuid,
-    counterpart_token: Option<u16>,
-    initiator_token: Option<u16>,
     counterpart_pubkey: PublicKey,
     initiator_pubkey: PublicKey,
 ) -> Result<(), MostroError> {
@@ -111,11 +109,7 @@ async fn notify_dispute_to_users(
         msg.get_inner_message_kind().request_id,
         Some(order_id),
         Action::DisputeInitiatedByPeer,
-        Some(Payload::Dispute(
-            dispute.clone().id,
-            counterpart_token,
-            None,
-        )),
+        Some(Payload::Dispute(dispute.clone().id, None)),
         counterpart_pubkey,
         None,
     )
@@ -126,7 +120,7 @@ async fn notify_dispute_to_users(
         msg.get_inner_message_kind().request_id,
         Some(order_id),
         Action::DisputeInitiatedByYou,
-        Some(Payload::Dispute(dispute.clone().id, initiator_token, None)),
+        Some(Payload::Dispute(dispute.clone().id, None)),
         initiator_pubkey,
         None,
     )
@@ -141,9 +135,8 @@ async fn notify_dispute_to_users(
 /// 1. Validates the order and dispute status
 /// 2. Updates the order status
 /// 3. Creates a new dispute record
-/// 4. Generates security tokens for both parties
-/// 5. Notifies both parties
-/// 6. Publishes the dispute event to the network
+/// 4. Notifies both parties
+/// 5. Publishes the dispute event to the network
 pub async fn dispute_action(
     msg: Message,
     event: &UnwrappedGift,
@@ -175,8 +168,8 @@ pub async fn dispute_action(
         Err(cause) => return Err(MostroCantDo(cause)),
     };
 
-    // Create new dispute record and generate security tokens
-    let mut dispute = Dispute::new(order_id, order.status.clone());
+    // Create new dispute record
+    let dispute = Dispute::new(order_id, order.status.clone());
 
     // Setup dispute
     if order.setup_dispute(is_buyer_dispute).is_ok() {
@@ -186,9 +179,6 @@ pub async fn dispute_action(
             .await
             .map_err(|cause| MostroInternalErr(ServiceError::DbAccessError(cause.to_string())))?;
     }
-
-    // Create tokens
-    let (initiator_token, counterpart_token) = dispute.create_tokens(is_buyer_dispute);
 
     // Save dispute to database
     let dispute = dispute
@@ -221,8 +211,6 @@ pub async fn dispute_action(
         &dispute,
         &msg,
         order_id,
-        counterpart_token,
-        initiator_token,
         *counterpart_pubkey,
         *initiator_pubkey,
     )

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -68,9 +68,10 @@ async fn publish_dispute_event(dispute: &Dispute, my_keys: &Keys) -> Result<(), 
 
 /// Gets information about the counterparty in a dispute.
 ///
-/// Returns a tuple containing:
-/// - The counterparty's public key as a String
-/// - A boolean indicating if the dispute was initiated by the buyer (true) or seller (false)
+/// Returns:
+/// - Ok(true) if the dispute was initiated by the buyer
+/// - Ok(false) if initiated by the seller
+/// - Err(CantDoReason::InvalidPubkey) if the sender matches neither party
 fn get_counterpart_info(sender: &str, buyer: &str, seller: &str) -> Result<bool, CantDoReason> {
     match sender {
         s if s == buyer => Ok(true),   // buyer is initiator
@@ -104,7 +105,7 @@ async fn notify_dispute_to_users(
     counterpart_pubkey: PublicKey,
     initiator_pubkey: PublicKey,
 ) -> Result<(), MostroError> {
-    // Message to discounterpart
+    // Message to counterpart
     enqueue_order_msg(
         msg.get_inner_message_kind().request_id,
         Some(order_id),

--- a/src/db.rs
+++ b/src/db.rs
@@ -272,13 +272,74 @@ async fn get_user_password() -> Result<(), MostroError> {
     Ok(())
 }
 
+/// Helper function to rebuild disputes table without token columns when DROP COLUMN is unsupported.
+///
+/// This creates a new table with the correct schema, copies data, and replaces the original table.
+/// Used as fallback when ALTER TABLE DROP COLUMN is not available in older SQLite versions.
+async fn rebuild_disputes_table_without_tokens(pool: &SqlitePool) -> Result<(), MostroError> {
+    tracing::info!("Rebuilding disputes table without token columns (SQLite compatibility mode)");
+    
+    // Create temporary table with new schema (without token columns)
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS disputes_temp (
+            id char(36) primary key not null,
+            order_id char(36) unique not null,
+            status varchar(10) not null,
+            order_previous_status varchar(10) not null,
+            solver_pubkey char(64),
+            created_at integer not null,
+            taken_at integer default 0
+        )
+        "#,
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(format!(
+        "Failed to create temporary disputes table: {}", e
+    ))))?;
+
+    // Copy data from original table to temporary table (excluding token columns)
+    sqlx::query(
+        r#"
+        INSERT INTO disputes_temp (id, order_id, status, order_previous_status, solver_pubkey, created_at, taken_at)
+        SELECT id, order_id, status, order_previous_status, solver_pubkey, created_at, taken_at
+        FROM disputes
+        "#,
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(format!(
+        "Failed to copy data to temporary table: {}", e
+    ))))?;
+
+    // Drop original table
+    sqlx::query("DROP TABLE disputes")
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(format!(
+            "Failed to drop original disputes table: {}", e
+        ))))?;
+
+    // Rename temporary table to disputes
+    sqlx::query("ALTER TABLE disputes_temp RENAME TO disputes")
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(format!(
+            "Failed to rename temporary table: {}", e
+        ))))?;
+
+    tracing::info!("Successfully rebuilt disputes table without token columns");
+    Ok(())
+}
+
 /// Migrates legacy disputes table by removing deprecated buyer_token and seller_token columns if present.
 ///
-/// This function checks if the deprecated token columns exist in the disputes table
-/// and removes them to maintain compatibility with the updated mostro-core.
-/// The function handles both cases where columns exist (legacy databases) and don't exist (newer databases).
+/// This function uses transactions for atomic operations and includes fallback logic for older SQLite versions
+/// that don't support ALTER TABLE DROP COLUMN. The function handles both cases where columns exist (legacy databases) 
+/// and don't exist (newer databases).
 async fn migrate_remove_token_columns(pool: &SqlitePool) -> Result<(), MostroError> {
-    // Check if buyer_token column exists
+    // Check if token columns exist
     let buyer_token_exists = sqlx::query_scalar::<_, i32>(
         r#"
         SELECT COUNT(*) 
@@ -291,7 +352,6 @@ async fn migrate_remove_token_columns(pool: &SqlitePool) -> Result<(), MostroErr
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?
         > 0;
 
-    // Check if seller_token column exists
     let seller_token_exists = sqlx::query_scalar::<_, i32>(
         r#"
         SELECT COUNT(*) 
@@ -304,31 +364,92 @@ async fn migrate_remove_token_columns(pool: &SqlitePool) -> Result<(), MostroErr
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?
         > 0;
 
-    // Remove buyer_token column if it exists
-    if buyer_token_exists {
-        tracing::info!("Removing deprecated buyer_token column from disputes table");
-        sqlx::query("ALTER TABLE disputes DROP COLUMN buyer_token")
-            .execute(pool)
-            .await
-            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-        tracing::info!("Successfully removed buyer_token column");
-    }
-
-    // Remove seller_token column if it exists
-    if seller_token_exists {
-        tracing::info!("Removing deprecated seller_token column from disputes table");
-        sqlx::query("ALTER TABLE disputes DROP COLUMN seller_token")
-            .execute(pool)
-            .await
-            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-        tracing::info!("Successfully removed seller_token column");
-    }
-
+    // If no token columns exist, no migration needed
     if !buyer_token_exists && !seller_token_exists {
         tracing::debug!("No deprecated token columns found in disputes table - migration not needed");
+        return Ok(());
     }
 
-    Ok(())
+    // Check SQLite version to determine if DROP COLUMN is supported
+    let sqlite_version = sqlx::query_scalar::<_, String>("SELECT sqlite_version()")
+        .fetch_one(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(format!(
+            "Failed to get SQLite version: {}", e
+        ))))?;
+    
+    tracing::info!("SQLite version: {}", sqlite_version);
+
+    // Parse version to check if DROP COLUMN is supported (requires 3.35.0+)
+    let supports_drop_column = sqlite_version
+        .split('.')
+        .take(3)
+        .map(|v| v.parse::<u32>().unwrap_or(0))
+        .collect::<Vec<_>>()
+        .get(..3)
+        .map(|parts| {
+            let major = parts[0];
+            let minor = parts.get(1).copied().unwrap_or(0);
+            major > 3 || (major == 3 && minor >= 35)
+        })
+        .unwrap_or(false);
+
+    if supports_drop_column {
+        // Try DROP COLUMN approach with transaction
+        tracing::info!("Attempting to remove token columns using DROP COLUMN (SQLite {})...", sqlite_version);
+        
+        let mut transaction = pool.begin().await.map_err(|e| {
+            MostroInternalErr(ServiceError::DbAccessError(format!(
+                "Failed to begin transaction: {}", e
+            )))
+        })?;
+
+        // Attempt to drop columns within transaction
+        let drop_result = async {
+            if buyer_token_exists {
+                sqlx::query("ALTER TABLE disputes DROP COLUMN buyer_token")
+                    .execute(&mut *transaction)
+                    .await?;
+                tracing::info!("Dropped buyer_token column");
+            }
+
+            if seller_token_exists {
+                sqlx::query("ALTER TABLE disputes DROP COLUMN seller_token")
+                    .execute(&mut *transaction)
+                    .await?;
+                tracing::info!("Dropped seller_token column");
+            }
+
+            Ok::<(), sqlx::Error>(())
+        }.await;
+
+        match drop_result {
+            Ok(_) => {
+                transaction.commit().await.map_err(|e| {
+                    MostroInternalErr(ServiceError::DbAccessError(format!(
+                        "Failed to commit transaction: {}", e
+                    )))
+                })?;
+                tracing::info!("Successfully removed token columns using DROP COLUMN");
+                Ok(())
+            }
+            Err(e) => {
+                tracing::warn!("DROP COLUMN failed ({}), falling back to table rebuild", e);
+                transaction.rollback().await.map_err(|rollback_err| {
+                    MostroInternalErr(ServiceError::DbAccessError(format!(
+                        "Failed to rollback transaction: {}", rollback_err
+                    )))
+                })?;
+                
+                // Fall back to table rebuild
+                rebuild_disputes_table_without_tokens(pool).await
+            }
+        }
+    } else {
+        // SQLite version doesn't support DROP COLUMN, use table rebuild
+        tracing::info!("SQLite version {} doesn't support DROP COLUMN, using table rebuild method", sqlite_version);
+        rebuild_disputes_table_without_tokens(pool).await
+    }
 }
 
 pub async fn connect() -> Result<Arc<Pool<Sqlite>>, MostroError> {

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -48,8 +48,6 @@ pub async fn hold_invoice_paid(
         None,
         Some(order.created_at),
         Some(order.expires_at),
-        None,
-        None,
     );
     let status;
 
@@ -257,8 +255,6 @@ mod tests {
                 None,
                 Some(created_at),
                 Some(expires_at),
-                None,
-                None,
             );
 
             // Verify the order data is constructed correctly
@@ -370,8 +366,6 @@ mod tests {
                 None,
                 Some(Timestamp::now().as_u64() as i64),
                 Some(Timestamp::now().as_u64() as i64 + 3600),
-                None,
-                None,
             );
 
             // Test payload with order data

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -285,9 +285,9 @@ mod tests {
     #[tokio::test]
     async fn test_zero_amount_invoice() {
         init_settings_test();
-        let payment_request = "lnbc1p52fjqxpp5h4g2avnvudp73e7yjw2fx4sytv3r7nze56yx7r7hnh432lfsquxqdq5g9kxy7fqd9h8vmmfvdjscqzzsxqyz5vqsp53jcfq55zd8k5ruqqcu8puvs76t36kv4ghgxdtnpkassxtqf99wcs9qxpqysgqszmr5khv07fkemakrhdrf8shqf4dtv70nle5rtzcrj8d0z7jdx28xgfkkev360vka56ssgv9e6hna8tf4cclnqas60k2uwq0fu5chncqtu95ay".to_string();
-        let zero_amount_err = is_valid_invoice(payment_request, Some(100), None);
-        assert_eq!(Ok(()), zero_amount_err.await);
+        let payment_request = "lnbcrt1p5tnk83pp5lqj87uf3ct7e4kluu3zcv3zvav9exwkj7chmpyt3u29g2p7uf6hqdqqcqzzsxqyz5vqsp5mrhkqtp7j8uhfzmcn6wdhj577jm87dvudnf28kefhzwwwh7zp7vq9qxpqysgq7ntan3nl38574gjrjne68740uymnc5xf39yryl9w7y2mcq9p3j53rwquhxukpjzclq4p8qmt89z7r4hmzzjkgj889ujgz0lr55c5gyqqeu4g52".to_string();
+        let is_valid = is_valid_invoice(payment_request, None, None);
+        assert_eq!(Ok(()), is_valid.await);
     }
 
     #[tokio::test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -459,8 +459,10 @@ pub async fn send_dm(
         .await
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
     info!(
-        "Sending DM, Event ID: {} with payload: {:#?}",
-        event.id, payload
+        "Sending DM, Event ID: {} to {} with payload: {:#?}",
+        event.id,
+        receiver_pubkey.to_hex(),
+        payload
     );
 
     if let Ok(client) = get_nostr_client() {
@@ -794,8 +796,6 @@ pub async fn set_waiting_invoice_status(
         order.fiat_amount,
         order.payment_method.clone(),
         order.premium,
-        None,
-        None,
         None,
         None,
         None,


### PR DESCRIPTION
- Update mostro-core to latest version removing buyer_token and seller_token
- Remove deprecated token columns from disputes migration
- Add automatic migration function to drop legacy columns from existing databases
- Ensure backward compatibility with existing database installations
- Update related dispute handling code to work with new schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic startup migration removes deprecated dispute columns to keep data current.

- Refactor
  - Simplified dispute workflow and admin notifications by removing per-party tokens.
  - Improved DM logging to include destination public key.
  - Reduced parameters for order creation calls.

- Tests
  - Lightning invoice validation updated to use regtest/testnet data.

- Chores
  - Updated dependencies (reqwest, mostro-core) for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->