### PR TITLE
feat: Publish NIP-01 Kind 0 metadata on startup

### DIFF
--- a/docs/NIP01_KIND0_METADATA.md
+++ b/docs/NIP01_KIND0_METADATA.md
@@ -1,0 +1,78 @@
+# NIP-01 Kind 0 Metadata Event
+
+Mostro now publishes a NIP-01 kind 0 metadata event on startup, allowing Nostr clients to display the instance's profile information (name, description, avatar, and website).
+
+## Background
+
+Mostro already published several Nostr events on startup and periodically:
+
+- **Kind 10002** (NIP-65 Relay List) — via the scheduler
+- **Kind 38385** (Mostro Info) — via the scheduler
+- **Kind 38383** (Orders) — as order events
+
+However, there was no **NIP-01 kind 0 metadata event**. This is the standard Nostr profile mechanism — every relay-aware client already knows how to fetch and display kind 0 metadata. Without it, clients could not show the Mostro instance's name, description, avatar, or website.
+
+## What Was Implemented
+
+A kind 0 metadata event is now published once on each startup, after the Nostr client connects and subscribes but before the LND connector initializes. This event is a **replaceable event** (per NIP-01), so relays keep only the latest version, ensuring the profile stays fresh across restarts.
+
+The implementation:
+
+1. Reads four optional configuration fields from `[mostro]` settings
+2. Builds a `nostr_sdk::Metadata` object with any configured fields
+3. Signs the event with the Mostro keypair
+4. Publishes to all connected relays
+
+If no metadata fields are configured, no event is published.
+
+## NIP-01 Kind 0 Specification
+
+Per [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md), a kind 0 event's `content` field contains a stringified JSON object:
+
+```json
+{
+  "name": "Mostro P2P",
+  "about": "A peer-to-peer Bitcoin trading daemon over the Lightning Network",
+  "picture": "https://example.com/mostro-avatar.png",
+  "website": "https://mostro.network"
+}
+```
+
+## Configuration
+
+Four optional fields were added to the `[mostro]` section in `settings.toml`:
+
+```toml
+[mostro]
+# NIP-01 Kind 0 Metadata (optional)
+# Human-readable name for this Mostro instance
+name = "Mostro P2P"
+# Short description of this Mostro instance
+about = "A peer-to-peer Bitcoin trading daemon over the Lightning Network"
+# URL to avatar image (recommended: square, max 128x128px)
+picture = "https://example.com/mostro-avatar.png"
+# Operator website URL
+website = "https://mostro.network"
+```
+
+All fields are `Option<String>` and default to `None`. The template (`settings.tpl.toml`) includes these fields commented out, so they are inactive by default.
+
+### Picture Size Recommendations
+
+The `picture` field should point to a small, square image:
+
+- **Maximum dimensions:** 128x128 pixels
+- **Format:** PNG or JPEG preferred
+- **Rationale:** Nostr clients typically display profile pictures as small avatars. Larger images waste bandwidth and relay storage. Some relays may reject events with excessively large content.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/config/types.rs` | Added `name`, `about`, `picture`, `website` fields to `MostroSettings` and its `Default` impl |
+| `settings.tpl.toml` | Added commented-out template entries for the four metadata fields |
+| `src/main.rs` | Added kind 0 metadata event publishing after Nostr client subscription |
+
+## Boot Sequence Position
+
+The metadata event is published at boot step 4, after the Nostr client connects (step 3) and before LND initialization (step 5). See [STARTUP_AND_CONFIG.md](STARTUP_AND_CONFIG.md) for the full boot sequence.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Quick links to architecture and feature guides.
 - Orders & Actions: ORDERS_AND_ACTIONS.md
 - Admin RPC & Disputes: ADMIN_RPC_AND_DISPUTES.md
 - RPC Interface Reference: RPC.md
+- NIP-01 Kind 0 Metadata: NIP01_KIND0_METADATA.md
 
 Tips
 - Run tests and lints before pushing: `cargo test`, `cargo fmt`, `cargo clippy --all-targets --all-features`.

--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -73,12 +73,13 @@ Before settings initialization, the daemon performs:
 1) Settings init: `cli::settings_init()` loads `settings.toml` (template: `settings.tpl.toml`).
 2) DB connect: `db::connect()` sets `config::DB_POOL`.
 3) Nostr: `util::connect_nostr()` sets `config::NOSTR_CLIENT`.
-4) LND: `LndConnector::new()` + `get_node_info()` → `config::LN_STATUS`.
-5) Held invoices: `db::find_held_invoices()` → resubscribe via `util::invoice_subscribe`.
-6) RPC: start if `rpc.enabled`.
-7) Scheduler: `scheduler::start_scheduler()`.
-8) Scheduler jobs: Payment retry job configured with `payment_retries_interval`
-9) Event loop: `app::run(keys, client, ln_client)`.
+4) NIP-01 Kind 0 Metadata: If any metadata fields (`name`, `about`, `picture`, `website`) are configured, publishes a kind 0 metadata event so clients can display the Mostro instance's profile.
+5) LND: `LndConnector::new()` + `get_node_info()` → `config::LN_STATUS`.
+6) Held invoices: `db::find_held_invoices()` → resubscribe via `util::invoice_subscribe`.
+7) RPC: start if `rpc.enabled`.
+8) Scheduler: `scheduler::start_scheduler()`.
+9) Scheduler jobs: Payment retry job configured with `payment_retries_interval`.
+10) Event loop: `app::run(keys, client, ln_client)`.
 
 ## Settings Structure
 
@@ -136,6 +137,12 @@ Configuration is loaded from `~/.mostro/settings.toml` (template: `settings.tpl.
 
 *Market Support:*
 - `fiat_currencies_accepted` (Vec<String>): Accepted fiat currencies; empty list accepts all (default: ['USD', 'EUR', 'ARS', 'CUP'])
