### PR TITLE
feat(bond): anti-abuse bond phase 0 foundation

### DIFF
--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -46,9 +46,9 @@ Add a new optional section to `settings.toml`. Missing section ≡
 # Master switch. When false the bond code paths are dead.
 enabled = false
 
-# Bond amount = max(amount_sats * order_amount_sats, base_amount_sats)
-# amount_sats is a fraction of the order amount (0.01 = 1%).
-amount_sats = 0.01
+# Bond amount = max(amount_pct * order_amount_sats, base_amount_sats)
+# amount_pct is a unitless fraction of the order amount (0.01 = 1%).
+amount_pct = 0.01
 # Floor, in sats. Prevents trivial bonds on small orders.
 base_amount_sats = 1000
 
@@ -109,7 +109,7 @@ Purely additive. Touches no trade flow.
   existing configs behave identically when merged.
 - Pure function `compute_bond_amount(order_amount_sats: i64, cfg: &AntiAbuseBondSettings) -> i64`
   in `src/app/bond/math.rs` (new module). Returns
-  `max((cfg.amount_sats * order_amount_sats).round() as i64, cfg.base_amount_sats)`
+  `max((cfg.amount_pct * order_amount_sats).round() as i64, cfg.base_amount_sats)`
   with saturating arithmetic. Tests for: 0% percentage, floor dominates,
   percentage dominates, huge amount saturation.
 - Enums (new file `src/app/bond/types.rs`):
@@ -123,16 +123,27 @@ Purely additive. Touches no trade flow.
   CREATE TABLE IF NOT EXISTS bonds (
     id               char(36) primary key not null,
     order_id         char(36) not null,
-    range_parent_id  char(36),          -- null unless range-child tracking (Phase 6)
-    pubkey           char(64) not null, -- trade pubkey of the bonded party
+    -- Phase 6: parent maker bond a child slash row belongs to. NULL for
+    -- parent / non-range rows.
+    parent_bond_id   char(36),
+    -- Phase 6: child (range-taken) order id this row represents. NULL for
+    -- parent / non-range rows.
+    child_order_id   char(36),
+    pubkey           char(64) not null,    -- trade pubkey of the bonded party
     role             varchar(8) not null,  -- 'maker' | 'taker'
     amount_sats      integer not null,
+    -- Phase 6: running total of sats already transitioned to a slashed
+    -- child. 0 for child / non-range rows.
+    slashed_share_sats integer not null default 0,
     state            varchar(16) not null, -- BondState
     slashed_reason   varchar(16),          -- BondSlashReason when state=Slashed
     hash             char(64),             -- payment hash of bond hold invoice
     preimage         char(64),             -- preimage retained by Mostro
     payment_request  text,                 -- bolt11 shown to payer
     payout_invoice   text,                 -- payout invoice from winner (Phase 3+)
+    -- Phase 3: routing-fee ceiling actually used for the payout attempt
+    -- (sats). NULL until the scheduler tries to pay the winner.
+    payout_routing_fee_sats integer,
     payout_attempts  integer not null default 0,
     locked_at        integer,
     released_at      integer,
@@ -142,12 +153,19 @@ Purely additive. Touches no trade flow.
   );
   CREATE INDEX IF NOT EXISTS idx_bonds_order_id ON bonds(order_id);
   CREATE INDEX IF NOT EXISTS idx_bonds_state    ON bonds(state);
