### PR TITLE
Aligned premium logic to lnp2p bot

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -137,15 +137,10 @@ pub async fn get_market_quote(
     };
 
     let mut sats = quote.result * 100_000_000_f64;
-    println!("Quote result: {}", sats);
 
     // Added premium value to have correct sats value
     if premium != 0 {
         sats = sats - (premium as f64) / 100_f64 * sats;
-        println!(
-            "Final amount - premium is {}% - Fees are {} sats",
-            premium, sats
-        );
     }
 
     Ok(sats as i64)
@@ -770,10 +765,6 @@ pub async fn get_market_amount_and_fee(
     // Update amount order
     let new_sats_amount = get_market_quote(&fiat_amount, fiat_code, premium).await?;
     let fee = get_fee(new_sats_amount);
-    println!(
-        "Final sats amount with premium and fee: {} - fees are {} sats",
-        new_sats_amount, fee
-    );
 
     Ok((new_sats_amount, fee))
 }


### PR DESCRIPTION
@grunch, @catrya,

this fix, aligning with correct implementation in lnp2p bot, the correct invoice amout when order has a premium, in mostro the _amount * premium_prc_ was summed to base amount, normally this is correct, but since the seller here pays the invoice we have to subtract it from base amount for the correctness of logic.

I left to println! to show on terminal the values to help @catrya in debug, i will remove them when tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed how premiums are applied to market quote calculations: premiums now reduce the computed quote amount, which alters the sats displayed in quotes and may affect users' shown quote values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->