### PR TITLE
fix: prevent stale Order writes from causing duplicate payments

### DIFF
--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -75,11 +75,23 @@ pub async fn admin_settle_action(
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
     // Persist the status change to DB before calling do_payment (same reason as release_action)
-    order_updated
-        .clone()
-        .update(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    let result =
+        sqlx::query("UPDATE orders SET status = ?, event_id = ? WHERE id = ? AND status = ?")
+            .bind(&order_updated.status)
+            .bind(&order_updated.event_id)
+            .bind(order_updated.id)
+            .bind(Status::Dispute.to_string())
+            .execute(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if result.rows_affected() == 0 {
+        tracing::warn!(
+            "Order {} not transitioned to settled-hold-invoice: status changed concurrently",
+            order_updated.id
+        );
+        return Ok(());
+    }
 
     // we check if there is a dispute
     let dispute = find_dispute_by_order_id(pool, order.id).await;

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -74,6 +74,13 @@ pub async fn admin_settle_action(
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
+    // Persist the status change to DB before calling do_payment (same reason as release_action)
+    order_updated
+        .clone()
+        .update(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
     // we check if there is a dispute
     let dispute = find_dispute_by_order_id(pool, order.id).await;
 

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -72,7 +72,6 @@ use mostro_core::error::MostroError::MostroInternalErr;
 use mostro_core::error::ServiceError;
 use mostro_core::order::Order;
 use sqlx::SqlitePool;
-use sqlx_crud::Crud;
 use std::collections::HashSet;
 use tokio::sync::mpsc::channel;
 use tracing::{error, info, warn};
@@ -120,7 +119,7 @@ async fn cleanup_stale_pending_markers(pool: &SqlitePool) {
 
     let mut stale_count = 0u32;
 
-    for mut pending_order in pending_orders {
+    for pending_order in pending_orders {
         let order_id = pending_order.id;
         let marker = pending_order
             .dev_fee_payment_hash
@@ -154,15 +153,29 @@ async fn cleanup_stale_pending_markers(pool: &SqlitePool) {
             order_id, age_display
         );
 
-        pending_order.dev_fee_paid = false;
-        pending_order.dev_fee_payment_hash = None;
-
-        match pending_order.update(pool).await {
-            Ok(_) => {
-                info!(
-                    "Reset stale PENDING for order {}, will retry payment",
-                    order_id
-                );
+        // Targeted update: only touch dev fee columns, and only if marker still matches.
+        match sqlx::query(
+            "UPDATE orders
+             SET dev_fee_paid = 0, dev_fee_payment_hash = NULL
+             WHERE id = ? AND dev_fee_payment_hash = ?",
+        )
+        .bind(order_id)
+        .bind(marker)
+        .execute(pool)
+        .await
+        {
+            Ok(result) => {
+                if result.rows_affected() > 0 {
+                    info!(
+                        "Reset stale PENDING for order {}, will retry payment",
+                        order_id
+                    );
+                } else {
+                    warn!(
+                        "Skipping stale PENDING reset for order {}: marker changed concurrently",
+                        order_id
+                    );
+                }
             }
             Err(e) => {
                 error!(
@@ -266,7 +279,7 @@ async fn recover_partial_payments(
         }
     };
 
-    for mut hash_order in hash_orders {
+    for hash_order in hash_orders {
         let order_id = hash_order.id;
         let existing_hash = hash_order.dev_fee_payment_hash.clone().unwrap_or_default();
 
@@ -281,16 +294,48 @@ async fn recover_partial_payments(
                     "Order {} payment already succeeded (hash {}), marking as paid",
                     order_id, existing_hash
                 );
-                hash_order.dev_fee_paid = true;
-                match hash_order.update(pool).await {
-                    Ok(updated) => {
-                        confirmed.insert(order_id);
-                        if let Err(e) = publish_dev_fee_audit_event(&updated, &existing_hash).await
-                        {
-                            warn!(
-                                "Failed to publish audit event for recovered order {}: {:?}",
-                                order_id, e
-                            );
+                // Targeted update: mark paid only, without touching unrelated order columns.
+                match sqlx::query(
+                    "UPDATE orders
+                     SET dev_fee_paid = 1
+                     WHERE id = ? AND dev_fee_paid = 0 AND dev_fee_payment_hash = ?",
+                )
+                .bind(order_id)
+                .bind(&existing_hash)
+                .execute(pool)
+                .await
+                {
+                    Ok(result) => {
+                        if result.rows_affected() > 0 {
+                            confirmed.insert(order_id);
+                            if let Ok(updated) =
+                                sqlx::query_as::<_, Order>("SELECT * FROM orders WHERE id = ?")
+                                    .bind(order_id)
+                                    .fetch_one(pool)
+                                    .await
+                            {
+                                if let Err(e) =
+                                    publish_dev_fee_audit_event(&updated, &existing_hash).await
+                                {
+                                    warn!(
+                                        "Failed to publish audit event for recovered order {}: {:?}",
+                                        order_id, e
+                                    );
+                                }
+                            }
+                        } else {
+                            // Already updated (or hash changed). If it's already paid, confirm it.
+                            if let Ok(is_paid) = sqlx::query_scalar::<_, i32>(
+                                "SELECT dev_fee_paid FROM orders WHERE id = ?",
+                            )
+                            .bind(order_id)
+                            .fetch_one(pool)
+                            .await
+                            {
+                                if is_paid != 0 {
+                                    confirmed.insert(order_id);
+                                }
+                            }
                         }
                     }
                     Err(e) => {
@@ -306,8 +351,17 @@ async fn recover_partial_payments(
                     "Order {} existing payment failed (hash {}), clearing for retry",
                     order_id, existing_hash
                 );
-                hash_order.dev_fee_payment_hash = None;
-                if let Err(e) = hash_order.update(pool).await {
+                // Targeted update: clear hash only if it still matches the one we checked.
+                if let Err(e) = sqlx::query(
+                    "UPDATE orders
+                     SET dev_fee_payment_hash = NULL
+                     WHERE id = ? AND dev_fee_paid = 0 AND dev_fee_payment_hash = ?",
+                )
+                .bind(order_id)
+                .bind(&existing_hash)
+                .execute(pool)
+                .await
+                {
                     error!(
                         "Failed to clear failed payment hash for order {}: {:?}",
                         order_id, e
@@ -348,7 +402,7 @@ async fn process_new_dev_fee_payments(
     };
     info!("Found {} orders with unpaid dev fees", unpaid_orders.len());
 
-    for mut order in unpaid_orders {
+    for order in unpaid_orders {
         let order_id = order.id;
 
         // STEP 0: Atomically claim this order to prevent duplicate processing.
@@ -410,15 +464,47 @@ async fn process_new_dev_fee_payments(
             "Storing payment hash {} for order {}",
             payment_hash_hex, order_id
         );
-        order.dev_fee_payment_hash = Some(payment_hash_hex.clone());
-
-        let order = match order.update(pool).await {
+        // Targeted update: store real hash only if we still own the PENDING marker.
+        let updated = match sqlx::query(
+            "UPDATE orders
+             SET dev_fee_payment_hash = ?
+             WHERE id = ? AND dev_fee_paid = 0 AND dev_fee_payment_hash = ?",
+        )
+        .bind(&payment_hash_hex)
+        .bind(order_id)
+        .bind(&pending_marker)
+        .execute(pool)
+        .await
+        {
             Err(e) => {
                 error!(
                     "Failed to store payment hash for order {}: {:?}",
                     order_id, e
                 );
                 release_pending_claim(pool, order_id, &pending_marker).await;
+                continue;
+            }
+            Ok(result) => result.rows_affected() > 0,
+        };
+
+        if !updated {
+            warn!(
+                "Order {}: cannot store dev fee payment hash; PENDING marker changed concurrently",
+                order_id
+            );
+            continue;
+        }
+
+        let order = match sqlx::query_as::<_, Order>("SELECT * FROM orders WHERE id = ?")
+            .bind(order_id)
+            .fetch_one(pool)
+            .await
+        {
+            Err(e) => {
+                error!(
+                    "Failed to reload order {} after storing payment hash: {:?}",
+                    order_id, e
+                );
                 continue;
             }
             Ok(updated_order) => {
@@ -470,7 +556,16 @@ async fn handle_payment_success(
 
     info!("Payment succeeded for order {}, verifying DB", order_id);
 
-    match order.update(pool).await {
+    match sqlx::query(
+        "UPDATE orders
+         SET dev_fee_paid = 1, dev_fee_payment_hash = ?
+         WHERE id = ? AND dev_fee_paid = 0",
+    )
+    .bind(payment_hash)
+    .bind(order_id)
+    .execute(pool)
+    .await
+    {
         Err(e) => {
             error!(
                 "CRITICAL: Dev fee PAID for order {} but DB update FAILED",
@@ -481,7 +576,21 @@ async fn handle_payment_success(
             error!("   Database error: {:?}", e);
             error!("   ACTION REQUIRED: Manual reconciliation");
         }
-        Ok(_) => {
+        Ok(result) => {
+            if result.rows_affected() == 0 {
+                // Already updated concurrently; still consider it confirmed if DB shows paid.
+                if let Ok(is_paid) =
+                    sqlx::query_scalar::<_, i32>("SELECT dev_fee_paid FROM orders WHERE id = ?")
+                        .bind(order_id)
+                        .fetch_one(pool)
+                        .await
+                {
+                    if is_paid != 0 {
+                        confirmed.insert(order_id);
+                    }
+                }
+                return;
+            }
             info!("Dev fee payment completed for order {}", order_id);
             info!("   Amount: {} sats, Hash: {}", dev_fee_amount, payment_hash);
             confirmed.insert(order_id);
@@ -511,7 +620,7 @@ async fn handle_payment_success(
 }
 
 async fn handle_payment_failure(
-    mut order: Order,
+    _order: Order,
     pool: &SqlitePool,
     order_id: uuid::Uuid,
     e: &MostroError,
@@ -527,8 +636,16 @@ async fn handle_payment_failure(
         "Keeping payment hash for order {} to let idempotency check verify on next cycle",
         order_id
     );
-    order.dev_fee_paid = false;
-    if let Err(db_err) = order.update(pool).await {
+    // Targeted no-op-ish update: never revert paid orders to unpaid.
+    if let Err(db_err) = sqlx::query(
+        "UPDATE orders
+         SET dev_fee_paid = 0
+         WHERE id = ? AND dev_fee_paid = 0",
+    )
+    .bind(order_id)
+    .execute(pool)
+    .await
+    {
         error!(
             "Failed to update order {} after payment failure: {:?}",
             order_id, db_err
@@ -537,7 +654,7 @@ async fn handle_payment_failure(
 }
 
 async fn handle_payment_timeout(
-    mut order: Order,
+    order: Order,
     pool: &SqlitePool,
     ln_client: &mut LndConnector,
     confirmed: &mut HashSet<uuid::Uuid>,
@@ -555,8 +672,16 @@ async fn handle_payment_timeout(
                 "Payment actually succeeded for order {} despite timeout",
                 order_id
             );
-            order.dev_fee_paid = true;
-            if let Err(e) = order.update(pool).await {
+            if let Err(e) = sqlx::query(
+                "UPDATE orders
+                 SET dev_fee_paid = 1
+                 WHERE id = ? AND dev_fee_paid = 0 AND dev_fee_payment_hash = ?",
+            )
+            .bind(order_id)
+            .bind(order.dev_fee_payment_hash.as_deref().unwrap_or_default())
+            .execute(pool)
+            .await
+            {
                 error!(
                     "Payment succeeded but failed to update DB for order {}: {:?}",
                     order_id, e
@@ -575,9 +700,17 @@ async fn handle_payment_timeout(
                 "Payment confirmed failed for order {}, clearing hash for retry",
                 order_id
             );
-            order.dev_fee_paid = false;
-            order.dev_fee_payment_hash = None;
-            if let Err(e) = order.clone().update(pool).await {
+            // Targeted reset: only clear hash if it still matches, and only while unpaid.
+            if let Err(e) = sqlx::query(
+                "UPDATE orders
+                 SET dev_fee_paid = 0, dev_fee_payment_hash = NULL
+                 WHERE id = ? AND dev_fee_paid = 0 AND dev_fee_payment_hash = ?",
+            )
+            .bind(order_id)
+            .bind(order.dev_fee_payment_hash.as_deref().unwrap_or_default())
+            .execute(pool)
+            .await
+            {
                 error!(
                     "Failed to reset after confirmed failure for order {}: {:?}",
                     order_id, e
@@ -1248,5 +1381,58 @@ mod tests {
 
         assert_eq!(row.0, 0);
         assert_eq!(row.1.as_deref(), Some("existing-hash"));
+    }
+
+    #[tokio::test]
+    async fn targeted_dev_fee_updates_do_not_overwrite_status() {
+        use mostro_core::order::Order;
+
+        let pool = setup_orders_db().await;
+        let order_id = uuid::Uuid::new_v4();
+
+        // Start in settled-hold-invoice with unpaid dev fee.
+        insert_test_order(
+            &pool,
+            order_id,
+            "settled-hold-invoice",
+            100,
+            false,
+            Some("PENDING-test-marker"),
+        )
+        .await;
+
+        // Stale snapshot (simulates dev-fee loop holding an Order across awaits).
+        let stale_copy = sqlx::query_as::<_, Order>("SELECT * FROM orders WHERE id = ?")
+            .bind(order_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        // Concurrently, buyer payment succeeds and status is advanced.
+        sqlx::query("UPDATE orders SET status = 'success' WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Dev-fee completion runs with stale copy; should only touch dev-fee fields.
+        let mut confirmed = HashSet::new();
+        handle_payment_success(stale_copy, &pool, &mut confirmed, "deadbeef").await;
+
+        let row: (String, i32, Option<String>) = sqlx::query_as(
+            "SELECT status, dev_fee_paid, dev_fee_payment_hash FROM orders WHERE id = ?",
+        )
+        .bind(order_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            row.0, "success",
+            "status must not be overwritten by dev-fee write"
+        );
+        assert_eq!(row.1, 1);
+        assert_eq!(row.2.as_deref(), Some("deadbeef"));
+        assert!(confirmed.contains(&order_id));
     }
 }

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -88,15 +88,13 @@ pub async fn check_failure_retries(
 
     // Only update payment-retry fields to avoid overwriting fields modified by
     // concurrent processes (dev_fee_paid, dev_fee_payment_hash, status, etc.)
-    sqlx::query(
-        "UPDATE orders SET failed_payment = ?, payment_attempts = ? WHERE id = ?",
-    )
-    .bind(order.failed_payment)
-    .bind(order.payment_attempts)
-    .bind(order.id)
-    .execute(pool)
-    .await
-    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    sqlx::query("UPDATE orders SET failed_payment = ?, payment_attempts = ? WHERE id = ?")
+        .bind(order.failed_payment)
+        .bind(order.payment_attempts)
+        .bind(order.id)
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
     Ok(order)
 }

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -564,15 +564,15 @@ async fn payment_success(
         // Only update status and event_id to avoid overwriting fields modified by
         // concurrent processes (dev_fee_paid, dev_fee_payment_hash, etc.)
         // The WHERE guard prevents double success transitions from concurrent tasks.
-        let result = sqlx::query(
-            "UPDATE orders SET status = ?, event_id = ? WHERE id = ? AND status = 'settled-hold-invoice'",
-        )
-        .bind(&order_updated.status)
-        .bind(&order_updated.event_id)
-        .bind(order_updated.id)
-        .execute(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+        let result =
+            sqlx::query("UPDATE orders SET status = ?, event_id = ? WHERE id = ? AND status = ?")
+                .bind(&order_updated.status)
+                .bind(&order_updated.event_id)
+                .bind(order_updated.id)
+                .bind(Status::SettledHoldInvoice.to_string())
+                .execute(pool)
+                .await
+                .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
         if result.rows_affected() == 0 {
             tracing::warn!(

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -86,11 +86,18 @@ pub async fn check_failure_retries(
         .await;
     }
 
-    order
-        .clone()
-        .update(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    // Only update payment-retry fields to avoid overwriting fields modified by
+    // concurrent processes (dev_fee_paid, dev_fee_payment_hash, status, etc.)
+    sqlx::query(
+        "UPDATE orders SET failed_payment = ?, payment_attempts = ? WHERE id = ?",
+    )
+    .bind(order.failed_payment)
+    .bind(order.payment_attempts)
+    .bind(order.id)
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
     Ok(order)
 }
 
@@ -189,6 +196,17 @@ pub async fn release_action(
     order = update_order_event(my_keys, Status::SettledHoldInvoice, &order)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+
+    // Persist the status change to DB before calling do_payment.
+    // do_payment spawns async tasks that capture an Order copy; without this
+    // explicit write the settled-hold-invoice status only lived in memory and
+    // was persisted as a side-effect of the full-row writes in
+    // check_failure_retries / payment_success (now replaced by targeted updates).
+    order
+        .clone()
+        .update(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
     // If there was an active dispute on this order, close it since the seller
     // released the funds, resolving the situation.
@@ -532,11 +550,27 @@ async fn payment_success(
     let pool = ctx.pool();
 
     if let Ok(order_updated) = update_order_event(my_keys, Status::Success, order).await {
-        order_updated
-            .clone()
-            .update(pool)
-            .await
-            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+        // Only update status and event_id to avoid overwriting fields modified by
+        // concurrent processes (dev_fee_paid, dev_fee_payment_hash, etc.)
+        // The WHERE guard prevents double success transitions from concurrent tasks.
+        let result = sqlx::query(
+            "UPDATE orders SET status = ?, event_id = ? WHERE id = ? AND status = 'settled-hold-invoice'",
+        )
+        .bind(&order_updated.status)
+        .bind(&order_updated.event_id)
+        .bind(order_updated.id)
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+        if result.rows_affected() == 0 {
+            tracing::warn!(
+                "Order {} not transitioned to success: already processed by another task",
+                order_updated.id
+            );
+            return Ok(());
+        }
+
         // Send dm to buyer to rate counterpart
         enqueue_order_msg(
             request_id,

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -200,11 +200,24 @@ pub async fn release_action(
     // explicit write the settled-hold-invoice status only lived in memory and
     // was persisted as a side-effect of the full-row writes in
     // check_failure_retries / payment_success (now replaced by targeted updates).
-    order
-        .clone()
-        .update(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    let result =
+        sqlx::query("UPDATE orders SET status = ?, event_id = ? WHERE id = ? AND status IN (?, ?)")
+            .bind(&order.status)
+            .bind(&order.event_id)
+            .bind(order.id)
+            .bind(Status::FiatSent.to_string())
+            .bind(Status::Dispute.to_string())
+            .execute(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if result.rows_affected() == 0 {
+        tracing::warn!(
+            "Order {} not transitioned to settled-hold-invoice: status changed concurrently",
+            order.id
+        );
+        return Ok(());
+    }
 
     // If there was an active dispute on this order, close it since the seller
     // released the funds, resolving the situation.


### PR DESCRIPTION
fix #691 
When buyer payment fails, `check_failure_retries` and `payment_success` perform full-row `order.clone().update(pool)` using a stale `Order` struct captured minutes earlier by `tokio::spawn`. This overwrites fields modified by concurrent processes, causing duplicate dev fee payments and duplicate buyer payments.                                                    
                                                                                                                      
  ## Root cause                                                                                                       
                                                            
  `do_payment` spawns async tasks that hold an `Order` copy. While the task waits for LND (can take minutes), other processes modify the same order in the DB, the dev fee cycle pays and writes `dev_fee_paid=true`, or another task succeeds and writes `status=success`. When the stale task finally calls `check_failure_retries`, the full-row write reverts these changes:                                                                               
                                                                                                                      
  - `dev_fee_paid` reverts to `false` → dev fee cycle pays again (duplicate)                                          
  - `status` reverts from `success` to `settled-hold-invoice` → buyer gets asked for a new invoice and gets paid again (duplicate)

  ## Changes                                                                                                          
                                                            
  - **`check_failure_retries`**: replace full-row write with targeted SQL that only updates `failed_payment` and `payment_attempts` — no longer overwrites `status`, `dev_fee_paid`, `dev_fee_payment_hash`, or any other field                                                        
  - **`payment_success`**: replace full-row write with targeted SQL that only updates `status` and `event_id`, with `WHERE status = 'settled-hold-invoice'` guard to prevent double success transitions from concurrent tasks                                                          
  - **`release_action` and `admin_settle_action`**: persist `settled-hold-invoice` status to DB before calling `do_payment` previously this status change only existed in memory and was persisted as a side-effect of the full-row writes  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Abort processing when a concurrent order status change is detected to prevent duplicate notifications, disputes handling, or payments.
  * Persist status/event markers earlier to reduce race conditions between status checks, dispute handling, messaging, and payment steps.

* **Performance**
  * Reduce unnecessary writes by updating only the specific fields that changed (dev fees, payment attempts, status/event), lowering contention and overwrite risk.

* **Tests**
  * Added a test ensuring targeted dev-fee updates do not overwrite concurrent status changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->