### PR TITLE
docs: Remove hardcoded line numbers and add guideline against them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@
 - Squash fixups before review.
 - PRs: link the motivating issue, include `cargo test` output, and call out schema or config changes to ease verification.
 
+## Documentation Guidelines
+- Do not hardcode source code line numbers in documentation (e.g., `src/app/take_buy.rs:11`). Line numbers drift as the codebase evolves, misleading developers. Reference file paths (`src/app/take_buy.rs`) or function names (`fn take_buy_action`) instead, which are far more stable and easily searchable.
+
 ## Security & Configuration Tips
 - Do not commit populated `settings.toml`. Copy from `settings.tpl.toml` to `~/.mostro/settings.toml` for local runs.
 - Protect LND credentials before `make docker-build`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,10 +50,10 @@ flowchart LR
 ### Per‑Action Summaries
 
 - `app/order.rs` – validates and creates new orders; persists to DB; emits acknowledgements.
-- `app/take_buy.rs` – buyer accepts a sell offer; checks order state, reserves amount. Entry: `src/app/take_buy.rs:11`.
+- `app/take_buy.rs` – buyer accepts a sell offer; checks order state, reserves amount.
 - `app/take_sell.rs` – seller accepts a buy offer; mirrors `take_buy` logic for sell side.
-- `app/add_invoice.rs` – records buyer invoice or creates hold invoice for escrow; may call LND. Entry: `src/app/add_invoice.rs:21`.
-- `app/release.rs` – releases held funds on successful trade; settles hold invoice via LND. Entry: `src/app/release.rs:94`.
+- `app/add_invoice.rs` – records buyer invoice or creates hold invoice for escrow; may call LND.
+- `app/release.rs` – releases held funds on successful trade; settles hold invoice via LND.
 - `app/fiat_sent.rs` – buyer signals fiat transfer; updates order state, notifies counterparty.
 - `app/cancel.rs` – cancels pending orders; may cancel hold invoice if present.
 - `app/dispute.rs` – opens a dispute; flags order and awaits admin solver.

--- a/docs/EVENT_ROUTING.md
+++ b/docs/EVENT_ROUTING.md
@@ -16,9 +16,9 @@ How Nostr events become actions and side effects.
 - Ensures monotonic `trade_index` for trading actions; verifies signature binding; auto-creates user on first valid trade.
 
 ## Key Actions (entries)
-- Take Buy: `src/app/take_buy.rs:12`
-- Add Invoice: `src/app/add_invoice.rs:34`
-- Release: `src/app/release.rs:160`
+- Take Buy: `src/app/take_buy.rs`
+- Add Invoice: `src/app/add_invoice.rs`
+- Release: `src/app/release.rs`
 - Cancel: `src/app/cancel.rs`
 - Dispute: `src/app/dispute.rs`
 


### PR DESCRIPTION
Remove stale source code line numbers from ARCHITECTURE.md and EVENT_ROUTING.md references. Add a documentation guideline to AGENTS.md prohibiting hardcoded line numbers since they drift as the codebase evolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation guidelines to avoid hardcoded line number references, improving long-term maintainability.
  * Reformatted documentation entries to use stable file path identifiers instead of specific line numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->