### PR TITLE
chore(deps): bump mostro-core to 0.9.1 and nostr-sdk to 0.44.1 (NIP-59 migration PR 1/6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08956454941d9577a2cde63ae6ee5d8bac4ffeee8398d02aa844ad4b3638723a"
+checksum = "47931c8de17481b95e05f2cac0ac8a077247a040631a929bbae656bfb48fc4e2"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1824,9 +1824,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.43.1"
+version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a97d745f1bd8d5e05a978632bbb87b0614567d5142906fe7c86fb2440faac6"
+checksum = "3aa5e3b6a278ed061835fe1ee293b71641e6bf8b401cfe4e1834bbf4ef0a34e1"
 dependencies = [
  "base64 0.22.1",
  "bech32",
@@ -1836,6 +1836,7 @@ dependencies = [
  "chacha20",
  "chacha20poly1305",
  "getrandom 0.2.16",
+ "hex",
  "instant",
  "scrypt",
  "secp256k1",
@@ -1847,9 +1848,9 @@ dependencies = [
 
 [[package]]
 name = "nostr-database"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c75a8c2175d2785ba73cfddef21d1e30da5fbbdf158569b6808ba44973a15b"
+checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
 dependencies = [
  "lru",
  "nostr",
@@ -1857,14 +1858,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "nostr-relay-pool"
-version = "0.43.1"
+name = "nostr-gossip"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2f43b70d13dfc50508a13cd902e11f4625312b2ce0e4b7c4c2283fd04001bd"
+checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
+dependencies = [
+ "nostr",
+]
+
+[[package]]
+name = "nostr-relay-pool"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b1073ccfbaea5549fb914a9d52c68dab2aecda61535e5143dd73e95445a804b"
 dependencies = [
  "async-utility",
  "async-wsocket",
  "atomic-destructor",
+ "hex",
  "lru",
  "negentropy",
  "nostr",
@@ -1875,15 +1886,17 @@ dependencies = [
 
 [[package]]
 name = "nostr-sdk"
-version = "0.43.0"
+version = "0.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "599f8963d6a1522a13b1a2b0ea6e168acfc367706606f1d33fa595e91fa22db0"
+checksum = "471732576710e779b64f04c55e3f8b5292f865fea228436daf19694f0bf70393"
 dependencies = [
  "async-utility",
  "nostr",
  "nostr-database",
+ "nostr-gossip",
  "nostr-relay-pool",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ mutants = "0.0.3" # For #[mutants::skip] annotations
 chrono = "0.4.35"
 easy-hasher = "2.2.1"
 lightning-invoice = { version = "0.33.1", features = ["std"] }
-nostr-sdk = { version = "0.43.0", features = ["nip59"] }
+nostr-sdk = { version = "0.44.1", features = ["nip44", "nip59"] }
 serde = { version = "1.0.210" }
 toml = "0.9.5"
 serde_json = "1.0.128"
@@ -70,7 +70,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.8.4", features = ["sqlx"] }
+mostro-core = { version = "0.9.1", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.45", features = ["derive"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -333,7 +333,7 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
                         .checked_sub_signed(chrono::Duration::seconds(10))
                         .unwrap()
                         .timestamp() as u64;
-                    if event.rumor.created_at.as_u64() < since_time {
+                    if event.rumor.created_at.as_secs() < since_time {
                         continue;
                     }
                     // Parse message and signature from rumor content put message in Message struct

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -191,7 +191,7 @@ pub async fn admin_take_dispute_action(
     // Update dispute fields
     dispute.status = Status::InProgress.to_string();
     dispute.solver_pubkey = Some(event.sender.to_string());
-    dispute.taken_at = Timestamp::now().as_u64() as i64;
+    dispute.taken_at = Timestamp::now().as_secs() as i64;
 
     info!("Dispute {} taken by {}", dispute.id, event.sender);
 

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -212,7 +212,7 @@ pub async fn update_user_reputation_action(
 /// Calculate the number of days since user creation.
 fn calculate_days_since_creation(created_at: i64) -> u64 {
     const SECONDS_IN_DAY: u64 = 86_400;
-    let now = Timestamp::now().as_u64();
+    let now = Timestamp::now().as_secs();
     u64::try_from(created_at)
         .ok()
         .filter(|ts| *ts > 0)
@@ -657,7 +657,7 @@ mod tests {
 
     #[test]
     fn test_calculate_days_since_creation_normal() {
-        let now = Timestamp::now().as_u64();
+        let now = Timestamp::now().as_secs();
         // User created 10 days ago
         let created_at = (now - 10 * 86_400) as i64;
         let days = calculate_days_since_creation(created_at);
@@ -680,7 +680,7 @@ mod tests {
 
     #[test]
     fn test_calculate_days_since_creation_partial_day() {
-        let now = Timestamp::now().as_u64();
+        let now = Timestamp::now().as_secs();
         // Created 1.5 days ago - should truncate to 1
         let created_at = (now - 86_400 - 43_200) as i64;
         let days = calculate_days_since_creation(created_at);

--- a/src/db.rs
+++ b/src/db.rs
@@ -593,7 +593,7 @@ pub async fn find_order_by_date(pool: &SqlitePool) -> Result<Vec<Order>, MostroE
           WHERE expires_at < ?1 AND status == 'pending'
         "#,
     )
-    .bind(expire_time.as_u64() as i64)
+    .bind(expire_time.as_secs() as i64)
     .fetch_all(pool)
     .await
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
@@ -612,7 +612,7 @@ pub async fn find_order_by_seconds(pool: &SqlitePool) -> Result<Vec<Order>, Most
           WHERE taken_at < ?1 AND ( status == 'waiting-buyer-invoice' OR status == 'waiting-payment' )
         "#,
     )
-    .bind(expire_time.as_u64() as i64)
+    .bind(expire_time.as_secs() as i64)
     .fetch_all(pool)
     .await
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
@@ -836,7 +836,7 @@ pub async fn add_new_user(pool: &SqlitePool, new_user: User) -> Result<String, M
     .bind(new_user.last_rating)
     .bind(new_user.max_rating)
     .bind(new_user.min_rating)
-    .bind(created_at.as_u64() as i64)
+    .bind(created_at.as_secs() as i64)
     .execute(pool)
     .await
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -119,7 +119,7 @@ pub async fn hold_invoice_paid(
     }
 
     // Update the invoice_held_at field
-    crate::db::update_order_invoice_held_at_time(pool, order.id, Timestamp::now().as_u64() as i64)
+    crate::db::update_order_invoice_held_at_time(pool, order.id, Timestamp::now().as_secs() as i64)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
@@ -241,7 +241,7 @@ mod tests {
             let fiat_amount = 100i64;
             let payment_method = "SEPA".to_string();
             let premium = 5;
-            let created_at = Timestamp::now().as_u64() as i64;
+            let created_at = Timestamp::now().as_secs() as i64;
             let expires_at = created_at + 3600;
 
             // Test SmallOrder creation logic
@@ -370,8 +370,8 @@ mod tests {
                 None,
                 None,
                 None,
-                Some(Timestamp::now().as_u64() as i64),
-                Some(Timestamp::now().as_u64() as i64 + 3600),
+                Some(Timestamp::now().as_secs() as i64),
+                Some(Timestamp::now().as_secs() as i64 + 3600),
             );
 
             // Test payload with order data
@@ -451,7 +451,7 @@ mod tests {
             // Test timestamp operations used in the flow
 
             let current_timestamp = Timestamp::now();
-            let timestamp_u64 = current_timestamp.as_u64();
+            let timestamp_u64 = current_timestamp.as_secs();
             let timestamp_i64 = timestamp_u64 as i64;
 
             // Verify timestamp is reasonable (after 2020, before 2050)

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -196,7 +196,7 @@ fn create_rating_tag(reputation_data: Option<(f64, i64, i64)>) -> String {
         // If operating day is 0, it means the user is new and we don't have a valid reputation data
         let days = if data.2 != 0 {
             let now = Timestamp::now();
-            (now.as_u64() - data.2 as u64) / SECONDS_IN_DAY
+            (now.as_secs() - data.2 as u64) / SECONDS_IN_DAY
         } else {
             0
         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -205,7 +205,7 @@ pub fn get_expiration_date(expire: Option<i64>) -> i64 {
     let mostro_settings = Settings::get_mostro();
     // We calculate order expiration
     let expire_date: i64;
-    let expires_at_max: i64 = Timestamp::now().as_u64() as i64
+    let expires_at_max: i64 = Timestamp::now().as_secs() as i64
         + Duration::days(mostro_settings.max_expiration_days.into()).num_seconds();
     if let Some(mut exp) = expire {
         if exp > expires_at_max {
@@ -213,7 +213,7 @@ pub fn get_expiration_date(expire: Option<i64>) -> i64 {
         };
         expire_date = exp;
     } else {
-        expire_date = Timestamp::now().as_u64() as i64
+        expire_date = Timestamp::now().as_secs() as i64
             + Duration::hours(mostro_settings.expiration_hours as i64).num_seconds();
     }
     expire_date
@@ -241,7 +241,7 @@ pub fn get_expiration_date(expire: Option<i64>) -> i64 {
 /// let dispute_expiration = get_expiration_timestamp_for_kind(38386);
 /// ```
 pub fn get_expiration_timestamp_for_kind(kind: u16) -> Option<i64> {
-    let now = Timestamp::now().as_u64() as i64;
+    let now = Timestamp::now().as_secs() as i64;
 
     // Try to get expiration from new configuration first
     if let Some(exp_config) = Settings::get_expiration() {
@@ -468,7 +468,7 @@ async fn prepare_new_order(
         fiat_amount: new_order.fiat_amount,
         premium: new_order.premium,
         buyer_invoice: new_order.buyer_invoice.clone(),
-        created_at: Timestamp::now().as_u64() as i64,
+        created_at: Timestamp::now().as_secs() as i64,
         expires_at: expiry_date,
         ..Default::default()
     };
@@ -1285,7 +1285,7 @@ pub async fn notify_taker_reputation(
 
     let reputation_data = match is_user_present(pool, master_key).await {
         Ok(user) => {
-            let now = Timestamp::now().as_u64();
+            let now = Timestamp::now().as_secs();
             UserInfo {
                 rating: user.total_rating,
                 reviews: user.total_reviews,


### PR DESCRIPTION
First PR in the NIP-59 transport migration tracked in #714. Pure compile fence — no behavior change, no call-site migration to the new `wrap_message` / `unwrap_message` / `validate_response` API yet. Those land in PRs 2–5.

## Summary

- `mostro-core` 0.8.4 → **0.9.1** (ships the centralized NIP-59 transport module).
- `nostr-sdk` 0.43.0 → **0.44.1** + enabled the `nip44` feature; both required by `mostro-core` 0.9.1.
- Mechanical rename of 19 `Timestamp::as_u64()` call sites to `as_secs()`. `as_u64` is deprecated in `nostr-sdk` 0.44 and same-signature — no behavior change. Lets `cargo clippy --all-targets --all-features -- -D warnings` stay green (enforced by the release pre-hook).

The existing `nip59::extract_rumor` + `EventBuilder::gift_wrap` paths in `src/util.rs::send_dm` and `src/app.rs::run`'s `Kind::GiftWrap` branch still compile and run unchanged — `nostr-sdk` 0.44 kept both. They'll be replaced in PR 2 (outbound `send_dm` → `wrap_message`) and PR 3 (inbound event loop → `unwrap_message`).

## Why no type alias / shim?

The PR 1 plan in #714 mentioned optionally introducing `type WrappedEvent = UnwrappedMessage` as a mechanical rename shim. Not needed — the old `UnwrappedGift` type and `extract_rumor` helper are still exported by `nostr-sdk` 0.44, so nothing in this repo has to rename yet. Skipping the shim keeps the diff minimal and makes the future PR-4 handler-signature rename a clean standalone change.

## Test plan

- [x] `cargo check --bin mostrod --tests` — clean
- [x] `cargo clippy --bin mostrod --all-features --tests -- -D warnings` — clean
- [x] `cargo test --bin mostrod` — 239 passed, 0 failed
- [ ] Local smoke test against a relay (not required for a compile-fence PR, but worth a sanity check if CI is light)

## Scope fence

- **No** changes to `send_dm`, the inbound event loop, handler signatures, `rpc/service.rs` admin bridge, or tests beyond the `as_u64` rename.
- **No** new imports from `mostro_core::nip59` yet.
- **No** PoW changes (open question 4 in #714 answered: defer).
- `validate_response` intentionally not imported (open question 2: skip; node is push-only).

Closes nothing on its own — follow-up PRs for the migration are tracked in #714.