### PR TITLE
feat(docker): cleartext CLI for default build, docker-mostro-up, docs and compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,12 @@ docker-relay-up:
 	echo "Starting Nostr relay" && \
 	docker compose up -d nostr-relay
 
+docker-mostro-up:
+	@set -o pipefail; \
+	cd docker && \
+	echo "Starting Mostro service only" && \
+	docker compose up -d mostro
+
 docker-down:
 	@set -o pipefail; \
 	cd docker && \

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -6,6 +6,8 @@ services:
     volumes:
       - ./config:/config  # settings.toml and mostro.db
     platform: linux/amd64
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - default
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -8,4 +8,4 @@ if [ ! -f /config/settings.toml ]; then
 fi
 
 # Run application (Mostro creates mostro.db at startup if missing)
-exec /usr/local/bin/mostrod -d /config
+exec /usr/local/bin/mostrod -d /config --cleartext

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,6 @@ pub struct Cli {
     #[arg(short, long)]
     password: Option<String>,
     /// Set cleartext password for db encryption (no password required)
-    #[cfg(feature = "startos")]
     #[arg(short, long, action = clap::ArgAction::SetTrue)]
     pub cleartext: bool,
 }
@@ -80,7 +79,10 @@ mod tests {
             cleartext: false,
         };
         #[cfg(not(feature = "startos"))]
-        let cli = Cli { dirsettings: None };
+        let cli = Cli {
+            dirsettings: None,
+            cleartext: false,
+        };
         assert!(cli.dirsettings.is_none());
 
         #[cfg(feature = "startos")]
@@ -92,6 +94,7 @@ mod tests {
         #[cfg(not(feature = "startos"))]
         let cli_with_path = Cli {
             dirsettings: Some("/custom/path".to_string()),
+            cleartext: false,
         };
         assert_eq!(cli_with_path.dirsettings.unwrap(), "/custom/path");
     }
@@ -145,7 +148,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "startos")]
     fn test_cli_parsing_cleartext_flag() {
         // Test parsing with cleartext flag (no value required)
         let result = Cli::try_parse_from(["mostro", "-c"]);
@@ -194,6 +196,7 @@ mod tests {
             #[cfg(not(feature = "startos"))]
             let cli = Cli {
                 dirsettings: custom_path.clone(),
+                cleartext: false,
             };
 
             if let Some(path) = cli.dirsettings.as_deref() {
@@ -213,7 +216,10 @@ mod tests {
                 cleartext: false,
             };
             #[cfg(not(feature = "startos"))]
-            let cli = Cli { dirsettings: None };
+            let cli = Cli {
+                dirsettings: None,
+                cleartext: false,
+            };
 
             if cli.dirsettings.is_none() {
                 // This is the expected path for default settings

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,8 @@
-#[cfg(feature = "startos")]
 use crate::cli::Cli;
 use crate::config::settings::Settings;
 use crate::config::MOSTRO_DB_PASSWORD;
 use argon2::password_hash::rand_core::OsRng;
 use argon2::{password_hash::SaltString, Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
-#[cfg(feature = "startos")]
 use clap::Parser;
 use mostro_core::order::Kind as OrderKind;
 use mostro_core::prelude::*;
@@ -210,7 +208,6 @@ async fn get_user_password() -> Result<(), MostroError> {
         }
     }
 
-    #[cfg(feature = "startos")]
     {
         let cli = Cli::parse();
         if cli.cleartext {


### PR DESCRIPTION
- Make cleartext option available in default build (not only StartOS)
- Add Parser trait import in db.rs for Cli::parse()
- docker/start.sh: run mostrod with --cleartext
- compose: extra_hosts for host.docker.internal (LND on host)
- Makefile: add docker-mostro-up to run Mostro without relay
- docker/README: run Mostro only, view logs, extra_hosts, Make commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `docker-mostro-up` make target to start only the Mostro service.
  * Added cleartext mode option for Docker deployments (runs without database password encryption).
  * Added support for running Mostro independently without the relay service.

* **Documentation**
  * Expanded Docker setup documentation with additional deployment patterns and examples.
  * Added instructions for log viewing and host service access configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->