### PR TITLE
feat(nip59): adopt mostro-core 0.10.0 dual-key gift wrap transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1767,9 +1767,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47931c8de17481b95e05f2cac0ac8a077247a040631a929bbae656bfb48fc4e2"
+checksum = "d76f4936f520e410ba2abf47113548ae231322209261a9b3a8aefbd10a869082"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.9.1", features = ["sqlx"] }
+mostro-core = { version = "0.10.0", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.45", features = ["derive"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,6 +55,7 @@ use mostro_core::error::CantDoReason;
 use mostro_core::error::MostroError;
 use mostro_core::error::ServiceError;
 use mostro_core::message::{Action, Message};
+use mostro_core::nip59::{unwrap_message, UnwrappedMessage};
 use mostro_core::user::User;
 use nostr_sdk::prelude::*;
 
@@ -86,7 +87,7 @@ fn warning_msg(action: &Action, err: ServiceError) {
 async fn manage_errors(
     e: MostroError,
     inner_message: Message,
-    event: UnwrappedGift,
+    event: UnwrappedMessage,
     action: &Action,
 ) {
     match e {
@@ -95,7 +96,8 @@ async fn manage_errors(
                 inner_message.get_inner_message_kind().request_id,
                 inner_message.get_inner_message_kind().id,
                 cause,
-                event.rumor.pubkey,
+                // Reply to the trade key that authored the rumor.
+                event.sender,
             )
             .await
         }
@@ -118,7 +120,7 @@ async fn manage_errors(
 /// * `msg` - The message containing action details and trade index information.
 async fn check_trade_index(
     ctx: &AppContext,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     msg: &Message,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -133,24 +135,14 @@ async fn check_trade_index(
     }
 
     // If user is present, we check the trade index and signature
-    match is_user_present(pool, event.sender.to_string()).await {
+    match is_user_present(pool, event.identity.to_string()).await {
         Ok(user) => {
             if let index @ 1.. = message_kind.trade_index() {
-                let content: (Message, Signature) = match serde_json::from_str::<(
-                    Message,
-                    nostr_sdk::secp256k1::schnorr::Signature,
-                )>(&event.rumor.content)
-                {
-                    Ok(data) => data,
-                    Err(e) => {
-                        tracing::error!("Error deserializing content: {}", e);
-                        return Err(MostroError::MostroInternalErr(
-                            ServiceError::MessageSerializationError,
-                        ));
-                    }
-                };
-
-                let (_, sig) = content;
+                // Inner-tuple signature is already decoded by unwrap_message.
+                let sig = event.signature.ok_or_else(|| {
+                    tracing::error!("Trade-index message missing inner signature");
+                    MostroError::MostroCantDo(CantDoReason::InvalidSignature)
+                })?;
 
                 if index <= user.last_trade_index {
                     tracing::info!("Invalid trade index");
@@ -163,7 +155,7 @@ async fn check_trade_index(
                     .await;
                     return Err(MostroError::MostroCantDo(CantDoReason::InvalidTradeIndex));
                 }
-                let msg = match msg.as_json() {
+                let msg_json = match msg.as_json() {
                     Ok(m) => m,
                     Err(e) => {
                         tracing::error!(
@@ -175,7 +167,7 @@ async fn check_trade_index(
                         ));
                     }
                 };
-                if !Message::verify_signature(msg, event.rumor.pubkey, sig) {
+                if !Message::verify_signature(msg_json, event.sender, sig) {
                     tracing::info!("Invalid signature");
                     return Err(MostroError::MostroCantDo(CantDoReason::InvalidSignature));
                 }
@@ -188,9 +180,9 @@ async fn check_trade_index(
                 if last_trade_index == 0 {
                     return Err(MostroError::MostroCantDo(CantDoReason::InvalidTradeIndex));
                 }
-                if event.sender != event.rumor.pubkey {
+                if event.identity != event.sender {
                     let new_user: User = User {
-                        pubkey: event.sender.to_string(),
+                        pubkey: event.identity.to_string(),
                         last_trade_index,
                         ..Default::default()
                     };
@@ -208,7 +200,7 @@ async fn check_trade_index(
 async fn handle_message_action_no_ln(
     action: &Action,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
     ctx: &AppContext,
 ) -> Result<()> {
@@ -270,7 +262,7 @@ async fn handle_message_action_no_ln(
 async fn handle_message_action(
     action: &Action,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
     ln_client: &mut LndConnector,
     ctx: &AppContext,
@@ -321,8 +313,14 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
                         tracing::warn!("Error in event verification")
                     };
 
-                    let event = match nip59::extract_rumor(my_keys, &event).await {
-                        Ok(u) => u,
+                    // Mostro-core's NIP-59 transport handles the dual-key layout
+                    // (identity key signs seal, trade key authors rumor) plus inner
+                    // tuple (message, signature) decoding and signature verification
+                    // in one shot.
+                    let unwrapped = match unwrap_message(&event, my_keys).await {
+                        Ok(Some(u)) => u,
+                        // Outer NIP-44 decrypt failed: not addressed to this node.
+                        Ok(None) => continue,
                         Err(e) => {
                             tracing::warn!("Error unwrapping gift: {}", e);
                             continue;
@@ -333,51 +331,28 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
                         .checked_sub_signed(chrono::Duration::seconds(10))
                         .unwrap()
                         .timestamp() as u64;
-                    if event.rumor.created_at.as_secs() < since_time {
+                    if unwrapped.created_at.as_secs() < since_time {
                         continue;
                     }
-                    // Parse message and signature from rumor content put message in Message struct
-                    let (message, sig) = match serde_json::from_str::<(Message, Option<Signature>)>(
-                        &event.rumor.content,
-                    ) {
-                        Ok((message, signature)) => (message, signature),
-                        Err(e) => {
-                            tracing::warn!("Failed to parse message, inner message, and signature from rumor content: {}", e);
-                            continue;
-                        }
-                    };
+                    let message = unwrapped.message.clone();
 
-                    // Serialize message to json
-                    let message_json = match message.clone().as_json() {
-                        Ok(message_json) => message_json,
-                        Err(e) => {
-                            tracing::warn!("Failed to serialize message: {}", e);
-                            continue;
-                        }
-                    };
-                    // Check if sender and rumor pubkey are different
-                    let sender_matches_rumor = event.sender == event.rumor.pubkey;
-                    if let Some(sig) = sig {
-                        // Verify signature only if sender and rumor pubkey are different
-                        if !sender_matches_rumor
-                            && !Message::verify_signature(message_json, event.rumor.pubkey, sig)
-                        {
-                            tracing::warn!(
-                                "Signature verification failed: sender {} does not match rumor pubkey {}",
-                                event.sender,
-                                event.rumor.pubkey
-                            );
-                            continue;
-                        }
-                    } else if !sender_matches_rumor {
-                        // If there is no signature and the sender does not match the rumor pubkey, there is also an error
-                        tracing::warn!("Error in event verification");
+                    // Full-privacy clients reuse the trade key as identity and send
+                    // unsigned rumors. Any other shape must carry a valid inner
+                    // signature — unwrap_message already verified it, so if identity
+                    // and sender differ here without a signature we bail out.
+                    if unwrapped.identity != unwrapped.sender && unwrapped.signature.is_none() {
+                        tracing::warn!(
+                            "Missing inner signature: identity {} differs from trade key {}",
+                            unwrapped.identity,
+                            unwrapped.sender
+                        );
                         continue;
                     }
+
                     // Get inner message kind
                     let inner_message = message.get_inner_message_kind();
                     // Check if message is message with trade index
-                    if let Err(e) = check_trade_index(&ctx, &event, &message).await {
+                    if let Err(e) = check_trade_index(&ctx, &unwrapped, &message).await {
                         tracing::warn!("Error checking trade index: {}", e);
                         continue;
                     }
@@ -387,7 +362,7 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
                             if let Err(e) = handle_message_action(
                                 &action,
                                 message.clone(),
-                                &event,
+                                &unwrapped,
                                 my_keys,
                                 ln_client,
                                 &ctx,
@@ -396,7 +371,7 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
                             {
                                 match e.downcast::<MostroError>() {
                                     Ok(err) => {
-                                        manage_errors(*err, message, event, &action).await;
+                                        manage_errors(*err, message, unwrapped, &action).await;
                                     }
                                     Err(e) => {
                                         tracing::error!("Unexpected error type: {}", e);
@@ -421,7 +396,7 @@ mod tests {
     use mostro_core::message::Action;
 
     use nostr_sdk::secp256k1::schnorr::Signature;
-    use nostr_sdk::{Keys, Kind as NostrKind, Timestamp, UnsignedEvent};
+    use nostr_sdk::{Keys, Kind as NostrKind, Timestamp};
 
     // Helper function to create test keys
     fn create_test_keys() -> Keys {
@@ -439,22 +414,18 @@ mod tests {
         )
     }
 
-    // Helper function to create UnwrappedGift for testing
-    fn create_test_unwrapped_gift() -> UnwrappedGift {
-        let keys = create_test_keys();
-        let sender_keys = create_test_keys();
+    // Helper function to create an UnwrappedMessage for testing. Identity and
+    // sender (trade key) are distinct to mirror the canonical Mostro flow.
+    fn create_test_unwrapped_message() -> UnwrappedMessage {
+        let identity = create_test_keys();
+        let trade = create_test_keys();
 
-        let unsigned_event = UnsignedEvent::new(
-            keys.public_key(),
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-
-        UnwrappedGift {
-            sender: sender_keys.public_key(),
-            rumor: unsigned_event,
+        UnwrappedMessage {
+            message: create_test_message(Action::NewOrder, None),
+            signature: None,
+            sender: trade.public_key(),
+            identity: identity.public_key(),
+            created_at: Timestamp::now(),
         }
     }
 
@@ -502,7 +473,7 @@ mod tests {
     #[tokio::test]
     async fn test_manage_errors_cant_do() {
         let message = create_test_message(Action::NewOrder, None);
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
         let action = Action::NewOrder;
 
         let error = MostroError::MostroCantDo(CantDoReason::InvalidSignature);
@@ -514,7 +485,7 @@ mod tests {
     #[tokio::test]
     async fn test_manage_errors_internal_error() {
         let message = create_test_message(Action::NewOrder, None);
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
         let action = Action::NewOrder;
 
         let error =
@@ -541,7 +512,7 @@ mod tests {
         #[tokio::test]
         async fn test_check_trade_index_non_trading_action() {
             let ctx = create_test_ctx().await;
-            let event = create_test_unwrapped_gift();
+            let event = create_test_unwrapped_message();
             let message = create_test_message(Action::FiatSent, None);
 
             let result = check_trade_index(&ctx, &event, &message).await;
@@ -551,7 +522,7 @@ mod tests {
         #[tokio::test]
         async fn test_check_trade_index_trading_action_no_index() {
             let ctx = create_test_ctx().await;
-            let event = create_test_unwrapped_gift();
+            let event = create_test_unwrapped_message();
             let message = create_test_message(Action::NewOrder, None);
 
             let result = check_trade_index(&ctx, &event, &message).await;
@@ -561,7 +532,7 @@ mod tests {
         #[tokio::test]
         async fn test_check_trade_index_with_valid_index() {
             let ctx = create_test_ctx().await;
-            let event = create_test_unwrapped_gift();
+            let event = create_test_unwrapped_message();
             let message = create_test_message(Action::NewOrder, Some(1));
 
             // This test would require database setup and user creation
@@ -596,7 +567,7 @@ mod tests {
                 .build();
 
             let my_keys = create_test_keys();
-            let event = create_test_unwrapped_gift();
+            let event = create_test_unwrapped_message();
             let msg = create_test_message(Action::LastTradeIndex, None);
 
             let result =
@@ -622,7 +593,7 @@ mod tests {
                 .build();
 
             let my_keys = create_test_keys();
-            let event = create_test_unwrapped_gift();
+            let event = create_test_unwrapped_message();
             let msg = create_restore_session_message();
 
             let result =
@@ -646,7 +617,7 @@ mod tests {
                 .build();
 
             let my_keys = create_test_keys();
-            let event = create_test_unwrapped_gift();
+            let event = create_test_unwrapped_message();
             let msg = create_test_message(Action::Orders, None);
 
             let result =
@@ -671,7 +642,7 @@ mod tests {
                 .build();
 
             let my_keys = create_test_keys();
-            let event = create_test_unwrapped_gift();
+            let event = create_test_unwrapped_message();
             let msg = create_test_message(Action::PayInvoice, None);
 
             let result =

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,7 +116,8 @@ async fn manage_errors(
 ///
 /// # Arguments
 /// * `ctx` - Application context providing database pool and other dependencies.
-/// * `event` - The unwrapped gift event containing the sender's information.
+/// * `event` - The unwrapped NIP-59 message (`UnwrappedMessage`) containing
+///   the sender's identity and trade keys.
 /// * `msg` - The message containing action details and trade index information.
 async fn check_trade_index(
     ctx: &AppContext,
@@ -322,7 +323,7 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
                         // Outer NIP-44 decrypt failed: not addressed to this node.
                         Ok(None) => continue,
                         Err(e) => {
-                            tracing::warn!("Error unwrapping gift: {}", e);
+                            tracing::warn!("Error unwrapping NIP-59 message: {}", e);
                             continue;
                         }
                     };

--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -4,7 +4,6 @@ use crate::util::{
     validate_invoice,
 };
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
 use sqlx_crud::Crud;
@@ -35,7 +34,7 @@ pub async fn pay_new_invoice(
 pub async fn add_invoice_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -48,7 +47,7 @@ pub async fn add_invoice_action(
     // Get buyer pubkey
     let buyer_pubkey = order.get_buyer_pubkey().map_err(MostroInternalErr)?;
     // Only the buyer can add an invoice
-    if buyer_pubkey != event.rumor.pubkey {
+    if buyer_pubkey != event.sender {
         return Err(MostroCantDo(CantDoReason::InvalidPeer));
     }
     // We save the invoice on db

--- a/src/app/admin_add_solver.rs
+++ b/src/app/admin_add_solver.rs
@@ -3,7 +3,6 @@ use crate::db::add_new_user;
 use crate::util::send_dm;
 use mostro_core::prelude::*;
 use mostro_core::user::User;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use tracing::{error, info};
 
@@ -47,7 +46,7 @@ fn parse_solver_payload(payload: &Payload) -> Result<(String, i64), MostroError>
 pub async fn admin_add_solver_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -59,7 +58,7 @@ pub async fn admin_add_solver_action(
         .as_ref()
         .ok_or(MostroCantDo(CantDoReason::InvalidTextMessage))?;
 
-    if event.sender.to_string() != my_keys.public_key().to_string() {
+    if event.identity.to_string() != my_keys.public_key().to_string() {
         return Err(MostroInternalErr(ServiceError::InvalidPubkey));
     }
 
@@ -85,7 +84,7 @@ pub async fn admin_add_solver_action(
         .as_json()
         .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
 
-    send_dm(event.rumor.pubkey, my_keys, &message, None)
+    send_dm(event.sender, my_keys, &message, None)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
 

--- a/src/app/admin_add_solver.rs
+++ b/src/app/admin_add_solver.rs
@@ -58,7 +58,7 @@ pub async fn admin_add_solver_action(
         .as_ref()
         .ok_or(MostroCantDo(CantDoReason::InvalidTextMessage))?;
 
-    if event.identity.to_string() != my_keys.public_key().to_string() {
+    if event.identity != my_keys.public_key() {
         return Err(MostroInternalErr(ServiceError::InvalidPubkey));
     }
 

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -10,7 +10,6 @@ use crate::lightning::LndConnector;
 use crate::nip33::{create_platform_tag_values, new_dispute_event};
 use crate::util::{enqueue_order_msg, get_order, send_dm, update_order_event};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx_crud::Crud;
 use tracing::{error, info};
@@ -46,7 +45,7 @@ use tracing::{error, info};
 pub async fn admin_cancel_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
     ln_client: &mut LndConnector,
 ) -> Result<(), MostroError> {
@@ -56,7 +55,7 @@ pub async fn admin_cancel_action(
     // Get order
     let order = get_order(&msg, pool).await?;
     // Check if the solver is assigned to the order
-    match is_assigned_solver(pool, &event.sender.to_string(), order.id).await {
+    match is_assigned_solver(pool, &event.identity.to_string(), order.id).await {
         Ok(false) => {
             // Check if admin has taken over the dispute
             if is_dispute_taken_by_admin(pool, order.id, &my_keys.public_key().to_string()).await? {
@@ -73,7 +72,7 @@ pub async fn admin_cancel_action(
         _ => {}
     }
 
-    if !solver_has_write_permission(pool, &event.sender.to_string(), order.id).await? {
+    if !solver_has_write_permission(pool, &event.identity.to_string(), order.id).await? {
         return Err(MostroCantDo(CantDoReason::NotAuthorized));
     }
 
@@ -84,7 +83,7 @@ pub async fn admin_cancel_action(
             Some(order.id),
             Action::CooperativeCancelAccepted,
             None,
-            event.sender,
+            event.identity,
             msg.get_inner_message_kind().trade_index,
         )
         .await;
@@ -177,7 +176,7 @@ pub async fn admin_cancel_action(
         .as_json()
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
     // Message to admin
-    send_dm(event.rumor.pubkey, my_keys, &message, None)
+    send_dm(event.sender, my_keys, &message, None)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -23,7 +23,9 @@ use tracing::{error, info};
 ///
 /// * `ctx` - Application context containing DB pool, settings, and message queue
 /// * `msg` - Incoming message with the order ID and request metadata
-/// * `event` - Unwrapped gift event with sender verification
+/// * `event` - Unwrapped NIP-59 message exposing `sender` (trade key, rumor
+///   author) and `identity` (long-lived identity key, seal signer); admin
+///   gating is performed against `event.identity`
 /// * `my_keys` - Mostro daemon's signing keys
 /// * `ln_client` - Lightning network client for hold invoice cancellation
 ///

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -8,7 +8,6 @@ use crate::nip33::{create_platform_tag_values, new_dispute_event};
 use crate::util::{enqueue_order_msg, get_order, settle_seller_hold_invoice, update_order_event};
 
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx_crud::Crud;
 use std::str::FromStr;
@@ -19,7 +18,7 @@ use super::release::do_payment;
 pub async fn admin_settle_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
     ln_client: &mut LndConnector,
 ) -> Result<(), MostroError> {
@@ -29,7 +28,7 @@ pub async fn admin_settle_action(
     // Get order
     let order = get_order(&msg, pool).await?;
 
-    match is_assigned_solver(pool, &event.sender.to_string(), order.id).await {
+    match is_assigned_solver(pool, &event.identity.to_string(), order.id).await {
         Ok(false) => {
             // Check if admin has taken over the dispute
             if is_dispute_taken_by_admin(pool, order.id, &my_keys.public_key().to_string()).await? {
@@ -50,7 +49,7 @@ pub async fn admin_settle_action(
         _ => {}
     }
 
-    if !solver_has_write_permission(pool, &event.sender.to_string(), order.id).await? {
+    if !solver_has_write_permission(pool, &event.identity.to_string(), order.id).await? {
         return Err(MostroCantDo(CantDoReason::NotAuthorized));
     }
 
@@ -61,7 +60,7 @@ pub async fn admin_settle_action(
             Some(order.id),
             Action::CooperativeCancelAccepted,
             None,
-            event.sender,
+            event.identity,
             msg.get_inner_message_kind().trade_index,
         )
         .await;
@@ -158,7 +157,7 @@ pub async fn admin_settle_action(
         Some(order_updated.id),
         Action::AdminSettled,
         None,
-        event.rumor.pubkey,
+        event.sender,
         msg.get_inner_message_kind().trade_index,
     )
     .await;

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -4,7 +4,6 @@ use crate::db::{find_solver_pubkey, is_user_present, user_has_solver_write_permi
 use crate::nip33::{create_platform_tag_values, new_dispute_event};
 use crate::util::{get_dispute, send_dm};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
 
@@ -150,7 +149,7 @@ pub async fn pubkey_event_can_solve(
 pub async fn admin_take_dispute_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     mostro_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -164,7 +163,7 @@ pub async fn admin_take_dispute_action(
     if let Ok(dispute_status) = DisputeStatus::from_str(&dispute.status) {
         if !pubkey_event_can_solve(
             pool,
-            &event.sender,
+            &event.identity,
             dispute_status,
             dispute.solver_pubkey.as_deref(),
             mostro_keys,
@@ -190,10 +189,10 @@ pub async fn admin_take_dispute_action(
 
     // Update dispute fields
     dispute.status = Status::InProgress.to_string();
-    dispute.solver_pubkey = Some(event.sender.to_string());
+    dispute.solver_pubkey = Some(event.identity.to_string());
     dispute.taken_at = Timestamp::now().as_secs() as i64;
 
-    info!("Dispute {} taken by {}", dispute.id, event.sender);
+    info!("Dispute {} taken by {}", dispute.id, event.identity);
 
     // Save it to DB
     dispute
@@ -217,7 +216,7 @@ pub async fn admin_take_dispute_action(
         .as_json()
         .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
     // Send the message to admin
-    send_dm(event.sender, mostro_keys, &message, None)
+    send_dm(event.identity, mostro_keys, &message, None)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
 
@@ -229,7 +228,7 @@ pub async fn admin_take_dispute_action(
         None,
         Action::AdminTookDispute,
         Some(Payload::Peer(Peer {
-            pubkey: event.sender.to_hex(),
+            pubkey: event.identity.to_hex(),
             reputation: None,
         })),
     )

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -4,7 +4,6 @@ use crate::db::{edit_pubkeys_order, update_order_to_initial_state};
 use crate::lightning::LndConnector;
 use crate::util::{enqueue_order_msg, get_order, update_order_event};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
 use sqlx_crud::Crud;
@@ -76,7 +75,7 @@ async fn notify_creator(order: &Order, request_id: Option<u64>) -> Result<(), Mo
 /// - Publishes a new replaceable nostr event and notifies both parties
 async fn cancel_cooperative_execution_step_2<L: CancelLightning + Send>(
     ctx: &AppContext,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     request_id: Option<u64>,
     mut order: Order,
     counterparty_pubkey: String,
@@ -86,7 +85,7 @@ async fn cancel_cooperative_execution_step_2<L: CancelLightning + Send>(
     let pool = ctx.pool();
     // Guard: the same party cannot both initiate and confirm the cooperative cancel.
     if let Some(initiator) = &order.cancel_initiator_pubkey {
-        if *initiator == event.rumor.pubkey.to_string() {
+        if *initiator == event.sender.to_string() {
             // We create a Message
             return Err(MostroCantDo(CantDoReason::InvalidPubkey));
         }
@@ -118,7 +117,7 @@ async fn cancel_cooperative_execution_step_2<L: CancelLightning + Send>(
         Some(order.id),
         Action::CooperativeCancelAccepted,
         None,
-        event.rumor.pubkey,
+        event.sender,
         None,
     )
     .await;
@@ -155,12 +154,12 @@ async fn cancel_cooperative_execution_step_2<L: CancelLightning + Send>(
 /// - Notifies both parties so the counterparty can confirm (step 2)
 async fn cancel_cooperative_execution_step_1(
     pool: &Pool<Sqlite>,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     mut order: Order,
     counterparty_pubkey: String,
     request_id: Option<u64>,
 ) -> Result<(), MostroError> {
-    order.cancel_initiator_pubkey = Some(event.rumor.pubkey.to_string());
+    order.cancel_initiator_pubkey = Some(event.sender.to_string());
     // update db
     let order = order
         .update(pool)
@@ -173,7 +172,7 @@ async fn cancel_cooperative_execution_step_1(
         Some(order.id),
         Action::CooperativeCancelInitiatedByYou,
         None,
-        event.rumor.pubkey,
+        event.sender,
         None,
     )
     .await;
@@ -201,7 +200,7 @@ async fn cancel_cooperative_execution_step_1(
 /// - Notify the maker/creator that the order is republished
 async fn cancel_order_by_taker<L: CancelLightning + Send>(
     pool: &Pool<Sqlite>,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     mut order: Order,
     my_keys: &Keys,
     request_id: Option<u64>,
@@ -220,7 +219,7 @@ async fn cancel_order_by_taker<L: CancelLightning + Send>(
         Some(order.id),
         Action::Canceled,
         None,
-        event.rumor.pubkey,
+        event.sender,
         None,
     )
     .await;
@@ -261,7 +260,7 @@ async fn cancel_order_by_taker<L: CancelLightning + Send>(
 /// - Notifies both parties
 async fn cancel_order_by_maker<L: CancelLightning + Send>(
     pool: &Pool<Sqlite>,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     order: Order,
     taker_pubkey: PublicKey,
     my_keys: &Keys,
@@ -286,7 +285,7 @@ async fn cancel_order_by_maker<L: CancelLightning + Send>(
         Some(order.id),
         Action::Canceled,
         None,
-        event.rumor.pubkey,
+        event.sender,
         None,
     )
     .await;
@@ -310,14 +309,14 @@ async fn cancel_order_by_maker<L: CancelLightning + Send>(
 /// notifies the maker. No invoice is involved yet in this state.
 async fn cancel_pending_order_from_maker(
     pool: &Pool<Sqlite>,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     order: &mut Order,
     my_keys: &Keys,
     request_id: Option<u64>,
 ) -> Result<(), MostroError> {
     // Validates if this user is the order creator
     order
-        .sent_from_maker(event.rumor.pubkey)
+        .sent_from_maker(event.sender)
         .map_err(|_| MostroCantDo(CantDoReason::IsNotYourOrder))?;
     // Publish a replaceable nostr event with updated status and persist it.
     match update_order_event(my_keys, Status::Canceled, order).await {
@@ -339,7 +338,7 @@ async fn cancel_pending_order_from_maker(
         Some(order.id),
         Action::Canceled,
         None,
-        event.rumor.pubkey,
+        event.sender,
         None,
     )
     .await;
@@ -353,7 +352,7 @@ async fn cancel_pending_order_from_maker(
 pub async fn cancel_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
     ln_client: &mut LndConnector,
 ) -> Result<(), MostroError> {
@@ -363,7 +362,7 @@ pub async fn cancel_action(
 async fn cancel_action_generic<L: CancelLightning + Send>(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
     ln_client: &mut L,
 ) -> Result<(), MostroError> {
@@ -408,7 +407,7 @@ async fn cancel_action_generic<L: CancelLightning + Send>(
 /// (step 1) or completes it (step 2) when both sides have acknowledged.
 async fn cancel_active_order<L: CancelLightning + Send>(
     ctx: &AppContext,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     mut order: Order,
     my_keys: &Keys,
     request_id: Option<u64>,
@@ -420,7 +419,7 @@ async fn cancel_active_order<L: CancelLightning + Send>(
     let buyer_pubkey = order.get_buyer_pubkey().map_err(MostroInternalErr)?;
 
     let counterparty_pubkey: String;
-    if buyer_pubkey == event.rumor.pubkey {
+    if buyer_pubkey == event.sender {
         order.buyer_cooperativecancel = true;
         counterparty_pubkey = seller_pubkey.to_string();
     } else {
@@ -462,7 +461,7 @@ async fn cancel_active_order<L: CancelLightning + Send>(
 /// can cancel. This ensures the correct party authorization for early cancels.
 async fn cancel_not_active_order<L: CancelLightning + Send>(
     pool: &Pool<Sqlite>,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     order: Order,
     my_keys: &Keys,
     request_id: Option<u64>,
@@ -481,7 +480,7 @@ async fn cancel_not_active_order<L: CancelLightning + Send>(
         return Err(MostroInternalErr(ServiceError::InvalidPubkey));
     };
 
-    if order.sent_from_maker(event.rumor.pubkey).is_ok() {
+    if order.sent_from_maker(event.sender).is_ok() {
         cancel_order_by_maker(
             pool,
             event,
@@ -492,7 +491,7 @@ async fn cancel_not_active_order<L: CancelLightning + Send>(
             ln_client,
         )
         .await?;
-    } else if event.rumor.pubkey == taker_pubkey {
+    } else if event.sender == taker_pubkey {
         cancel_order_by_taker(
             pool,
             event,
@@ -513,23 +512,24 @@ async fn cancel_not_active_order<L: CancelLightning + Send>(
 mod tests {
     use super::*;
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
-    use nostr_sdk::{Keys, Kind as NostrKind, Timestamp, UnsignedEvent};
+    use nostr_sdk::{Keys, Timestamp};
     use sqlx::SqlitePool;
     use sqlx_crud::Crud;
     use std::sync::Arc;
 
-    fn create_unwrapped_gift_with_pubkey(pubkey: PublicKey) -> UnwrappedGift {
-        let unsigned_event = UnsignedEvent::new(
-            pubkey,
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-
-        UnwrappedGift {
+    fn create_unwrapped_gift_with_pubkey(pubkey: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::Order(MessageKind::new(
+                Some(uuid::Uuid::new_v4()),
+                Some(1),
+                None,
+                Action::Cancel,
+                None,
+            )),
+            signature: None,
             sender: pubkey,
-            rumor: unsigned_event,
+            identity: pubkey,
+            created_at: Timestamp::now(),
         }
     }
 

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -517,7 +517,11 @@ mod tests {
     use sqlx_crud::Crud;
     use std::sync::Arc;
 
-    fn create_unwrapped_gift_with_pubkey(pubkey: PublicKey) -> UnwrappedMessage {
+    /// Build an `UnwrappedMessage` whose trade key (rumor author / `sender`)
+    /// is `pubkey`. The identity key is generated separately so the fixture
+    /// reflects the dual-key flow: handlers that gate on `sender` see the
+    /// caller; handlers that gate on `identity` see an unrelated key.
+    fn create_unwrapped_message_with_pubkey(pubkey: PublicKey) -> UnwrappedMessage {
         UnwrappedMessage {
             message: Message::Order(MessageKind::new(
                 Some(uuid::Uuid::new_v4()),
@@ -528,7 +532,7 @@ mod tests {
             )),
             signature: None,
             sender: pubkey,
-            identity: pubkey,
+            identity: Keys::generate().public_key(),
             created_at: Timestamp::now(),
         }
     }
@@ -612,7 +616,7 @@ mod tests {
 
         // Event is sent by a third party (neither maker nor taker) to trigger auth guard.
         let intruder = Keys::generate().public_key();
-        let event = create_unwrapped_gift_with_pubkey(intruder);
+        let event = create_unwrapped_message_with_pubkey(intruder);
 
         let msg = Message::new_order(Some(order.id), Some(1), None, Action::Cancel, None);
         let my_keys = Keys::generate();

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -7,7 +7,6 @@ use crate::db::find_dispute_by_order_id;
 use crate::nip33::{create_platform_tag_values, new_dispute_event};
 use crate::util::{enqueue_order_msg, get_order};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 
 use sqlx_crud::traits::Crud;
@@ -153,7 +152,7 @@ async fn notify_dispute_to_users(
 pub async fn dispute_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -175,7 +174,7 @@ pub async fn dispute_action(
         (_, None) => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
     };
     // Get message sender
-    let message_sender = event.rumor.pubkey.to_string();
+    let message_sender = event.sender.to_string();
     // Get counterpart info
     let is_buyer_dispute = match get_counterpart_info(&message_sender, &buyer, &seller) {
         Ok(is_buyer_dispute) => is_buyer_dispute,

--- a/src/app/fiat_sent.rs
+++ b/src/app/fiat_sent.rs
@@ -1,7 +1,6 @@
 use crate::app::context::AppContext;
 use crate::util::{enqueue_order_msg, get_order, update_order_event};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx_crud::Crud;
 
@@ -9,7 +8,7 @@ use sqlx_crud::Crud;
 pub async fn fiat_sent_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -23,7 +22,7 @@ pub async fn fiat_sent_action(
 
     // Check if the pubkey is the buyer pubkey - Only the buyer can send fiat
     // if someone else tries to send fiat, we return an error
-    if order.get_buyer_pubkey().ok() != Some(event.rumor.pubkey) {
+    if order.get_buyer_pubkey().ok() != Some(event.sender) {
         return Err(MostroCantDo(CantDoReason::InvalidPubkey));
     }
 
@@ -43,7 +42,7 @@ pub async fn fiat_sent_action(
 
     // Create peer
     let peer = Peer {
-        pubkey: event.rumor.pubkey.to_string(),
+        pubkey: event.sender.to_string(),
         reputation: None,
     };
 
@@ -69,7 +68,7 @@ pub async fn fiat_sent_action(
         Some(order_updated.id),
         Action::FiatSentOk,
         Some(Payload::Peer(peer)),
-        event.rumor.pubkey,
+        event.sender,
         None,
     )
     .await;

--- a/src/app/last_trade_index.rs
+++ b/src/app/last_trade_index.rs
@@ -112,7 +112,7 @@ mod tests {
     // Helper function to create UnwrappedMessage for testing. `sender_keys`
     // stands in for the long-lived identity key; the trade key is generated
     // separately so the two fields stay distinguishable.
-    fn create_test_unwrapped_gift(sender_keys: &Keys) -> UnwrappedMessage {
+    fn create_test_unwrapped_message(sender_keys: &Keys) -> UnwrappedMessage {
         let trade = create_test_keys();
         println!(
             "Creating UnwrappedMessage with identity pubkey: {}",
@@ -196,7 +196,7 @@ mod tests {
         let sender_keys = create_test_keys();
 
         // Create test event for non-existent user
-        let event = create_test_unwrapped_gift(&sender_keys);
+        let event = create_test_unwrapped_message(&sender_keys);
 
         // Create test message kind
         let kind = MessageKind::new(None, Some(1234567890), None, Action::LastTradeIndex, None);

--- a/src/app/last_trade_index.rs
+++ b/src/app/last_trade_index.rs
@@ -2,7 +2,6 @@ use crate::app::context::AppContext;
 use crate::db::is_user_present;
 use crate::util::send_dm;
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 
 /// Handles a `last_trade_index` action request from a user.
@@ -44,14 +43,14 @@ use nostr_sdk::prelude::*;
 pub async fn last_trade_index(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
     // Get requester pubkey (sender of the message)
-    let requester_pubkey = event.sender.to_string();
+    let requester_pubkey = event.identity.to_string();
     // Get trade key from the event rumor
-    let trade_key = event.rumor.pubkey;
+    let trade_key = event.sender;
 
     // Get request id
     let request_id = msg.get_inner_message_kind().request_id;
@@ -101,7 +100,7 @@ pub async fn last_trade_index(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nostr_sdk::{Keys, Kind as NostrKind, Timestamp, UnsignedEvent};
+    use nostr_sdk::{Keys, Timestamp};
     use sqlx::sqlite::SqlitePoolOptions;
     use sqlx::SqlitePool;
 
@@ -110,25 +109,28 @@ mod tests {
         Keys::generate()
     }
 
-    // Helper function to create UnwrappedGift for testing
-    fn create_test_unwrapped_gift(sender_keys: &Keys) -> UnwrappedGift {
-        let keys = create_test_keys();
-
-        let unsigned_event = UnsignedEvent::new(
-            keys.public_key(),
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
+    // Helper function to create UnwrappedMessage for testing. `sender_keys`
+    // stands in for the long-lived identity key; the trade key is generated
+    // separately so the two fields stay distinguishable.
+    fn create_test_unwrapped_gift(sender_keys: &Keys) -> UnwrappedMessage {
+        let trade = create_test_keys();
         println!(
-            "Creating UnwrappedGift with sender pubkey: {}",
+            "Creating UnwrappedMessage with identity pubkey: {}",
             sender_keys.public_key()
         );
 
-        UnwrappedGift {
-            sender: sender_keys.public_key(),
-            rumor: unsigned_event,
+        UnwrappedMessage {
+            message: Message::Restore(MessageKind::new(
+                None,
+                Some(1),
+                None,
+                Action::LastTradeIndex,
+                None,
+            )),
+            signature: None,
+            sender: trade.public_key(),
+            identity: sender_keys.public_key(),
+            created_at: Timestamp::now(),
         }
     }
 

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -185,7 +185,7 @@ mod tests {
         )
     }
 
-    fn create_test_unwrapped_gift() -> UnwrappedMessage {
+    fn create_test_unwrapped_message() -> UnwrappedMessage {
         let identity = create_test_keys();
         let trade = create_test_keys();
 
@@ -234,7 +234,7 @@ mod tests {
             .with_settings(test_settings())
             .build();
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
 
         // Create message without order payload
         let msg = Message::Order(MessageKind {
@@ -259,7 +259,7 @@ mod tests {
             .with_settings(test_settings())
             .build();
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
 
         // fiat_amount = 0 should be rejected by check_fiat_amount
         let msg = create_test_order_message(0, 50000);
@@ -291,7 +291,7 @@ mod tests {
             .with_settings(test_settings())
             .build();
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
 
         // amount < 0 should be rejected by check_amount
         let msg = create_test_order_message(100, -50000);
@@ -313,7 +313,7 @@ mod tests {
             .with_settings(test_settings())
             .build();
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
         let msg = create_test_message(Some(1));
 
         // This test would require:
@@ -333,7 +333,7 @@ mod tests {
             .with_settings(test_settings())
             .build();
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
 
         let msg = create_test_message(Some(1));
 
@@ -349,7 +349,7 @@ mod tests {
             .with_settings(test_settings())
             .build();
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
 
         let msg = create_test_message(Some(1));
         // Structural check: ensure call does not panic
@@ -366,16 +366,16 @@ mod tests {
             .build();
         let keys = create_test_keys();
 
-        // Test case 1: sender == rumor.pubkey, no trade_index
-        let mut event = create_test_unwrapped_gift();
+        // Test case 1: identity == sender, no trade_index
+        let mut event = create_test_unwrapped_message();
         event.identity = event.sender;
         let msg = create_test_message(None);
 
         let _ = order_action(&ctx, msg, &event, &keys).await;
 
-        // Test case 2: sender != rumor.pubkey, no trade_index
-        let event2 = create_test_unwrapped_gift();
-        // sender and rumor.pubkey are already different by default
+        // Test case 2: identity != sender, no trade_index
+        let event2 = create_test_unwrapped_message();
+        // identity and sender are already distinct by default
         let msg2 = create_test_message(None);
 
         // Structural check: ensure call returns a Result without panicking

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -2,7 +2,6 @@ use crate::app::context::AppContext;
 use crate::db::update_user_trade_index;
 use crate::util::{get_bitcoin_price, publish_order, validate_invoice};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use nostr_sdk::Keys;
 
@@ -65,11 +64,11 @@ async fn calculate_and_check_quote(
 /// # Examples
 ///
 /// ```rust,ignore
-/// # use your_crate::{order_action, Message, UnwrappedGift, Keys, AppContext};
+/// # use your_crate::{order_action, Message, UnwrappedMessage, Keys, AppContext};
 /// # async fn run_example(ctx: &AppContext) -> Result<(), MostroError> {
 /// // Initialize dummy instances; in a real application, replace these with actual values.
 /// let msg = Message::default();
-/// let event = UnwrappedGift::default();
+/// let event = UnwrappedMessage::default();
 /// let my_keys = Keys::default();
 ///
 /// // Process the order if present in the message.
@@ -80,7 +79,7 @@ async fn calculate_and_check_quote(
 pub async fn order_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -131,7 +130,7 @@ pub async fn order_action(
         let trade_index = match msg.get_inner_message_kind().trade_index {
             Some(trade_index) => trade_index,
             None => {
-                if event.sender == event.rumor.pubkey {
+                if event.identity == event.sender {
                     0
                 } else {
                     return Err(MostroInternalErr(ServiceError::InvalidPayload));
@@ -140,7 +139,7 @@ pub async fn order_action(
         };
 
         // Update trade index only after all checks are done
-        update_user_trade_index(pool, event.sender.to_string(), trade_index)
+        update_user_trade_index(pool, event.identity.to_string(), trade_index)
             .await
             .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
@@ -149,9 +148,9 @@ pub async fn order_action(
             pool,
             my_keys,
             order,
-            event.rumor.pubkey,
             event.sender,
-            event.rumor.pubkey,
+            event.identity,
+            event.sender,
             request_id,
             msg.get_inner_message_kind().trade_index,
         )
@@ -165,7 +164,7 @@ mod tests {
     use super::*;
     use mostro_core::message::MessageKind;
 
-    use nostr_sdk::{Keys, Kind as NostrKind, Timestamp, UnsignedEvent};
+    use nostr_sdk::{Keys, Timestamp};
     use sqlx::SqlitePool;
 
     async fn create_test_pool() -> SqlitePool {
@@ -186,21 +185,16 @@ mod tests {
         )
     }
 
-    fn create_test_unwrapped_gift() -> UnwrappedGift {
-        let keys = create_test_keys();
-        let sender_keys = create_test_keys();
+    fn create_test_unwrapped_gift() -> UnwrappedMessage {
+        let identity = create_test_keys();
+        let trade = create_test_keys();
 
-        let unsigned_event = UnsignedEvent::new(
-            keys.public_key(),
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-
-        UnwrappedGift {
-            sender: sender_keys.public_key(),
-            rumor: unsigned_event,
+        UnwrappedMessage {
+            message: create_test_message(None),
+            signature: None,
+            sender: trade.public_key(),
+            identity: identity.public_key(),
+            created_at: Timestamp::now(),
         }
     }
 
@@ -374,7 +368,7 @@ mod tests {
 
         // Test case 1: sender == rumor.pubkey, no trade_index
         let mut event = create_test_unwrapped_gift();
-        event.sender = event.rumor.pubkey;
+        event.identity = event.sender;
         let msg = create_test_message(None);
 
         let _ = order_action(&ctx, msg, &event, &keys).await;

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -7,7 +7,7 @@ use nostr_sdk::prelude::*;
 pub async fn orders_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
     // Get order
@@ -29,7 +29,7 @@ pub async fn orders_action(
     }
 
     // Get orders
-    let orders = get_user_orders_by_id(pool, ids, &event.sender.to_string()).await?;
+    let orders = get_user_orders_by_id(pool, ids, &event.identity.to_string()).await?;
     if orders.is_empty() {
         return Err(MostroCantDo(CantDoReason::NotFound));
     }
@@ -49,7 +49,7 @@ pub async fn orders_action(
         None,
         Action::Orders,
         Some(response_payload),
-        event.rumor.pubkey,
+        event.sender,
         None,
     )
     .await;

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -254,7 +254,11 @@ mod tests {
         Keys::generate()
     }
 
-    fn create_unwrapped_gift_with_pubkey(pubkey: PublicKey) -> UnwrappedMessage {
+    /// Build an `UnwrappedMessage` whose trade key (rumor author / `sender`)
+    /// is `pubkey` — these tests gate on `event.sender` to identify
+    /// buyer/seller — and whose identity key is generated separately so the
+    /// fixture exercises the dual-key flow rather than full-privacy mode.
+    fn create_unwrapped_message_with_pubkey(pubkey: PublicKey) -> UnwrappedMessage {
         UnwrappedMessage {
             message: Message::Order(MessageKind::new(
                 Some(Uuid::new_v4()),
@@ -265,7 +269,7 @@ mod tests {
             )),
             signature: None,
             sender: pubkey,
-            identity: pubkey,
+            identity: Keys::generate().public_key(),
             created_at: Timestamp::now(),
         }
     }
@@ -313,7 +317,7 @@ mod tests {
         let buyer_pk = buyer_keys.public_key();
 
         // Event where the sender is the seller (so seller_rating = true)
-        let event = create_unwrapped_gift_with_pubkey(seller_pk);
+        let event = create_unwrapped_message_with_pubkey(seller_pk);
 
         // Insert Success order in DB
         let order = create_test_order(Status::Success, seller_pk, buyer_pk);
@@ -346,7 +350,7 @@ mod tests {
         let buyer_pk = buyer_keys.public_key();
 
         // Event where the sender is the buyer (so buyer_rating = true)
-        let event = create_unwrapped_gift_with_pubkey(buyer_pk);
+        let event = create_unwrapped_message_with_pubkey(buyer_pk);
 
         // SettledHoldInvoice order in DB
         let order = create_test_order(Status::SettledHoldInvoice, seller_pk, buyer_pk);
@@ -401,7 +405,7 @@ mod tests {
         let order = order.create(&pool).await.unwrap();
 
         // Event where sender is the buyer (buyer_rating = true)
-        let event = create_unwrapped_gift_with_pubkey(buyer_pk);
+        let event = create_unwrapped_message_with_pubkey(buyer_pk);
         let msg = create_rate_user_message(order.id, 5);
 
         let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;
@@ -460,7 +464,7 @@ mod tests {
         let order = order.create(&pool).await.unwrap();
 
         // Buyer tries to rate again
-        let event = create_unwrapped_gift_with_pubkey(buyer_pk);
+        let event = create_unwrapped_message_with_pubkey(buyer_pk);
         let msg = create_rate_user_message(order.id, 5);
 
         let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;
@@ -510,7 +514,7 @@ mod tests {
         let order = order.create(&pool).await.unwrap();
 
         // Event where sender is the seller (seller_rating = true)
-        let event = create_unwrapped_gift_with_pubkey(seller_pk);
+        let event = create_unwrapped_message_with_pubkey(seller_pk);
         let msg = create_rate_user_message(order.id, 4);
 
         let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -2,7 +2,6 @@ use crate::app::context::AppContext;
 use crate::db::{is_user_present, update_user_rating};
 use crate::util::{enqueue_order_msg, get_order, update_user_rating_event};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 
 pub fn prepare_variables_for_vote(
@@ -71,7 +70,7 @@ pub fn prepare_variables_for_vote(
 pub async fn update_user_reputation_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -80,7 +79,7 @@ pub async fn update_user_reputation_action(
 
     // Prepare variables for vote
     let (counterpart_trade_pubkey, buyer_rating, seller_rating) =
-        prepare_variables_for_vote(&event.rumor.pubkey.to_string(), &order)?;
+        prepare_variables_for_vote(&event.sender.to_string(), &order)?;
 
     // Check if order is success, but sellers can rate in status settled-hold-invoice
     if !(order.check_status(Status::Success).is_ok()
@@ -200,7 +199,7 @@ pub async fn update_user_reputation_action(
             Some(order.id),
             Action::RateReceived,
             Some(Payload::RatingUser(new_rating)),
-            event.rumor.pubkey,
+            event.sender,
             None,
         )
         .await;
@@ -227,7 +226,7 @@ mod tests {
     use crate::config::MOSTRO_CONFIG;
     use mostro_core::message::{MessageKind, Payload};
     use mostro_core::order::Order;
-    use nostr_sdk::{Keys, Kind as NostrKind, Timestamp, UnsignedEvent};
+    use nostr_sdk::{Keys, Timestamp};
     use sqlx::SqlitePool;
     use sqlx_crud::Crud;
     use uuid::Uuid;
@@ -255,17 +254,19 @@ mod tests {
         Keys::generate()
     }
 
-    fn create_unwrapped_gift_with_pubkey(pubkey: PublicKey) -> UnwrappedGift {
-        let unsigned_event = UnsignedEvent::new(
-            pubkey,
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-        UnwrappedGift {
+    fn create_unwrapped_gift_with_pubkey(pubkey: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::Order(MessageKind::new(
+                Some(Uuid::new_v4()),
+                Some(1),
+                None,
+                Action::RateUser,
+                None,
+            )),
+            signature: None,
             sender: pubkey,
-            rumor: unsigned_event,
+            identity: pubkey,
+            created_at: Timestamp::now(),
         }
     }
 

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -8,7 +8,6 @@ use crate::util::{enqueue_order_msg, get_order, settle_seller_hold_invoice, upda
 use fedimint_tonic_lnd::lnrpc::payment::PaymentStatus;
 use lnurl::lightning_address::LightningAddress;
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
 use sqlx_crud::Crud;
@@ -157,7 +156,7 @@ pub async fn check_failure_retries(
 pub async fn release_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
     ln_client: &mut LndConnector,
 ) -> Result<(), MostroError> {
@@ -172,7 +171,7 @@ pub async fn release_action(
     let buyer_pubkey = order.get_buyer_pubkey().map_err(MostroInternalErr)?;
 
     // Check if the pubkey is the seller pubkey - Only the seller can release funds
-    if seller_pubkey != event.rumor.pubkey {
+    if seller_pubkey != event.sender {
         return Err(MostroCantDo(CantDoReason::InvalidPeer));
     }
 

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -1,7 +1,6 @@
 use crate::app::context::AppContext;
 use crate::{db::RestoreSessionManager, util::enqueue_restore_session_msg};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 
 /// Handle restore session action
@@ -9,13 +8,13 @@ use nostr_sdk::prelude::*;
 /// and immediately returns, avoiding blocking the main application
 pub async fn restore_session_action(
     ctx: &AppContext,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
     // Get user master key from the event sender
-    let master_key = event.sender.to_string();
+    let master_key = event.identity.to_string();
     // Get trade key from the event rumor
-    let trade_key = event.rumor.pubkey.to_string();
+    let trade_key = event.sender.to_string();
 
     // Validate the master key format
     if !master_key.chars().all(|c| c.is_ascii_hexdigit()) || master_key.len() != 64 {

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -5,13 +5,12 @@ use crate::util::{
 
 use crate::db::{seller_has_pending_order, update_user_trade_index};
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 
 pub async fn take_buy_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -23,7 +22,7 @@ pub async fn take_buy_action(
     let request_id = msg.get_inner_message_kind().request_id;
 
     // Check if the buyer has a pending order
-    if seller_has_pending_order(pool, event.sender.to_string()).await? {
+    if seller_has_pending_order(pool, event.identity.to_string()).await? {
         return Err(MostroCantDo(CantDoReason::PendingOrderExists));
     }
 
@@ -38,7 +37,7 @@ pub async fn take_buy_action(
 
     // Validate that the order was sent from the correct maker
     order
-        .not_sent_from_maker(event.rumor.pubkey)
+        .not_sent_from_maker(event.sender)
         .map_err(MostroCantDo)?;
 
     // Get the fiat amount requested by the user for range orders
@@ -68,15 +67,15 @@ pub async fn take_buy_action(
     }
 
     // Get seller and buyer public keys
-    let seller_pubkey = event.rumor.pubkey;
+    let seller_pubkey = event.sender;
     let buyer_pubkey = order.get_buyer_pubkey().map_err(MostroInternalErr)?;
 
     // Add seller identity and trade index to the order
-    order.master_seller_pubkey = Some(event.sender.to_string());
+    order.master_seller_pubkey = Some(event.identity.to_string());
     let trade_index = match msg.get_inner_message_kind().trade_index {
         Some(trade_index) => trade_index,
         None => {
-            if event.sender == event.rumor.pubkey {
+            if event.identity == event.sender {
                 0
             } else {
                 return Err(MostroInternalErr(ServiceError::InvalidPayload));
@@ -89,7 +88,7 @@ pub async fn take_buy_action(
     order.set_timestamp_now();
 
     // Update trade index only after all checks are done
-    update_user_trade_index(pool, event.sender.to_string(), trade_index)
+    update_user_trade_index(pool, event.identity.to_string(), trade_index)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -179,7 +179,7 @@ mod tests {
         )
     }
 
-    fn create_test_unwrapped_gift() -> UnwrappedMessage {
+    fn create_test_unwrapped_message() -> UnwrappedMessage {
         let identity = create_test_keys();
         let trade = create_test_keys();
 
@@ -204,7 +204,7 @@ mod tests {
         let pool = create_test_pool().await;
         let ctx = build_test_context(pool.clone());
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
         let msg = create_test_message(Some(1));
 
         // This test would require:
@@ -221,7 +221,7 @@ mod tests {
         let pool = create_test_pool().await;
         let ctx = build_test_context(pool.clone());
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
         let msg = create_test_message(Some(1));
 
         // This test would require:
@@ -237,22 +237,22 @@ mod tests {
         let ctx = build_test_context(pool.clone());
         let keys = create_test_keys();
 
-        // Test case 1: sender == rumor.pubkey, no trade_index
-        let mut event = create_test_unwrapped_gift();
+        // Test case 1: identity == sender, no trade_index
+        let mut event = create_test_unwrapped_message();
         event.identity = event.sender;
         let msg = create_test_message(None);
 
         let result = take_sell_action(&ctx, msg, &event, &keys).await;
-        // Should use trade_index = 0 when sender == rumor.pubkey
+        // Should use trade_index = 0 when identity == sender
         assert!(result.is_ok() || result.is_err());
 
-        // Test case 2: sender != rumor.pubkey, no trade_index
-        let event2 = create_test_unwrapped_gift();
-        // sender and rumor.pubkey are already different by default
+        // Test case 2: identity != sender, no trade_index
+        let event2 = create_test_unwrapped_message();
+        // identity and sender are already distinct by default
         let msg2 = create_test_message(None);
 
         let result2 = take_sell_action(&ctx, msg2, &event2, &keys).await;
-        // Should fail with InvalidPayload when sender != rumor.pubkey and no trade_index
+        // Should fail with InvalidPayload when identity != sender and no trade_index
         if let Err(MostroInternalErr(ServiceError::InvalidPayload)) = result2 {}
 
         // Test case 3: with trade_index
@@ -266,7 +266,7 @@ mod tests {
         let pool = create_test_pool().await;
         let ctx = build_test_context(pool.clone());
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
         let msg = create_test_message(Some(1));
 
         // This test would require:
@@ -281,7 +281,7 @@ mod tests {
         let pool = create_test_pool().await;
         let ctx = build_test_context(pool.clone());
         let keys = create_test_keys();
-        let event = create_test_unwrapped_gift();
+        let event = create_test_unwrapped_message();
 
         // Test with no payment request (should update order status)
         let msg1 = create_test_message(Some(1));

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -5,7 +5,6 @@ use crate::util::{
     set_waiting_invoice_status, show_hold_invoice, update_order_event, validate_invoice,
 };
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
 use sqlx_crud::Crud;
@@ -37,7 +36,7 @@ async fn update_order_status(
 pub async fn take_sell_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
@@ -47,7 +46,7 @@ pub async fn take_sell_action(
     // Get request id
     let request_id = msg.get_inner_message_kind().request_id;
     // Check if the seller has a pending order
-    if buyer_has_pending_order(pool, event.sender.to_string()).await? {
+    if buyer_has_pending_order(pool, event.identity.to_string()).await? {
         return Err(MostroCantDo(CantDoReason::PendingOrderExists));
     }
 
@@ -62,7 +61,7 @@ pub async fn take_sell_action(
 
     // Validate that the order was sent from the correct maker
     order
-        .not_sent_from_maker(event.rumor.pubkey)
+        .not_sent_from_maker(event.sender)
         .map_err(MostroCantDo)?;
 
     // Get seller pubkey
@@ -100,13 +99,13 @@ pub async fn take_sell_action(
     let payment_request = validate_invoice(&msg, &order).await?;
 
     // Add buyer pubkey to order
-    order.buyer_pubkey = Some(event.rumor.pubkey.to_string());
+    order.buyer_pubkey = Some(event.sender.to_string());
     // Add buyer identity pubkey to order
-    order.master_buyer_pubkey = Some(event.sender.to_string());
+    order.master_buyer_pubkey = Some(event.identity.to_string());
     let trade_index = match msg.get_inner_message_kind().trade_index {
         Some(trade_index) => trade_index,
         None => {
-            if event.sender == event.rumor.pubkey {
+            if event.identity == event.sender {
                 0
             } else {
                 return Err(MostroInternalErr(ServiceError::InvalidPayload));
@@ -119,7 +118,7 @@ pub async fn take_sell_action(
     order.set_timestamp_now();
 
     // Update trade index only after all checks are done
-    update_user_trade_index(pool, event.sender.to_string(), trade_index)
+    update_user_trade_index(pool, event.identity.to_string(), trade_index)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
@@ -132,7 +131,7 @@ pub async fn take_sell_action(
         show_hold_invoice(
             my_keys,
             payment_request,
-            &event.rumor.pubkey,
+            &event.sender,
             &seller_pubkey,
             order,
             request_id,
@@ -148,7 +147,7 @@ mod tests {
     use super::*;
 
     use mostro_core::order::{Kind as OrderKind, Status};
-    use nostr_sdk::{Keys, Kind as NostrKind, Timestamp, UnsignedEvent};
+    use nostr_sdk::{Keys, Timestamp};
     use sqlx::SqlitePool;
 
     async fn create_test_pool() -> SqlitePool {
@@ -180,21 +179,16 @@ mod tests {
         )
     }
 
-    fn create_test_unwrapped_gift() -> UnwrappedGift {
-        let keys = create_test_keys();
-        let sender_keys = create_test_keys();
+    fn create_test_unwrapped_gift() -> UnwrappedMessage {
+        let identity = create_test_keys();
+        let trade = create_test_keys();
 
-        let unsigned_event = UnsignedEvent::new(
-            keys.public_key(),
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-
-        UnwrappedGift {
-            sender: sender_keys.public_key(),
-            rumor: unsigned_event,
+        UnwrappedMessage {
+            message: create_test_message(None),
+            signature: None,
+            sender: trade.public_key(),
+            identity: identity.public_key(),
+            created_at: Timestamp::now(),
         }
     }
 
@@ -245,7 +239,7 @@ mod tests {
 
         // Test case 1: sender == rumor.pubkey, no trade_index
         let mut event = create_test_unwrapped_gift();
-        event.sender = event.rumor.pubkey;
+        event.identity = event.sender;
         let msg = create_test_message(None);
 
         let result = take_sell_action(&ctx, msg, &event, &keys).await;

--- a/src/app/trade_pubkey.rs
+++ b/src/app/trade_pubkey.rs
@@ -2,14 +2,13 @@ use crate::app::context::AppContext;
 use crate::util::{enqueue_order_msg, get_order};
 
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx_crud::Crud;
 
 pub async fn trade_pubkey_action(
     ctx: &AppContext,
     msg: Message,
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
 ) -> Result<(), MostroError> {
     let pool = ctx.pool();
     // Get request id
@@ -38,15 +37,15 @@ pub async fn trade_pubkey_action(
     };
 
     match (master_buyer_key, master_seller_key) {
-        (Some(master_buyer_pubkey), _) if master_buyer_pubkey == event.sender.to_string() => {
-            order.buyer_pubkey = Some(event.rumor.pubkey.to_string());
+        (Some(master_buyer_pubkey), _) if master_buyer_pubkey == event.identity.to_string() => {
+            order.buyer_pubkey = Some(event.sender.to_string());
         }
-        (_, Some(master_seller_pubkey)) if master_seller_pubkey == event.sender.to_string() => {
-            order.seller_pubkey = Some(event.rumor.pubkey.to_string());
+        (_, Some(master_seller_pubkey)) if master_seller_pubkey == event.identity.to_string() => {
+            order.seller_pubkey = Some(event.sender.to_string());
         }
         _ => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
     };
-    order.creator_pubkey = event.rumor.pubkey.to_string();
+    order.creator_pubkey = event.sender.to_string();
 
     // We a message to the seller
     enqueue_order_msg(
@@ -54,7 +53,7 @@ pub async fn trade_pubkey_action(
         Some(order.id),
         Action::TradePubkey,
         None,
-        event.rumor.pubkey,
+        event.sender,
         None,
     )
     .await;

--- a/src/rpc/service.rs
+++ b/src/rpc/service.rs
@@ -9,7 +9,8 @@ use crate::rpc::admin::{
     TakeDisputeResponse, ValidateDbPasswordRequest, ValidateDbPasswordResponse,
 };
 use crate::rpc::rate_limiter::RateLimiter;
-use nostr_sdk::{nips::nip59::UnwrappedGift, Keys};
+use mostro_core::nip59::UnwrappedMessage;
+use nostr_sdk::Keys;
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use std::time::Duration;
@@ -48,7 +49,7 @@ impl AdminServiceImpl {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::app::admin_cancel::admin_cancel_action;
         use mostro_core::message::{Action, Message};
-        use nostr_sdk::{Kind as NostrKind, Timestamp, UnsignedEvent};
+        use nostr_sdk::Timestamp;
         use uuid::Uuid;
 
         // Create a mock message for the admin cancel action
@@ -60,18 +61,14 @@ impl AdminServiceImpl {
             None,
         );
 
-        // Create a mock UnwrappedGift event
-        let unsigned_event = UnsignedEvent::new(
-            self.keys.public_key(),
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-
-        let event = UnwrappedGift {
+        // Admin RPC flows synthesize the inbound event using the node's own
+        // keys for both identity and trade slots.
+        let event = UnwrappedMessage {
+            message: msg.clone(),
+            signature: None,
             sender: self.keys.public_key(),
-            rumor: unsigned_event,
+            identity: self.keys.public_key(),
+            created_at: Timestamp::now(),
         };
 
         use crate::app::context::AppContext;
@@ -110,7 +107,7 @@ impl AdminServiceImpl {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::app::admin_settle::admin_settle_action;
         use mostro_core::message::{Action, Message};
-        use nostr_sdk::{Kind as NostrKind, Timestamp, UnsignedEvent};
+        use nostr_sdk::Timestamp;
         use uuid::Uuid;
 
         let msg = Message::new_order(
@@ -121,17 +118,12 @@ impl AdminServiceImpl {
             None,
         );
 
-        let unsigned_event = UnsignedEvent::new(
-            self.keys.public_key(),
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-
-        let event = UnwrappedGift {
+        let event = UnwrappedMessage {
+            message: msg.clone(),
+            signature: None,
             sender: self.keys.public_key(),
-            rumor: unsigned_event,
+            identity: self.keys.public_key(),
+            created_at: Timestamp::now(),
         };
 
         use crate::app::context::AppContext;
@@ -170,7 +162,7 @@ impl AdminServiceImpl {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::app::admin_add_solver::admin_add_solver_action;
         use mostro_core::message::{Action, Message, Payload};
-        use nostr_sdk::{Kind as NostrKind, Timestamp, UnsignedEvent};
+        use nostr_sdk::Timestamp;
 
         let msg = Message::new_dispute(
             None,
@@ -180,17 +172,12 @@ impl AdminServiceImpl {
             Some(Payload::TextMessage(solver_pubkey)),
         );
 
-        let unsigned_event = UnsignedEvent::new(
-            self.keys.public_key(),
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-
-        let event = UnwrappedGift {
+        let event = UnwrappedMessage {
+            message: msg.clone(),
+            signature: None,
             sender: self.keys.public_key(),
-            rumor: unsigned_event,
+            identity: self.keys.public_key(),
+            created_at: Timestamp::now(),
         };
 
         use crate::app::context::AppContext;
@@ -228,7 +215,7 @@ impl AdminServiceImpl {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::app::admin_take_dispute::admin_take_dispute_action;
         use mostro_core::message::{Action, Message};
-        use nostr_sdk::{Kind as NostrKind, Timestamp, UnsignedEvent};
+        use nostr_sdk::Timestamp;
         use uuid::Uuid;
 
         let msg = Message::new_dispute(
@@ -239,17 +226,12 @@ impl AdminServiceImpl {
             None,
         );
 
-        let unsigned_event = UnsignedEvent::new(
-            self.keys.public_key(),
-            Timestamp::now(),
-            NostrKind::GiftWrap,
-            Vec::new(),
-            "",
-        );
-
-        let event = UnwrappedGift {
+        let event = UnwrappedMessage {
+            message: msg.clone(),
+            signature: None,
             sender: self.keys.public_key(),
-            rumor: unsigned_event,
+            identity: self.keys.public_key(),
+            created_at: Timestamp::now(),
         };
 
         use crate::app::context::AppContext;

--- a/src/rpc/service.rs
+++ b/src/rpc/service.rs
@@ -61,8 +61,14 @@ impl AdminServiceImpl {
             None,
         );
 
-        // Admin RPC flows synthesize the inbound event using the node's own
-        // keys for both identity and trade slots.
+        // Admin RPC flows synthesize the inbound event with the node's own
+        // pubkey in both `identity` and `sender` slots. Authorization is then
+        // enforced downstream by the handlers, which check `event.identity`
+        // against `is_assigned_solver` / `solver_has_write_permission` (and
+        // for cancel/settle, fall back to `is_dispute_taken_by_admin`). For
+        // these flows to succeed, the operator must register the daemon's own
+        // pubkey as an admin/solver with write permission. Authentication of
+        // the gRPC caller itself happens at the transport layer, not here.
         let event = UnwrappedMessage {
             message: msg.clone(),
             signature: None,

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,7 +17,6 @@ use crate::NOSTR_CLIENT;
 use chrono::Duration;
 use fedimint_tonic_lnd::lnrpc::invoice::InvoiceState;
 use mostro_core::prelude::*;
-use nostr::nips::nip59::UnwrappedGift;
 use nostr_sdk::prelude::*;
 use sqlx::Pool;
 use sqlx::QueryBuilder;
@@ -509,23 +508,23 @@ pub async fn send_dm(
     );
     let message = Message::from_json(payload)
         .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
-    // We compose the content, as this is a message from Mostro
-    // and Mostro don't have trade key, we don't need to sign the payload
-    let content = (message, Option::<String>::None);
-    let content = serde_json::to_string(&content)
-        .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
-    // We create the rumor
-    let rumor = EventBuilder::text_note(content).build(sender_keys.public_key());
-    let mut tags: Vec<Tag> = Vec::with_capacity(1 + usize::from(expiration.is_some()));
 
-    if let Some(timestamp) = expiration {
-        tags.push(Tag::expiration(timestamp));
-    }
-    let tags = Tags::from_list(tags);
+    // Mostro node holds a single keypair: it doubles as identity and trade key.
+    // Server-originated messages are unsigned because clients don't track a
+    // trade_index for the node.
+    let event = wrap_message(
+        &message,
+        sender_keys,
+        sender_keys,
+        receiver_pubkey,
+        WrapOptions {
+            signed: false,
+            expiration,
+            ..WrapOptions::default()
+        },
+    )
+    .await?;
 
-    let event = EventBuilder::gift_wrap(sender_keys, &receiver_pubkey, rumor, tags)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
     info!(
         "Sending DM, Event ID: {} to {} with payload: {:#?}",
         event.id,
@@ -1032,7 +1031,7 @@ pub async fn rate_counterpart(
 /// Settle a seller hold invoice
 #[allow(clippy::too_many_arguments)]
 pub async fn settle_seller_hold_invoice(
-    event: &UnwrappedGift,
+    event: &UnwrappedMessage,
     ln_client: &mut LndConnector,
     action: Action,
     is_admin: bool,
@@ -1043,8 +1042,8 @@ pub async fn settle_seller_hold_invoice(
         .get_seller_pubkey()
         .map_err(|_| MostroCantDo(CantDoReason::InvalidPubkey))?
         .to_string();
-    // Get sender pubkey
-    let sender_pubkey = event.rumor.pubkey.to_string();
+    // Get sender pubkey (trade key that authored the rumor)
+    let sender_pubkey = event.sender.to_string();
     // Check if the pubkey is right
     if !is_admin && sender_pubkey != seller_pubkey {
         return Err(MostroCantDo(CantDoReason::InvalidPubkey));


### PR DESCRIPTION
## Summary
- Bumps `mostro-core` from 0.9.1 to **0.10.0**, which introduces a dedicated [`nip59` transport module](https://github.com/MostroP2P/mostro-core/blob/main/docs/NIP59_TRANSPORT.md) that implements the protocol's dual-key gift wrap per [mostro.network/protocol/key_management.html](https://mostro.network/protocol/key_management.html): long-lived **identity key** signs the seal, per-trade **trade key** authors the rumor.
- Switches the daemon's inbound and outbound NIP-59 paths off `nostr-sdk`'s generic `UnwrappedGift` / `EventBuilder::gift_wrap` and onto `mostro_core::nip59::{wrap_message, unwrap_message, UnwrappedMessage, WrapOptions}`. The old path was only safe because `nostr-sdk` 0.44 rejects rumors where `rumor.pubkey != seal.pubkey` via `SenderMismatch`; with Mostro's dual-key layout that check is now handled inside mostro-core, together with NIP-44 decryption and inner-tuple signature verification.
- `util::send_dm` now calls `wrap_message` with `WrapOptions { signed: false, expiration, .. }` — the node has no trade index to prove, so server-originated messages stay unsigned, as in the previous implementation.
- The main event loop in `src/app.rs` unwraps via `unwrap_message`, drops the manual rumor-content re-parse + fallback signature verification (both already performed by the new API), and treats `Ok(None)` as "not addressed to this node" vs. `Err` as a protocol violation.
- All action handlers and the gRPC admin service now take `&UnwrappedMessage` instead of `&UnwrappedGift`. Field usages are renamed to make the key separation explicit:
  - old `event.sender` (seal signer) → `event.identity`
  - old `event.rumor.pubkey` (rumor author) → `event.sender`
  - old `event.rumor.created_at` → `event.created_at`
- `check_trade_index` consumes the pre-verified `UnwrappedMessage::signature` directly instead of re-decoding the `(Message, Signature)` tuple from the rumor content.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — 239 tests pass locally
- [ ] Smoke test end-to-end with a 0.10.x-capable client (identity ≠ trade keys and full-privacy identity == trade keys) once a review build is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated core dependency to v0.10.0 (sqlx feature preserved)

* **Refactor**
  * Unified message/unwrapping flow across handlers for more reliable identity and routing
  * Message-sending and session/restore flows updated to use the consolidated message format, reducing parsing inconsistencies and improving authorization behavior across features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->