### PR TITLE
refactor(nip59): route send_dm through mostro_core::wrap_message (NIP-59 migration PR 2/6)

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -509,23 +509,19 @@ pub async fn send_dm(
     );
     let message = Message::from_json(payload)
         .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
-    // We compose the content, as this is a message from Mostro
-    // and Mostro don't have trade key, we don't need to sign the payload
-    let content = (message, Option::<String>::None);
-    let content = serde_json::to_string(&content)
-        .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
-    // We create the rumor
-    let rumor = EventBuilder::text_note(content).build(sender_keys.public_key());
-    let mut tags: Vec<Tag> = Vec::with_capacity(1 + usize::from(expiration.is_some()));
 
-    if let Some(timestamp) = expiration {
-        tags.push(Tag::expiration(timestamp));
-    }
-    let tags = Tags::from_list(tags);
+    // Mostro identity holds no trade keys, so the inner rumor tuple is
+    // `(Message, None)` — `signed = false`. `wrap_message` builds the
+    // rumor, seal, outer gift wrap, ephemeral key, random-timestamp
+    // tweak and `p` tag for us; we only pick the wrap-level knobs.
+    // PoW is deferred to a follow-up (see issue #714, open question 4).
+    let opts = WrapOptions {
+        pow: 0,
+        expiration,
+        signed: false,
+    };
+    let event = wrap_message(&message, sender_keys, receiver_pubkey, opts).await?;
 
