### PR TITLE
fix(bond): align bond invoice memo with spec §6.1

### DIFF
--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -131,7 +131,7 @@ pub async fn request_taker_bond(
     // `order.amount`), so concurrent takers on a market-priced range
     // order each post a bond sized to their own quote.
     let amount = compute_bond_amount(taker_ctx.amount, cfg);
-    let memo = format!("Bond for Mostro order {}", order.id);
+    let memo = format!("mostro bond order_id={}", order.id);
 
     let mut ln_client = LndConnector::new().await?;
     let (invoice_resp, preimage, hash) = ln_client


### PR DESCRIPTION
## Summary

`request_taker_bond` in `src/app/bond/flow.rs` was emitting the LND hold-invoice memo as `\"Bond for Mostro order <uuid>\"`. The spec at §6.1 and §6.3 of `docs/ANTI_ABUSE_BOND.md` documents the memo as `\"mostro bond order_id=<uuid>\"` and declares it **authoritative** for clients identifying the bond bolt11 (vs. the trade hold invoice that follows) until Phase 1.5 introduces \`Action::PayBondInvoice\`.

Found during a spec ↔ code audit of Phases 0 and 1. A client following the spec's recommended memo-parsing approach would not recognise the daemon's current memo string.

## Change

One-line format change:

\`\`\`diff
-    let memo = format!(\"Bond for Mostro order {}\", order.id);
+    let memo = format!(\"mostro bond order_id={}\", order.id);
\`\`\`

## Test plan

- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -D warnings\` clean
- [x] \`cargo test\` — 259 passing
- [ ] Smoke test with bonds enabled: take an order, verify the LND hold-invoice memo on the bond bolt11 matches \"mostro bond order_id=<uuid>\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)