### PR TITLE
add order_expires_at to order event

### DIFF
--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -241,7 +241,7 @@ pub fn order_to_tags(
                 vec!["lightning".to_string()],
             ),
             Tag::custom(
-                TagKind::Custom(Cow::Borrowed("order_expires_at")),
+                TagKind::Custom(Cow::Borrowed("expires_at")),
                 vec![order.expires_at.to_string()],
             ),
             Tag::custom(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orders now include explicit expiration date information in their event metadata, enabling clients and services to display, filter, and act on order expiration timelines more reliably.
  * Improves visibility of impending expirations and helps automate expiration-related workflows (notifications, cleanup, or hide-expired behaviors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->