+
+*NIP-01 Kind 0 Metadata (optional):*
+- `name` (Option\<String\>): Human-readable name for this Mostro instance (default: None)
+- `about` (Option\<String\>): Short description of this Mostro instance (default: None)
+- `picture` (Option\<String\>): URL to avatar image, recommended square max 128x128px (default: None)
+- `website` (Option\<String\>): Operator website URL (default: None)
 
 **RPC** (`src/config/types.rs:55-74`):
 - `enabled` (bool): Enable RPC server (Rust Default: false)

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -23,6 +23,15 @@ nsec_privkey = 'nsec1...'
 relays = ['ws://localhost:7000']
 
 [mostro]
+# NIP-01 Kind 0 Metadata (optional)
+# Human-readable name for this Mostro instance
+# name = "Mostro"
+# Short description of this Mostro instance
+# about = "A peer-to-peer Bitcoin trading daemon over the Lightning Network"
+# URL to avatar image (recommended: square, max 128x128px)
+# picture = "https://mostro.network/mostro-avatar.png"
+# Operator website URL
+# website = "https://mostro.network"
 # Mostro Fee
 fee = 0
 # Max routing fee that we want to pay to the network, 0.001 = 0.1%

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -108,6 +108,14 @@ pub struct MostroSettings {
     /// Development fee as percentage of Mostro fee (0.10 to 1.0)
     /// Example: 0.30 means 30% of the Mostro fee goes to development
     pub dev_fee_percentage: f64,
+    /// NIP-01 kind 0 metadata: human-readable name for this Mostro instance
+    pub name: Option<String>,
+    /// NIP-01 kind 0 metadata: short description of this Mostro instance
+    pub about: Option<String>,
+    /// NIP-01 kind 0 metadata: URL to avatar image (recommended max 128x128px)
+    pub picture: Option<String>,
+    /// NIP-01 kind 0 metadata: operator website URL
+    pub website: Option<String>,
 }
 
 impl Default for MostroSettings {
@@ -133,6 +141,10 @@ impl Default for MostroSettings {
             ],
             max_orders_per_response: 10,
             dev_fee_percentage: 0.30,
+            name: None,
+            about: None,
+            picture: None,
+            website: None,
         }
     }
 }


### PR DESCRIPTION
Publish Mostro identity metadata (name, about, picture, website) as a NIP-01 Kind 0 event when the relay connection is established. Metadata fields are configurable via settings.toml under [mostro_identity].

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional node metadata configuration (name, about, picture, website) that automatically publishes on startup

* **Documentation**
  * Added guide for NIP-01 Kind 0 metadata configuration
  * Updated settings template with metadata field examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->