### PR TITLE
fix: fix for bug introduced in 0.17.2 blocking range orders

### DIFF
--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -97,9 +97,12 @@ pub async fn order_action(
             return Err(MostroCantDo(cause));
         }
 
-        // Validate fiat_amount is positive
-        if let Err(cause) = order.check_fiat_amount() {
-            return Err(MostroCantDo(cause));
+        // `check_fiat_amount` in mostro-core requires fiat_amount > 0. Range orders set
+        // min/max and use fiat_amount == 0, so only run it for single-amount orders.
+        if order.min_amount.is_none() && order.max_amount.is_none() {
+            if let Err(cause) = order.check_fiat_amount() {
+                return Err(MostroCantDo(cause));
+            }
         }
 
         // Validate amount (sats) is non-negative


### PR DESCRIPTION
### Title

fix: allow range orders with `fiat_amount == 0` in `order_action`

## Summary

v0.17.2 started validating every new order with `check_fiat_amount()` unconditionally. Range orders encode the band with `min_amount` / `max_amount` and use **`fiat_amount == 0`**, so they were rejected before range handling ran. This change calls `check_fiat_amount()` only for **single-amount** orders (no min/max), restoring correct behavior for range listings without changing `mostro-core`.

## Changes

- In `order_action` (`src/app/order.rs`), gate `check_fiat_amount()` on `min_amount` and `max_amount` both absent.
- Add a short comment explaining why (strict core check vs range placeholder fiat).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed order validation logic to properly handle both single-amount and range orders. Range orders can now process without triggering fiat amount validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->