### PR TITLE
Added protobuf to rust.yml in publish stage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,6 +132,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install protobuf compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with: { cache-on-failure: true }


### PR DESCRIPTION
Fix for gh actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to ensure required compiler tools are available during the publish stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->