### PR TITLE
feat: add interactive setup wizard for first-time configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +707,19 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
 
 [[package]]
 name = "digest"
@@ -787,6 +813,12 @@ checksum = "c1019fa28f600f5b581b7a603d515c3f1635da041ca211b5055804788673abfe"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_home"
@@ -1706,6 +1738,7 @@ dependencies = [
  "chrono",
  "clap",
  "clearscreen",
+ "dialoguer",
  "dirs",
  "easy-hasher",
  "fedimint-tonic-lnd",
@@ -2789,6 +2822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,6 +3628,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ clap = { version = "4.5.45", features = ["derive"] }
 lnurl-rs = { version = "0.9.0", default-features = false, features = ["ureq"] }
 once_cell = "1.20.2"
 bitcoin = "0.32.5"
+dialoguer = "0.11"
 dirs = "6.0.0"
 clearscreen = "4.0.1"
 tonic = "0.14.2"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,6 +5,7 @@ pub mod settings;
 /// It includes structures for database, lightning, Nostr, and Mostro settings, as well as functions to initialize and access these settings.
 pub mod types;
 pub mod util;
+pub mod wizard;
 
 // Mostro configuration module
 // This module provides global configuration settings for the Mostro lightning configuration.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -3,11 +3,11 @@ use crate::config::types::{
     DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings, NostrSettings,
     RpcSettings,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 // Mostro configuration settings struct
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Settings {
     /// Url of database for Mostro
     pub database: DatabaseSettings,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -3,18 +3,18 @@
 use crate::config::constants::DEV_FEE_AUDIT_EVENT_KIND;
 use crate::config::MOSTRO_CONFIG;
 use mostro_core::prelude::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Event expiration configuration settings
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct ExpirationSettings {
-    /// Order events (kind 38383) expiration in days
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order_days: Option<u32>,
-    /// Rating events (kind 38384) expiration in days
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rating_days: Option<u32>,
-    /// Dispute events (kind 38386) expiration in days
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dispute_days: Option<u32>,
-    /// Fee audit events (kind 8383) expiration in days
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fee_audit_days: Option<u32>,
 }
 
@@ -97,13 +97,13 @@ macro_rules! impl_try_from_settings {
     };
 }
 /// Database configuration settings
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct DatabaseSettings {
     /// Database connection URL (e.g., "postgres://user:pass@localhost/dbname")  
     pub url: String,
 }
 /// Lightning configuration settings
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct LightningSettings {
     /// LND certificate file path
     pub lnd_cert_file: String,
@@ -123,7 +123,7 @@ pub struct LightningSettings {
     pub payment_retries_interval: u32,
 }
 /// Nostr configuration settings
-#[derive(Debug, Deserialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct NostrSettings {
     /// Nostr private key
     pub nsec_privkey: String,
@@ -131,7 +131,7 @@ pub struct NostrSettings {
     pub relays: Vec<String>,
 }
 /// RPC configuration settings
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct RpcSettings {
     /// Enable RPC server
     pub enabled: bool,
@@ -161,7 +161,7 @@ impl Default for RpcSettings {
 
 /// Mostro configuration settings
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct MostroSettings {
     /// Fee percentage for the Mostro
     pub fee: f64,
@@ -194,13 +194,13 @@ pub struct MostroSettings {
     /// Development fee as percentage of Mostro fee (0.10 to 1.0)
     /// Example: 0.30 means 30% of the Mostro fee goes to development
     pub dev_fee_percentage: f64,
-    /// NIP-01 kind 0 metadata: human-readable name for this Mostro instance
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// NIP-01 kind 0 metadata: short description of this Mostro instance
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub about: Option<String>,
-    /// NIP-01 kind 0 metadata: URL to avatar image (recommended max 128x128px)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub picture: Option<String>,
-    /// NIP-01 kind 0 metadata: operator website URL
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub website: Option<String>,
     /// Publish exchange rates to Nostr (kind 30078, NIP-33)
     #[serde(default = "default_publish_exchange_rates")]

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -3,10 +3,12 @@
 /// It includes functions to initialize the default settings directory and create a settings file from the template if it doesn't exist.
 /// It also includes functions to add a trailing slash to a path if it doesn't already have one.
 use crate::config::constants::{MAX_DEV_FEE_PERCENTAGE, MIN_DEV_FEE_PERCENTAGE};
+use crate::config::wizard;
 use crate::config::{init_mostro_settings, Settings};
 use mostro_core::error::MostroError::{self, *};
 use mostro_core::error::ServiceError;
 use std::fs;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 const DB_FILENAME: &str = "mostro.db";
@@ -55,17 +57,28 @@ pub fn init_configuration_file(config_path: Option<String>) -> Result<(), Mostro
             .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
     }
     let config_file_path = settings_dir.join("settings.toml");
-    // Check if settings.toml file exists
-    if !config_file_path.exists() {
-        std::fs::write(&config_file_path, include_bytes!("../../settings.tpl.toml"))
-            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
-        println!(
-            "Created settings file from template at {} for Mostro - Edit it to configure your Mostro instance",
-            config_file_path.display()
-        );
-        std::process::exit(0);
+    if !config_file_path.exists() {
+        let settings = if std::io::stdin().is_terminal() {
+            // Interactive: show setup menu (wizard or manual template)
+            wizard::run_setup_menu(&settings_dir, &config_file_path)?
+        } else {
+            // Non-interactive (Docker, CI, systemd): copy template and exit
+            std::fs::write(&config_file_path, include_bytes!("../../settings.tpl.toml"))
+                .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+            println!(
+                "Created settings file from template at {} - Edit it to configure your Mostro instance",
+                config_file_path.display()
+            );
+            std::process::exit(0);
+        };
+
+        validate_mostro_settings(&settings)?;
+        init_mostro_settings(settings);
+        tracing::info!("Settings correctly loaded!");
+        return Ok(());
     }
+
     // Read the file content
     let contents = fs::read_to_string(&config_file_path)
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -77,14 +77,25 @@ fn run_setup_wizard(settings_dir: &Path, config_file_path: &Path) -> Result<Sett
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
     {
-        use std::os::unix::fs::OpenOptionsExt;
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(config_file_path)
-            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+        #[cfg(unix)]
+        let file = {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(config_file_path)
+        };
+        #[cfg(not(unix))]
+        let file = {
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(config_file_path)
+        };
+        let mut file = file.map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
         file.write_all(toml_content.as_bytes())
             .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
     }

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -1,0 +1,292 @@
+use std::path::{Path, PathBuf};
+
+use dialoguer::{Confirm, Input, Password, Select};
+use mostro_core::error::MostroError::{self, MostroInternalErr};
+use mostro_core::error::ServiceError;
+use nostr_sdk::prelude::*;
+
+use super::settings::Settings;
+use super::types::{
+    DatabaseSettings, LightningSettings, MostroSettings, NostrSettings, RpcSettings,
+};
+
+const TEMPLATE_BYTES: &[u8] = include_bytes!("../../settings.tpl.toml");
+
+/// Show the initial setup menu and return a configured Settings if the user
+/// chose the interactive wizard. If manual setup is chosen, the template is
+/// written and the process exits.
+pub fn run_setup_menu(
+    settings_dir: &Path,
+    config_file_path: &Path,
+) -> Result<Settings, MostroError> {
+    println!("\nWelcome to Mostro! No configuration found.\n");
+
+    let choices = &[
+        "Interactive setup (guided wizard)",
+        "Manual setup (creates settings.toml template for you to edit)",
+    ];
+
+    let selection = Select::new()
+        .with_prompt("How would you like to set up your instance?")
+        .items(choices)
+        .default(0)
+        .interact()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    match selection {
+        0 => {
+            let settings = run_setup_wizard(settings_dir, config_file_path)?;
+            Ok(settings)
+        }
+        _ => {
+            std::fs::write(config_file_path, TEMPLATE_BYTES)
+                .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+            println!(
+                "Created settings file from template at {} - Edit it to configure your Mostro instance",
+                config_file_path.display()
+            );
+            std::process::exit(0);
+        }
+    }
+}
+
+fn run_setup_wizard(
+    settings_dir: &Path,
+    config_file_path: &Path,
+) -> Result<Settings, MostroError> {
+    println!("\n--- Lightning (LND) Configuration ---\n");
+
+    let lightning = prompt_lightning_settings()?;
+
+    println!("\n--- Nostr Configuration ---\n");
+
+    let nostr = prompt_nostr_settings()?;
+
+    println!("\n--- Mostro Configuration ---\n");
+
+    let mostro = prompt_mostro_settings()?;
+
+    let settings = Settings {
+        database: DatabaseSettings::default(),
+        lightning,
+        nostr,
+        mostro,
+        rpc: RpcSettings::default(),
+        expiration: None,
+    };
+
+    let toml_content = toml::to_string_pretty(&settings)
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    std::fs::write(config_file_path, toml_content)
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    println!(
+        "\nConfiguration saved to {}\n",
+        config_file_path.display()
+    );
+
+    // Override database URL to use settings directory
+    let mut settings = settings;
+    settings.database.url = format!(
+        "sqlite://{}",
+        settings_dir.join("mostro.db").display()
+    );
+
+    Ok(settings)
+}
+
+fn prompt_lightning_settings() -> Result<LightningSettings, MostroError> {
+    let lnd_cert_file: String = Input::new()
+        .with_prompt("Path to LND tls.cert file")
+        .validate_with(|input: &String| validate_file_exists(input))
+        .interact_text()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    let lnd_macaroon_file: String = Input::new()
+        .with_prompt("Path to LND admin.macaroon file")
+        .validate_with(|input: &String| validate_file_exists(input))
+        .interact_text()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    let lnd_grpc_host: String = Input::new()
+        .with_prompt("LND gRPC host")
+        .default("https://127.0.0.1:10009".to_string())
+        .interact_text()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    Ok(LightningSettings {
+        lnd_cert_file,
+        lnd_macaroon_file,
+        lnd_grpc_host,
+        invoice_expiration_window: 3600,
+        hold_invoice_cltv_delta: 144,
+        hold_invoice_expiration_window: 300,
+        payment_attempts: 3,
+        payment_retries_interval: 60,
+    })
+}
+
+fn prompt_nostr_settings() -> Result<NostrSettings, MostroError> {
+    let has_nsec = Confirm::new()
+        .with_prompt("Do you have an existing nsec key?")
+        .default(false)
+        .interact()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    let nsec_privkey = if has_nsec {
+        Password::new()
+            .with_prompt("Enter your nsec private key")
+            .validate_with(|input: &String| validate_nsec(input))
+            .interact()
+            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?
+    } else {
+        let keys = Keys::generate();
+        let nsec = keys.secret_key().to_bech32().map_err(|e| {
+            MostroInternalErr(ServiceError::IOError(e.to_string()))
+        })?;
+        let npub = keys.public_key().to_bech32().map_err(|e| {
+            MostroInternalErr(ServiceError::IOError(e.to_string()))
+        })?;
+
+        println!("\nGenerated new Nostr keypair:");
+        println!("  nsec: {}", nsec);
+        println!("  npub: {}", npub);
+        println!("\n  IMPORTANT: Save your nsec in a secure place. You will need it to recover your Mostro identity.\n");
+
+        nsec
+    };
+
+    let relays_input: String = Input::new()
+        .with_prompt("Nostr relays (comma-separated)")
+        .default("wss://relay.mostro.network".to_string())
+        .validate_with(|input: &String| validate_relays(input))
+        .interact_text()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    let relays: Vec<String> = relays_input
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    Ok(NostrSettings {
+        nsec_privkey,
+        relays,
+    })
+}
+
+fn prompt_mostro_settings() -> Result<MostroSettings, MostroError> {
+    let fee: f64 = Input::new()
+        .with_prompt("Mostro fee (e.g. 0.01 = 1%)")
+        .default(0.0)
+        .interact_text()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    let fiat_input: String = Input::new()
+        .with_prompt("Fiat currencies accepted (comma-separated, empty = all)")
+        .default(String::new())
+        .show_default(false)
+        .interact_text()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    let fiat_currencies_accepted: Vec<String> = if fiat_input.trim().is_empty() {
+        vec![]
+    } else {
+        fiat_input
+            .split(',')
+            .map(|s| s.trim().to_uppercase())
+            .filter(|s| !s.is_empty())
+            .collect()
+    };
+
+    Ok(MostroSettings {
+        fee,
+        fiat_currencies_accepted,
+        ..MostroSettings::default()
+    })
+}
+
+// --- Validation helpers ---
+
+pub fn validate_file_exists(path: &str) -> Result<(), String> {
+    let expanded = expand_tilde(path);
+    if expanded.exists() {
+        Ok(())
+    } else {
+        Err(format!("File not found: {}", expanded.display()))
+    }
+}
+
+pub fn validate_nsec(input: &str) -> Result<(), String> {
+    Keys::parse(input.trim()).map(|_| ()).map_err(|e| format!("Invalid nsec key: {}", e))
+}
+
+pub fn validate_relays(input: &str) -> Result<(), String> {
+    let relays: Vec<&str> = input.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+    if relays.is_empty() {
+        return Err("At least one relay is required".to_string());
+    }
+    for relay in &relays {
+        if !relay.starts_with("ws://") && !relay.starts_with("wss://") {
+            return Err(format!("Invalid relay URL (must start with ws:// or wss://): {}", relay));
+        }
+    }
+    Ok(())
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if path.starts_with("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(&path[2..]);
+        }
+    }
+    PathBuf::from(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_nsec_valid() {
+        assert!(validate_nsec("nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd").is_ok());
+    }
+
+    #[test]
+    fn test_validate_nsec_invalid() {
+        assert!(validate_nsec("not_a_valid_nsec").is_err());
+        assert!(validate_nsec("").is_err());
+    }
+
+    #[test]
+    fn test_validate_relays_valid() {
+        assert!(validate_relays("wss://relay.mostro.network").is_ok());
+        assert!(validate_relays("wss://relay1.com, wss://relay2.com").is_ok());
+        assert!(validate_relays("ws://localhost:7000").is_ok());
+    }
+
+    #[test]
+    fn test_validate_relays_invalid() {
+        assert!(validate_relays("").is_err());
+        assert!(validate_relays("http://not-a-relay.com").is_err());
+        assert!(validate_relays("wss://good.com, http://bad.com").is_err());
+    }
+
+    #[test]
+    fn test_validate_file_exists_nonexistent() {
+        assert!(validate_file_exists("/nonexistent/path/to/file.cert").is_err());
+    }
+
+    #[test]
+    fn test_expand_tilde() {
+        let expanded = expand_tilde("~/test");
+        assert!(!expanded.to_string_lossy().starts_with("~/"));
+    }
+
+    #[test]
+    fn test_expand_tilde_no_tilde() {
+        let path = "/absolute/path";
+        assert_eq!(expand_tilde(path), PathBuf::from(path));
+    }
+}

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -1,3 +1,4 @@
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use dialoguer::{Confirm, Input, Select};
@@ -75,8 +76,18 @@ fn run_setup_wizard(settings_dir: &Path, config_file_path: &Path) -> Result<Sett
     let toml_content = toml::to_string_pretty(&settings)
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
-    std::fs::write(config_file_path, toml_content)
-        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(config_file_path)
+            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+        file.write_all(toml_content.as_bytes())
+            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+    }
 
     println!("\nConfiguration saved to {}\n", config_file_path.display());
 
@@ -93,12 +104,14 @@ fn prompt_lightning_settings() -> Result<LightningSettings, MostroError> {
         .validate_with(|input: &String| validate_file_exists(input))
         .interact_text()
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+    let lnd_cert_file = resolve_file_path(&lnd_cert_file)?;
 
     let lnd_macaroon_file: String = Input::new()
         .with_prompt("Path to LND admin.macaroon file")
         .validate_with(|input: &String| validate_file_exists(input))
         .interact_text()
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+    let lnd_macaroon_file = resolve_file_path(&lnd_macaroon_file)?;
 
     let lnd_grpc_host: String = Input::new()
         .with_prompt("LND gRPC host")
@@ -204,11 +217,23 @@ fn prompt_mostro_settings() -> Result<MostroSettings, MostroError> {
 
 pub fn validate_file_exists(path: &str) -> Result<(), String> {
     let expanded = expand_tilde(path);
-    if expanded.exists() {
-        Ok(())
-    } else {
-        Err(format!("File not found: {}", expanded.display()))
+    if !expanded.exists() {
+        return Err(format!("File not found: {}", expanded.display()));
     }
+    if !expanded.is_file() {
+        return Err(format!(
+            "Path is not a regular file: {}",
+            expanded.display()
+        ));
+    }
+    Ok(())
+}
+
+pub fn resolve_file_path(path: &str) -> Result<String, MostroError> {
+    let expanded = expand_tilde(path);
+    std::fs::canonicalize(&expanded)
+        .map(|p| p.to_string_lossy().into_owned())
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))
 }
 
 pub fn validate_nsec(input: &str) -> Result<(), String> {

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use dialoguer::{Confirm, Input, Password, Select};
+use dialoguer::{Confirm, Input, Select};
 use mostro_core::error::MostroError::{self, MostroInternalErr};
 use mostro_core::error::ServiceError;
 use nostr_sdk::prelude::*;
@@ -135,10 +135,10 @@ fn prompt_nostr_settings() -> Result<NostrSettings, MostroError> {
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
     let nsec_privkey = if has_nsec {
-        Password::new()
+        Input::new()
             .with_prompt("Enter your nsec private key")
             .validate_with(|input: &String| validate_nsec(input))
-            .interact()
+            .interact_text()
             .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?
     } else {
         let keys = Keys::generate();

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -50,10 +50,7 @@ pub fn run_setup_menu(
     }
 }
 
-fn run_setup_wizard(
-    settings_dir: &Path,
-    config_file_path: &Path,
-) -> Result<Settings, MostroError> {
+fn run_setup_wizard(settings_dir: &Path, config_file_path: &Path) -> Result<Settings, MostroError> {
     println!("\n--- Lightning (LND) Configuration ---\n");
 
     let lightning = prompt_lightning_settings()?;
@@ -81,17 +78,11 @@ fn run_setup_wizard(
     std::fs::write(config_file_path, toml_content)
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
-    println!(
-        "\nConfiguration saved to {}\n",
-        config_file_path.display()
-    );
+    println!("\nConfiguration saved to {}\n", config_file_path.display());
 
     // Override database URL to use settings directory
     let mut settings = settings;
-    settings.database.url = format!(
-        "sqlite://{}",
-        settings_dir.join("mostro.db").display()
-    );
+    settings.database.url = format!("sqlite://{}", settings_dir.join("mostro.db").display());
 
     Ok(settings)
 }
@@ -142,12 +133,14 @@ fn prompt_nostr_settings() -> Result<NostrSettings, MostroError> {
             .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?
     } else {
         let keys = Keys::generate();
-        let nsec = keys.secret_key().to_bech32().map_err(|e| {
-            MostroInternalErr(ServiceError::IOError(e.to_string()))
-        })?;
-        let npub = keys.public_key().to_bech32().map_err(|e| {
-            MostroInternalErr(ServiceError::IOError(e.to_string()))
-        })?;
+        let nsec = keys
+            .secret_key()
+            .to_bech32()
+            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+        let npub = keys
+            .public_key()
+            .to_bech32()
+            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
         println!("\nGenerated new Nostr keypair:");
         println!("  nsec: {}", nsec);
@@ -219,26 +212,35 @@ pub fn validate_file_exists(path: &str) -> Result<(), String> {
 }
 
 pub fn validate_nsec(input: &str) -> Result<(), String> {
-    Keys::parse(input.trim()).map(|_| ()).map_err(|e| format!("Invalid nsec key: {}", e))
+    Keys::parse(input.trim())
+        .map(|_| ())
+        .map_err(|e| format!("Invalid nsec key: {}", e))
 }
 
 pub fn validate_relays(input: &str) -> Result<(), String> {
-    let relays: Vec<&str> = input.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+    let relays: Vec<&str> = input
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
     if relays.is_empty() {
         return Err("At least one relay is required".to_string());
     }
     for relay in &relays {
         if !relay.starts_with("ws://") && !relay.starts_with("wss://") {
-            return Err(format!("Invalid relay URL (must start with ws:// or wss://): {}", relay));
+            return Err(format!(
+                "Invalid relay URL (must start with ws:// or wss://): {}",
+                relay
+            ));
         }
     }
     Ok(())
 }
 
 fn expand_tilde(path: &str) -> PathBuf {
-    if path.starts_with("~/") {
+    if let Some(stripped) = path.strip_prefix("~/") {
         if let Some(home) = dirs::home_dir() {
-            return home.join(&path[2..]);
+            return home.join(stripped);
         }
     }
     PathBuf::from(path)
@@ -250,7 +252,10 @@ mod tests {
 
     #[test]
     fn test_validate_nsec_valid() {
-        assert!(validate_nsec("nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd").is_ok());
+        assert!(
+            validate_nsec("nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd")
+                .is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adds an interactive CLI wizard that runs on first launch when no settings.toml exists. Users can choose between a guided setup (prompts for LND paths, nsec key with optional generation, relays, fee, and fiat currencies) or manual template editing. Non-TTY environments (Docker, CI) fall back to the existing template-copy-and-exit behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive first-run configuration wizard: choose guided setup or write a manual template; guided flow prompts for Lightning, Nostr, and app settings, validates inputs, may generate and display a Nostr keypair, and writes a completed config with secure permissions.
  * Settings can now be serialized so configuration persists after interactive setup; non-interactive mode still creates a template and exits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->