-    let event = EventBuilder::gift_wrap(sender_keys, &receiver_pubkey, rumor, tags)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
     info!(
         "Sending DM, Event ID: {} to {} with payload: {:#?}",
         event.id,
@@ -1481,10 +1477,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_send_dm() {
+    async fn test_send_dm_outbound_wrap_shape() {
+        // `send_dm` itself can't be exercised here without racing on the
+        // global NOSTR_CLIENT initialized by other tests — under parallel
+        // execution it's nondeterministic whether the client exists. So
+        // instead we pin down the invariant that matters: the wrap shape
+        // `send_dm` emits. Mostro-side traffic must be unsigned (the node
+        // holds no trade keys), the sender must be the Mostro identity,
+        // and the inner message must round-trip byte-for-byte.
         initialize();
-        // Mock the send_dm function
-        let receiver_pubkey = Keys::generate().public_key();
+        let receiver_keys = Keys::generate();
+        let sender_keys = Keys::generate();
         let uuid = uuid!("308e1272-d5f4-47e6-bd97-3504baea9c23");
         let message = Message::Order(MessageKind::new(
             Some(uuid),
@@ -1493,12 +1496,30 @@ mod tests {
             Action::FiatSent,
             None,
         ));
-        let payload = message.as_json().unwrap();
-        let sender_keys = Keys::generate();
-        // Now error is well manager this call will fail now, previously test was ok becuse error was not managed
-        // now just make it ok and then will make a better test
-        let result = send_dm(receiver_pubkey, &sender_keys, &payload, None).await;
-        assert!(result.is_err());
+
+        let event = wrap_message(
+            &message,
+            &sender_keys,
+            receiver_keys.public_key(),
+            WrapOptions {
+                pow: 0,
+                expiration: None,
+                signed: false,
+            },
+        )
+        .await
+        .expect("wrap");
+
+        let unwrapped = unwrap_message(&event, &receiver_keys)
+            .await
+            .expect("unwrap result")
+            .expect("addressed to receiver");
+        assert!(unwrapped.signature.is_none(), "Mostro-side wrap is unsigned");
+        assert_eq!(unwrapped.sender, sender_keys.public_key());
+        assert_eq!(
+            unwrapped.message.as_json().unwrap(),
+            message.as_json().unwrap()
+        );
     }
 
     #[tokio::test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1514,7 +1514,10 @@ mod tests {
             .await
             .expect("unwrap result")
             .expect("addressed to receiver");
-        assert!(unwrapped.signature.is_none(), "Mostro-side wrap is unsigned");
+        assert!(
+            unwrapped.signature.is_none(),
+            "Mostro-side wrap is unsigned"
+        );
         assert_eq!(unwrapped.sender, sender_keys.public_key());
         assert_eq!(
             unwrapped.message.as_json().unwrap(),


### PR DESCRIPTION
Second PR in the NIP-59 transport migration tracked in #714. Outbound side only — replaces the hand-rolled rumor + gift-wrap chain in \`send_dm\` with a call to \`mostro_core::nip59::wrap_message\`.

## Summary

- \`src/util.rs::send_dm\`: delete the manual \`(Message, Option::<String>::None)\` tuple, \`EventBuilder::text_note(...).build(...)\` rumor, tag assembly, and \`EventBuilder::gift_wrap(...)\` call. Replace with:

  \`\`\`rust
  let opts = WrapOptions { pow: 0, expiration, signed: false };
  let event = wrap_message(&message, sender_keys, receiver_pubkey, opts).await?;
  \`\`\`

- \`signed: false\` — the Mostro node holds **no** trade keys, so the inner rumor stays \`(Message, None)\` as before. Note: \`mostro-core\` 0.9.1 does **not** auto-skip signing based on \`trade_index\`; \`signed\` is the explicit switch. The issue description suggested \`signed: true\` would behave conditionally, which was incorrect — verified against \`mostro-core-0.9.1/src/nip59.rs\`.
- Public \`send_dm\` signature unchanged; every caller in \`scheduler.rs\`, \`admin_add_solver\`, \`admin_cancel\`, \`admin_take_dispute\`, \`last_trade_index\` compiles and runs unchanged.
- \`?\` for error propagation now that \`wrap_message\` returns \`MostroError\` directly (previously the \`EventBuilder::gift_wrap\` error was manually mapped to \`NostrError\`).

## Test changes

\`test_send_dm\` was a placeholder that happened to pass only because the old \`EventBuilder::gift_wrap\` path errored in a no-client unit-test environment — the original inline comment even admitted this. Post-migration, \`wrap_message\` is pure offline crypto and succeeds; the \`if let Ok(client) = get_nostr_client()\` fall-through then returns \`Ok(())\`. But inside the full suite, a different test initialises \`NOSTR_CLIENT\` globally, which makes any \`send_dm\` assertion race-dependent on execution order.

Rewrote the test as \`test_send_dm_outbound_wrap_shape\`:

- No longer calls \`send_dm\` (would be flaky under parallel execution).
- Exercises \`wrap_message\` + \`unwrap_message\` directly, which is the crypto actually moved by this PR.
- Asserts the three invariants that matter for the Mostro → user direction: unsigned tuple, \`sender = Mostro identity\`, inner message round-trips byte-for-byte.

## Respecting the open-question answers on #714

| Question | Answer | Applied here |
|---|---|---|
| 1. Replay window | Caller-side, keep 10s guard | Inbound only, lands in PR 3 |
| 2. \`validate_response\` | Skip (node is push-only) | Not imported |
| 3. Admin bridge shape | Mechanical migration first | Still on \`UnwrappedGift\`; PR 5 handles it |
| 4. PoW | Defer to separate issue | \`pow: 0\` |

## Test plan

- [x] \`cargo check --bin mostrod --tests\` clean
- [x] \`cargo clippy --bin mostrod --all-features --tests -- -D warnings\` clean
- [x] \`cargo test --bin mostrod\` — 239 passed, 0 failed
- [ ] Smoke test against a real relay (not required for this layer — wrap output is byte-compatible with the previous \`EventBuilder::gift_wrap\` output since \`wrap_message\` uses the same underlying \`nip59\` primitives)

## Scope fence

- **No** inbound changes: \`src/app.rs::run\`'s \`Kind::GiftWrap\` branch, \`check_trade_index\`, and every handler reading \`event.rumor.pubkey\` stay exactly as they are.
- **No** RPC admin-bridge changes.
- **No** new handler-signature migration.