### PR TITLE
Automated badge for toolchain and version in README.md

### DIFF
--- a/.github/workflows/sync-readme-badges.yml
+++ b/.github/workflows/sync-readme-badges.yml
@@ -24,6 +24,10 @@ jobs:
         id: channel
         run: |
           CHANNEL=$(sed -n 's/^channel = "\([^"]*\)".*/\1/p' rust-toolchain.toml)
+          if [ -z "${CHANNEL}" ]; then
+            echo "::error::rust-toolchain.toml: could not extract 'channel'; got empty value. Check the file format."
+            exit 1
+          fi
           echo "channel=${CHANNEL}" >> "$GITHUB_OUTPUT"
 
       - name: Update Rust badge in README

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Mostro supports three deployment methods. For production deployments, see [INSTA
 ### Prerequisites
 
 **All Methods**:
-- Rust 1.86+ (for native builds)
+- Rust 1.93.0+ (for native builds)
 - Lightning Network node (LND required)
   - Recommended: [Polar](https://lightningpolar.com/) for local testing
   - Production: Full LND node with adequate liquidity
@@ -818,7 +818,7 @@ cd mostro
 
 2. **Install development tools**:
 ```bash
-# Rust toolchain (1.86+)
+# Rust toolchain (1.93.0+)
 rustup update stable
 
 # SQLx CLI (for database migrations)


### PR DESCRIPTION
Sync README badges with toolchain and crates.io

- Version badge: Use dynamic crates.io badge so the README shows the published crate version (no manual updates).
- Rust badge: Set to the version from rust-toolchain.toml (1.93.0+) and add a GitHub Action that updates the README when rust-toolchain.toml changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated README Rust version requirement badge from 1.86+ to 1.93.0+
  * Changed version badge to dynamically reflect the latest crates.io release

* **Chores**
  * Added automated workflow to keep README badges synchronized with rust-toolchain configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->