### PR TITLE
feat(bond): add Phase 0 schema columns for split, forfeit window, and retry separation

### DIFF
--- a/migrations/20260423120000_anti_abuse_bond.sql
+++ b/migrations/20260423120000_anti_abuse_bond.sql
@@ -53,10 +53,33 @@ CREATE TABLE IF NOT EXISTS bonds (
   -- Routing-fee ceiling actually used for the payout attempt (sats). NULL
   -- until the scheduler tries to pay the winner.
   payout_routing_fee_sats integer,
-  -- Number of payout invoice requests attempted so far.
+  -- Phase 3: portion of `amount_sats` that the node retains on slash. Frozen
+  -- at the moment the bond enters `pending-payout` so a later config change
+  -- or daemon restart cannot re-balance the split. NULL for any bond that
+  -- never reached `pending-payout`. The counterparty share is always derived
+  -- as `amount_sats - node_share_sats` so they cannot drift.
+  node_share_sats  integer,
+  -- Phase 3: counts ONLY `send_payment` retries against an invoice the
+  -- counterparty has already submitted. `payout_max_retries` is checked
+  -- against this counter alone — invoice-request DMs do NOT count here
+  -- (see `invoice_request_attempts` below).
   payout_attempts  integer not null default 0,
+  -- Phase 3: counts how many `Action::AddInvoice` DMs the scheduler has
+  -- sent asking the counterparty for a payout invoice. Bounded by the
+  -- forfeit window (`payout_claim_window_days`), not by `payout_max_retries`,
+  -- so a slow-responding counterparty cannot prematurely flip the bond to
+  -- `failed`. Reset to 0 when the invoice is finally received.
+  invoice_request_attempts integer not null default 0,
+  -- Phase 3: timestamp of the last `AddInvoice` DM. Drives the
+  -- `payout_invoice_window_seconds` cadence check ("don't re-DM before the
+  -- window has elapsed"). Persisted so a daemon restart doesn't trigger an
+  -- immediate re-DM.
+  last_invoice_request_at integer,
   locked_at        integer,
   released_at      integer,
+  -- Set on entry to `pending-payout` (i.e. when the slash decision is
+  -- made), not on the later `slashed` transition. Anchors the
+  -- `payout_claim_window_days` forfeit deadline (see Phase 3).
   slashed_at       integer,
   created_at       integer not null,
   FOREIGN KEY(order_id) REFERENCES orders(id)

--- a/src/app/bond/model.rs
+++ b/src/app/bond/model.rs
@@ -71,13 +71,34 @@ pub struct Bond {
     pub payout_invoice: Option<String>,
     /// Routing-fee ceiling actually used for the payout attempt (sats).
     pub payout_routing_fee_sats: Option<i64>,
-    /// Number of payout invoice requests attempted so far.
+    /// Phase 3: portion of `amount_sats` that the node retains on slash.
+    /// Frozen at the moment the bond enters `PendingPayout`. `None` until
+    /// then; the counterparty share is always derived as
+    /// `amount_sats - node_share_sats` so they cannot drift.
+    pub node_share_sats: Option<i64>,
+    /// Number of `send_payment` retries against an invoice the counterparty
+    /// has already submitted. Bumped only on Phase 3 step 6 (send_payment
+    /// failure); `payout_max_retries` is checked against this counter
+    /// alone. Invoice-request DMs do NOT increment this — see
+    /// `invoice_request_attempts`.
     pub payout_attempts: i64,
+    /// Phase 3: number of `Action::AddInvoice` DMs sent to the counterparty
+    /// asking for a payout invoice. Bounded by the forfeit window
+    /// (`payout_claim_window_days`), not by `payout_max_retries`. Reset to
+    /// 0 when the counterparty finally submits an invoice.
+    pub invoice_request_attempts: i64,
+    /// Phase 3: timestamp of the last `Action::AddInvoice` DM. Drives the
+    /// `payout_invoice_window_seconds` cadence check; persisted so a
+    /// daemon restart doesn't trigger an immediate re-DM.
+    pub last_invoice_request_at: Option<i64>,
     /// Timestamp when the bond hold invoice reached `Accepted`.
     pub locked_at: Option<i64>,
     /// Timestamp when the bond transitioned to `Released`.
     pub released_at: Option<i64>,
-    /// Timestamp when the bond transitioned to `Slashed`.
+    /// Timestamp when the bond transitioned to `PendingPayout` (i.e. when
+    /// the slash decision was made). Anchors the
+    /// `payout_claim_window_days` forfeit deadline. Not touched on the
+    /// later `Slashed` / `Forfeited` / `Failed` transitions.
     pub slashed_at: Option<i64>,
     /// Timestamp when the row was created.
     pub created_at: i64,
@@ -103,7 +124,10 @@ impl Bond {
             payment_request: None,
             payout_invoice: None,
             payout_routing_fee_sats: None,
+            node_share_sats: None,
             payout_attempts: 0,
+            invoice_request_attempts: 0,
+            last_invoice_request_at: None,
             locked_at: None,
             released_at: None,
             slashed_at: None,
@@ -126,6 +150,10 @@ mod tests {
         assert_eq!(b.amount_sats, 1_000);
         assert_eq!(b.slashed_share_sats, 0);
         assert!(b.hash.is_none());
+        assert!(b.node_share_sats.is_none());
+        assert_eq!(b.payout_attempts, 0);
+        assert_eq!(b.invoice_request_attempts, 0);
+        assert!(b.last_invoice_request_at.is_none());
         assert!(b.locked_at.is_none());
         assert!(b.released_at.is_none());
         assert!(b.slashed_at.is_none());


### PR DESCRIPTION
## Summary

Aligns the Phase 0 bond migration with three columns that the
`docs/ANTI_ABUSE_BOND.md` spec adds to the up-front schema:

- `node_share_sats` — frozen split decision persisted at the moment
  a bond enters `pending-payout`, so a later config change or daemon
  restart cannot re-balance an in-flight payout.
- `invoice_request_attempts` + `last_invoice_request_at` — separate
  the "keep nudging the counterparty for a payout invoice" loop from
  the "we have an invoice but `send_payment` keeps failing" loop. The
  existing single `payout_attempts` counter conflated the two, and
  with default `payout_max_retries = 5` a slow-responding
  counterparty would exhaust the budget on invoice-request DMs alone
  and prematurely flip the bond to `failed` despite no actual
  payment failure.

The migration is edited in place (not via a follow-up `ALTER TABLE`)
because the bond feature has not been used in production on `main`
yet. `Bond::new_requested()` and its defaults test cover the new
fields. No behaviour change in Phase 0/1 — these columns are read
by Phase 3+ scheduler logic that has not landed yet.

Also tightens documentation on `payout_attempts` (now explicitly
counts only `send_payment` retries) and `slashed_at` (now documents
that it is set on entry to `pending-payout` and anchors the forfeit
deadline).

## Test plan

- [x] `cargo build`
- [x] `cargo test bond::` — all 32 bond tests green
- [x] `cargo clippy --all-targets` — clean
- [ ] Reviewer to confirm in-place migration edit is acceptable
      (no production deploy of the as-shipped migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)