+  CREATE INDEX IF NOT EXISTS idx_bonds_parent   ON bonds(parent_bond_id);
   ```
 
+  The Phase 0 migration lands the full column set up-front (parent/child
+  range columns, `slashed_share_sats`, `payout_routing_fee_sats`) rather
+  than staging ALTER TABLEs per phase. Later phases only add code, not
+  schema.
+
   Run `cargo sqlx prepare -- --bin mostrod` to refresh `sqlx-data.json`.
-- `Bond` model (sqlx-crud) and repository helpers in `src/db/bonds.rs`:
-  `create_bond`, `find_bond_by_order_and_role`, `find_bonds_by_state`,
-  `update_bond_state`.
+- `Bond` model (sqlx-crud) and repository helpers in `src/app/bond/db.rs`:
+  `create_bond`, `find_bond_by_order_and_role` (parent rows only —
+  filters on `parent_bond_id IS NULL`), `find_bonds_by_state`,
+  `update_bond`.
 - Unit tests for each helper.
 
 ### 5.2 Non-goals
@@ -442,7 +460,7 @@ need to slash.
 For a child order with sats amount `child_sats` and parent bond computed
 from `parent_max_sats`:
 
-```
+```text
 share_fraction  = child_sats / parent_max_sats
 slash_amount    = round(parent_bond_amount * share_fraction)
 ```

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -1,0 +1,632 @@
+# Anti-Abuse Bond — Implementation Spec
+
+> Implementation guide for [issue #711](https://github.com/MostroP2P/mostro/issues/711).
+> This document is the single source of truth as the feature is rolled out across
+> several PRs. Each phase below maps to one **small, atomic PR** that can be
+> reviewed, tested, and released independently.
+
+## 1. Goal
+
+Add an **opt-in, node-level** anti-abuse bond. A taker (and later a maker) locks
+a Lightning hold invoice when entering a trade. The bond is:
+
+- **Released** on normal completion or any cancellation that happens before a
+  timeout elapses.
+- **Slashed** (claimed by Mostro and paid to the counterparty) only in clearly
+  defined conditions configured by the node operator:
+  - `slash_on_lost_dispute = true` → the bonded party loses the dispute.
+  - `slash_on_waiting_timeout = true` → the bonded party lets the waiting-state
+    timeout actually elapse.
+
+Disabled by default. Nodes that don't flip `enabled = true` see zero behavior
+change.
+
+## 2. Guiding principles
+
+1. **Opt-in and off-by-default.** Every phase must preserve today's behavior
+   when `[anti_abuse_bond].enabled = false`.
+2. **Atomic PRs.** Each phase below is scoped to one coherent change that can
+   ship (and revert) independently. No phase leaves the daemon in an incoherent
+   state.
+3. **Never slash unless the cause is unambiguous.** The worst failure mode is
+   stealing a good user's bond. When in doubt, release.
+4. **Bond is separate from escrow.** A second hold invoice, its own row, its
+   own lifecycle. It must not be deducted from or conflated with trade escrow.
+5. **Tests accompany every phase.** Rust unit tests co-located with the module;
+   `cargo test`, `cargo clippy --all-targets --all-features`, and
+   `cargo sqlx prepare -- --bin mostrod` must stay green.
+
+## 3. Configuration surface (final shape)
+
+Add a new optional section to `settings.toml`. Missing section ≡
+`enabled = false`.
+
+```toml
+[anti_abuse_bond]
+# Master switch. When false the bond code paths are dead.
+enabled = false
+
+# Bond amount = max(amount_sats * order_amount_sats, base_amount_sats)
+# amount_sats is a fraction of the order amount (0.01 = 1%).
+amount_sats = 0.01
+# Floor, in sats. Prevents trivial bonds on small orders.
+base_amount_sats = 1000
+
+# Which flows require the bond.
+#   "take"   → only the taker posts a bond
+#   "create" → only the maker posts a bond
+#   "both"   → both sides
+apply_to = "take"
+
+# Slash conditions. Both default to false so enabling the feature with
+# an incomplete config never slashes anyone by accident.
+slash_on_lost_dispute  = true
+slash_on_waiting_timeout = false
+
+# Bond payout retries (applies once the bond is slashed and Mostro needs
+# a payout invoice from the winning counterparty).
+payout_invoice_window_seconds = 300
+payout_max_retries           = 5
+```
+
+**`apply_to` is deliberately expressive** so phases can be rolled out one side
+at a time on production nodes — operators can keep `apply_to = "take"` until
+Phase 5 has been in production long enough to trust on the maker side.
+
+## 4. Phase overview
+
+The issue proposes three phases. We split them further so each PR is small
+enough to review without a marathon session. Data-model and payout plumbing
+come early (Phase 0 & 3) and are reused by every subsequent slash path.
+
+| Phase | PR scope | Depends on |
+|------:|----------|------------|
+| 0 | Foundation: config schema, `bonds` table, pure helpers, types | — |
+| 1 | Taker bond lifecycle: **lock + always release** (no slashing yet) | 0 |
+| 2 | Taker bond: slash on **lost dispute** | 1 |
+| 3 | Payout flow: `add-invoice` to winner, routing-fee estimation, retries, audit event | 2 |
+| 4 | Taker bond: slash on **timeout** (apply_to=take, slash_on_waiting_timeout) | 3 |
+| 5 | Maker bond (non-range): lock + dispute slash reusing phase 3 payout | 3 |
+| 6 | Maker bond for **range orders** with proportional slashes | 5 |
+| 7 | Maker bond: slash on **timeout** | 5 |
+| 8 | Public config exposure (Mostro info event) + operator docs polish | 7 |
+
+Phases 4, 5, 6, 7 can partially overlap in time but must land in this order on
+`main` to keep review scope honest.
+
+---
+
+## 5. Phase 0 — Foundation
+
+Purely additive. Touches no trade flow.
+
+### 5.1 Scope
+
+- `AntiAbuseBondSettings` struct in `src/config/types.rs` with a matching
+  `Default` impl (`enabled = false`). Add `Option<AntiAbuseBondSettings>` field
+  to `Settings` plus `Settings::get_bond()` accessor.
+- Update `settings.tpl.toml` with the block from §3, fully commented so
+  existing configs behave identically when merged.
+- Pure function `compute_bond_amount(order_amount_sats: i64, cfg: &AntiAbuseBondSettings) -> i64`
+  in `src/app/bond/math.rs` (new module). Returns
+  `max((cfg.amount_sats * order_amount_sats).round() as i64, cfg.base_amount_sats)`
+  with saturating arithmetic. Tests for: 0% percentage, floor dominates,
+  percentage dominates, huge amount saturation.
+- Enums (new file `src/app/bond/types.rs`):
+  - `BondRole { Maker, Taker }`
+  - `BondState { Requested, Locked, Released, PendingPayout, Slashed, Failed }`
+  - `BondSlashReason { LostDispute, Timeout }`
+- Database migration
+  `migrations/<ts>_anti_abuse_bond.sql` creating:
+
+  ```sql
+  CREATE TABLE IF NOT EXISTS bonds (
+    id               char(36) primary key not null,
+    order_id         char(36) not null,
+    range_parent_id  char(36),          -- null unless range-child tracking (Phase 6)
+    pubkey           char(64) not null, -- trade pubkey of the bonded party
+    role             varchar(8) not null,  -- 'maker' | 'taker'
+    amount_sats      integer not null,
+    state            varchar(16) not null, -- BondState
+    slashed_reason   varchar(16),          -- BondSlashReason when state=Slashed
+    hash             char(64),             -- payment hash of bond hold invoice
+    preimage         char(64),             -- preimage retained by Mostro
+    payment_request  text,                 -- bolt11 shown to payer
+    payout_invoice   text,                 -- payout invoice from winner (Phase 3+)
+    payout_attempts  integer not null default 0,
+    locked_at        integer,
+    released_at      integer,
+    slashed_at       integer,
+    created_at       integer not null,
+    FOREIGN KEY(order_id) REFERENCES orders(id)
+  );
+  CREATE INDEX IF NOT EXISTS idx_bonds_order_id ON bonds(order_id);
+  CREATE INDEX IF NOT EXISTS idx_bonds_state    ON bonds(state);
+  ```
+
+  Run `cargo sqlx prepare -- --bin mostrod` to refresh `sqlx-data.json`.
+- `Bond` model (sqlx-crud) and repository helpers in `src/db/bonds.rs`:
+  `create_bond`, `find_bond_by_order_and_role`, `find_bonds_by_state`,
+  `update_bond_state`.
+- Unit tests for each helper.
+
+### 5.2 Non-goals
+
+- No LND calls, no take flow edits, no scheduler hooks. Just the building
+  blocks.
+
+### 5.3 Acceptance
+
+- `cargo test` green; new tests for `compute_bond_amount` and CRUD helpers.
+- `cargo clippy --all-targets --all-features` clean.
+- Toggling `enabled = true` does nothing yet — verified by explicit test that
+  spins up the daemon config and asserts no handler branches on the bond
+  config.
+
+---
+
+## 6. Phase 1 — Taker bond: lock + always release
+
+Wire the bond into the take flow but **never slash**. This lets operators
+turn the feature on in staging to exercise hold-invoice custody with zero risk
+to users.
+
+### 6.1 Scope
+
+- Gate `enabled && apply_to ∈ { "take", "both" }`. Otherwise existing code
+  path is untouched.
+- `src/app/bond/flow.rs`:
+  - `request_taker_bond(ctx, order, taker_pubkey, request_id) -> Result<Bond, MostroError>`
+    - Compute bond amount from order amount (use max_amount for range orders
+      so Phase 6 migration is trivial — but range-maker handling is Phase 6;
+      for taker on a range order we use the exact amount chosen by the taker).
+    - `LndConnector::create_hold_invoice` with a dedicated memo
+      (`"mostro bond order_id=<uuid>"`).
+    - Persist `Bond { state: Requested, hash, preimage, payment_request }`.
+    - Enqueue a new `Action::AddBondInvoice` message to the taker with the
+      bolt11 so the client pays it.
+    - `LndConnector::subscribe_invoice(hash, ..)` feeding a bond listener
+      (new file `src/flow.rs` companion or inside `bond/flow.rs`). On
+      `Accepted`, transition the bond to `Locked`.
+  - `release_bond(ctx, &Bond)` — `cancel_hold_invoice(hash)`, mark
+    `Released`, set `released_at`.
+- Modify `take_buy_action` / `take_sell_action`:
+  - If the bond is enabled for take, **do not** call `show_hold_invoice` yet.
+    Instead, stash all computed trade state on the order row (status stays
+    `Pending` or a new ephemeral `WaitingTakerBond` status — see §6.2), call
+    `request_taker_bond`, and return.
+  - Add an internal continuation that fires when the bond subscriber reports
+    `Accepted`. It resumes the original take: calls `show_hold_invoice`
+    (sell-side) or `set_waiting_invoice_status` (buy-side), flipping order
+    status to `WaitingPayment` / `WaitingBuyerInvoice`.
+- Wire bond release into every existing exit:
+  - `release_action` settle path → `release_bond` after seller invoice
+    settles.
+  - `cancel_action` (cooperative and unilateral) → `release_bond` whenever
+    the hold escrow is canceled.
+  - `admin_cancel_action`, `admin_settle_action` → always `release_bond` in
+    Phase 1 (slash logic lands in Phase 2).
+  - `scheduler::job_cancel_orders` → when an order is reset/canceled,
+    release bonds attached to it.
+- New status `WaitingTakerBond` in `mostro_core::order::Status` (requires a
+  PR in `mostro-core` first; note: this doc only tracks the Mostro-daemon
+  side). **Alternative**: reuse `Pending` and track bond state in the
+  `bonds` table alone. Decision deferred to PR review; recommendation is
+  the explicit status for observability.
+- Tests:
+  - Happy path: take → bond locked → escrow flow → release settles bond.
+  - Taker never funds the bond hold invoice → expiration leaves order
+    returned to `Pending` (no bond outstanding; no user harmed).
+  - Cooperative cancel after bond locked → bond released.
+
+### 6.2 Open question to resolve in the PR
+
+- **New `WaitingTakerBond` status vs reusing `Pending`.**
+  - Adding a status is a breaking protocol hint for clients that filter
+    status tags; should coincide with a minor version bump in mostro-core.
+  - Reusing `Pending` is cheaper but makes it harder for clients to render
+    "waiting for your bond."
+  - Default recommendation: **add the status** because it matches the new
+    `AddBondInvoice` action and is forward-compatible with the maker bond
+    that will need a similar state.
+
+### 6.3 Acceptance
+
+- Feature disabled: no behavior change. Integration test that takes an order
+  with `enabled=false` passes identically.
+- Feature enabled, apply_to=take: taker must fund a second hold invoice; all
+  exits release it.
+
+---
+
+## 7. Phase 2 — Taker dispute slash
+
+Behavior gate: `enabled && apply_to ∈ {take, both} && slash_on_lost_dispute`.
+
+### 7.1 Scope
+
+- `admin_settle_action` and `admin_cancel_action` already know who won (seller
+  wins → settle hold; buyer wins → cancel hold and payout).
+  - For each outcome, compute whether the **taker** lost.
+    - Taker identity is already derivable: on a Buy order the taker is the
+      seller, on a Sell order the taker is the buyer.
+  - If taker lost and slash flag on → set taker bond
+    `state = PendingPayout, slashed_reason = LostDispute`. Do **not** settle
+    the bond hold invoice yet — that's Phase 3 so it coincides with the
+    payout flow.
+  - If taker won (or flag off) → `release_bond`.
+- Tests for both disputes (Buy and Sell), both outcomes, flag on/off.
+
+### 7.2 Non-goals
+
+- No actual Lightning payout in this phase. `PendingPayout` is persisted and
+  surfaces in logs; the scheduler in Phase 3 picks it up.
+
+### 7.3 Acceptance
+
+- With flag off: Phase 1 behavior preserved (release).
+- With flag on + taker lost: bond row is `PendingPayout`.
+- With flag on + taker won: bond released.
+
+---
+
+## 8. Phase 3 — Payout flow
+
+Shared infrastructure used by every slash path afterwards. Non-blocking:
+trade finalization must never wait on the payout.
+
+### 8.1 Scope
+
+- New scheduler job `job_process_bond_payouts` in `src/scheduler.rs`,
+  mirroring `job_process_dev_fee_payment`:
+  - Polls `PendingPayout` bonds at a fixed interval (default 60s).
+  - For each:
+    1. If no `payout_invoice` yet, and either no outstanding DM to the
+       winner or the window has elapsed: enqueue an `Action::AddInvoice`
+       DM to the winning counterparty asking for a bolt11 for
+       `amount_sats - estimated_routing_fee`. Increment
+       `payout_attempts`.
+    2. If an invoice was received (see handler below), **estimate the
+       routing fee** via `LndConnector::query_routes(dest, amount)`
+       (thin wrapper over LND `router::query_routes`); fall back to
+       `amount * max_routing_fee` if the RPC fails.
+    3. `settle_hold_invoice(preimage)` on the bond hash to claim the
+       forfeited sats into Mostro's wallet.
+    4. `send_payment` to the winner invoice with capped fee.
+    5. On success → `state = Slashed`, `slashed_at = now`, publish audit
+       event.
+    6. On failure → bump `payout_attempts`; once `payout_max_retries`
+       reached, transition to `Failed` and leave a tracing error.
+- New action handler `add_bond_invoice_action` in a new
+  `src/app/bond/payout.rs` module. Receives an `Action::AddInvoice` reply
+  from a bond-payout candidate (distinct from the buyer-invoice
+  `add_invoice_action` — disambiguated by the presence of a bond row in
+  `PendingPayout` for the order / sender pair).
+- Audit event: new Nostr kind (reusing the dev-fee style: custom kind
+  number, registered in `src/config/constants.rs`). Tags:
+  `order-id`, `role`, `reason`, `amount`, `hash` (bond payout hash,
+  **not** the trade payment hash), `y`, `z = bond-slash`. No counterparty
+  pubkeys, consistent with dev-fee audit privacy. Expiration uses
+  `ExpirationSettings` with a new optional `bond_slash_days` field.
+- Unit tests: routing-fee fallback, retries exhaustion, settle-then-pay
+  ordering.
+
+### 8.2 Failure modes & invariants
+
+- **`settle` must succeed before `send_payment`.** If settle fails we leave
+  the bond in `PendingPayout` and retry on the next tick; the bonded party's
+  HTLC stays held, which is the correct safety posture.
+- **Partial success: settle OK, send_payment failed.** The bond state moves
+  to `PendingPayout` with a best-effort retry. The winner is kept informed
+  via periodic DMs. If retries exhaust, state becomes `Failed`; at that
+  point Mostro keeps the sats (unavoidable with the HTLC settled) and logs
+  loudly. This is a known limitation to be addressed only if it shows up
+  in practice; node operators can manually pay the winner from logs.
+- **Non-blocking:** `release_action`, `admin_settle_action`, etc. return
+  success the moment the trade escrow resolves. Bond payout happens later.
+
+### 8.3 Acceptance
+
+- End-to-end test: dispute-lost taker bond → winner gets a DM → winner
+  submits bolt11 → bond payout settles → Nostr audit event published.
+- Retry test: winner never answers → scheduler keeps retrying up to
+  `payout_max_retries`, then `Failed`.
+
+---
+
+## 9. Phase 4 — Taker timeout slash
+
+Gate: `enabled && apply_to ∈ {take, both} && slash_on_waiting_timeout`.
+
+### 9.1 Scope
+
+- Critical invariant (from the issue): **bond is slashed only when the
+  timeout actually elapsed.** Cancels before the timeout — mutual,
+  unilateral, admin — must always release the bond. This prevents a
+  malicious maker from cancelling at minute N-1 to steal a taker's bond.
+- Modify `scheduler::job_cancel_orders`:
+  - Today it walks orders whose `taken_at` + timeout ≤ now. That path is
+    the one — and only one — trigger for a timeout slash. Cancels from
+    `cancel_action` / `admin_cancel_action` do not enter this path, so
+    the invariant holds by construction.
+  - When the waiting-state timeout elapses on an order in
+    `WaitingBuyerInvoice` / `WaitingPayment`:
+    - Identify the *responsible* side (the one that didn't do their duty):
+      - `WaitingBuyerInvoice` → buyer is responsible.
+      - `WaitingPayment` → seller is responsible.
+    - Is that party the **taker**? (Sell order + waiting-payment = taker
+      is seller; Buy order + waiting-buyer-invoice = taker is buyer; etc.)
+    - If yes and the slash flag is on: set taker bond
+      `state = PendingPayout, slashed_reason = Timeout`. Then continue
+      the existing behavior (cancel escrow hold invoice, republish
+      order as `Pending` for maker-initiated flows). Order republishes
+      — the maker doesn't need to re-post.
+- Message to the slashed user: new localized string explaining forfeiture
+  with the configured flag value.
+- Tests:
+  - "Cancel at minute 5 of a 15-minute timeout" — bond released, no slash.
+  - "Taker silent past 15-minute timeout" — bond slashed,
+    `BondSlashReason::Timeout`, order returned to `Pending`.
+  - Flag off → no slash even when timeout elapses (old behavior).
+
+### 9.2 Acceptance
+
+- Attack-invariant test passes: malicious maker cancels before timeout →
+  bond always released, even across both flag values.
+- Timeout slash feeds Phase 3 payout flow.
+
+---
+
+## 10. Phase 5 — Maker bond (non-range) + dispute slash
+
+Gate: `enabled && apply_to ∈ {create, both}`.
+
+### 10.1 Scope
+
+- Extend `publish_order` (`src/util.rs`) to request a bond from the maker
+  when enabled, **before** the order is published to Nostr. The order row
+  exists in DB with a transient status (recommend `WaitingMakerBond` in
+  `mostro-core`). No NIP-33 order event is emitted until the bond is
+  `Locked`.
+- Once the bond subscriber reports `Accepted`, continue the existing
+  `publish_order` work (compute tags, emit event, set `event_id`).
+- Bond release hooks:
+  - Order completed → `release_bond`.
+  - Order cancelled before ever being taken → `release_bond`.
+  - Order expired in `Pending` → `release_bond`.
+  - Maker loses dispute and `slash_on_lost_dispute` → `PendingPayout`
+    with reason `LostDispute`, reusing Phase 3 payout.
+  - Maker wins dispute → `release_bond`.
+- Tests for each.
+
+### 10.2 Open question: bond amount for a range maker order
+
+A range order has `min_amount`/`max_amount` in fiat but no single sats
+amount up front. **Use `max_amount` converted at current price** to size
+the maker bond — consistent with "worst-case exposure." That's also how
+Phase 6 will split proportional slashes. If the price drifts between
+publication and take, the bond is computed against the sats value at
+publication time and is not repriced.
+
+### 10.3 Acceptance
+
+- Feature disabled: no change.
+- Feature enabled, apply_to=create: order is not visible in the book until
+  bond locks. A client that abandons the bond invoice → order never shows
+  up; no ghost book entry.
+
+---
+
+## 11. Phase 6 — Range-order maker bond with proportional slashes
+
+Dependent on Phase 5. This is the only genuinely subtle phase; keep the
+review bar high.
+
+### 11.1 Data model addition
+
+Extend `Bond` with:
+- `child_order_id char(36)` — set on a **child bond row** that represents a
+  partial slash/release on the parent.
+- `parent_bond_id char(36)` — on child rows, references the maker's parent
+  bond.
+- `slashed_share_sats integer default 0` — on the parent bond row,
+  running total of sats already slashed.
+
+The maker posts **one** hold invoice (parent) sized against `max_amount`.
+When a child order is created inside the range, no new maker bond hold
+invoice is needed — we track the slice via a child row only if/when we
+need to slash.
+
+### 11.2 Slash math
+
+For a child order with sats amount `child_sats` and parent bond computed
+from `parent_max_sats`:
+
+```
+share_fraction  = child_sats / parent_max_sats
+slash_amount    = round(parent_bond_amount * share_fraction)
+```
+
+On dispute loss for that child (and slash flag on):
+- Insert a child bond row (`parent_bond_id`, `amount_sats = slash_amount`,
+  `state = PendingPayout`, `slashed_reason = LostDispute`).
+- The scheduler's payout job queries the winner, receives an invoice for
+  `slash_amount - routing_fee`, claims `slash_amount` from the parent hold
+  invoice… but LND hold invoices do not natively support partial claims.
+
+**Implementation reality for partial slash:**
+A BOLT11 hold invoice is all-or-nothing. We cannot settle only part of it.
+The workable strategies:
+
+1. **Accumulate and settle-at-close.** Track `slashed_share_sats` on the
+   parent. Keep the parent hold invoice locked for the entire life of the
+   range order. At parent close (exhaustion / expiration / cancellation):
+   - If `slashed_share_sats == 0` → `cancel_hold_invoice(parent)` and
+     release.
+   - If `slashed_share_sats == parent_bond_amount` → `settle` and payout
+     the accumulated winnings (multiple winners are supported by keeping
+     child rows with their own `payout_invoice`).
+   - If partial → there is no way to claim exactly the slashed sats from a
+     single HTLC; we must choose between:
+     - **(a)** Claim the whole bond, pay out the slashed share to winners,
+       and refund the unslashed share back to the maker via `add-invoice`
+       (maker becomes a counterparty here). Reuses Phase 3 plumbing.
+     - **(b)** Never lock a parent bond; require a per-child bond at take
+       time. Simpler to reason about but breaks the issue's requirement
+       that the maker bond exists **before** the order is visible.
+
+We recommend **(a)**. Acceptable cost: maker sees one extra `add-invoice`
+DM at range-close if there were partial slashes.
+
+2. **Fallback on HTLC expiry.** If the range order is still active when
+   the hold invoice CLTV is about to expire, the scheduler must settle or
+   cancel before LND does it for us. `hold_invoice_cltv_delta` in settings
+   bounds this. Document the operator impact.
+
+### 11.3 Scope
+
+- Parent/child bond rows and helpers.
+- Range-order publication sizes bond against `max_amount`.
+- Child slash: creates child row in `PendingPayout`; does not touch the
+  parent HTLC yet.
+- Parent close: resolve according to strategy (a) above.
+- Extensive tests:
+  - No slashes → full release to maker on close.
+  - One small child slashed → pay winner, refund unslashed to maker.
+  - Multiple child slashes across the range → each winner paid, residual
+    refunded.
+  - Cancellation during active children → pending slashes still
+    actionable after.
+
+### 11.4 Acceptance
+
+- Issue invariant from §"Range Orders" satisfied: proportional slash, full
+  release on close, child independence.
+- No path exists that settles the parent hold invoice before the range is
+  resolved.
+
+---
+
+## 12. Phase 7 — Maker timeout slash
+
+Gate: `enabled && apply_to ∈ {create, both} && slash_on_waiting_timeout`.
+
+Symmetric to Phase 4. The responsible party on a given waiting state might
+be the maker (e.g. a sell-maker who never paid the hold invoice after the
+buyer-taker submitted their invoice). Reuse the dispatch in
+`job_cancel_orders` and reuse the Phase 3 payout.
+
+Keep the Phase 4 invariant: cancels before timeout always release.
+
+Tests mirror Phase 4 from the maker side. For range orders, a per-child
+timeout slashes the child's share via the Phase 6 partial-slash path.
+
+---
+
+## 13. Phase 8 — Public exposure + docs
+
+### 13.1 Scope
+
+- Extend the Mostro info event (`src/nip33.rs::info_to_tags`) with the
+  bond config snapshot so clients can show users what the node enforces
+  before they trade:
+  - `bond` (`enabled` | `disabled`)
+  - `bond-apply-to` (`take`/`create`/`both`)
+  - `bond-slash-dispute` (`true`/`false`)
+  - `bond-slash-timeout` (`true`/`false`)
+  - `bond-amount-pct` / `bond-amount-floor`
+- README + `docs/ARCHITECTURE.md`: add the bond flow to the per-action
+  table and to the sequence diagrams.
+- `docs/LIGHTNING_OPS.md`: operator runbook section for bonds (how to
+  read audit events, how to resolve a `Failed` bond manually).
+- `CHANGELOG.md` entry (user-visible: new optional config, opt-in).
+
+### 13.2 Acceptance
+
+- `mostro info` output (and client-visible info tags) surfaces the bond
+  policy.
+- Docs build; markdown lint clean.
+
+---
+
+## 14. Cross-cutting concerns
+
+### 14.1 Privacy
+
+- The bond audit event deliberately omits buyer/seller pubkeys (dev-fee
+  precedent). The only party-identifying info that could leak is the
+  payout invoice's routing hints, which is unavoidable but does not
+  reveal more than a normal Lightning payment.
+
+### 14.2 Backward compatibility
+
+- Database migration is purely additive; existing orders are unaffected.
+- Default config is `enabled = false`; old `settings.toml` files work as
+  is.
+- New `Status` / `Action` variants in `mostro-core` (Phases 1 & 5) must
+  ship in that crate first and be pinned to a version in this repo's
+  `Cargo.toml`. Clients must handle unknown statuses gracefully — this
+  is already the case.
+
+### 14.3 Protocol/tag changes
+
+Per `CONTRIBUTING.md § Protocol / Tag Changes`, the new info-event tags
+(Phase 8) require a compatibility statement in the PR body. New
+`AddBondInvoice`, `BondLocked`, `BondSlashed` actions (Phases 1–4)
+similarly need a cross-kind scope declaration.
+
+### 14.4 Testing discipline
+
+- Unit tests per phase as listed above, co-located under
+  `#[cfg(test)] mod tests` in the touched module.
+- Integration-style tests against an in-memory SQLite (see existing
+  patterns in `src/util.rs::tests`).
+- Manual LND regression checklist in each PR body:
+  - lock a bond on polar/regtest
+  - release via normal flow
+  - release via cancel
+  - (from Phase 2) slash via dispute
+  - (from Phase 3) winner receives payout
+
+### 14.5 Observability
+
+- `tracing` spans in each bond transition with
+  `bond_id`, `order_id`, `role`, `state`.
+- A structured log line on every state change is enough; no Prometheus
+  wiring needed until we see real traffic.
+
+---
+
+## 15. Answers to the issue's open questions
+
+1. **Hold invoice library support.** LND already powers hold invoices in
+   Mostro (`LndConnector::create_hold_invoice`). The bond reuses this
+   primitive; no new library.
+2. **Preimage custody.** Already held by Mostro today
+   (`orders.preimage`). Bonds follow the same model in the new
+   `bonds.preimage` column.
+3. **Order-book visibility with maker bond.** Phase 5 defers publishing
+   the NIP-33 order event until the bond locks. Confirmed approach.
+4. **Rollover on re-take/re-create.** Each `take` or `create` is
+   independent; a fresh bond row is created each time. No rollover.
+5. **Dispute state machine.** Today's resolution flows
+   (`admin_settle_action`, `admin_cancel_action`) already know the
+   winning side; Phase 2 leverages that directly.
+6. **Routing-fee estimation.** LND `router::query_routes` gives a pre-
+   payment fee estimate. Fallback: `amount * max_routing_fee` using the
+   existing Mostro setting. Implemented in Phase 3.
+7. **Range-order partial slash tracking.** Phase 6 introduces
+   parent/child bond rows and accumulates `slashed_share_sats` on the
+   parent, resolving the HTLC at range close. Strategy (a) detailed in
+   §11.2.
+
+---
+
+## 16. Tracking
+
+Each phase ships as a separate PR that links this document. The PR
+description must state: which phase, which gate flags it touches, and
+the manual LND/regtest evidence that the bond behaved correctly.
+
+When the full plan has landed, this spec is kept in `docs/` as the
+feature's reference.

--- a/migrations/20260423120000_anti_abuse_bond.sql
+++ b/migrations/20260423120000_anti_abuse_bond.sql
@@ -1,0 +1,67 @@
+-- Anti-abuse bond storage (issue #711, Phase 0).
+--
+-- The bond is an opt-in hold invoice locked by a trading party (taker, maker,
+-- or both — controlled by the `[anti_abuse_bond]` settings block). Rows in
+-- this table are only created when the feature is enabled; existing orders
+-- are unaffected.
+--
+-- Later phases will hook trade flows into this table:
+--   Phase 1: taker bond lock + always-release.
+--   Phase 2: taker bond slash on lost dispute.
+--   Phase 3: payout flow to the winning counterparty.
+--   Phase 4: taker timeout slash.
+--   Phase 5: maker bond.
+--   Phase 6: range-order proportional slashes (parent/child rows).
+--   Phase 7: maker timeout slash.
+CREATE TABLE IF NOT EXISTS bonds (
+  id               char(36) primary key not null,
+  order_id         char(36) not null,
+  -- Parent bond id for Phase 6 range-order child slashes. NULL for parent /
+  -- non-range bonds. Self-referential FK is intentionally not declared so
+  -- that child rows can be created independently of their parent lifecycle.
+  parent_bond_id   char(36),
+  -- Child order id used by Phase 6 when a single maker parent bond records
+  -- proportional slashes against individual children. NULL for parent /
+  -- non-range bonds.
+  child_order_id   char(36),
+  -- Trade pubkey of the bonded party. Not the identity pubkey.
+  pubkey           char(64) not null,
+  -- 'maker' | 'taker'
+  role             varchar(8) not null,
+  -- Amount (sats) covered by this bond row. For a parent bond this is the
+  -- total locked; for a child slash row this is the proportional slice.
+  amount_sats      integer not null,
+  -- Running total of sats already transitioned to a slashed child. Used on
+  -- parent bonds in Phase 6 to decide between full-settle and
+  -- settle+refund at parent close. Unused (0) for child / non-range rows.
+  slashed_share_sats integer not null default 0,
+  -- BondState serialization: 'requested' | 'locked' | 'released' |
+  -- 'pending-payout' | 'slashed' | 'failed'
+  state            varchar(16) not null,
+  -- BondSlashReason: 'lost-dispute' | 'timeout'. NULL unless state in
+  -- ('pending-payout', 'slashed').
+  slashed_reason   varchar(16),
+  -- Bond hold invoice hash (hex). NULL until the hold invoice is created.
+  hash             char(64),
+  -- Preimage retained by Mostro so a slash does not depend on cooperation
+  -- from the bonded party. NULL for child rows that share a parent HTLC.
+  preimage         char(64),
+  -- bolt11 payment request shown to the bonded party.
+  payment_request  text,
+  -- bolt11 payout invoice from the winning counterparty (Phase 3+).
+  payout_invoice   text,
+  -- Routing-fee ceiling actually used for the payout attempt (sats). NULL
+  -- until the scheduler tries to pay the winner.
+  payout_routing_fee_sats integer,
+  -- Number of payout invoice requests attempted so far.
+  payout_attempts  integer not null default 0,
+  locked_at        integer,
+  released_at      integer,
+  slashed_at       integer,
+  created_at       integer not null,
+  FOREIGN KEY(order_id) REFERENCES orders(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_bonds_order_id ON bonds(order_id);
+CREATE INDEX IF NOT EXISTS idx_bonds_state    ON bonds(state);
+CREATE INDEX IF NOT EXISTS idx_bonds_parent   ON bonds(parent_bond_id);

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -94,8 +94,9 @@ port = 50051
 #
 # [anti_abuse_bond]
 # enabled = false
-# # bond = max(amount_sats * order_amount, base_amount_sats)
-# amount_sats = 0.01
+# # bond = max(amount_pct * order_amount_sats, base_amount_sats)
+# # amount_pct is a unitless fraction (0.01 = 1%); base_amount_sats is a sat floor.
+# amount_pct = 0.01
 # base_amount_sats = 1000
 # # "take" | "create" | "both"
 # apply_to = "take"

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -87,3 +87,19 @@ listen_address = "127.0.0.1"
 port = 50051
 # Duration in seconds after which inactive rate-limiter entries are evicted
 # rate_limiter_stale_duration = 3600
+
+# Anti-abuse bond (issue #711). Opt-in, disabled by default. Uncomment to
+# require a Lightning hold-invoice bond from takers and/or makers. See
+# docs/ANTI_ABUSE_BOND.md for the full phased rollout.
+#
+# [anti_abuse_bond]
+# enabled = false
+# # bond = max(amount_sats * order_amount, base_amount_sats)
+# amount_sats = 0.01
+# base_amount_sats = 1000
+# # "take" | "create" | "both"
+# apply_to = "take"
+# slash_on_lost_dispute = true
+# slash_on_waiting_timeout = false
+# payout_invoice_window_seconds = 300
+# payout_max_retries = 5

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ pub mod admin_add_solver; // Admin functionality to add dispute solvers
 pub mod admin_cancel; // Admin order cancellation
 pub mod admin_settle; // Admin dispute settlement
 pub mod admin_take_dispute; // Admin dispute handling
+pub mod bond; // Anti-abuse bond data + helpers (issue #711)
 pub mod cancel; // User order cancellation
 pub mod dev_fee; // Dev fee payment lifecycle
 pub mod dispute; // User dispute handling

--- a/src/app/bond/db.rs
+++ b/src/app/bond/db.rs
@@ -21,21 +21,30 @@ pub async fn create_bond(
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
 }
 
-/// Look up the bond row for a given order + role. Returns `None` if no
-/// bond exists for that pair (the normal case when the feature is off or
-/// doesn't apply to the role).
+/// Look up the parent bond row for a given order + role. Returns `None`
+/// if no bond exists for that pair (the normal case when the feature is
+/// off or doesn't apply to the role).
+///
+/// Phase 6 introduces child slash rows that share the parent's `order_id`
+/// and `role`; those rows carry a non-NULL `parent_bond_id`. The
+/// `parent_bond_id IS NULL` predicate keeps this lookup pinned to the
+/// parent bond so state transitions always target the right row.
 pub async fn find_bond_by_order_and_role(
     pool: &Pool<Sqlite>,
     order_id: Uuid,
     role: BondRole,
 ) -> Result<Option<Bond>, mostro_core::error::MostroError> {
     let role_str = role.to_string();
-    sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE order_id = ? AND role = ? LIMIT 1")
-        .bind(order_id)
-        .bind(role_str)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+    sqlx::query_as::<_, Bond>(
+        "SELECT * FROM bonds \
+         WHERE order_id = ? AND role = ? AND parent_bond_id IS NULL \
+         LIMIT 1",
+    )
+    .bind(order_id)
+    .bind(role_str)
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
 }
 
 /// List every bond currently in the given state. Used by the Phase 3
@@ -129,6 +138,33 @@ mod tests {
             .expect("row present");
         assert_eq!(fetched.id, created.id);
         assert_eq!(fetched.role, "taker");
+    }
+
+    #[tokio::test]
+    async fn fetch_by_order_and_role_ignores_child_rows() {
+        // Phase 6 will store child slash rows that share the parent bond's
+        // `order_id` and `role`; the lookup must still return the parent.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        let child_order_id = Uuid::new_v4();
+        insert_parent_order(&pool, order_id).await;
+        insert_parent_order(&pool, child_order_id).await;
+
+        let parent = create_bond(&pool, dummy_bond(order_id, BondRole::Maker))
+            .await
+            .expect("insert parent");
+
+        let mut child = dummy_bond(order_id, BondRole::Maker);
+        child.parent_bond_id = Some(parent.id);
+        child.child_order_id = Some(child_order_id);
+        create_bond(&pool, child).await.expect("insert child");
+
+        let fetched = find_bond_by_order_and_role(&pool, order_id, BondRole::Maker)
+            .await
+            .expect("query")
+            .expect("row present");
+        assert_eq!(fetched.id, parent.id);
+        assert!(fetched.parent_bond_id.is_none());
     }
 
     #[tokio::test]

--- a/src/app/bond/db.rs
+++ b/src/app/bond/db.rs
@@ -1,0 +1,173 @@
+//! Database helpers for the `bonds` table.
+//!
+//! Phase 0 exposes the CRUD surface later phases will need. Nothing in
+//! this module hits LND or the Nostr client — it's purely storage.
+
+use mostro_core::error::{MostroError::MostroInternalErr, ServiceError};
+use sqlx::{Pool, Sqlite};
+use sqlx_crud::Crud;
+use uuid::Uuid;
+
+use super::model::Bond;
+use super::types::{BondRole, BondState};
+
+/// Insert a new bond row. Returns the persisted `Bond`.
+pub async fn create_bond(
+    pool: &Pool<Sqlite>,
+    bond: Bond,
+) -> Result<Bond, mostro_core::error::MostroError> {
+    bond.create(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
+/// Look up the bond row for a given order + role. Returns `None` if no
+/// bond exists for that pair (the normal case when the feature is off or
+/// doesn't apply to the role).
+pub async fn find_bond_by_order_and_role(
+    pool: &Pool<Sqlite>,
+    order_id: Uuid,
+    role: BondRole,
+) -> Result<Option<Bond>, mostro_core::error::MostroError> {
+    let role_str = role.to_string();
+    sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE order_id = ? AND role = ? LIMIT 1")
+        .bind(order_id)
+        .bind(role_str)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
+/// List every bond currently in the given state. Used by the Phase 3
+/// payout scheduler.
+pub async fn find_bonds_by_state(
+    pool: &Pool<Sqlite>,
+    state: BondState,
+) -> Result<Vec<Bond>, mostro_core::error::MostroError> {
+    let state_str = state.to_string();
+    sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE state = ? ORDER BY created_at ASC")
+        .bind(state_str)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
+/// Update a bond row by primary key. Returns the persisted `Bond`.
+pub async fn update_bond(
+    pool: &Pool<Sqlite>,
+    bond: Bond,
+) -> Result<Bond, mostro_core::error::MostroError> {
+    bond.update(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::bond::model::Bond;
+    use crate::app::bond::types::BondRole;
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn setup_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("open in-memory sqlite");
+        // Minimal orders table: bonds has an FK on it.
+        sqlx::query(include_str!(
+            "../../../migrations/20221222153301_orders.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("orders migration");
+        sqlx::query(include_str!(
+            "../../../migrations/20260423120000_anti_abuse_bond.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bonds migration");
+        // SQLite doesn't enforce FKs unless asked. Turn them on so the FK to
+        // `orders` is a real constraint in tests (mirrors production).
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await
+            .expect("enable fk");
+        pool
+    }
+
+    async fn insert_parent_order(pool: &Pool<Sqlite>, id: Uuid) {
+        sqlx::query(
+            r#"INSERT INTO orders (
+                id, kind, event_id, status, premium, payment_method,
+                amount, fiat_code, fiat_amount, created_at, expires_at
+            ) VALUES (?, 'buy', ?, 'pending', 0, 'ln', 1000, 'USD', 10, 0, 0)"#,
+        )
+        .bind(id)
+        .bind(id.simple().to_string())
+        .execute(pool)
+        .await
+        .expect("insert parent order");
+    }
+
+    fn dummy_bond(order_id: Uuid, role: BondRole) -> Bond {
+        Bond::new_requested(order_id, "a".repeat(64), role, 1_500)
+    }
+
+    #[tokio::test]
+    async fn insert_and_fetch_by_order_and_role() {
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_parent_order(&pool, order_id).await;
+        let created = create_bond(&pool, dummy_bond(order_id, BondRole::Taker))
+            .await
+            .expect("insert");
+        let fetched = find_bond_by_order_and_role(&pool, order_id, BondRole::Taker)
+            .await
+            .expect("query")
+            .expect("row present");
+        assert_eq!(fetched.id, created.id);
+        assert_eq!(fetched.role, "taker");
+    }
+
+    #[tokio::test]
+    async fn fetch_missing_returns_none() {
+        let pool = setup_pool().await;
+        let res = find_bond_by_order_and_role(&pool, Uuid::new_v4(), BondRole::Taker)
+            .await
+            .expect("query");
+        assert!(res.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_by_state_filters() {
+        let pool = setup_pool().await;
+        let order_a = Uuid::new_v4();
+        let order_b = Uuid::new_v4();
+        insert_parent_order(&pool, order_a).await;
+        insert_parent_order(&pool, order_b).await;
+        let bond_a = create_bond(&pool, dummy_bond(order_a, BondRole::Taker))
+            .await
+            .unwrap();
+        let _bond_b = create_bond(&pool, dummy_bond(order_b, BondRole::Maker))
+            .await
+            .unwrap();
+
+        // Flip one to Locked.
+        let mut locked = bond_a.clone();
+        locked.state = BondState::Locked.to_string();
+        locked.locked_at = Some(42);
+        update_bond(&pool, locked).await.unwrap();
+
+        let requested = find_bonds_by_state(&pool, BondState::Requested)
+            .await
+            .unwrap();
+        assert_eq!(requested.len(), 1);
+        assert_eq!(requested[0].order_id, order_b);
+
+        let locked = find_bonds_by_state(&pool, BondState::Locked).await.unwrap();
+        assert_eq!(locked.len(), 1);
+        assert_eq!(locked[0].order_id, order_a);
+    }
+}

--- a/src/app/bond/math.rs
+++ b/src/app/bond/math.rs
@@ -5,7 +5,7 @@
 //! Computation:
 //!
 //! ```text
-//! bond_amount = max(amount_sats * order_amount_sats, base_amount_sats)
+//! bond_amount = max(amount_pct * order_amount_sats, base_amount_sats)
 //! ```
 
 use crate::config::AntiAbuseBondSettings;
@@ -20,17 +20,17 @@ use crate::config::AntiAbuseBondSettings;
 /// - Arithmetic is saturating: a pathological huge order can't overflow.
 pub fn compute_bond_amount(order_amount_sats: i64, cfg: &AntiAbuseBondSettings) -> i64 {
     let base = cfg.base_amount_sats.max(0);
-    if order_amount_sats <= 0 || cfg.amount_sats <= 0.0 {
+    if order_amount_sats <= 0 || cfg.amount_pct <= 0.0 {
         return base;
     }
 
     // f64 is sufficient here: we cap Lightning order amounts in sats well
     // below 2^53 at config time, so the multiplication is exact.
-    let pct_raw = (order_amount_sats as f64) * cfg.amount_sats;
+    let pct_raw = (order_amount_sats as f64) * cfg.amount_pct;
     let pct_rounded = pct_raw.round();
 
     // Saturate to i64 before comparing with the floor to guarantee no UB on
-    // absurd inputs (e.g. `amount_sats = 1e18`).
+    // absurd inputs (e.g. `amount_pct = 1e18`).
     let pct_sats: i64 = if pct_rounded >= i64::MAX as f64 {
         i64::MAX
     } else if pct_rounded <= 0.0 {
@@ -49,7 +49,7 @@ mod tests {
     fn cfg_with(pct: f64, floor: i64) -> AntiAbuseBondSettings {
         AntiAbuseBondSettings {
             enabled: true,
-            amount_sats: pct,
+            amount_pct: pct,
             base_amount_sats: floor,
             ..AntiAbuseBondSettings::default()
         }
@@ -106,7 +106,8 @@ mod tests {
         // 0.007 * 333 = 2.331 → 2
         let cfg = cfg_with(0.007, 0);
         assert_eq!(compute_bond_amount(333, &cfg), 2);
-        // 0.007 * 500 = 3.5 → 4 (round half to even gives 4 here)
+        // 0.007 * 500 = 3.5 → 4. `f64::round()` rounds half away from
+        // zero, not half-to-even, so 3.5 → 4 deterministically.
         let cfg = cfg_with(0.007, 0);
         assert_eq!(compute_bond_amount(500, &cfg), 4);
     }

--- a/src/app/bond/math.rs
+++ b/src/app/bond/math.rs
@@ -1,0 +1,121 @@
+//! Pure helpers for bond-amount computation.
+//!
+//! Kept separate from config and model layers so tests can exercise all
+//! edge cases without spinning up a daemon. See issue #711 §Bond
+//! Computation:
+//!
+//! ```text
+//! bond_amount = max(amount_sats * order_amount_sats, base_amount_sats)
+//! ```
+
+use crate::config::AntiAbuseBondSettings;
+
+/// Compute the bond size in satoshis for an order of `order_amount_sats`
+/// using the operator's configured percentage / floor.
+///
+/// - `order_amount_sats` is clamped at 0: negative order amounts (which
+///   should never reach here) yield the floor.
+/// - The percentage result is rounded to the nearest sat.
+/// - The floor is enforced so a tiny order never yields a trivial bond.
+/// - Arithmetic is saturating: a pathological huge order can't overflow.
+pub fn compute_bond_amount(order_amount_sats: i64, cfg: &AntiAbuseBondSettings) -> i64 {
+    let base = cfg.base_amount_sats.max(0);
+    if order_amount_sats <= 0 || cfg.amount_sats <= 0.0 {
+        return base;
+    }
+
+    // f64 is sufficient here: we cap Lightning order amounts in sats well
+    // below 2^53 at config time, so the multiplication is exact.
+    let pct_raw = (order_amount_sats as f64) * cfg.amount_sats;
+    let pct_rounded = pct_raw.round();
+
+    // Saturate to i64 before comparing with the floor to guarantee no UB on
+    // absurd inputs (e.g. `amount_sats = 1e18`).
+    let pct_sats: i64 = if pct_rounded >= i64::MAX as f64 {
+        i64::MAX
+    } else if pct_rounded <= 0.0 {
+        0
+    } else {
+        pct_rounded as i64
+    };
+
+    pct_sats.max(base)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg_with(pct: f64, floor: i64) -> AntiAbuseBondSettings {
+        AntiAbuseBondSettings {
+            enabled: true,
+            amount_sats: pct,
+            base_amount_sats: floor,
+            ..AntiAbuseBondSettings::default()
+        }
+    }
+
+    #[test]
+    fn floor_dominates_on_tiny_orders() {
+        let cfg = cfg_with(0.01, 1_000);
+        // 1% of 50_000 = 500 < floor
+        assert_eq!(compute_bond_amount(50_000, &cfg), 1_000);
+    }
+
+    #[test]
+    fn percentage_dominates_on_large_orders() {
+        let cfg = cfg_with(0.01, 1_000);
+        // 1% of 10_000_000 = 100_000 > floor
+        assert_eq!(compute_bond_amount(10_000_000, &cfg), 100_000);
+    }
+
+    #[test]
+    fn floor_and_percentage_equal_at_threshold() {
+        // Example from the issue: 100k sats order, 1% pct, 1k floor → 1000.
+        let cfg = cfg_with(0.01, 1_000);
+        assert_eq!(compute_bond_amount(100_000, &cfg), 1_000);
+    }
+
+    #[test]
+    fn zero_percentage_returns_floor() {
+        let cfg = cfg_with(0.0, 500);
+        assert_eq!(compute_bond_amount(1_000_000, &cfg), 500);
+    }
+
+    #[test]
+    fn zero_order_returns_floor() {
+        let cfg = cfg_with(0.01, 250);
+        assert_eq!(compute_bond_amount(0, &cfg), 250);
+    }
+
+    #[test]
+    fn negative_order_returns_floor() {
+        let cfg = cfg_with(0.01, 250);
+        assert_eq!(compute_bond_amount(-5_000, &cfg), 250);
+    }
+
+    #[test]
+    fn negative_floor_clamped_to_zero() {
+        let cfg = cfg_with(0.01, -10);
+        // Percentage still applies; floor clamps to 0 so it cannot negate.
+        assert_eq!(compute_bond_amount(10_000, &cfg), 100);
+    }
+
+    #[test]
+    fn rounds_to_nearest_sat() {
+        // 0.007 * 333 = 2.331 → 2
+        let cfg = cfg_with(0.007, 0);
+        assert_eq!(compute_bond_amount(333, &cfg), 2);
+        // 0.007 * 500 = 3.5 → 4 (round half to even gives 4 here)
+        let cfg = cfg_with(0.007, 0);
+        assert_eq!(compute_bond_amount(500, &cfg), 4);
+    }
+
+    #[test]
+    fn saturates_on_absurd_percentage() {
+        let cfg = cfg_with(1e18, 0);
+        // No overflow; clamps to i64::MAX. Not a realistic config but
+        // the guard prevents a panic.
+        assert_eq!(compute_bond_amount(i64::MAX, &cfg), i64::MAX);
+    }
+}

--- a/src/app/bond/mod.rs
+++ b/src/app/bond/mod.rs
@@ -1,0 +1,19 @@
+//! Anti-abuse bond module (issue #711).
+//!
+//! Phase 0 delivers only the data plumbing: configuration types live in
+//! `crate::config::types`, and this module provides the bond model, the
+//! `BondRole` / `BondState` / `BondSlashReason` enums, and the pure helper
+//! for computing a bond amount. Later phases add the trade-flow hooks; see
+//! `docs/ANTI_ABUSE_BOND.md`.
+//!
+//! Everything here is **inert** unless `Settings::is_bond_enabled()` is true.
+//! Callers must gate on that flag.
+
+pub mod db;
+pub mod math;
+pub mod model;
+pub mod types;
+
+pub use math::compute_bond_amount;
+pub use model::Bond;
+pub use types::{BondRole, BondSlashReason, BondState};

--- a/src/app/bond/model.rs
+++ b/src/app/bond/model.rs
@@ -1,0 +1,119 @@
+//! `Bond` is the database row type for the `bonds` table.
+//!
+//! String-typed `role` / `state` / `slashed_reason` keep the SQL dump
+//! readable. The daemon translates through [`super::types`] when it needs
+//! to pattern-match.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use sqlx_crud::SqlxCrud;
+use uuid::Uuid;
+
+use super::types::{BondRole, BondState};
+
+/// Database representation of an anti-abuse bond row.
+///
+/// Created only when `[anti_abuse_bond]` is `enabled = true` and the flow
+/// in question matches `apply_to`. A bond row can outlive the trade it was
+/// attached to, because a slashed bond still needs a payout to complete;
+/// that's why fields that only become meaningful after slash (e.g.
+/// `payout_invoice`) are optional.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, FromRow, SqlxCrud, PartialEq, Eq)]
+#[external_id]
+pub struct Bond {
+    /// Unique identifier for the bond row.
+    pub id: Uuid,
+    /// Order the bond is attached to.
+    pub order_id: Uuid,
+    /// For Phase 6 child-slash rows: the parent maker bond. `None` on a
+    /// parent row or on a non-range bond.
+    pub parent_bond_id: Option<Uuid>,
+    /// For Phase 6: the child (range-taken) order id this row represents.
+    /// `None` on a parent row or on a non-range bond.
+    pub child_order_id: Option<Uuid>,
+    /// Trade pubkey of the bonded party. Hex-encoded, 64 chars.
+    pub pubkey: String,
+    /// `maker` or `taker`. See [`BondRole`].
+    pub role: String,
+    /// Amount (sats) this bond row represents.
+    pub amount_sats: i64,
+    /// Running total of sats already slashed from a parent bond; used by
+    /// Phase 6 range-order accounting. 0 for child and non-range rows.
+    pub slashed_share_sats: i64,
+    /// Serialized [`BondState`].
+    pub state: String,
+    /// Serialized [`super::types::BondSlashReason`]; `None` unless slashed
+    /// / pending payout.
+    pub slashed_reason: Option<String>,
+    /// Bond hold invoice payment hash (hex, 64 chars).
+    pub hash: Option<String>,
+    /// Preimage retained by Mostro. `None` on child rows that share the
+    /// parent HTLC.
+    pub preimage: Option<String>,
+    /// bolt11 payment request shown to the bonded party.
+    pub payment_request: Option<String>,
+    /// bolt11 invoice from the winning counterparty (Phase 3+).
+    pub payout_invoice: Option<String>,
+    /// Routing-fee ceiling actually used for the payout attempt (sats).
+    pub payout_routing_fee_sats: Option<i64>,
+    /// Number of payout invoice requests attempted so far.
+    pub payout_attempts: i64,
+    /// Timestamp when the bond hold invoice reached `Accepted`.
+    pub locked_at: Option<i64>,
+    /// Timestamp when the bond transitioned to `Released`.
+    pub released_at: Option<i64>,
+    /// Timestamp when the bond transitioned to `Slashed`.
+    pub slashed_at: Option<i64>,
+    /// Timestamp when the row was created.
+    pub created_at: i64,
+}
+
+impl Bond {
+    /// Construct a new `Requested` bond row. The caller is responsible for
+    /// inserting it via `Crud::create`.
+    pub fn new_requested(order_id: Uuid, pubkey: String, role: BondRole, amount_sats: i64) -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            order_id,
+            parent_bond_id: None,
+            child_order_id: None,
+            pubkey,
+            role: role.to_string(),
+            amount_sats,
+            slashed_share_sats: 0,
+            state: BondState::Requested.to_string(),
+            slashed_reason: None,
+            hash: None,
+            preimage: None,
+            payment_request: None,
+            payout_invoice: None,
+            payout_routing_fee_sats: None,
+            payout_attempts: 0,
+            locked_at: None,
+            released_at: None,
+            slashed_at: None,
+            created_at: Utc::now().timestamp(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_requested_defaults() {
+        let order_id = Uuid::new_v4();
+        let b = Bond::new_requested(order_id, "a".repeat(64), BondRole::Taker, 1_000);
+        assert_eq!(b.order_id, order_id);
+        assert_eq!(b.role, "taker");
+        assert_eq!(b.state, "requested");
+        assert_eq!(b.amount_sats, 1_000);
+        assert_eq!(b.slashed_share_sats, 0);
+        assert!(b.hash.is_none());
+        assert!(b.locked_at.is_none());
+        assert!(b.released_at.is_none());
+        assert!(b.slashed_at.is_none());
+    }
+}

--- a/src/app/bond/model.rs
+++ b/src/app/bond/model.rs
@@ -148,7 +148,10 @@ mod tests {
             !json.contains("payout_invoice"),
             "payout_invoice leaked: {json}"
         );
-        assert!(!json.contains("lnbc1pSECRET"), "payout_invoice value leaked: {json}");
+        assert!(
+            !json.contains("lnbc1pSECRET"),
+            "payout_invoice value leaked: {json}"
+        );
         // Non-secret fields still serialize as usual.
         assert!(json.contains("hash"));
         assert!(json.contains("order_id"));

--- a/src/app/bond/model.rs
+++ b/src/app/bond/model.rs
@@ -50,10 +50,24 @@ pub struct Bond {
     pub hash: Option<String>,
     /// Preimage retained by Mostro. `None` on child rows that share the
     /// parent HTLC.
+    ///
+    /// **Secret.** Never serialize: the preimage is the capability that
+    /// settles the bond HTLC, so leaking it to an audit event, Nostr
+    /// payload, or RPC response would let a third party race Mostro to
+    /// claim the bond. `skip_serializing` keeps it out of any serde
+    /// output a later phase might accidentally introduce; the field is
+    /// still loaded from the DB via `sqlx::FromRow` as normal.
+    #[serde(skip_serializing)]
     pub preimage: Option<String>,
     /// bolt11 payment request shown to the bonded party.
     pub payment_request: Option<String>,
     /// bolt11 invoice from the winning counterparty (Phase 3+).
+    ///
+    /// Defense-in-depth: not a capability like `preimage`, but it
+    /// identifies the winner's node and is payable by anyone who sees
+    /// it. Kept out of serde output until a phase has a concrete reason
+    /// to publish it.
+    #[serde(skip_serializing)]
     pub payout_invoice: Option<String>,
     /// Routing-fee ceiling actually used for the payout attempt (sats).
     pub payout_routing_fee_sats: Option<i64>,
@@ -115,5 +129,28 @@ mod tests {
         assert!(b.locked_at.is_none());
         assert!(b.released_at.is_none());
         assert!(b.slashed_at.is_none());
+    }
+
+    #[test]
+    fn serialize_omits_secret_fields() {
+        // The preimage is the capability that settles the bond HTLC;
+        // `payout_invoice` identifies the winner. Both must stay out of
+        // any serde output a future phase accidentally adds.
+        let mut b = Bond::new_requested(Uuid::new_v4(), "a".repeat(64), BondRole::Taker, 1_000);
+        b.preimage = Some("deadbeef".repeat(8));
+        b.payout_invoice = Some("lnbc1pSECRET".to_string());
+        b.hash = Some("c0ffee".repeat(10) + "c0ff");
+
+        let json = serde_json::to_string(&b).expect("serialize");
+        assert!(!json.contains("preimage"), "preimage leaked: {json}");
+        assert!(!json.contains("deadbeef"), "preimage value leaked: {json}");
+        assert!(
+            !json.contains("payout_invoice"),
+            "payout_invoice leaked: {json}"
+        );
+        assert!(!json.contains("lnbc1pSECRET"), "payout_invoice value leaked: {json}");
+        // Non-secret fields still serialize as usual.
+        assert!(json.contains("hash"));
+        assert!(json.contains("order_id"));
     }
 }

--- a/src/app/bond/types.rs
+++ b/src/app/bond/types.rs
@@ -1,0 +1,188 @@
+//! String-backed enums persisted in the `bonds` table.
+//!
+//! These are the daemon-internal counterparts to the `[anti_abuse_bond]`
+//! configuration. We stringify for storage rather than using an integer
+//! discriminant so that a DB dump remains readable by operators.
+
+use std::fmt;
+use std::str::FromStr;
+
+/// Which side of a trade a bond row represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BondRole {
+    Maker,
+    Taker,
+}
+
+impl fmt::Display for BondRole {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BondRole::Maker => f.write_str("maker"),
+            BondRole::Taker => f.write_str("taker"),
+        }
+    }
+}
+
+impl FromStr for BondRole {
+    type Err = BondParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "maker" => Ok(BondRole::Maker),
+            "taker" => Ok(BondRole::Taker),
+            other => Err(BondParseError::UnknownRole(other.to_string())),
+        }
+    }
+}
+
+/// Lifecycle states for a bond row.
+///
+/// The state machine is intentionally narrow:
+///
+/// ```text
+///  Requested ──► Locked ──┬──► Released (happy / cancelled-before-timeout)
+///                         └──► PendingPayout ──┬──► Slashed   (winner paid)
+///                                              └──► Failed    (retries exhausted)
+/// ```
+///
+/// A bond never goes back to an earlier state. `Failed` is a terminal,
+/// operator-intervention-required state and is deliberately distinct from
+/// `Slashed` so dashboards can alarm on it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BondState {
+    /// Hold invoice created; waiting for the bonded party to pay it so LND
+    /// reports `Accepted`.
+    Requested,
+    /// Hold invoice accepted by LND. The bond is in force.
+    Locked,
+    /// Hold invoice was cancelled (not slashed). Terminal happy exit.
+    Released,
+    /// A slash condition was hit; Mostro is working on paying the winner.
+    PendingPayout,
+    /// Winner paid successfully. Terminal.
+    Slashed,
+    /// Payout retries exhausted. Terminal, requires operator attention.
+    Failed,
+}
+
+impl fmt::Display for BondState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            BondState::Requested => "requested",
+            BondState::Locked => "locked",
+            BondState::Released => "released",
+            BondState::PendingPayout => "pending-payout",
+            BondState::Slashed => "slashed",
+            BondState::Failed => "failed",
+        };
+        f.write_str(s)
+    }
+}
+
+impl FromStr for BondState {
+    type Err = BondParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "requested" => Ok(BondState::Requested),
+            "locked" => Ok(BondState::Locked),
+            "released" => Ok(BondState::Released),
+            "pending-payout" => Ok(BondState::PendingPayout),
+            "slashed" => Ok(BondState::Slashed),
+            "failed" => Ok(BondState::Failed),
+            other => Err(BondParseError::UnknownState(other.to_string())),
+        }
+    }
+}
+
+/// Why a bond transitioned to `PendingPayout` / `Slashed`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BondSlashReason {
+    /// Bonded party lost the dispute (Phase 2 / 5).
+    LostDispute,
+    /// Bonded party let the waiting-state timeout actually elapse
+    /// (Phase 4 / 7). A cancellation before the timeout is NEVER this.
+    Timeout,
+}
+
+impl fmt::Display for BondSlashReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BondSlashReason::LostDispute => f.write_str("lost-dispute"),
+            BondSlashReason::Timeout => f.write_str("timeout"),
+        }
+    }
+}
+
+impl FromStr for BondSlashReason {
+    type Err = BondParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "lost-dispute" => Ok(BondSlashReason::LostDispute),
+            "timeout" => Ok(BondSlashReason::Timeout),
+            other => Err(BondParseError::UnknownSlashReason(other.to_string())),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BondParseError {
+    UnknownRole(String),
+    UnknownState(String),
+    UnknownSlashReason(String),
+}
+
+impl fmt::Display for BondParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BondParseError::UnknownRole(v) => write!(f, "unknown bond role: {v}"),
+            BondParseError::UnknownState(v) => write!(f, "unknown bond state: {v}"),
+            BondParseError::UnknownSlashReason(v) => {
+                write!(f, "unknown bond slash reason: {v}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for BondParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn role_roundtrip() {
+        for r in [BondRole::Maker, BondRole::Taker] {
+            assert_eq!(BondRole::from_str(&r.to_string()).unwrap(), r);
+        }
+    }
+
+    #[test]
+    fn state_roundtrip() {
+        for s in [
+            BondState::Requested,
+            BondState::Locked,
+            BondState::Released,
+            BondState::PendingPayout,
+            BondState::Slashed,
+            BondState::Failed,
+        ] {
+            assert_eq!(BondState::from_str(&s.to_string()).unwrap(), s);
+        }
+    }
+
+    #[test]
+    fn slash_reason_roundtrip() {
+        for s in [BondSlashReason::LostDispute, BondSlashReason::Timeout] {
+            assert_eq!(BondSlashReason::from_str(&s.to_string()).unwrap(), s);
+        }
+    }
+
+    #[test]
+    fn unknown_parse_rejected() {
+        assert!(BondRole::from_str("solver").is_err());
+        assert!(BondState::from_str("in-progress").is_err());
+        assert!(BondSlashReason::from_str("whatever").is_err());
+    }
+}

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -267,6 +267,7 @@ pub mod test_utils {
             lightning: LightningSettings::default(),
             rpc: RpcSettings::default(),
             expiration: Some(ExpirationSettings::default()),
+            anti_abuse_bond: None,
         }
     }
 }

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -1049,6 +1049,7 @@ mod tests {
             lightning: Default::default(),
             rpc: Default::default(),
             expiration: Some(Default::default()),
+            anti_abuse_bond: None,
         });
     }
 

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -240,6 +240,7 @@ mod tests {
             lightning: Default::default(),
             rpc: Default::default(),
             expiration: Some(Default::default()),
+            anti_abuse_bond: None,
         });
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,7 +21,8 @@ use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 pub use settings::{get_db_pool, init_mostro_settings, Settings};
 pub use types::{
-    DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings, NostrSettings,
+    AntiAbuseBondSettings, BondApplyTo, DatabaseSettings, ExpirationSettings, LightningSettings,
+    MostroSettings, NostrSettings,
 };
 
 // Global variables for Mostro configuration, Nostr client, Lightning status, and database pool

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,7 +1,7 @@
 use super::{DB_POOL, MOSTRO_CONFIG};
 use crate::config::types::{
-    DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings, NostrSettings,
-    RpcSettings,
+    AntiAbuseBondSettings, DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings,
+    NostrSettings, RpcSettings,
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -21,6 +21,9 @@ pub struct Settings {
     pub rpc: RpcSettings,
     /// Event expiration configuration settings
     pub expiration: Option<ExpirationSettings>,
+    /// Anti-abuse bond configuration (issue #711). Absent section ≡ disabled.
+    #[serde(default)]
+    pub anti_abuse_bond: Option<AntiAbuseBondSettings>,
 }
 
 /// Initialize the global MOSTRO_CONFIG struct
@@ -77,5 +80,23 @@ impl Settings {
             .expect("No settings found")
             .expiration
             .as_ref()
+    }
+
+    /// This function retrieves the anti-abuse bond configuration from the
+    /// global `MOSTRO_CONFIG`. Returns `None` when the `[anti_abuse_bond]`
+    /// block is absent (treated as disabled).
+    pub fn get_bond() -> Option<&'static AntiAbuseBondSettings> {
+        MOSTRO_CONFIG
+            .get()
+            .expect("No settings found")
+            .anti_abuse_bond
+            .as_ref()
+    }
+
+    /// True when the feature is configured AND explicitly enabled. This is
+    /// the single gate every bond-related code path must check before
+    /// running. Keeps the opt-in guarantee simple to audit.
+    pub fn is_bond_enabled() -> bool {
+        Self::get_bond().is_some_and(|cfg| cfg.enabled)
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -41,10 +41,14 @@ pub struct AntiAbuseBondSettings {
     /// Master switch. When false, no bond is required and no slashing occurs.
     #[serde(default)]
     pub enabled: bool,
-    /// Percentage of the order amount used for the bond (0.01 = 1%). The
-    /// actual bond is `max(amount_sats * order_amount, base_amount_sats)`.
+    /// Fraction of the order amount used for the bond (0.01 = 1%). The
+    /// actual bond is `max(amount_pct * order_amount_sats, base_amount_sats)`.
+    ///
+    /// Named `amount_pct` (not `amount_sats`) because the value is a
+    /// unitless fraction, not a sat quantity — the latter would conflict
+    /// with `Bond::amount_sats`, which *is* an integer sat amount.
     #[serde(default = "default_bond_amount_pct")]
-    pub amount_sats: f64,
+    pub amount_pct: f64,
     /// Floor applied to the bond computation, in satoshis.
     #[serde(default = "default_bond_base_amount")]
     pub base_amount_sats: i64,
@@ -89,7 +93,7 @@ impl Default for AntiAbuseBondSettings {
     fn default() -> Self {
         Self {
             enabled: false,
-            amount_sats: default_bond_amount_pct(),
+            amount_pct: default_bond_amount_pct(),
             base_amount_sats: default_bond_base_amount(),
             apply_to: BondApplyTo::default(),
             slash_on_lost_dispute: false,
@@ -366,7 +370,7 @@ mod anti_abuse_bond_tests {
         assert!(!cfg.slash_on_lost_dispute);
         assert!(!cfg.slash_on_waiting_timeout);
         assert_eq!(cfg.apply_to, BondApplyTo::Take);
-        assert_eq!(cfg.amount_sats, 0.01);
+        assert_eq!(cfg.amount_pct, 0.01);
         assert_eq!(cfg.base_amount_sats, 1_000);
         assert_eq!(cfg.payout_invoice_window_seconds, 300);
         assert_eq!(cfg.payout_max_retries, 5);

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -5,6 +5,101 @@ use crate::config::MOSTRO_CONFIG;
 use mostro_core::prelude::*;
 use serde::{Deserialize, Serialize};
 
+/// Scope of the anti-abuse bond enforcement.
+///
+/// `apply_to` in `[anti_abuse_bond]` selects which trade flow(s) must post a
+/// bond. The feature is deliberately scoped so operators can roll it out one
+/// side at a time (taker first, maker later) as successive phases land.
+#[derive(Debug, Deserialize, Serialize, Default, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum BondApplyTo {
+    #[default]
+    Take,
+    Create,
+    Both,
+}
+
+impl BondApplyTo {
+    /// True when the taker side of a trade must lock a bond.
+    pub fn applies_to_taker(self) -> bool {
+        matches!(self, BondApplyTo::Take | BondApplyTo::Both)
+    }
+
+    /// True when the maker side of a trade must lock a bond.
+    pub fn applies_to_maker(self) -> bool {
+        matches!(self, BondApplyTo::Create | BondApplyTo::Both)
+    }
+}
+
+/// Anti-abuse bond configuration (issue #711).
+///
+/// Opt-in. When `enabled = false` (the default) every code path added by
+/// this feature remains inert — existing orders behave exactly as before.
+/// See `docs/ANTI_ABUSE_BOND.md` for the full phased rollout.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct AntiAbuseBondSettings {
+    /// Master switch. When false, no bond is required and no slashing occurs.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Percentage of the order amount used for the bond (0.01 = 1%). The
+    /// actual bond is `max(amount_sats * order_amount, base_amount_sats)`.
+    #[serde(default = "default_bond_amount_pct")]
+    pub amount_sats: f64,
+    /// Floor applied to the bond computation, in satoshis.
+    #[serde(default = "default_bond_base_amount")]
+    pub base_amount_sats: i64,
+    /// Which trade flow(s) require the bond.
+    #[serde(default)]
+    pub apply_to: BondApplyTo,
+    /// Slash the bond when the bonded party loses a dispute.
+    #[serde(default)]
+    pub slash_on_lost_dispute: bool,
+    /// Slash the bond when the bonded party lets the waiting-state timeout
+    /// actually elapse. A cancellation before the timeout MUST always
+    /// release the bond regardless of this flag; see §Phase 4 of the spec.
+    #[serde(default)]
+    pub slash_on_waiting_timeout: bool,
+    /// How long (seconds) Mostro waits between payout-invoice retries
+    /// when asking the winning counterparty for a bolt11. Used by Phase 3.
+    #[serde(default = "default_payout_invoice_window_seconds")]
+    pub payout_invoice_window_seconds: u64,
+    /// Maximum number of payout-invoice retries before a bond transitions
+    /// to `failed` state. Used by Phase 3.
+    #[serde(default = "default_payout_max_retries")]
+    pub payout_max_retries: u32,
+}
+
+fn default_bond_amount_pct() -> f64 {
+    0.01
+}
+
+fn default_bond_base_amount() -> i64 {
+    1_000
+}
+
+fn default_payout_invoice_window_seconds() -> u64 {
+    300
+}
+
+fn default_payout_max_retries() -> u32 {
+    5
+}
+
+impl Default for AntiAbuseBondSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            amount_sats: default_bond_amount_pct(),
+            base_amount_sats: default_bond_base_amount(),
+            apply_to: BondApplyTo::default(),
+            slash_on_lost_dispute: false,
+            slash_on_waiting_timeout: false,
+            payout_invoice_window_seconds: default_payout_invoice_window_seconds(),
+            payout_max_retries: default_payout_max_retries(),
+        }
+    }
+}
+
 /// Event expiration configuration settings
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct ExpirationSettings {
@@ -259,3 +354,72 @@ impl_try_from_settings!(
     MostroSettings => mostro,
     RpcSettings => rpc
 );
+
+#[cfg(test)]
+mod anti_abuse_bond_tests {
+    use super::*;
+
+    #[test]
+    fn defaults_are_off() {
+        let cfg = AntiAbuseBondSettings::default();
+        assert!(!cfg.enabled);
+        assert!(!cfg.slash_on_lost_dispute);
+        assert!(!cfg.slash_on_waiting_timeout);
+        assert_eq!(cfg.apply_to, BondApplyTo::Take);
+        assert_eq!(cfg.amount_sats, 0.01);
+        assert_eq!(cfg.base_amount_sats, 1_000);
+        assert_eq!(cfg.payout_invoice_window_seconds, 300);
+        assert_eq!(cfg.payout_max_retries, 5);
+    }
+
+    #[test]
+    fn apply_to_predicates() {
+        assert!(BondApplyTo::Take.applies_to_taker());
+        assert!(!BondApplyTo::Take.applies_to_maker());
+        assert!(!BondApplyTo::Create.applies_to_taker());
+        assert!(BondApplyTo::Create.applies_to_maker());
+        assert!(BondApplyTo::Both.applies_to_taker());
+        assert!(BondApplyTo::Both.applies_to_maker());
+    }
+
+    #[test]
+    fn toml_omits_block() {
+        #[derive(serde::Deserialize)]
+        struct Stub {
+            anti_abuse_bond: Option<AntiAbuseBondSettings>,
+        }
+        let parsed: Stub = toml::from_str("").expect("empty toml is valid");
+        assert!(parsed.anti_abuse_bond.is_none());
+    }
+
+    #[test]
+    fn toml_minimal_block_defaults() {
+        #[derive(serde::Deserialize)]
+        struct Stub {
+            anti_abuse_bond: AntiAbuseBondSettings,
+        }
+        let parsed: Stub =
+            toml::from_str("[anti_abuse_bond]\nenabled = true").expect("minimal block parses");
+        assert!(parsed.anti_abuse_bond.enabled);
+        // Unspecified fields fall back to the documented defaults.
+        assert_eq!(parsed.anti_abuse_bond.apply_to, BondApplyTo::Take);
+        assert_eq!(parsed.anti_abuse_bond.base_amount_sats, 1_000);
+    }
+
+    #[test]
+    fn toml_apply_to_both() {
+        #[derive(serde::Deserialize)]
+        struct Stub {
+            anti_abuse_bond: AntiAbuseBondSettings,
+        }
+        let parsed: Stub = toml::from_str(
+            r#"[anti_abuse_bond]
+enabled = true
+apply_to = "both"
+slash_on_lost_dispute = true"#,
+        )
+        .expect("toml parses");
+        assert_eq!(parsed.anti_abuse_bond.apply_to, BondApplyTo::Both);
+        assert!(parsed.anti_abuse_bond.slash_on_lost_dispute);
+    }
+}

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -71,6 +71,7 @@ fn run_setup_wizard(settings_dir: &Path, config_file_path: &Path) -> Result<Sett
         mostro,
         rpc: RpcSettings::default(),
         expiration: None,
+        anti_abuse_bond: None,
     };
 
     let toml_content = toml::to_string_pretty(&settings)


### PR DESCRIPTION
Adds the inert data and configuration layer for the anti-abuse bond feature described in docs/ANTI_ABUSE_BOND.md (issue #711):

- [anti_abuse_bond] settings block, opt-in and disabled by default, with Settings::is_bond_enabled() gate.
- bonds table + Bond sqlx model + CRUD helpers under src/app/bond/.
- BondRole / BondState / BondSlashReason enums with parse roundtrips.
- Pure compute_bond_amount helper: max(amount_sats * order_amount, base_amount_sats).

No trade flow, scheduler, or LND path is touched in this PR; every code path added here is behind the disabled-by-default gate. Later phases (taker lock, dispute slash, payout, timeout slash, maker bond, range orders) will hook into the same data model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anti-abuse bond infrastructure with database storage, configuration options, and amount calculation logic.

* **Documentation**
  * Specification document detailing bond feature phases, lifecycle, database schema, configuration surface, payout workflows, and acceptance tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->