### PR TITLE
feat(bond): Phase 3 — payout flow for slashed bonds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1304,7 +1304,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2db8b7cdb6d1b58312b019f0f588755617b84dc2690b4f11c0b5fdb7fd3ca677"
+checksum = "0b972de34af6574c8fbb2a6e8fd6a8e478fd45875ef4eae45165668b30246cf0"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1906,7 +1906,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2302,7 +2302,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2339,9 +2339,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2559,7 +2559,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3122,7 +3122,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd16bab24c530f7bc026014ce4810e6d427abf5f4d5a5977c46ef97bd420ef4"
+checksum = "2db8b7cdb6d1b58312b019f0f588755617b84dc2690b4f11c0b5fdb7fd3ca677"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.11.2", features = ["sqlx"] }
+mostro-core = { version = "0.11.3", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.45", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.11.1", features = ["sqlx"] }
+mostro-core = { version = "0.11.2", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.45", features = ["derive"] }

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -994,7 +994,12 @@ trade finalization must never wait on the payout.
        `now - last_invoice_request_at >= payout_invoice_window_seconds`):
        enqueue an `Action::AddBondInvoice` DM (mostro-core 0.11.2+)
        to the recipient (see "Recipient resolution" below) asking for
-       a bolt11 for `counterparty_share_sats - estimated_routing_fee`.
+       a bolt11 for the full `counterparty_share_sats` — the handler
+       validates the invoice principal against `counterparty_share_sats`
+       with fee = 0, so the routing fee must come out of Mostro's
+       wallet, not the invoice principal. (The bonded user may use
+       the estimated routing fee as guidance when choosing a recipient
+       node, but it is not subtracted from the requested amount.)
        The DM **must include the forfeit deadline** (e.g. "claim by
        <ISO timestamp> or your share will be forfeited") via a
        `Payload::TextMessage` body alongside the action, so the user

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -1096,7 +1096,22 @@ must land hand-in-hand with the client adoption. See §14.3.
        Bounding invoice requests is the forfeit window's job
        (`payout_claim_window_days`), not the retry budget's. The node
        share never leaves Mostro's wallet, so it has no separate
-       invoice step.
+       invoice step. **Persist-first ordering invariant:** the DB
+       UPDATE that bumps `invoice_request_attempts` /
+       `last_invoice_request_at` must commit *before*
+       `Action::AddBondInvoice` is enqueued for outbound delivery,
+       and is conditioned on `WHERE state = 'pending-payout'`. If
+       the UPDATE matches zero rows (row has moved on to `Forfeited`
+       / `Slashed` / `Failed` between the scheduler snapshot and
+       this write), the message is **not** enqueued. Enqueue-first
+       would let a crash or DB failure between enqueue and UPDATE
+       leave the durable state unchanged while the recipient (or
+       relays, after publisher flush) has already seen a nudge,
+       producing duplicate `Action::AddBondInvoice` messages on the
+       next tick. Persist-first makes the DB the source of truth:
+       the worst-case failure mode loses *one* nudge (re-prompted on
+       the next tick once the cadence window elapses); a
+       duplicate-nudge mode is impossible.
     2. If an invoice was received (see handler below), **estimate the
        routing fee** via `LndConnector::query_routes(dest, amount)`
        (thin wrapper over LND `router::query_routes`); fall back to

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -186,7 +186,7 @@ slash path.
 | 1 | Taker bond lifecycle: **lock + always release** (no slashing yet) | 0 | ✅ shipped (PR #719) |
 | 1.5 | Protocol cleanup: dedicated `Action::PayBondInvoice` + `Status::WaitingTakerBond` (retire the Phase 1 `PayInvoice` reuse) | 1 | pending |
 | 2 | Solver-directed dispute slash via `BondResolution` payload (taker bond) | 1.5 | pending |
-| 3 | Payout flow: `add-invoice` to winner, routing-fee estimation, retries, audit event | 2 | pending |
+| 3 | Payout flow: `add-bond-invoice` to winner, routing-fee estimation, retries | 2 | pending |
 | 4 | Timeout slash for taker bond (`slash_on_waiting_timeout`) | 3 | pending |
 | 5 | Maker bond (non-range): lock + dispute slash reusing Phase 2/3 | 3 | pending |
 | 6 | Maker bond for **range orders** with proportional slashes | 5 | pending |
@@ -992,13 +992,14 @@ trade finalization must never wait on the payout.
     1. If no `payout_invoice` yet, and the cadence window has elapsed
        (i.e. `last_invoice_request_at IS NULL` or
        `now - last_invoice_request_at >= payout_invoice_window_seconds`):
-       enqueue an `Action::AddInvoice` DM to the recipient (see
-       "Recipient resolution" below) asking for a bolt11 for
-       `counterparty_share_sats - estimated_routing_fee`. The DM
-       **must include the forfeit deadline** (e.g. "claim by <ISO
-       timestamp> or your share will be forfeited") so the user knows
-       the clock is running. Bump `invoice_request_attempts` and set
-       `last_invoice_request_at = now`. **Do not touch
+       enqueue an `Action::AddBondInvoice` DM (mostro-core 0.11.2+)
+       to the recipient (see "Recipient resolution" below) asking for
+       a bolt11 for `counterparty_share_sats - estimated_routing_fee`.
+       The DM **must include the forfeit deadline** (e.g. "claim by
+       <ISO timestamp> or your share will be forfeited") via a
+       `Payload::TextMessage` body alongside the action, so the user
+       knows the clock is running. Bump `invoice_request_attempts`
+       and set `last_invoice_request_at = now`. **Do not touch
        `payout_attempts`** — that counter only governs `send_payment`
        retries (step 6); mixing the two would let a slow-responding
        counterparty exhaust `payout_max_retries` on invoice-request
@@ -1017,9 +1018,9 @@ trade finalization must never wait on the payout.
        Mostro's wallet).
     4. `send_payment` to the counterparty invoice with capped fee.
        Only `counterparty_share_sats - routing_fee` leaves Mostro.
-    5. On success → `state = Slashed`, publish audit event with
-       `outcome = paid`. (`slashed_at` is **not** touched here — it
-       was set at the `PendingPayout` transition; see Phase 2 §7.3.)
+    5. On success → `state = Slashed`. (`slashed_at` is **not**
+       touched here — it was set at the `PendingPayout` transition;
+       see Phase 2 §7.3.)
     6. On `send_payment` failure → bump `payout_attempts` (this is
        the *only* place that increments it); once `payout_max_retries`
        reached, transition to `Failed` and leave a tracing error.
@@ -1028,12 +1029,12 @@ trade finalization must never wait on the payout.
        `Forfeited` (the user never gave us an invoice).
 
   When `slash_node_share_pct = 1.0` the counterparty leg is skipped
-  entirely (no `AddInvoice` DM, no `send_payment`, no forfeit window
-  to wait for); the bond goes straight from `PendingPayout` → settle →
-  `Slashed` after step 3.
+  entirely (no `AddBondInvoice` DM, no `send_payment`, no forfeit
+  window to wait for); the bond goes straight from `PendingPayout` →
+  settle → `Slashed` after step 3.
 
-- **Recipient resolution.** Step 1 above sends `Action::AddInvoice` to
-  the *non-slashed counterparty* of the trade — the party who is
+- **Recipient resolution.** Step 1 above sends `Action::AddBondInvoice`
+  to the *non-slashed counterparty* of the trade — the party who is
   neither the bonded user (`bond.pubkey`) nor a co-slashed party.
   Because `BondResolution` flags are dispute-only and `bond.pubkey`
   is not enough on its own to recover the trade-flow side
@@ -1054,10 +1055,9 @@ trade finalization must never wait on the payout.
     taker have active bonds, neither party deserves restitution
     (§15.2 — "both behaved badly"). For each row, treat as
     `slash_node_share_pct = 1.0` for that payout: skip the
-    `AddInvoice` DM, retain `amount_sats` in full, settle the HTLC
-    in step 3, transition to `Slashed` with the audit event tagged
-    accordingly. (Phase 5+ wires this; Phase 2's taker-only world
-    cannot reach this branch.)
+    `AddBondInvoice` DM, retain `amount_sats` in full, settle the
+    HTLC in step 3, transition to `Slashed`. (Phase 5+ wires this;
+    Phase 2's taker-only world cannot reach this branch.)
 
 - Late-invoice race: the `add_bond_invoice_action` handler (below)
   must check the bond is still in `PendingPayout` before persisting
@@ -1067,10 +1067,11 @@ trade finalization must never wait on the payout.
   per-row decision, no locks needed — the state column is the
   arbiter.
 - New action handler `add_bond_invoice_action` in a new
-  `src/app/bond/payout.rs` module. Receives an `Action::AddInvoice` reply
-  from a bond-payout candidate (distinct from the buyer-invoice
-  `add_invoice_action` — disambiguated by the presence of a bond row in
-  `PendingPayout` for the order / sender pair). On accepting a valid
+  `src/app/bond/payout.rs` module. Receives an `Action::AddBondInvoice`
+  reply from a bond-payout candidate. The dedicated action type
+  (mostro-core 0.11.2+) keeps it disjoint from the buyer-invoice
+  `add_invoice_action` at the routing layer rather than relying on
+  ambient DB state. On accepting a valid
   invoice it persists `payout_invoice` and **resets
   `invoice_request_attempts = 0`** in the same DB write, marking a
   clean transition from the invoice-request phase to the
@@ -1081,24 +1082,6 @@ trade finalization must never wait on the payout.
   invoice" from "nudges after a hypothetical re-prompt" if a future
   phase ever introduces one. Any "took N nudges to respond" logging
   for observability should capture the value *before* the reset.
-- Audit event: new Nostr kind (reusing the dev-fee style: custom kind
-  number, registered in `src/config/constants.rs`). Tags:
-  `order-id`, `role` (maker/taker — which posted the bond),
-  `reason` (`lost-dispute` | `timeout`),
-  `outcome` (`paid` | `forfeited`) — `paid` means the counterparty
-  received their share; `forfeited` means the claim window expired
-  and the node retained `amount_sats` in full. (`Failed` does **not**
-  emit an audit event — it is an operator-attention state, not a
-  normal outcome.)
-  `amount` (total slashed sats, == `node_share + counterparty_share`),
-  `node-share`, `counterparty-share` (the originally-decided split,
-  in sats; on `outcome = forfeited` the node's actual retention is
-  `amount`, but the original split is preserved here for audit so
-  observers can reconstruct what *would* have been paid),
-  `hash` (bond payout hash, **not** the trade payment hash),
-  `y`, `z = bond-slash`. No counterparty pubkeys, consistent with
-  dev-fee audit privacy. Expiration uses `ExpirationSettings` with a new
-  optional `bond_slash_days` field.
 - Unit tests: routing-fee fallback, retries exhaustion, settle-then-pay
   ordering.
 
@@ -1135,9 +1118,8 @@ trade finalization must never wait on the payout.
 - End-to-end test: dispute resolved with `slash_buyer=true` and
   `slash_node_share_pct = 0.5` → buyer-side counterparty (the seller)
   is asked for a bolt11 sized at `floor(amount/2) − routing_fee`,
-  submits it → bond payout settles → Nostr audit event publishes
-  matching `amount`, `node-share`, `counterparty-share` tags
-  (split sums exactly to `amount`, no rounding leak).
+  submits it → bond payout settles (split sums exactly to `amount`,
+  no rounding leak).
 - Edge case `slash_node_share_pct = 0.0` → behaviour identical to the
   pre-split design (full counterparty payout).
 - Edge case `slash_node_share_pct = 1.0` → settle the HTLC, no
@@ -1152,9 +1134,8 @@ trade finalization must never wait on the payout.
 - **Forfeit window test**: bond enters `PendingPayout`, counterparty
   never replies; advance the test clock by
   `payout_claim_window_days + 1`; on the next scheduler tick the bond
-  settles and transitions to `Forfeited`; audit event publishes with
-  `outcome = forfeited`. Node retains `amount_sats` in full. No
-  `send_payment` was ever attempted.
+  settles and transitions to `Forfeited`. Node retains `amount_sats`
+  in full. No `send_payment` was ever attempted.
 - **Late-invoice rejection**: bond is `Forfeited`; counterparty
   submits a bolt11 after the deadline; `add_bond_invoice_action`
   rejects it with a "claim window expired" message; bond stays
@@ -1490,6 +1471,11 @@ these requires a compatibility statement:
   1 reuse of `Action::PayInvoice` / `Status::Pending` for bonds.
 - `Payload::BondResolution` variant in mostro-core (Phase 2).
   **Released in `mostro-core` 0.11.0** (same release).
+- `Action::AddBondInvoice` in mostro-core (Phase 3). **Released in
+  `mostro-core` 0.11.2.** Counterparty-direction dual of
+  `Action::PayBondInvoice`; keeps the bond-payout reply disjoint from
+  the buyer-invoice `Action::AddInvoice` so the daemon can route on
+  action type alone.
 - `Status::WaitingMakerBond` (Phase 5). Not yet shipped upstream;
   needs a follow-up `mostro-core` minor release before Phase 5 can
   land here.

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -985,6 +985,52 @@ payout from sats Mostro already holds.
 
 ### 8.1 Scope
 
+**`Payload::BondPayoutRequest` variant in `mostro-core` 0.11.3+.**
+
+The `Action::AddBondInvoice` message Mostro sends to the winning
+counterparty must carry the original slash anchor (`slashed_at`), not
+just the order context. If the recipient is offline or the relay is
+down for several days, a deadline derived from "now + window" at the
+client *receive time* would silently drift past the real forfeit
+moment; the client would tell the user they have N days left when in
+reality they have far fewer. Shipping `slashed_at` on every retry of
+the message guarantees the client always computes the deadline from
+the same fixed anchor the daemon uses, regardless of when the
+message lands.
+
+From `mostro-core::message::Payload`:
+
+```rust
+/// Bond payout invoice request carried by [`Action::AddBondInvoice`].
+/// Asks the winning counterparty for a bolt11 sized at the order's
+/// `amount` (= counterparty share) and ships the slash anchor so the
+/// client can render the forfeit deadline locally as
+/// `slashed_at + bond_payout_claim_window_days * 86_400`, even if the
+/// message arrives days after it was emitted.
+BondPayoutRequest(BondPayoutRequest)
+```
+
+```rust
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct BondPayoutRequest {
+    /// Order context (id, kind, amount = counterparty_share_sats,
+    /// fiat metadata, etc.) — the same `SmallOrder` shape the client
+    /// already renders for other order-bearing actions.
+    pub order: SmallOrder,
+    /// Unix timestamp (seconds, UTC) when the slash decision was
+    /// recorded. Frozen at the `Locked → PendingPayout` CAS and
+    /// re-shipped verbatim on every cadence retry of the request.
+    pub slashed_at: i64,
+}
+```
+
+`MessageKind::verify` accepts this variant only on
+`Action::AddBondInvoice`. Any other action carrying it returns
+`ServiceError::InvalidPayload`. The variant is serde-additive: clients
+on `mostro-core` 0.11.2 (which only knows `Payload::Order` for this
+action) will reject the message, so the daemon-side bump to 0.11.3
+must land hand-in-hand with the client adoption. See §14.3.
+
 - Split computation, applied **once** at the moment a bond transitions
   to `PendingPayout` (`admin_settle_action` / `admin_cancel_action`
   in Phase 2; `job_cancel_orders` in Phase 4 / 7). The value is
@@ -1023,29 +1069,31 @@ payout from sats Mostro already holds.
     1. If no `payout_invoice` yet, and the cadence window has elapsed
        (i.e. `last_invoice_request_at IS NULL` or
        `now - last_invoice_request_at >= payout_invoice_window_seconds`):
-       enqueue an `Action::AddBondInvoice` message (mostro-core 0.11.2+)
+       enqueue an `Action::AddBondInvoice` message (mostro-core 0.11.3+)
        to the recipient (see "Recipient resolution" below) asking for
-       a bolt11 for the full `counterparty_share_sats` — the handler
-       validates the invoice principal against `counterparty_share_sats`
-       with fee = 0, so the routing fee must come out of Mostro's
-       wallet, not the invoice principal. (The bonded user may use
-       the estimated routing fee as guidance when choosing a recipient
-       node, but it is not subtracted from the requested amount.)
-       The message carries **only the structured request payload** — no
-       hardcoded human-readable text. The forfeit deadline is not
-       shipped inline: the client computes it locally from the slash
-       moment (observable on the order's audit trail) plus
-       `bond_payout_claim_window_days`, which Mostro advertises on the
-       kind-38385 info event (§13.1). Keeping the wire payload
-       text-free lets clients render the warning ("your share will be
-       forfeited in N days") in the user's own locale, and avoids
-       baking English copy into the daemon. Bump
-       `invoice_request_attempts` and set `last_invoice_request_at =
-       now`. **Do not touch `payout_attempts`** — that counter only
-       governs `send_payment` retries (step 4); mixing the two would
-       let a slow-responding counterparty exhaust `payout_max_retries`
-       on invoice-request messages alone and prematurely flip the bond to
-       `Failed`. Bounding invoice requests is the forfeit window's job
+       a bolt11 for the full `counterparty_share_sats`. The message
+       body is a `Payload::BondPayoutRequest { order, slashed_at }`
+       (see the variant contract above): `order.amount` carries the
+       counterparty share so the handler can validate the invoice
+       principal with fee = 0 (the routing fee comes out of Mostro's
+       wallet, not the invoice principal), and `slashed_at` carries
+       the slash anchor so the client can render the forfeit deadline
+       locally as `slashed_at + bond_payout_claim_window_days *
+       86_400` — accurate even if the message lands days after Mostro
+       emitted it. (The bonded user may use the estimated routing fee
+       as guidance when choosing a recipient node, but it is not
+       subtracted from the requested amount.) The message carries no
+       hardcoded human-readable text; clients render the warning
+       ("your share will be forfeited in N days") in the user's own
+       locale using `slashed_at` from this payload and
+       `bond_payout_claim_window_days` from the kind-38385 info event
+       (§13.1). Bump `invoice_request_attempts` and set
+       `last_invoice_request_at = now`. **Do not touch
+       `payout_attempts`** — that counter only governs `send_payment`
+       retries (step 4); mixing the two would let a slow-responding
+       counterparty exhaust `payout_max_retries` on invoice-request
+       messages alone and prematurely flip the bond to `Failed`.
+       Bounding invoice requests is the forfeit window's job
        (`payout_claim_window_days`), not the retry budget's. The node
        share never leaves Mostro's wallet, so it has no separate
        invoice step.
@@ -1575,6 +1623,18 @@ these requires a compatibility statement:
   `Action::PayBondInvoice`; keeps the bond-payout reply disjoint from
   the buyer-invoice `Action::AddInvoice` so the daemon can route on
   action type alone.
+- `Payload::BondPayoutRequest` variant in mostro-core (Phase 3).
+  **Targets `mostro-core` 0.11.3** (not yet released). Carries
+  `{ order: SmallOrder, slashed_at: i64 }` on `Action::AddBondInvoice`
+  so the client can compute the forfeit deadline from the slash
+  anchor instead of from message receipt time. Without this anchor a
+  recipient offline for several days would see a deadline silently
+  shifted into the future; with it, the deadline is fixed and
+  identical across every cadence retry. The variant is serde-additive
+  but a client on 0.11.2 will reject the message (it expects
+  `Payload::Order`), so the daemon-side bump and the client update
+  must land together. `MessageKind::verify` accepts this variant only
+  on `Action::AddBondInvoice`.
 - `Status::WaitingMakerBond` (Phase 5). Not yet shipped upstream;
   needs a follow-up `mostro-core` minor release before Phase 5 can
   land here.

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -1105,13 +1105,17 @@ trade finalization must never wait on the payout.
   wallet and the node leg is done. The only thing the retry loop is
   driving from that point on is the counterparty payout.
 - **Partial success: settle OK, counterparty `send_payment` failed.**
-  The bond state stays in `PendingPayout` with a best-effort retry. The
-  winner is kept informed via periodic messages. If retries exhaust, state
-  becomes `Failed`; at that point Mostro is holding the counterparty
-  share (unavoidable with the HTLC already settled) and logs loudly.
-  The node share is unaffected — it was always going to stay. This is
-  a known limitation; node operators can manually pay the winner from
-  logs.
+  The bond state stays in `PendingPayout` with a best-effort retry on
+  the next scheduler tick. Periodic `Action::AddBondInvoice` messages
+  are **only** scheduled by §8.1 step 1, whose precondition is
+  `payout_invoice IS NULL` — once the winner has already submitted a
+  bolt11, that branch is skipped and the retry loop runs silently
+  (tracing logs only, no wire notification to the winner). If retries
+  exhaust, state becomes `Failed`; at that point Mostro is holding the
+  counterparty share (unavoidable with the HTLC already settled) and
+  logs loudly. The node share is unaffected — it was always going to
+  stay. This is a known limitation; node operators can manually pay
+  the winner from logs.
 - **Counterparty never claims (forfeit path).** Distinct from
   `Failed`: there is no `payout_invoice` because the counterparty
   never sent one. After `payout_claim_window_days` from `slashed_at`,

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -260,20 +260,20 @@ Purely additive. Touches no trade flow.
     -- Phase 3: counts ONLY `send_payment` retries against an invoice
     -- the counterparty has already submitted. Bumped only by step 6
     -- of the §8.1 scheduler loop. `payout_max_retries` is checked
-    -- against this counter alone — invoice-request DMs do NOT count
-    -- here (see `invoice_request_attempts` below).
+    -- against this counter alone — invoice-request messages do NOT
+    -- count here (see `invoice_request_attempts` below).
     payout_attempts  integer not null default 0,
-    -- Phase 3: counts how many `Action::AddInvoice` DMs the scheduler
-    -- has sent asking the counterparty for a payout invoice. Bumped
-    -- by step 1 of §8.1. Bounded by the forfeit window
+    -- Phase 3: counts how many `Action::AddInvoice` messages the
+    -- scheduler has sent asking the counterparty for a payout invoice.
+    -- Bumped by step 1 of §8.1. Bounded by the forfeit window
     -- (`payout_claim_window_days`), not by `payout_max_retries`, so
     -- a slow-responding counterparty cannot prematurely flip the
     -- bond to `Failed`.
     invoice_request_attempts integer not null default 0,
-    -- Phase 3: timestamp of the last `AddInvoice` DM. Drives the
-    -- `payout_invoice_window_seconds` cadence check ("don't re-DM
+    -- Phase 3: timestamp of the last `AddInvoice` message. Drives the
+    -- `payout_invoice_window_seconds` cadence check ("don't re-send
     -- before the window has elapsed"). Persisted so a daemon restart
-    -- doesn't trigger an immediate re-DM.
+    -- doesn't trigger an immediate re-send.
     last_invoice_request_at integer,
     locked_at        integer,
     released_at      integer,
@@ -525,7 +525,7 @@ changes — pure ergonomics.
 Lands **before Phase 2 on purpose**. Phase 2 introduces dispute
 slashes and the `BondResolution` payload; once that ships and
 operators flip `enabled = true` in production, every taker on every
-bond-enabled node sees the bond DM. We want clients to have already
+bond-enabled node sees the bond message. We want clients to have already
 adopted the clean API by then so the seller-as-taker case (§6.3)
 never has to lean on memo parsing in the wild.
 
@@ -554,7 +554,7 @@ never has to lean on memo parsing in the wild.
 - **`mostrod` changes** in `src/app/bond/flow.rs::request_taker_bond`
   and the take handlers:
   - Replace `Action::PayInvoice` with `Action::PayBondInvoice` when
-    enqueuing the bond DM.
+    enqueuing the bond message.
   - Set the order's status to `Status::WaitingTakerBond` while the
     bond is outstanding (instead of leaving it in `Pending`). Add
     the NIP-69 mapping in `nip33::create_status_tags`:
@@ -602,7 +602,7 @@ never has to lean on memo parsing in the wild.
     preimage yet) and notifies its taker with `Action::Canceled`.
     Once a bond does win, the handler iterates every other still-
     `Requested` bond on the order, calls `release_bond` on each
-    (LND hold-invoice cancel + `BondState::Released`), and DMs
+    (LND hold-invoice cancel + `BondState::Released`), and messages
     each loser an `Action::Canceled`. Only after this cleanup does
     it copy the winning bond's `taker_*` context onto the order
     and call `resume_take_after_bond`.
@@ -670,7 +670,7 @@ never has to lean on memo parsing in the wild.
 ### 6.5.2 Client compatibility
 
 - A client that only knows `Action::PayInvoice` will silently ignore
-  the bond DM after this phase ships, the bond will never lock, and
+  the bond message after this phase ships, the bond will never lock, and
   the take will time out and release. No funds at risk, but the take
   fails. This is the expected behaviour for unknown-action handling
   per §14.2 ("Clients must handle unknown statuses gracefully") — it
@@ -687,7 +687,7 @@ never has to lean on memo parsing in the wild.
 
 ### 6.5.3 Tests
 
-- Bond DM enqueues with `Action::PayBondInvoice`, not `PayInvoice`.
+- Bond message enqueues with `Action::PayBondInvoice`, not `PayInvoice`.
 - Order's **DB** status flips to `WaitingTakerBond` while the bond is
   outstanding, flips out to `WaitingPayment` /
   `WaitingBuyerInvoice` (per the existing trade flow) once the bond
@@ -738,7 +738,7 @@ never has to lean on memo parsing in the wild.
   guard ensures exactly one transition to `Locked` succeeds. The
   loser's handler observes `rows_affected = 0`, calls
   `cancel_hold_invoice` on its own hash to release its taker's
-  HTLC without settling, and DMs `Action::Canceled` to its taker.
+  HTLC without settling, and messages `Action::Canceled` to its taker.
   Net effect is identical to the staggered case; no double-lock
   and no settled HTLC for the loser.
 - Seller-as-taker case: one `PayBondInvoice` followed by one
@@ -986,13 +986,13 @@ trade finalization must never wait on the payout.
       bolt11): `settle_hold_invoice(preimage)`, transition the bond
       to `state = Forfeited`, publish the audit event with
       `outcome = forfeited`, and stop. The node retains the full
-      `amount_sats`. No further DMs or `send_payment` runs.
+      `amount_sats`. No further messages or `send_payment` runs.
     - Otherwise, proceed with the normal payout steps below.
   - Normal payout steps:
     1. If no `payout_invoice` yet, and the cadence window has elapsed
        (i.e. `last_invoice_request_at IS NULL` or
        `now - last_invoice_request_at >= payout_invoice_window_seconds`):
-       enqueue an `Action::AddBondInvoice` DM (mostro-core 0.11.2+)
+       enqueue an `Action::AddBondInvoice` message (mostro-core 0.11.2+)
        to the recipient (see "Recipient resolution" below) asking for
        a bolt11 for the full `counterparty_share_sats` — the handler
        validates the invoice principal against `counterparty_share_sats`
@@ -1000,16 +1000,21 @@ trade finalization must never wait on the payout.
        wallet, not the invoice principal. (The bonded user may use
        the estimated routing fee as guidance when choosing a recipient
        node, but it is not subtracted from the requested amount.)
-       The DM **must include the forfeit deadline** (e.g. "claim by
-       <ISO timestamp> or your share will be forfeited") via a
-       `Payload::TextMessage` body alongside the action, so the user
-       knows the clock is running. Bump `invoice_request_attempts`
-       and set `last_invoice_request_at = now`. **Do not touch
-       `payout_attempts`** — that counter only governs `send_payment`
-       retries (step 6); mixing the two would let a slow-responding
-       counterparty exhaust `payout_max_retries` on invoice-request
-       DMs alone and prematurely flip the bond to `Failed`. Bounding
-       invoice requests is the forfeit window's job
+       The message carries **only the structured request payload** — no
+       hardcoded human-readable text. The forfeit deadline is not
+       shipped inline: the client computes it locally from the slash
+       moment (observable on the order's audit trail) plus
+       `bond_payout_claim_window_days`, which Mostro advertises on the
+       kind-38385 info event (§13.1). Keeping the wire payload
+       text-free lets clients render the warning ("your share will be
+       forfeited in N days") in the user's own locale, and avoids
+       baking English copy into the daemon. Bump
+       `invoice_request_attempts` and set `last_invoice_request_at =
+       now`. **Do not touch `payout_attempts`** — that counter only
+       governs `send_payment` retries (step 6); mixing the two would
+       let a slow-responding counterparty exhaust `payout_max_retries`
+       on invoice-request messages alone and prematurely flip the bond to
+       `Failed`. Bounding invoice requests is the forfeit window's job
        (`payout_claim_window_days`), not the retry budget's. The node
        share never leaves Mostro's wallet, so it has no separate
        invoice step.
@@ -1034,7 +1039,7 @@ trade finalization must never wait on the payout.
        `Forfeited` (the user never gave us an invoice).
 
   When `slash_node_share_pct = 1.0` the counterparty leg is skipped
-  entirely (no `AddBondInvoice` DM, no `send_payment`, no forfeit
+  entirely (no `AddBondInvoice` message, no `send_payment`, no forfeit
   window to wait for); the bond goes straight from `PendingPayout` →
   settle → `Slashed` after step 3.
 
@@ -1060,7 +1065,7 @@ trade finalization must never wait on the payout.
     taker have active bonds, neither party deserves restitution
     (§15.2 — "both behaved badly"). For each row, treat as
     `slash_node_share_pct = 1.0` for that payout: skip the
-    `AddBondInvoice` DM, retain `amount_sats` in full, settle the
+    `AddBondInvoice` message, retain `amount_sats` in full, settle the
     HTLC in step 3, transition to `Slashed`. (Phase 5+ wires this;
     Phase 2's taker-only world cannot reach this branch.)
 
@@ -1101,7 +1106,7 @@ trade finalization must never wait on the payout.
   driving from that point on is the counterparty payout.
 - **Partial success: settle OK, counterparty `send_payment` failed.**
   The bond state stays in `PendingPayout` with a best-effort retry. The
-  winner is kept informed via periodic DMs. If retries exhaust, state
+  winner is kept informed via periodic messages. If retries exhaust, state
   becomes `Failed`; at that point Mostro is holding the counterparty
   share (unavoidable with the HTLC already settled) and logs loudly.
   The node share is unaffected — it was always going to stay. This is
@@ -1113,7 +1118,7 @@ trade finalization must never wait on the payout.
   the scheduler settles the HTLC and transitions to `Forfeited`. No
   manual operator action is needed — this is a normal terminal
   state, designed-in. Default 15 days gives even users with sporadic
-  Nostr presence ample time to see the DM and respond.
+  Nostr presence ample time to see the message and respond.
 - **Non-blocking:** `release_action`, `admin_settle_action`, etc. return
   success the moment the trade escrow resolves. Bond payout happens
   later.
@@ -1128,7 +1133,7 @@ trade finalization must never wait on the payout.
 - Edge case `slash_node_share_pct = 0.0` → behaviour identical to the
   pre-split design (full counterparty payout).
 - Edge case `slash_node_share_pct = 1.0` → settle the HTLC, no
-  `AddInvoice` DM is enqueued, no `send_payment` runs, bond goes
+  `AddInvoice` message is enqueued, no `send_payment` runs, bond goes
   straight to `Slashed`.
 - **Persistence test**: a bond enters `PendingPayout` under
   `slash_node_share_pct = 0.5`; before payout completes, simulate a
@@ -1343,7 +1348,7 @@ it. The workable strategies:
        visible.
 
 We recommend **(a)**. Acceptable cost: maker sees one extra `add-invoice`
-DM at range-close if there were partial slashes.
+message at range-close if there were partial slashes.
 
 The split is applied **per child** (each child's `slashed_share_sats`
 is split independently), so the audit event for each child carries its
@@ -1405,20 +1410,40 @@ Tests mirror Phase 4 from the maker side; the "no slash" rows in the
 
 ### 13.1 Scope
 
-- Extend the Mostro info event (`src/nip33.rs::info_to_tags`) with the
-  bond config snapshot so clients can show users what the node enforces
-  before they trade:
-  - `bond` (`enabled` | `disabled`)
-  - `bond-apply-to` (`take` | `create` | `both`)
-  - `bond-slash-timeout` (`true` | `false`)
-  - `bond-amount-pct` / `bond-amount-floor`
-  - `bond-slash-node-share-pct` (the operator's `slash_node_share_pct`,
-    so users know up-front how a slashed bond is split between the node
-    and the winning counterparty).
-  - `bond-payout-claim-window-days` (the operator's
-    `payout_claim_window_days`, so users know how long they have to
-    submit a payout invoice before forfeiting their share).
-  - **No `bond-slash-dispute` tag**: dispute slashes are solver-driven
+- The Mostro info event (`src/nip33.rs::info_to_tags`) carries the
+  bond config snapshot so clients can show users what the node
+  enforces before they trade. **The full set below is shipped in
+  Phase 3** alongside the payout flow itself — the
+  `Action::AddBondInvoice` message intentionally carries no
+  human-readable deadline text, so the wire payload alone is not
+  enough for a client to warn the user; the kind-38385 tags close
+  that gap and let every warning render in the user's locale. Tag
+  naming follows the snake_case convention used elsewhere in
+  `info_to_tags` (`mostro_version`, `hold_invoice_expiration_window`,
+  etc.). The set:
+  - `bond_enabled` (`true` | `false`) — **always emitted**, including
+    on nodes where `[anti_abuse_bond]` is absent or `enabled =
+    false`. Disambiguates "feature off on this node" from "older
+    daemon that doesn't speak bond at all": the latter omits the tag
+    entirely, the former emits `false`. All remaining bond tags are
+    emitted only when this is `true`.
+  - `bond_apply_to` (`take` | `create` | `both`) — whether the user
+    needs to lock a bond as maker, taker, or both.
+  - `bond_slash_on_waiting_timeout` (`true` | `false`) — node policy:
+    can a bond be slashed for missing a waiting-state timeout, or
+    only by solver directive in a dispute?
+  - `bond_amount_pct` / `bond_base_amount_sats` — bond economics:
+    `max(amount_pct * order_amount, base_amount_sats)`.
+  - `bond_slash_node_share_pct` — fraction of a slashed bond retained
+    by the node (the rest goes to the winning counterparty). Lets the
+    user see up-front what they would actually receive.
+  - `bond_payout_claim_window_days` — number of days the winning
+    counterparty has, from `slashed_at`, to submit a payout invoice
+    before forfeiting their share. Clients add this to `slashed_at`
+    to render the deadline ("you have N days to claim") in the user's
+    own locale; Mostro never ships that text inline on the
+    `AddBondInvoice` message itself.
+  - **No `bond_slash_dispute` tag**: dispute slashes are solver-driven
     per resolution, not a node-policy switch.
 - Update `docs/admin_settle_order.html` and `admin_cancel_order.html`
   upstream (`mostro.network/protocol/`) with an "Optional payload —

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -13,10 +13,12 @@ locks a Lightning hold invoice when entering a trade. The bond is:
 - **Released** on normal completion, on any cancellation that happens before
   a waiting-state timeout elapses, and on dispute resolutions where the
   solver does not direct otherwise.
-- **Slashed** (claimed by Mostro and split between the node and the
-  winning counterparty per `slash_node_share_pct`; the node share funds
-  solver compensation, the remainder is paid out to the counterparty as
-  before — see §15.4) under two unambiguous conditions:
+- **Slashed** (claimed by Mostro **immediately at slash time** via
+  `settle_hold_invoice`, then split between the node and the winning
+  counterparty per `slash_node_share_pct`; the node share funds
+  solver compensation, the remainder is paid out to the counterparty
+  asynchronously by the Phase 3 scheduler — see §15.4) under two
+  unambiguous conditions:
   1. **Solver directive on dispute resolution.** The solver explicitly
      instructs Mostro to slash one or both bonds via the `BondResolution`
      payload of `admin-settle` / `admin-cancel`. The slash decision is
@@ -258,7 +260,7 @@ Purely additive. Touches no trade flow.
     -- `amount_sats - node_share_sats` so they cannot drift.
     node_share_sats  integer,
     -- Phase 3: counts ONLY `send_payment` retries against an invoice
-    -- the counterparty has already submitted. Bumped only by step 6
+    -- the counterparty has already submitted. Bumped only by step 5
     -- of the §8.1 scheduler loop. `payout_max_retries` is checked
     -- against this counter alone — invoice-request messages do NOT
     -- count here (see `invoice_request_attempts` below).
@@ -909,15 +911,36 @@ or a legacy admin client):
    and has no bond) so the operator can decide whether to widen
    `apply_to`.
 4. On a valid payload: perform the trade resolution (settle or cancel)
-   first, then for each bond marked for slash transition
-   `state = PendingPayout, slashed_reason = LostDispute, slashed_at = now`,
-   and persist the split per §8.1 (compute `node_share_sats` from the
-   current `slash_node_share_pct` and write it in the same DB update).
-   Bonds not marked for slash are cancelled (`cancel_hold_invoice`) and
-   marked `Released` immediately.
+   first, then for each bond marked for slash:
+   1. **Settle the bond hold invoice immediately** via
+      `settle_hold_invoice(preimage)`. This claims the bonded sats into
+      Mostro's wallet at slash time — the HTLC is no longer encumbered
+      by the time the slash step returns. The settle is the
+      load-bearing side effect of the slash decision; the row
+      transition that follows is bookkeeping.
+   2. CAS the row `state = PendingPayout, slashed_reason =
+      LostDispute, slashed_at = now`, and persist the split per §8.1
+      (compute `node_share_sats` from the current
+      `slash_node_share_pct` and write it in the same DB update).
+   3. **Settle MUST succeed before the CAS runs.** If
+      `settle_hold_invoice` fails with a transient transport error,
+      the row stays `Locked` so a future admin retry can re-attempt
+      the slash. LND's idempotent "already settled" response (admin
+      retry after a partial failure where settle succeeded but the
+      CAS lost a race) is treated as success and the CAS proceeds.
 
-The actual Lightning payout to the counterparty is asynchronous and
-handled by Phase 3.
+   Bonds not marked for slash are cancelled (`cancel_hold_invoice`)
+   and marked `Released` immediately.
+
+   When both bonds are slashed in a single dispute, this loop runs
+   `settle_hold_invoice` **once per bond** — two HTLCs claimed before
+   the slash step returns.
+
+The recipient payout (asking the winning counterparty for a bolt11,
+`send_payment`, retries, forfeiture on the long-stop window) is
+asynchronous and handled by Phase 3. Phase 3 never calls
+`settle_hold_invoice` — by the time it sees a `PendingPayout` row, the
+sats are already in Mostro's wallet.
 
 ### 7.4 Validation rules summary
 
@@ -954,7 +977,11 @@ handled by Phase 3.
 ## 8. Phase 3 — Payout flow
 
 Shared infrastructure used by every slash path afterwards. Non-blocking:
-trade finalization must never wait on the payout.
+trade finalization must never wait on the **counterparty** payout
+(asking for a bolt11, `send_payment`, retries, forfeiture). The
+slashed HTLC itself is **already settled** by the slash step before
+this phase runs (see Phase 2 §7.3); Phase 3 only drives the recipient
+payout from sats Mostro already holds.
 
 ### 8.1 Scope
 
@@ -983,9 +1010,13 @@ trade finalization must never wait on the payout.
   - For each, **first check the forfeit window**:
     - If `now - slashed_at >= payout_claim_window_days * 86400` and
       `payout_invoice IS NULL` (the counterparty never submitted a
-      bolt11): `settle_hold_invoice(preimage)`, transition the bond
-      to `state = Forfeited`, publish the audit event with
-      `outcome = forfeited`, and stop. The node retains the full
+      bolt11): CAS the row to `state = Forfeited` with `AND
+      payout_invoice IS NULL` (so a late `add_bond_invoice_action`
+      arrival doesn't get silently discarded), publish the audit
+      event with `outcome = forfeited`, and stop. The HTLC was
+      already settled at slash time, so the sats are already in
+      Mostro's wallet — Phase 3 does **not** call
+      `settle_hold_invoice` here. The node retains the full
       `amount_sats`. No further messages or `send_payment` runs.
     - Otherwise, proceed with the normal payout steps below.
   - Normal payout steps:
@@ -1011,7 +1042,7 @@ trade finalization must never wait on the payout.
        baking English copy into the daemon. Bump
        `invoice_request_attempts` and set `last_invoice_request_at =
        now`. **Do not touch `payout_attempts`** — that counter only
-       governs `send_payment` retries (step 6); mixing the two would
+       governs `send_payment` retries (step 4); mixing the two would
        let a slow-responding counterparty exhaust `payout_max_retries`
        on invoice-request messages alone and prematurely flip the bond to
        `Failed`. Bounding invoice requests is the forfeit window's job
@@ -1022,16 +1053,14 @@ trade finalization must never wait on the payout.
        routing fee** via `LndConnector::query_routes(dest, amount)`
        (thin wrapper over LND `router::query_routes`); fall back to
        `amount * max_routing_fee` if the RPC fails.
-    3. `settle_hold_invoice(preimage)` on the bond hash to claim the
-       forfeited sats into Mostro's wallet. After this call,
-       `node_share_sats` is implicitly retained (it just stays in
-       Mostro's wallet).
-    4. `send_payment` to the counterparty invoice with capped fee.
-       Only `counterparty_share_sats - routing_fee` leaves Mostro.
-    5. On success → `state = Slashed`. (`slashed_at` is **not**
+    3. `send_payment` to the counterparty invoice with capped fee.
+       Only `counterparty_share_sats - routing_fee` leaves Mostro;
+       the sats are drawn from the slash-time settle (the HTLC was
+       claimed in Phase 2 §7.3 step 4.1).
+    4. On success → `state = Slashed`. (`slashed_at` is **not**
        touched here — it was set at the `PendingPayout` transition;
        see Phase 2 §7.3.)
-    6. On `send_payment` failure → bump `payout_attempts` (this is
+    5. On `send_payment` failure → bump `payout_attempts` (this is
        the *only* place that increments it); once `payout_max_retries`
        reached, transition to `Failed` and leave a tracing error.
        `Failed` is reserved for *technical* failure (we have an
@@ -1041,7 +1070,8 @@ trade finalization must never wait on the payout.
   When `slash_node_share_pct = 1.0` the counterparty leg is skipped
   entirely (no `AddBondInvoice` message, no `send_payment`, no forfeit
   window to wait for); the bond goes straight from `PendingPayout` →
-  settle → `Slashed` after step 3.
+  `Slashed` (a single state-flip; the HTLC was already settled at
+  slash time, so there is nothing left for the scheduler to do).
 
 - **Recipient resolution.** Step 1 above sends `Action::AddBondInvoice`
   to the *non-slashed counterparty* of the trade — the party who is
@@ -1063,11 +1093,12 @@ trade finalization must never wait on the payout.
   - **Both bonds slashed in a single dispute (Phase 5+ only).** When
     the solver's `BondResolution` sets both flags and both maker and
     taker have active bonds, neither party deserves restitution
-    (§15.2 — "both behaved badly"). For each row, treat as
-    `slash_node_share_pct = 1.0` for that payout: skip the
-    `AddBondInvoice` message, retain `amount_sats` in full, settle the
-    HTLC in step 3, transition to `Slashed`. (Phase 5+ wires this;
-    Phase 2's taker-only world cannot reach this branch.)
+    (§15.2 — "both behaved badly"). Both HTLCs are settled at slash
+    time (Phase 2 §7.3 step 4.1 runs once per slashed bond). For each
+    row, treat as `slash_node_share_pct = 1.0` for that payout: skip
+    the `AddBondInvoice` message, retain `amount_sats` in full, and
+    transition straight to `Slashed`. (Phase 5+ wires this; Phase 2's
+    taker-only world cannot reach this branch.)
 
 - Late-invoice race: the `add_bond_invoice_action` handler (below)
   must check the bond is still in `PendingPayout` before persisting
@@ -1092,40 +1123,52 @@ trade finalization must never wait on the payout.
   invoice" from "nudges after a hypothetical re-prompt" if a future
   phase ever introduces one. Any "took N nudges to respond" logging
   for observability should capture the value *before* the reset.
-- Unit tests: routing-fee fallback, retries exhaustion, settle-then-pay
-  ordering.
+- Unit tests: routing-fee fallback, retries exhaustion, forfeit CAS
+  race against late `add_bond_invoice_action`.
 
 ### 8.2 Failure modes & invariants
 
-- **`settle` must succeed before `send_payment`.** If settle fails we
-  leave the bond in `PendingPayout` and retry on the next tick; the
-  bonded party's HTLC stays held, which is the correct safety posture.
-- **Node share is retained unconditionally on settle.** Once
-  `settle_hold_invoice` succeeds, `node_share_sats` is in Mostro's
-  wallet and the node leg is done. The only thing the retry loop is
-  driving from that point on is the counterparty payout.
-- **Partial success: settle OK, counterparty `send_payment` failed.**
+- **Slashed HTLC is settled at slash time, not by the scheduler.**
+  Phase 2 §7.3 step 4.1 runs `settle_hold_invoice(preimage)` before
+  the row is flipped to `PendingPayout`. By the time Phase 3 sees the
+  row the sats are already in Mostro's wallet. The scheduler never
+  calls `settle_hold_invoice`; failure modes that previously hinged
+  on "settle before send_payment" ordering are now impossible by
+  construction.
+- **Node share is retained unconditionally.** The slash-time settle
+  delivers the full `amount_sats` into Mostro's wallet; the node
+  share is whatever the `send_payment` step doesn't pay out
+  (forfeiture leaves the whole `amount_sats` in the node).
+- **Partial failure on the counterparty leg: `send_payment` failed.**
   The bond state stays in `PendingPayout` with a best-effort retry on
   the next scheduler tick. Periodic `Action::AddBondInvoice` messages
   are **only** scheduled by §8.1 step 1, whose precondition is
   `payout_invoice IS NULL` — once the winner has already submitted a
   bolt11, that branch is skipped and the retry loop runs silently
   (tracing logs only, no wire notification to the winner). If retries
-  exhaust, state becomes `Failed`; at that point Mostro is holding the
-  counterparty share (unavoidable with the HTLC already settled) and
-  logs loudly. The node share is unaffected — it was always going to
-  stay. This is a known limitation; node operators can manually pay
-  the winner from logs.
+  exhaust, state becomes `Failed`; at that point Mostro is holding
+  the counterparty share (unavoidable: the HTLC was settled at slash
+  time, so the sats are already on hand but unroutable) and logs
+  loudly. The node share is unaffected — it was always going to stay.
+  This is a known limitation; node operators can manually pay the
+  winner from logs.
 - **Counterparty never claims (forfeit path).** Distinct from
   `Failed`: there is no `payout_invoice` because the counterparty
   never sent one. After `payout_claim_window_days` from `slashed_at`,
-  the scheduler settles the HTLC and transitions to `Forfeited`. No
-  manual operator action is needed — this is a normal terminal
-  state, designed-in. Default 15 days gives even users with sporadic
+  the scheduler CAS-transitions the row to `Forfeited` (no LND call,
+  the HTLC was already claimed at slash time). The CAS predicate
+  includes `AND payout_invoice IS NULL` so a late invoice landing
+  between the scheduler's snapshot and the UPDATE keeps the row in
+  `PendingPayout` for the next tick to route through
+  `send_payment`. Default 15 days gives even users with sporadic
   Nostr presence ample time to see the message and respond.
-- **Non-blocking:** `release_action`, `admin_settle_action`, etc. return
-  success the moment the trade escrow resolves. Bond payout happens
-  later.
+- **Non-blocking on the counterparty leg.** `admin_settle_action` /
+  `admin_cancel_action` return success as soon as both (a) the trade
+  escrow resolves and (b) the slashed bond HTLCs are settled by
+  Phase 2. The counterparty payout (`AddBondInvoice` →
+  `send_payment` → retries / forfeiture) happens later under the
+  scheduler. Trade finalization waits on slash-time settle but never
+  on the recipient payout.
 
 ### 8.3 Acceptance
 
@@ -1141,20 +1184,34 @@ trade finalization must never wait on the payout.
   exactly to `amount_sats` (no rounding leak).
 - Edge case `slash_node_share_pct = 0.0` → behaviour identical to the
   pre-split design (full counterparty payout).
-- Edge case `slash_node_share_pct = 1.0` → settle the HTLC, no
-  `AddBondInvoice` message is enqueued, no `send_payment` runs, bond goes
-  straight to `Slashed`.
+- Edge case `slash_node_share_pct = 1.0` → the HTLC was settled at
+  slash time; the scheduler does **not** call `settle_hold_invoice`.
+  No `AddBondInvoice` message is enqueued, no `send_payment` runs;
+  the bond is CAS-transitioned straight from `PendingPayout` to
+  `Slashed`.
 - **Persistence test**: a bond enters `PendingPayout` under
   `slash_node_share_pct = 0.5`; before payout completes, simulate a
   daemon restart with `slash_node_share_pct = 0.9` in the new
   config; payout still uses the original 0.5 split (read from
   `node_share_sats`). Same shape: change config back and forth
   during `PendingPayout` ticks → split is unaffected.
-- **Forfeit window test**: bond enters `PendingPayout`, counterparty
-  never replies; advance the test clock by
-  `payout_claim_window_days + 1`; on the next scheduler tick the bond
-  settles and transitions to `Forfeited`. Node retains `amount_sats`
-  in full. No `send_payment` was ever attempted.
+- **Slash-time settle (Phase 2 contract)**: dispute resolution with
+  `slash_buyer=true` → `settle_hold_invoice` runs exactly once for
+  the slashed bond before `apply_bond_resolution` returns; the row
+  enters `PendingPayout` only after the HTLC is claimed. Verify the
+  call count from the LND stub and the row state in one go.
+- **Slash-both settles two HTLCs**: both `slash_seller=true` and
+  `slash_buyer=true` with bonds on each side → `settle_hold_invoice`
+  runs twice (once per bond) and both rows reach `PendingPayout`.
+- **Non-slashed release stays release-only**: `BondResolution` with
+  both flags `false` → `settle_hold_invoice` is **not** called; the
+  bond moves to `Released` via the Phase 1 cancel path.
+- **Forfeit window test**: bond enters `PendingPayout` (HTLC already
+  settled at slash time), counterparty never replies; advance the
+  test clock by `payout_claim_window_days + 1`; on the next
+  scheduler tick the row transitions to `Forfeited` via a pure SQL
+  CAS — no `settle_hold_invoice` or `send_payment` is attempted by
+  the scheduler. Node retains `amount_sats` in full.
 - **Late-invoice rejection**: bond is `Forfeited`; counterparty
   submits a bolt11 after the deadline; `add_bond_invoice_action`
   rejects it with a "claim window expired" message; bond stays
@@ -1216,13 +1273,16 @@ adding maker bond rows to the lookup.
 
 - Modify `scheduler::job_cancel_orders`: when the waiting-state timeout
   elapses on an order in `WaitingBuyerInvoice` / `WaitingPayment`, run
-  the §9.2 lookup. If a bond exists for the responsible party, set
-  `state = PendingPayout, slashed_reason = Timeout` (Phase 3 picks it
-  up). Continue the existing cancel-escrow + republish work. The
-  payout recipient is then resolved by Phase 3 per the "Recipient
-  resolution" rule in §8.1: `slashed_reason = Timeout` plus the §9.2
-  responsibility entry uniquely names the non-slashed counterparty
-  (`WaitingBuyerInvoice` → seller; `WaitingPayment` → buyer).
+  the §9.2 lookup. If a bond exists for the responsible party, reuse
+  the Phase 2 slash primitive: **settle the bond hold invoice
+  immediately** (`settle_hold_invoice(preimage)`) and CAS the row to
+  `state = PendingPayout, slashed_reason = Timeout` (Phase 3 then
+  picks it up for the asynchronous counterparty payout). Continue
+  the existing cancel-escrow + republish work. The payout recipient
+  is resolved by Phase 3 per the "Recipient resolution" rule in
+  §8.1: `slashed_reason = Timeout` plus the §9.2 responsibility entry
+  uniquely names the non-slashed counterparty (`WaitingBuyerInvoice`
+  → seller; `WaitingPayment` → buyer).
 - Localised message to the slashed user explaining forfeiture.
 - Tests:
   - "Cancel at minute 5 of a 15-minute timeout" → bond released, no
@@ -1611,8 +1671,8 @@ costs on the timeout path. If neither is funded, both roles are
 volunteer-only, which doesn't scale.
 
 The split solves this without introducing a new payment rail: the
-slash already routes through Mostro's wallet (the HTLC must be settled
-before any payout can happen — §8.1 step 3), so retaining a fraction
+slash already routes through Mostro's wallet (the HTLC is settled at
+slash time, Phase 2 §7.3 step 4.1), so retaining a fraction
 is free. `slash_node_share_pct` is the knob that decides what fraction
 that is. Defaults to **0.5** as a reasonable starting point — half to
 the wronged counterparty (preserves the deterrent: the cheater still
@@ -1643,18 +1703,22 @@ unambiguous to the *bonded* party; how Mostro then divides the
 forfeited sats is an internal accounting decision).
 
 The forfeit window (`payout_claim_window_days`, default 15) is the
-long-stop tail of the same logic. If the wronged counterparty never
-submits a payout invoice — because they lost their key, gave up on
-the platform, or simply forgot — the sats cannot sit in
-`PendingPayout` forever (the HTLC has a CLTV, and the node has a
-real liability tracking unclaimed funds). After the window expires
-the node retains the counterparty share too; the bond closes as
-`Forfeited`. This keeps the on-chain accounting deterministic and
-removes the "Mostro mysteriously holds X sats" failure mode without
-manual intervention. From the cheater's side the deterrent is again
-unaffected — they lost their bond either way. From the wronged
-counterparty's side the message is clear (and surfaced in the info
-event per §13.1): claim within N days or forfeit.
+long-stop tail of the same logic. The slash-time settle already
+deposited the full `amount_sats` into Mostro's wallet, but the
+counterparty share is still owed to the wronged party as a
+`send_payment` whenever they submit a bolt11. If they never do —
+because they lost their key, gave up on the platform, or simply
+forgot — the row cannot sit in `PendingPayout` forever (operators
+would have a growing pile of "owed" sats with no resolution path).
+After the window expires the row CAS-transitions to `Forfeited` and
+the node retains the counterparty share too; the bond closes
+cleanly. This keeps accounting deterministic and removes the
+"Mostro mysteriously holds X sats" failure mode without manual
+intervention. From the cheater's side the deterrent is again
+unaffected — they lost their bond either way (the HTLC was claimed
+at slash time). From the wronged counterparty's side the message is
+clear (and surfaced in the info event per §13.1): claim within N
+days or forfeit.
 
 ---
 

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -98,9 +98,9 @@ base_amount_sats = 1000
 # because it is a *posting-timing* distinction — the bond is requested at
 # maker-create-time or taker-take-time. The party's role in the trade
 # flow (buyer or seller) is derived from the order kind (§3.1).
-#   "take"   → only the taker posts a bond
-#   "create" → only the maker posts a bond
-#   "both"   → both sides
+#   "take" → only the taker posts a bond
+#   "make" → only the maker posts a bond
+#   "both" → both sides
 apply_to = "take"
 
 # Automatic slash on waiting-state timeout. Only applies when the
@@ -263,14 +263,14 @@ Purely additive. Touches no trade flow.
     -- against this counter alone — invoice-request messages do NOT
     -- count here (see `invoice_request_attempts` below).
     payout_attempts  integer not null default 0,
-    -- Phase 3: counts how many `Action::AddInvoice` messages the
+    -- Phase 3: counts how many `Action::AddBondInvoice` messages the
     -- scheduler has sent asking the counterparty for a payout invoice.
     -- Bumped by step 1 of §8.1. Bounded by the forfeit window
     -- (`payout_claim_window_days`), not by `payout_max_retries`, so
     -- a slow-responding counterparty cannot prematurely flip the
     -- bond to `Failed`.
     invoice_request_attempts integer not null default 0,
-    -- Phase 3: timestamp of the last `AddInvoice` message. Drives the
+    -- Phase 3: timestamp of the last `Action::AddBondInvoice` message. Drives the
     -- `payout_invoice_window_seconds` cadence check ("don't re-send
     -- before the window has elapsed"). Persisted so a daemon restart
     -- doesn't trigger an immediate re-send.
@@ -1127,13 +1127,18 @@ trade finalization must never wait on the payout.
 
 - End-to-end test: dispute resolved with `slash_buyer=true` and
   `slash_node_share_pct = 0.5` → buyer-side counterparty (the seller)
-  is asked for a bolt11 sized at `floor(amount/2) − routing_fee`,
-  submits it → bond payout settles (split sums exactly to `amount`,
-  no rounding leak).
+  is asked for a bolt11 sized at the full counterparty share
+  (`amount_sats − floor(amount_sats * slash_node_share_pct)` =
+  `floor(amount/2)`). The payout-invoice principal carries the
+  counterparty share **only**; routing fee is paid separately from
+  Mostro's own wallet (capped at `max_routing_fee` and recorded into
+  `payout_routing_fee_sats`), not deducted from the requested
+  principal. Submits it → bond payout settles, the two shares sum
+  exactly to `amount_sats` (no rounding leak).
 - Edge case `slash_node_share_pct = 0.0` → behaviour identical to the
   pre-split design (full counterparty payout).
 - Edge case `slash_node_share_pct = 1.0` → settle the HTLC, no
-  `AddInvoice` message is enqueued, no `send_payment` runs, bond goes
+  `AddBondInvoice` message is enqueued, no `send_payment` runs, bond goes
   straight to `Slashed`.
 - **Persistence test**: a bond enters `PendingPayout` under
   `slash_node_share_pct = 0.5`; before payout completes, simulate a
@@ -1200,7 +1205,7 @@ Worked rows for `apply_to = "take"`:
 | `buy`      | `WaitingBuyerInvoice`  | buyer = maker  | no     | no slash |
 | `buy`      | `WaitingPayment`       | seller = taker | yes    | slash taker bond |
 
-Phase 7 fills the "no slash" rows for `apply_to ∈ { create, both }` by
+Phase 7 fills the "no slash" rows for `apply_to ∈ { make, both }` by
 adding maker bond rows to the lookup.
 
 ### 9.3 Scope
@@ -1237,7 +1242,7 @@ adding maker bond rows to the lookup.
 
 ## 10. Phase 5 — Maker bond (non-range) + dispute slash
 
-Gate: `enabled && apply_to ∈ { create, both }`.
+Gate: `enabled && apply_to ∈ { make, both }`.
 
 ### 10.1 Bond lifecycle (maker-specific)
 
@@ -1282,7 +1287,7 @@ publication time and is not repriced.
 ### 10.4 Acceptance
 
 - Feature disabled: no change.
-- Feature enabled, apply_to=create: order is not visible in the book
+- Feature enabled, apply_to=make: order is not visible in the book
   until bond locks. A client that abandons the bond invoice → order
   never shows up; no ghost book entry.
 - Phase 2 dispute slashes targeting the maker (e.g. `slash_seller=true`
@@ -1389,7 +1394,7 @@ the maker.
 
 ## 12. Phase 7 — Maker timeout slash
 
-Gate: `enabled && slash_on_waiting_timeout && apply_to ∈ { create, both }`.
+Gate: `enabled && slash_on_waiting_timeout && apply_to ∈ { make, both }`.
 
 Symmetric to Phase 4. Reuses §9.2's buyer/seller responsibility table —
 this phase simply makes the lookup find a maker bond when the
@@ -1427,7 +1432,7 @@ Tests mirror Phase 4 from the maker side; the "no slash" rows in the
     daemon that doesn't speak bond at all": the latter omits the tag
     entirely, the former emits `false`. All remaining bond tags are
     emitted only when this is `true`.
-  - `bond_apply_to` (`take` | `create` | `both`) — whether the user
+  - `bond_apply_to` (`take` | `make` | `both`) — whether the user
     needs to lock a bond as maker, taker, or both.
   - `bond_slash_on_waiting_timeout` (`true` | `false`) — node policy:
     can a bond be slashed for missing a waiting-state timeout, or

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -1113,7 +1113,12 @@ must land hand-in-hand with the client adoption. See §14.3.
        reached, transition to `Failed` and leave a tracing error.
        `Failed` is reserved for *technical* failure (we have an
        invoice but can't route to it) and is distinct from
-       `Forfeited` (the user never gave us an invoice).
+       `Forfeited` (the user never gave us an invoice). `Failed` is
+       *user-recoverable inside the claim window*: a fresh
+       `AddBondInvoice` from the recipient transitions the row back
+       to `PendingPayout`, overwrites `payout_invoice`, and resets
+       `payout_attempts` to 0 (see `add_bond_invoice_action` below).
+       Past the claim window, `Failed` requires operator attention.
 
   When `slash_node_share_pct = 1.0` the counterparty leg is skipped
   entirely (no `AddBondInvoice` message, no `send_payment`, no forfeit
@@ -1194,12 +1199,39 @@ must land hand-in-hand with the client adoption. See §14.3.
   `payout_invoice IS NULL` — once the winner has already submitted a
   bolt11, that branch is skipped and the retry loop runs silently
   (tracing logs only, no wire notification to the winner). If retries
-  exhaust, state becomes `Failed`; at that point Mostro is holding
-  the counterparty share (unavoidable: the HTLC was settled at slash
-  time, so the sats are already on hand but unroutable) and logs
-  loudly. The node share is unaffected — it was always going to stay.
-  This is a known limitation; node operators can manually pay the
-  winner from logs.
+  exhaust, state becomes `Failed` and Mostro logs loudly. The node
+  share is unaffected — it was always going to stay.
+- **User-side recovery from `Failed`.** `Failed` is *not* a hard
+  terminal state from the recipient's perspective. A fresh
+  `AddBondInvoice` from the same recipient resurrects the bond via a
+  guarded CAS:
+  `UPDATE bonds SET state='pending-payout', payout_invoice=?,
+   payout_attempts=0, invoice_request_attempts=0
+   WHERE id=? AND state='failed'`, gated in Rust by `now -
+   slashed_at < payout_claim_window_days * 86_400`. The scheduler
+  then routes the new bolt11 on its next tick with a fresh retry
+  budget. Race safety:
+  - **Scheduler vs. resurrection.** The scheduler enumerates
+    `PendingPayout` rows only and never sees `Failed`, so no
+    `send_payment` runs against a row mid-resurrection.
+  - **Concurrent `AddBondInvoice` calls.** The `WHERE state='failed'`
+    predicate matches at most once; the second caller observes
+    `state='pending-payout'` at execution time, gets `rows_affected
+    = 0`, and is rejected with `CantDo(NotAllowedByStatus)`. The
+    winner's invoice is the one that persists.
+  - **`on_send_payment_failure` racing the user's resubmission.**
+    The PendingPayout CAS guards on `payout_invoice IS NULL`, so a
+    user submission against a row that still has the in-flight
+    invoice is rejected (not silently swapped). Once the row
+    transitions to `Failed`, the resurrection path takes over.
+  - **Claim-window edge.** The check is `>=` (`now - slashed_at >=
+    claim_window_seconds` rejects); the boundary belongs to operator
+    territory. A submission landing one second inside the window is
+    accepted even if a re-failure later finishes outside it — the
+    scheduler does not re-evaluate the window once the bond is back
+    in `PendingPayout` with an invoice.
+  Past the claim window, `Failed` requires operator attention; the
+  operator can pay the winner manually from logs.
 - **Counterparty never claims (forfeit path).** Distinct from
   `Failed`: there is no `payout_invoice` because the counterparty
   never sent one. After `payout_claim_window_days` from `slashed_at`,
@@ -1267,11 +1299,33 @@ must land hand-in-hand with the client adoption. See §14.3.
 - **`Failed` vs. `Forfeited` distinction**: counterparty submits a
   valid invoice on day 1 but it never routes; after
   `payout_max_retries` the bond goes to `Failed` (not `Forfeited`,
-  even though the 15-day window is still open). `Failed` requires
-  operator attention; `Forfeited` does not.
+  even though the 15-day window is still open). `Failed` is
+  user-recoverable inside the claim window (next test); past the
+  window it requires operator attention. `Forfeited` is never
+  recoverable.
 - Retry test: counterparty submits an invoice that never routes →
   scheduler keeps retrying up to `payout_max_retries`, then `Failed`.
   Node share already retained; only the counterparty share is stuck.
+- **`Failed` resurrection inside the claim window**: bond is `Failed`
+  on day 2 of a 15-day window; counterparty submits a fresh, routable
+  bolt11 via `AddBondInvoice`. Row transitions back to
+  `PendingPayout`, `payout_invoice` is overwritten, `payout_attempts`
+  and `invoice_request_attempts` reset to 0, `slashed_at` is **not**
+  touched. The next scheduler tick routes the new bolt11
+  successfully → bond → `Slashed`. Repeat the cycle (resurrect → fail
+  → resurrect) within the window and verify each resurrection
+  delivers a full retry budget.
+- **`Failed` past the claim window stays `Failed`**: bond is `Failed`
+  on day 16 (1 day past the 15-day window); counterparty's
+  `AddBondInvoice` is rejected with `CantDo(NotAllowedByStatus)`. The
+  row remains `Failed` with original `payout_attempts` and
+  `payout_invoice` intact so operator diagnostics are preserved.
+- **Concurrent-resurrection race**: two `AddBondInvoice` messages
+  land against a `Failed` bond near-simultaneously. Exactly one
+  resurrection CAS lands (the bolt11 of the winner is the one
+  persisted); the loser receives `CantDo(NotAllowedByStatus)`. No
+  in-flight `send_payment` overlaps because the scheduler does not
+  enumerate `Failed` rows.
 
 ---
 

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -186,7 +186,7 @@ slash path.
 | 1 | Taker bond lifecycle: **lock + always release** (no slashing yet) | 0 | ✅ shipped (PR #719) |
 | 1.5 | Protocol cleanup: dedicated `Action::PayBondInvoice` + `Status::WaitingTakerBond` (retire the Phase 1 `PayInvoice` reuse) | 1 | pending |
 | 2 | Solver-directed dispute slash via `BondResolution` payload (taker bond) | 1.5 | pending |
-| 3 | Payout flow: `add-bond-invoice` to winner, routing-fee estimation, retries | 2 | pending |
+| 3 | Payout flow: `Action::AddBondInvoice` to winner, routing-fee estimation, retries | 2 | pending |
 | 4 | Timeout slash for taker bond (`slash_on_waiting_timeout`) | 3 | pending |
 | 5 | Maker bond (non-range): lock + dispute slash reusing Phase 2/3 | 3 | pending |
 | 6 | Maker bond for **range orders** with proportional slashes | 5 | pending |

--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -165,7 +165,7 @@ pub static MESSAGE_QUEUES: LazyLock<MessageQueues> =
     LazyLock::new(MessageQueues::default);
 ```
 
-(`MessageQueues` holds `Arc<RwLock<…>>` queues for order DMs, cant-do messages, rating events, and restore-session messages.)
+(`MessageQueues` holds `Arc<RwLock<…>>` queues for order messages, cant-do messages, rating events, and restore-session messages.)
 
 There is **no** database password or separate global for SQLite; the daemon opens the file URL from `[database]` in `settings.toml` only.
 

--- a/migrations/20260518120000_bond_payout_payment_hash.sql
+++ b/migrations/20260518120000_bond_payout_payment_hash.sql
@@ -1,0 +1,20 @@
+-- Phase 3 follow-up: persist the bolt11 payment_hash of the counterparty
+-- payout invoice so `pay_counterparty` is idempotent across crash/restart
+-- and transient DB failures.
+--
+-- Without this anchor, a successful `send_payment` followed by a failed
+-- "state = Slashed" CAS would leave the row in `PendingPayout` with the
+-- sats already in flight. The next scheduler tick would call
+-- `send_payment` again, LND would reject the duplicate (invoice already
+-- paid), and `on_send_payment_failure` would burn the retry budget — in
+-- the worst case flipping the row to `Failed` despite a successful
+-- delivery.
+--
+-- The column is written via a CAS guarded on `state = 'pending-payout'`
+-- right before each `send_payment` attempt. On the next entry to
+-- `pay_counterparty`, if this column is set, the scheduler reconciles
+-- with LND's `track_payment_v2` for this hash before invoking a fresh
+-- send. The `apply_payout_invoice` Failed→PendingPayout resurrection
+-- clears this column so the new invoice's hash is not shadowed by the
+-- stale one.
+ALTER TABLE bonds ADD COLUMN payout_payment_hash char(64);

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -98,7 +98,7 @@ port = 50051
 # # amount_pct is a unitless fraction (0.01 = 1%); base_amount_sats is a sat floor.
 # amount_pct = 0.01
 # base_amount_sats = 1000
-# # "take" | "create" | "both"
+# # "take" | "make" | "both"
 # apply_to = "take"
 # # Note: there is no `slash_on_lost_dispute` flag — dispute slashes are
 # # solver-directed via the `BondResolution` payload (Phase 2).

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,7 @@ use crate::app::admin_add_solver::admin_add_solver_action;
 use crate::app::admin_cancel::admin_cancel_action;
 use crate::app::admin_settle::admin_settle_action;
 use crate::app::admin_take_dispute::admin_take_dispute_action;
+use crate::app::bond::add_bond_invoice_action;
 use crate::app::cancel::cancel_action;
 use crate::app::context::AppContext;
 use crate::app::dispute::dispute_action;
@@ -222,6 +223,9 @@ async fn handle_message_action_no_ln(
             .await
             .map_err(|e| e.into()),
         Action::AddInvoice => add_invoice_action(ctx, msg, event, my_keys)
+            .await
+            .map_err(|e| e.into()),
+        Action::AddBondInvoice => add_bond_invoice_action(ctx, msg, event, my_keys)
             .await
             .map_err(|e| e.into()),
         Action::PayInvoice => Err(MostroError::MostroCantDo(CantDoReason::InvalidAction).into()),

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -216,10 +216,17 @@ pub async fn admin_cancel_action(
     // (release-by-default when absent). The buyer/seller pubkeys on
     // the order row are immutable through the dispute cycle, so the
     // original `order` snapshot is the right context for resolving
-    // sides to bonds. The Lightning payout side is Phase 3.
-    if let Err(e) =
-        bond::apply_bond_resolution(pool, &order, &bond_resolution, BondSlashReason::LostDispute)
-            .await
+    // sides to bonds. Slashed bonds have their hold invoices settled
+    // immediately; the recipient payout to the winning counterparty
+    // is still Phase 3's job.
+    if let Err(e) = bond::apply_bond_resolution(
+        pool,
+        ln_client,
+        &order,
+        &bond_resolution,
+        BondSlashReason::LostDispute,
+    )
+    .await
     {
         tracing::warn!(
             order_id = %order.id,

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -205,11 +205,14 @@ pub async fn admin_settle_action(
         .await;
     }
     // Phase 2: apply the solver's `BondResolution` (release-by-default
-    // when absent, otherwise slash the flagged sides). The actual
-    // Lightning payout to the wronged counterparty is Phase 3's job;
-    // here we only transition the bond rows.
+    // when absent, otherwise slash the flagged sides). Slashed bonds
+    // have their hold invoices settled immediately; the recipient
+    // payout (asking the winning counterparty for a bolt11,
+    // `send_payment`, retries, forfeiture on the long-stop window) is
+    // still Phase 3's job.
     if let Err(e) = bond::apply_bond_resolution(
         pool,
+        ln_client,
         &order_updated,
         &bond_resolution,
         BondSlashReason::LostDispute,

--- a/src/app/bond/db.rs
+++ b/src/app/bond/db.rs
@@ -184,6 +184,12 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bonds migration");
+        sqlx::query(include_str!(
+            "../../../migrations/20260518120000_bond_payout_payment_hash.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bond_payout_payment_hash migration");
         // SQLite doesn't enforce FKs unless asked. Turn them on so the FK to
         // `orders` is a real constraint in tests (mirrors production).
         sqlx::query("PRAGMA foreign_keys = ON")

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -20,7 +20,7 @@
 //! `taker_*` columns until one bond wins the lock race —
 //! [`on_bond_invoice_accepted`] promotes the winner's columns onto the
 //! order, cancels every other still-`Requested` bond on the order,
-//! and DMs each loser `Action::Canceled`. A malicious taker who never
+//! and messages each loser `Action::Canceled`. A malicious taker who never
 //! pays their bond does not block the order book: their HTLC expires
 //! on its own LND-side TTL and the bond is released.
 //!
@@ -221,7 +221,7 @@ pub async fn request_taker_bond(
     .await;
 
     // Phase 1.5: park the order at `WaitingTakerBond` while the bond is
-    // outstanding. The bond subscriber is armed before the DM is sent
+    // outstanding. The bond subscriber is armed before the message is sent
     // (a few lines up), so a fast `Accepted` callback can have already
     // transitioned this order to `WaitingPayment` / `WaitingBuyerInvoice`
     // by the time we get here; a concurrent maker cancel can have moved
@@ -574,8 +574,8 @@ pub async fn resubscribe_active_bonds(pool: &Arc<Pool<Sqlite>>) -> Result<(), Mo
 ///    notify our taker, and exit).
 /// 3. On `rows_affected == 1` (we won), iterate every other still-
 ///    `Requested` bond on the order, release each (cancels the LND
-///    hold invoice + marks `Released`), and DM `Action::Canceled` to
-///    each losing taker.
+///    hold invoice + marks `Released`), and message `Action::Canceled`
+///    to each losing taker.
 /// 4. Copy the winning bond's `taker_*` columns onto the order row
 ///    (pubkeys, identity, trade index, per-bond pricing, optional
 ///    buyer invoice), then call `resume_take_after_bond` to drive
@@ -667,7 +667,7 @@ async fn on_bond_invoice_accepted(
 
         // We just won. Tear down every other still-`Requested` bond on
         // this order: cancel the LND hold invoice (so the loser
-        // taker's funds aren't held) and DM them `Action::Canceled`.
+        // taker's funds aren't held) and message them `Action::Canceled`.
         let losers = match find_active_bonds_for_order(pool, current.order_id).await {
             Ok(rows) => rows,
             Err(e) => {
@@ -736,7 +736,7 @@ async fn on_bond_invoice_accepted(
     resume_take_after_bond(pool, order, &my_keys, request_id).await
 }
 
-/// DM the taker of a losing concurrent bond that their take was
+/// Message the taker of a losing concurrent bond that their take was
 /// cancelled because another taker locked their bond first.
 async fn notify_loser(bond: &Bond) {
     if let Ok(taker_pk) = PublicKey::from_str(&bond.pubkey) {

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -1052,6 +1052,12 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bonds migration");
+        sqlx::query(include_str!(
+            "../../../migrations/20260518120000_bond_payout_payment_hash.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bond_payout_payment_hash migration");
         pool
     }
 

--- a/src/app/bond/mod.rs
+++ b/src/app/bond/mod.rs
@@ -13,6 +13,7 @@ pub mod db;
 pub mod flow;
 pub mod math;
 pub mod model;
+pub mod payout;
 pub mod slash;
 pub mod types;
 
@@ -22,5 +23,6 @@ pub use flow::{
 };
 pub use math::{compute_bond_amount, compute_node_share};
 pub use model::Bond;
+pub use payout::{add_bond_invoice_action, run_bond_payout_cycle};
 pub use slash::{apply_bond_resolution, extract_bond_resolution, validate_bond_resolution};
 pub use types::{BondRole, BondSlashReason, BondState};

--- a/src/app/bond/model.rs
+++ b/src/app/bond/model.rs
@@ -82,12 +82,12 @@ pub struct Bond {
     /// alone. Invoice-request messages do NOT increment this — see
     /// `invoice_request_attempts`.
     pub payout_attempts: i64,
-    /// Phase 3: number of `Action::AddInvoice` messages sent to the
+    /// Phase 3: number of `Action::AddBondInvoice` messages sent to the
     /// counterparty asking for a payout invoice. Bounded by the forfeit
     /// window (`payout_claim_window_days`), not by `payout_max_retries`.
     /// Reset to 0 when the counterparty finally submits an invoice.
     pub invoice_request_attempts: i64,
-    /// Phase 3: timestamp of the last `Action::AddInvoice` message. Drives
+    /// Phase 3: timestamp of the last `Action::AddBondInvoice` message. Drives
     /// the `payout_invoice_window_seconds` cadence check; persisted so a
     /// daemon restart doesn't trigger an immediate re-send.
     pub last_invoice_request_at: Option<i64>,

--- a/src/app/bond/model.rs
+++ b/src/app/bond/model.rs
@@ -79,17 +79,17 @@ pub struct Bond {
     /// Number of `send_payment` retries against an invoice the counterparty
     /// has already submitted. Bumped only on Phase 3 step 6 (send_payment
     /// failure); `payout_max_retries` is checked against this counter
-    /// alone. Invoice-request DMs do NOT increment this — see
+    /// alone. Invoice-request messages do NOT increment this — see
     /// `invoice_request_attempts`.
     pub payout_attempts: i64,
-    /// Phase 3: number of `Action::AddInvoice` DMs sent to the counterparty
-    /// asking for a payout invoice. Bounded by the forfeit window
-    /// (`payout_claim_window_days`), not by `payout_max_retries`. Reset to
-    /// 0 when the counterparty finally submits an invoice.
+    /// Phase 3: number of `Action::AddInvoice` messages sent to the
+    /// counterparty asking for a payout invoice. Bounded by the forfeit
+    /// window (`payout_claim_window_days`), not by `payout_max_retries`.
+    /// Reset to 0 when the counterparty finally submits an invoice.
     pub invoice_request_attempts: i64,
-    /// Phase 3: timestamp of the last `Action::AddInvoice` DM. Drives the
-    /// `payout_invoice_window_seconds` cadence check; persisted so a
-    /// daemon restart doesn't trigger an immediate re-DM.
+    /// Phase 3: timestamp of the last `Action::AddInvoice` message. Drives
+    /// the `payout_invoice_window_seconds` cadence check; persisted so a
+    /// daemon restart doesn't trigger an immediate re-send.
     pub last_invoice_request_at: Option<i64>,
     /// Timestamp when the bond hold invoice reached `Accepted`.
     pub locked_at: Option<i64>,

--- a/src/app/bond/model.rs
+++ b/src/app/bond/model.rs
@@ -71,6 +71,24 @@ pub struct Bond {
     pub payout_invoice: Option<String>,
     /// Routing-fee ceiling actually used for the payout attempt (sats).
     pub payout_routing_fee_sats: Option<i64>,
+    /// bolt11 payment_hash of the counterparty's payout invoice (hex,
+    /// 64 chars). Written via a CAS guarded on
+    /// `state = 'pending-payout'` *before* every `send_payment` attempt,
+    /// so it acts as the idempotency anchor for the counterparty payout
+    /// leg: if a `send_payment` succeeds but the subsequent
+    /// `state = 'slashed'` CAS fails (transient DB error, process
+    /// crash), the next scheduler tick re-enters `pay_counterparty`,
+    /// sees this hash, reconciles against LND's `track_payment_v2`, and
+    /// avoids re-invoking `send_payment` against an invoice LND has
+    /// already paid. Cleared by `apply_payout_invoice` on
+    /// Failed→PendingPayout resurrection so the new invoice's hash is
+    /// not shadowed by a stale one.
+    ///
+    /// Defense-in-depth: not a capability like `preimage`, but it
+    /// identifies the payment. Kept out of serde output until a phase
+    /// has a concrete reason to publish it.
+    #[serde(skip_serializing)]
+    pub payout_payment_hash: Option<String>,
     /// Phase 3: portion of `amount_sats` that the node retains on slash.
     /// Frozen at the moment the bond enters `PendingPayout`. `None` until
     /// then; the counterparty share is always derived as
@@ -151,6 +169,7 @@ impl Bond {
             payment_request: None,
             payout_invoice: None,
             payout_routing_fee_sats: None,
+            payout_payment_hash: None,
             node_share_sats: None,
             payout_attempts: 0,
             invoice_request_attempts: 0,
@@ -196,12 +215,14 @@ mod tests {
     #[test]
     fn serialize_omits_secret_fields() {
         // The preimage is the capability that settles the bond HTLC;
-        // `payout_invoice` identifies the winner. Both must stay out of
-        // any serde output a future phase accidentally adds.
+        // `payout_invoice` identifies the winner; `payout_payment_hash`
+        // identifies the payment. All three must stay out of any serde
+        // output a future phase accidentally adds.
         let mut b = Bond::new_requested(Uuid::new_v4(), "a".repeat(64), BondRole::Taker, 1_000);
         b.preimage = Some("deadbeef".repeat(8));
         b.payout_invoice = Some("lnbc1pSECRET".to_string());
         b.hash = Some("c0ffee".repeat(10) + "c0ff");
+        b.payout_payment_hash = Some("ba5eba11".repeat(8));
 
         let json = serde_json::to_string(&b).expect("serialize");
         assert!(!json.contains("preimage"), "preimage leaked: {json}");
@@ -213,6 +234,14 @@ mod tests {
         assert!(
             !json.contains("lnbc1pSECRET"),
             "payout_invoice value leaked: {json}"
+        );
+        assert!(
+            !json.contains("payout_payment_hash"),
+            "payout_payment_hash leaked: {json}"
+        );
+        assert!(
+            !json.contains("ba5eba11"),
+            "payout_payment_hash value leaked: {json}"
         );
         // Non-secret fields still serialize as usual.
         assert!(json.contains("hash"));

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -72,7 +72,7 @@ use uuid::Uuid;
 use crate::app::context::AppContext;
 use crate::config::settings::Settings;
 use crate::lightning::invoice::{decode_invoice, is_valid_invoice};
-use crate::lightning::LndConnector;
+use crate::lightning::{routing_fee_cap_sats, LndConnector};
 use crate::util::{bytes_to_string, enqueue_order_msg};
 
 use super::db::find_bonds_by_state;
@@ -573,8 +573,11 @@ async fn pay_counterparty(
     // point on, every re-entry into this function for this bond will
     // take the reconciliation branch above instead of issuing a
     // duplicate send.
-    let max_routing_fee = Settings::get_mostro().max_routing_fee;
-    let routing_fee_cap = ((counterparty_share as f64) * max_routing_fee).ceil() as i64;
+    // Mirror exactly what `send_payment` will pass to LND as
+    // `fee_limit_sat`, so this informational column never misleads an
+    // operator debugging a payout (notably small ones, where LND uses a
+    // 1% rate with a 10-sat floor rather than `max_routing_fee`).
+    let routing_fee_cap = routing_fee_cap_sats(counterparty_share);
     let persisted = sqlx::query(
         "UPDATE bonds \
            SET payout_routing_fee_sats = ?, payout_payment_hash = ? \
@@ -602,8 +605,8 @@ async fn pay_counterparty(
         return Ok(());
     }
 
-    // send_payment. The helper internally caps the fee at
-    // `counterparty_share * max_routing_fee`.
+    // send_payment. The helper caps the fee via `routing_fee_cap_sats`,
+    // the same value persisted above as `payout_routing_fee_sats`.
     let (tx, mut rx) = channel(100);
     let send_outcome = ln_client
         .send_payment(invoice, counterparty_share, tx)

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -1,0 +1,1023 @@
+//! Phase 3 — bond payout flow.
+//!
+//! Shared infrastructure that drains the queue of bonds Phase 2 left in
+//! [`BondState::PendingPayout`] (and Phase 4+/5+/7 will fill the same
+//! queue from the timeout and maker paths). Two entry points:
+//!
+//! - [`run_bond_payout_cycle`] — called once per scheduler tick. Walks
+//!   every `PendingPayout` bond and drives it forward by one step: ask
+//!   the non-slashed counterparty for a bolt11 if we haven't yet,
+//!   `settle_hold_invoice` once we have one, then `send_payment` for
+//!   the counterparty share. Settles + transitions to `Forfeited`
+//!   instead when `payout_claim_window_days` has elapsed with no
+//!   invoice.
+//! - [`add_bond_invoice_action`] — the action handler that consumes the
+//!   counterparty's `Action::AddBondInvoice` reply, validates it, and
+//!   persists the bolt11 onto the bond row.
+//!
+//! ## Why a dedicated action type
+//!
+//! Phase 3 originally reused `Action::AddInvoice` (the buyer-flow
+//! action) and disambiguated by looking up a `PendingPayout` bond for
+//! the order/sender pair. The protocol decision in this PR is to ship
+//! `Action::AddBondInvoice` instead — it's the counterparty-direction
+//! dual of Phase 1.5's `Action::PayBondInvoice`, and keeps the two
+//! invoice flows disjoint at the routing layer. See
+//! `docs/ANTI_ABUSE_BOND.md` §8.1 and §14.3.
+//!
+//! ## Split snapshot
+//!
+//! Every `PendingPayout` row was written with `node_share_sats` frozen
+//! at the moment of transition (Phase 2 §7.3 step 4). The scheduler
+//! reads that column; it never re-reads `slash_node_share_pct` from
+//! config. This makes the split deterministic across daemon restarts
+//! and operator config changes.
+//!
+//! ## Recipient resolution
+//!
+//! The non-slashed counterparty is recomputed from `order.{buyer,
+//! seller}_pubkey` + `bond.pubkey` + `slashed_reason` at scheduler time.
+//! No new schema column is needed; the same mapping the Phase 2
+//! validator uses on the way *in* applies here on the way *out*.
+
+use std::str::FromStr;
+
+use chrono::Utc;
+use fedimint_tonic_lnd::lnrpc::payment::PaymentStatus;
+use mostro_core::error::{
+    CantDoReason,
+    MostroError::{self, MostroCantDo, MostroInternalErr},
+    ServiceError,
+};
+use mostro_core::message::{Action, Message, Payload};
+use mostro_core::nip59::UnwrappedMessage;
+use mostro_core::order::{Order, SmallOrder};
+use nostr_sdk::prelude::*;
+use sqlx::{Pool, Sqlite};
+use sqlx_crud::Crud;
+use tokio::sync::mpsc::channel;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+use crate::app::context::AppContext;
+use crate::config::settings::Settings;
+use crate::lightning::invoice::is_valid_invoice;
+use crate::lightning::LndConnector;
+use crate::util::enqueue_order_msg;
+
+use super::db::find_bonds_by_state;
+use super::model::Bond;
+use super::types::{BondSlashReason, BondState};
+
+/// One full pass over every bond in [`BondState::PendingPayout`].
+///
+/// Mirror of `dev_fee::run_dev_fee_cycle`: each tick walks the work
+/// queue and advances each row by at most one step. The scheduler
+/// calls this from a single task, so there is no in-process contention
+/// — but every state transition is still done with a guarded CAS so a
+/// concurrent admin retry or a daemon restart that re-fires the same
+/// tick cannot double-settle a row.
+pub async fn run_bond_payout_cycle(pool: &Pool<Sqlite>, ln_client: &mut LndConnector) {
+    let bonds = match find_bonds_by_state(pool, BondState::PendingPayout).await {
+        Ok(b) => b,
+        Err(e) => {
+            error!("bond payout: failed to enumerate PendingPayout bonds: {e}");
+            return;
+        }
+    };
+    if bonds.is_empty() {
+        return;
+    }
+    info!(
+        "bond payout: processing {} PendingPayout bond(s)",
+        bonds.len()
+    );
+
+    for bond in bonds {
+        if let Err(e) = process_one_bond(pool, ln_client, &bond).await {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "bond payout: bond cycle errored: {e}"
+            );
+        }
+    }
+}
+
+/// Drive a single bond forward by one step.
+///
+/// The state machine inside `PendingPayout` is:
+///
+/// ```text
+///                          ┌── forfeit window elapsed AND no invoice ─► settle ─► Forfeited
+///                          │
+///   PendingPayout ─────────┤── no invoice yet AND cadence ok ───► AddBondInvoice DM
+///                          │
+///                          │── invoice present (or node_share_pct=1.0) ─► settle ─► [send_payment]
+///                          │                                                              │
+///                          └──── send_payment success ─► Slashed                          │
+///                                                                                         │
+///                                            send_payment failure ─► retry (or Failed) ◄──┘
+/// ```
+///
+/// Each call advances by at most one of these arms; the scheduler
+/// reruns the row on the next tick until a terminal state is reached.
+async fn process_one_bond(
+    pool: &Pool<Sqlite>,
+    ln_client: &mut LndConnector,
+    bond: &Bond,
+) -> Result<(), MostroError> {
+    let cfg = Settings::get_bond();
+    let claim_window_seconds = cfg
+        .map(|c| c.payout_claim_window_days as i64 * 86_400)
+        .unwrap_or(15 * 86_400);
+    let invoice_window_seconds = cfg
+        .map(|c| c.payout_invoice_window_seconds as i64)
+        .unwrap_or(300);
+    let max_retries = cfg.map(|c| c.payout_max_retries as i64).unwrap_or(5);
+
+    let now = Utc::now().timestamp();
+    let slashed_at = bond.slashed_at.unwrap_or(now);
+
+    // Forfeit window has elapsed and counterparty never submitted a
+    // bolt11: settle the HTLC into Mostro's wallet and transition to
+    // `Forfeited`. The node retains `amount_sats` in full. No further
+    // DMs or `send_payment` attempts.
+    if bond.payout_invoice.is_none() && now - slashed_at >= claim_window_seconds {
+        return forfeit_bond(pool, ln_client, bond).await;
+    }
+
+    // Normal payout: either request an invoice (counterparty leg), or
+    // settle + pay (HTLC and counterparty leg).
+    let node_share_sats = bond.node_share_sats.unwrap_or(0);
+    let counterparty_share = bond.amount_sats - node_share_sats;
+
+    if counterparty_share <= 0 {
+        // `slash_node_share_pct = 1.0` (or full retention) — there's no
+        // counterparty leg. Settle the HTLC and transition straight to
+        // `Slashed`. No `AddBondInvoice` DM, no `send_payment`.
+        return settle_node_only(pool, ln_client, bond).await;
+    }
+
+    match bond.payout_invoice.as_deref() {
+        None => {
+            request_payout_invoice(pool, bond, invoice_window_seconds, claim_window_seconds).await
+        }
+        Some(invoice) => settle_and_pay(pool, ln_client, bond, invoice, max_retries).await,
+    }
+}
+
+/// Settle the HTLC into Mostro's wallet and transition to `Forfeited`.
+async fn forfeit_bond(
+    pool: &Pool<Sqlite>,
+    ln_client: &mut LndConnector,
+    bond: &Bond,
+) -> Result<(), MostroError> {
+    if let Some(preimage) = bond.preimage.as_deref() {
+        if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "forfeit: settle_hold_invoice failed: {e} — will retry on next tick"
+            );
+            return Err(e);
+        }
+    } else {
+        warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "forfeit: bond has no preimage; transitioning to Forfeited without LND settle"
+        );
+    }
+
+    let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
+        .bind(BondState::Forfeited.to_string())
+        .bind(bond.id)
+        .bind(BondState::PendingPayout.to_string())
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if result.rows_affected() == 1 {
+        info!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            amount_sats = bond.amount_sats,
+            "bond forfeited: claim window elapsed, node retains full amount"
+        );
+    }
+    Ok(())
+}
+
+/// Counterparty share is empty (`slash_node_share_pct = 1.0`): settle
+/// the HTLC and transition to `Slashed`. No DMs, no `send_payment`.
+async fn settle_node_only(
+    pool: &Pool<Sqlite>,
+    ln_client: &mut LndConnector,
+    bond: &Bond,
+) -> Result<(), MostroError> {
+    if let Some(preimage) = bond.preimage.as_deref() {
+        if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "node-only payout: settle_hold_invoice failed: {e} — will retry on next tick"
+            );
+            return Err(e);
+        }
+    } else {
+        warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "node-only payout: bond has no preimage; transitioning to Slashed without LND settle"
+        );
+    }
+
+    let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
+        .bind(BondState::Slashed.to_string())
+        .bind(bond.id)
+        .bind(BondState::PendingPayout.to_string())
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if result.rows_affected() == 1 {
+        info!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            amount_sats = bond.amount_sats,
+            "bond slashed (node-only): full amount retained by Mostro"
+        );
+    }
+    Ok(())
+}
+
+/// Ask the non-slashed counterparty for a payout bolt11 via
+/// `Action::AddBondInvoice`. Skip if the previous request landed
+/// within `payout_invoice_window_seconds`. Bumps
+/// `invoice_request_attempts` and `last_invoice_request_at` only — the
+/// retry budget (`payout_max_retries`) is for `send_payment` failures
+/// once an invoice is in hand, not for invoice-request DMs.
+async fn request_payout_invoice(
+    pool: &Pool<Sqlite>,
+    bond: &Bond,
+    invoice_window_seconds: i64,
+    claim_window_seconds: i64,
+) -> Result<(), MostroError> {
+    let now = Utc::now().timestamp();
+    if let Some(last) = bond.last_invoice_request_at {
+        if now - last < invoice_window_seconds {
+            return Ok(());
+        }
+    }
+
+    let order = match Order::by_id(pool, bond.order_id)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?
+    {
+        Some(o) => o,
+        None => {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "request_payout_invoice: order row missing; skipping"
+            );
+            return Ok(());
+        }
+    };
+
+    let reason = bond
+        .slashed_reason
+        .as_deref()
+        .and_then(|s| BondSlashReason::from_str(s).ok())
+        .ok_or_else(|| {
+            MostroInternalErr(ServiceError::UnexpectedError(format!(
+                "bond {} in PendingPayout has unparseable slashed_reason {:?}",
+                bond.id, bond.slashed_reason
+            )))
+        })?;
+
+    let recipient_pubkey = match resolve_recipient(&order, bond, reason)? {
+        Some(pk) => pk,
+        None => {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "request_payout_invoice: cannot resolve recipient; skipping (will retry on next tick)"
+            );
+            return Ok(());
+        }
+    };
+
+    let counterparty_share = bond.amount_sats - bond.node_share_sats.unwrap_or(0);
+    let order_kind = order.get_order_kind().map_err(MostroInternalErr)?;
+
+    let small = SmallOrder::new(
+        Some(order.id),
+        Some(order_kind),
+        None,
+        counterparty_share,
+        order.fiat_code.clone(),
+        order.min_amount,
+        order.max_amount,
+        order.fiat_amount,
+        order.payment_method.clone(),
+        order.premium,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    let deadline_unix = bond.slashed_at.unwrap_or(now) + claim_window_seconds;
+    let deadline = chrono::DateTime::<Utc>::from_timestamp(deadline_unix, 0)
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+        .unwrap_or_else(|| deadline_unix.to_string());
+
+    info!(
+        bond_id = %bond.id,
+        order_id = %bond.order_id,
+        amount_sats = counterparty_share,
+        recipient = %recipient_pubkey,
+        deadline = %deadline,
+        attempt = bond.invoice_request_attempts + 1,
+        "bond payout: requesting invoice from counterparty"
+    );
+
+    // The notification carries the request payload. The deadline is
+    // shipped as a separate `SendDm` text message so the user sees a
+    // human-readable claim window alongside the structured request.
+    enqueue_order_msg(
+        None,
+        Some(order.id),
+        Action::AddBondInvoice,
+        Some(Payload::Order(small)),
+        recipient_pubkey,
+        None,
+    )
+    .await;
+
+    let deadline_msg = format!(
+        "Bond payout pending. Submit a Lightning invoice for {counterparty_share} sats via add-bond-invoice before {deadline} or your share will be forfeited."
+    );
+    enqueue_order_msg(
+        None,
+        Some(order.id),
+        Action::SendDm,
+        Some(Payload::TextMessage(deadline_msg)),
+        recipient_pubkey,
+        None,
+    )
+    .await;
+
+    sqlx::query(
+        "UPDATE bonds \
+           SET invoice_request_attempts = invoice_request_attempts + 1, \
+               last_invoice_request_at = ? \
+         WHERE id = ? AND state = ?",
+    )
+    .bind(now)
+    .bind(bond.id)
+    .bind(BondState::PendingPayout.to_string())
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(())
+}
+
+/// Settle the bond HTLC into Mostro's wallet, then `send_payment` the
+/// counterparty share to the bolt11 they submitted. Order matters:
+/// settle must succeed before send_payment, otherwise we'd be paying
+/// from sats we don't yet hold.
+async fn settle_and_pay(
+    pool: &Pool<Sqlite>,
+    ln_client: &mut LndConnector,
+    bond: &Bond,
+    invoice: &str,
+    max_retries: i64,
+) -> Result<(), MostroError> {
+    let counterparty_share = bond.amount_sats - bond.node_share_sats.unwrap_or(0);
+
+    // Settle the bond HTLC. If settle fails, the row stays in
+    // `PendingPayout` and the scheduler retries on the next tick.
+    // The bonded user's HTLC stays held — the correct safety posture
+    // when we cannot confirm we have the sats yet.
+    if let Some(preimage) = bond.preimage.as_deref() {
+        if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
+            // Distinguish "already settled" (idempotent retry) from
+            // genuine transport failures the same way release_bond
+            // distinguishes already-canceled.
+            let already = is_already_settled_error(&e);
+            if !already {
+                warn!(
+                    bond_id = %bond.id,
+                    order_id = %bond.order_id,
+                    "settle_and_pay: settle_hold_invoice failed: {e} — retrying on next tick"
+                );
+                return Err(e);
+            }
+            info!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "settle_and_pay: bond HTLC already settled; proceeding to send_payment"
+            );
+        }
+    } else {
+        warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "settle_and_pay: bond has no preimage; cannot settle HTLC"
+        );
+    }
+
+    // Routing-fee ceiling: derived from MostroSettings::max_routing_fee
+    // applied to the counterparty share. The spec mentions
+    // `query_routes` as a finer estimate, but `send_payment` already
+    // accepts a `fee_limit_sat` and the existing helper computes that.
+    // We record what we used into `payout_routing_fee_sats` so
+    // operators can read the cap from logs.
+    let max_routing_fee = Settings::get_mostro().max_routing_fee;
+    let routing_fee_cap = ((counterparty_share as f64) * max_routing_fee).ceil() as i64;
+    let _ = sqlx::query("UPDATE bonds SET payout_routing_fee_sats = ? WHERE id = ? AND state = ?")
+        .bind(routing_fee_cap)
+        .bind(bond.id)
+        .bind(BondState::PendingPayout.to_string())
+        .execute(pool)
+        .await;
+
+    // send_payment. The helper internally caps the fee at
+    // `counterparty_share * max_routing_fee`.
+    let (tx, mut rx) = channel(100);
+    let send_outcome = ln_client
+        .send_payment(invoice, counterparty_share, tx)
+        .await;
+    if let Err(e) = send_outcome {
+        return on_send_payment_failure(pool, bond, max_retries, &format!("{e}")).await;
+    }
+
+    // Collect the first terminal status from the stream. Mirrors
+    // dev_fee::send_dev_fee_payment.
+    let mut succeeded = false;
+    let mut failure: Option<String> = None;
+    while let Some(msg) = rx.recv().await {
+        if let Ok(status) = PaymentStatus::try_from(msg.payment.status) {
+            match status {
+                PaymentStatus::Succeeded => {
+                    succeeded = true;
+                    break;
+                }
+                PaymentStatus::Failed => {
+                    failure = Some(format!(
+                        "payment failed: reason {}",
+                        msg.payment.failure_reason
+                    ));
+                    break;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    if succeeded {
+        let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
+            .bind(BondState::Slashed.to_string())
+            .bind(bond.id)
+            .bind(BondState::PendingPayout.to_string())
+            .execute(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+        if result.rows_affected() == 1 {
+            info!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                amount_sats = bond.amount_sats,
+                counterparty_share_sats = counterparty_share,
+                "bond payout: send_payment succeeded; bond transitioned to Slashed"
+            );
+        }
+        return Ok(());
+    }
+
+    let msg = failure.unwrap_or_else(|| "payment stream ended without terminal status".to_string());
+    on_send_payment_failure(pool, bond, max_retries, &msg).await
+}
+
+/// Bump `payout_attempts`; on `payout_max_retries` reached, transition
+/// the bond to `Failed`. This counter only increments on real
+/// `send_payment` failures, not on invoice-request DMs.
+async fn on_send_payment_failure(
+    pool: &Pool<Sqlite>,
+    bond: &Bond,
+    max_retries: i64,
+    cause: &str,
+) -> Result<(), MostroError> {
+    let new_attempts = bond.payout_attempts + 1;
+    sqlx::query("UPDATE bonds SET payout_attempts = ? WHERE id = ? AND state = ?")
+        .bind(new_attempts)
+        .bind(bond.id)
+        .bind(BondState::PendingPayout.to_string())
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if new_attempts >= max_retries {
+        sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
+            .bind(BondState::Failed.to_string())
+            .bind(bond.id)
+            .bind(BondState::PendingPayout.to_string())
+            .execute(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+        error!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            attempts = new_attempts,
+            "bond payout: send_payment exhausted retries — transitioning to Failed; node share retained, counterparty share stranded (operator review required). last error: {cause}"
+        );
+    } else {
+        warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            attempts = new_attempts,
+            max_retries,
+            "bond payout: send_payment failure ({cause}); will retry on next tick"
+        );
+    }
+    Ok(())
+}
+
+/// Classify an error string from `settle_hold_invoice` as a benign
+/// "already settled" outcome (idempotent retry) vs. a transport
+/// failure that warrants leaving the bond in `PendingPayout` for the
+/// next tick.
+fn is_already_settled_error(err: &MostroError) -> bool {
+    let s = err.to_string().to_lowercase();
+    s.contains("already settled")
+        || s.contains("invoice already settled")
+        || s.contains("code=alreadyexists")
+}
+
+/// Map `(order, bond, reason)` to the non-slashed counterparty's
+/// pubkey. Returns `None` when the order's buyer/seller fields are
+/// unset (e.g. an in-flight take that never completed) so the caller
+/// can no-op and retry on the next tick rather than crash.
+///
+/// - **`LostDispute`.** The bonded user is the slashed side; the
+///   recipient is whoever is *not* `bond.pubkey` on the order. This
+///   collapses the four §3.1 cases (sell/buy × seller/buyer) into a
+///   single lookup at this layer.
+/// - **`Timeout` (Phase 4+).** Same logic — the slashed party is the
+///   one responsible for the elapsed waiting state, and the recipient
+///   is the other side. The §9.2 table is encoded by *who got
+///   slashed*, not consulted here.
+fn resolve_recipient(
+    order: &Order,
+    bond: &Bond,
+    _reason: BondSlashReason,
+) -> Result<Option<PublicKey>, MostroError> {
+    let buyer = order.buyer_pubkey.as_deref();
+    let seller = order.seller_pubkey.as_deref();
+    let recipient_str = match (buyer, seller) {
+        (Some(b), Some(s)) if bond.pubkey == b => Some(s),
+        (Some(b), Some(s)) if bond.pubkey == s => Some(b),
+        _ => None,
+    };
+    let pk = recipient_str
+        .map(PublicKey::from_str)
+        .transpose()
+        .map_err(|e| MostroInternalErr(ServiceError::UnexpectedError(e.to_string())))?;
+    Ok(pk)
+}
+
+// ── Inbound action handler ──────────────────────────────────────────────
+
+/// `Action::AddBondInvoice` handler: the counterparty replies with the
+/// payout bolt11. Persists `payout_invoice` and resets
+/// `invoice_request_attempts` to 0 in the same UPDATE.
+///
+/// Rejects with `CantDo(NotAllowedByStatus)` if the bond has already
+/// moved out of `PendingPayout` — most importantly the `Forfeited`
+/// case, which is the "claim window expired" path. The CAS predicate
+/// is the arbiter; no clocks are read here.
+pub async fn add_bond_invoice_action(
+    ctx: &AppContext,
+    msg: Message,
+    event: &UnwrappedMessage,
+    _my_keys: &Keys,
+) -> Result<(), MostroError> {
+    let pool = ctx.pool();
+    let kind = msg.get_inner_message_kind();
+    let order_id = kind.id.ok_or(MostroCantDo(CantDoReason::InvalidPayload))?;
+    let payment_request = match kind.get_payment_request() {
+        Some(pr) if !pr.is_empty() => pr,
+        _ => return Err(MostroCantDo(CantDoReason::InvalidInvoice)),
+    };
+
+    let sender = event.sender;
+    let bond = find_active_bond_in_pending_payout(pool, order_id, &sender.to_string()).await?;
+    let bond = match bond {
+        Some(b) => b,
+        None => {
+            // No `PendingPayout` bond for this sender on this order.
+            // Two natural reasons: the bond was never slashed (and so
+            // there is nothing to invoice for), or the claim window
+            // already expired and the row moved to `Forfeited`. From
+            // the user's perspective both look the same — they sent
+            // us an invoice we cannot route.
+            return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+        }
+    };
+
+    let counterparty_share = bond.amount_sats - bond.node_share_sats.unwrap_or(0);
+    if counterparty_share <= 0 {
+        // `slash_node_share_pct = 1.0` — there is no counterparty
+        // share to pay out. Reject so the user isn't left waiting on
+        // a payment that will never come.
+        return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+    }
+
+    // Validate the bolt11 amount matches the counterparty share. Fee
+    // 0 because the counterparty share is what arrives at the
+    // recipient; routing fees come out of Mostro's own wallet, not
+    // the invoice principal.
+    if is_valid_invoice(
+        payment_request.clone(),
+        Some(counterparty_share as u64),
+        Some(0),
+    )
+    .await
+    .is_err()
+    {
+        return Err(MostroCantDo(CantDoReason::InvalidInvoice));
+    }
+
+    // CAS the row: only persist the invoice if the bond is *still* in
+    // `PendingPayout` and *still* has no `payout_invoice`. Both
+    // predicates close the obvious races (the scheduler racing to
+    // Forfeited; a concurrent duplicate AddBondInvoice).
+    let result = sqlx::query(
+        "UPDATE bonds \
+           SET payout_invoice = ?, invoice_request_attempts = 0 \
+         WHERE id = ? AND state = ? AND payout_invoice IS NULL",
+    )
+    .bind(&payment_request)
+    .bind(bond.id)
+    .bind(BondState::PendingPayout.to_string())
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if result.rows_affected() == 0 {
+        return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+    }
+
+    info!(
+        bond_id = %bond.id,
+        order_id = %bond.order_id,
+        sender = %sender,
+        "bond payout: invoice accepted; awaiting scheduler tick for settle+pay"
+    );
+
+    Ok(())
+}
+
+/// Find a `PendingPayout` bond on `order_id` whose recipient (the
+/// non-slashed side) matches `sender_pubkey`.
+///
+/// The bond row stores `bond.pubkey` = slashed user's trade pubkey,
+/// not the recipient's. So we look up the order, compute the
+/// recipient via [`resolve_recipient`], and confirm it matches the
+/// sender of the AddBondInvoice reply.
+async fn find_active_bond_in_pending_payout(
+    pool: &Pool<Sqlite>,
+    order_id: Uuid,
+    sender_pubkey: &str,
+) -> Result<Option<Bond>, MostroError> {
+    let bonds: Vec<Bond> = sqlx::query_as::<_, Bond>(
+        "SELECT * FROM bonds WHERE order_id = ? AND state = ? \
+         ORDER BY slashed_at DESC",
+    )
+    .bind(order_id)
+    .bind(BondState::PendingPayout.to_string())
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if bonds.is_empty() {
+        return Ok(None);
+    }
+
+    let order = match Order::by_id(pool, order_id)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?
+    {
+        Some(o) => o,
+        None => return Ok(None),
+    };
+
+    for bond in bonds {
+        let reason = match bond
+            .slashed_reason
+            .as_deref()
+            .and_then(|r| BondSlashReason::from_str(r).ok())
+        {
+            Some(r) => r,
+            None => continue,
+        };
+        if let Some(recipient) = resolve_recipient(&order, &bond, reason)? {
+            if recipient.to_string() == sender_pubkey {
+                return Ok(Some(bond));
+            }
+        }
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::bond::db::create_bond;
+    use crate::app::bond::types::BondRole;
+    use mostro_core::order::{Kind, Status};
+    use sqlx::sqlite::SqlitePoolOptions;
+
+    async fn setup_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("open in-memory sqlite");
+        sqlx::query(include_str!(
+            "../../../migrations/20221222153301_orders.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("orders migration");
+        for stmt in include_str!("../../../migrations/20251126120000_dev_fee.sql")
+            .split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && !s.lines().all(|l| l.trim_start().starts_with("--")))
+        {
+            sqlx::query(stmt)
+                .execute(&pool)
+                .await
+                .expect("dev_fee migration");
+        }
+        sqlx::query(include_str!(
+            "../../../migrations/20260423120000_anti_abuse_bond.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bonds migration");
+        pool
+    }
+
+    fn taker_pk() -> &'static str {
+        "1111111111111111111111111111111111111111111111111111111111111111"
+    }
+    fn maker_pk() -> &'static str {
+        "2222222222222222222222222222222222222222222222222222222222222222"
+    }
+
+    async fn insert_order(pool: &Pool<Sqlite>, id: Uuid, seller: &str, buyer: &str) {
+        sqlx::query(
+            r#"INSERT INTO orders (
+                id, kind, event_id, status, premium, payment_method,
+                amount, fiat_code, fiat_amount, created_at, expires_at,
+                seller_pubkey, buyer_pubkey
+            ) VALUES (?, 'sell', ?, ?, 0, 'cash', 100000, 'USD', 10, 0, 0, ?, ?)"#,
+        )
+        .bind(id)
+        .bind(id.simple().to_string())
+        .bind(Status::Dispute.to_string())
+        .bind(seller)
+        .bind(buyer)
+        .execute(pool)
+        .await
+        .expect("insert order");
+    }
+
+    fn pending_payout_bond(
+        order_id: Uuid,
+        pubkey: &str,
+        amount: i64,
+        node_share: i64,
+        slashed_at: i64,
+        invoice: Option<&str>,
+        last_request: Option<i64>,
+    ) -> Bond {
+        let mut b = Bond::new_requested(order_id, pubkey.to_string(), BondRole::Taker, amount);
+        b.state = BondState::PendingPayout.to_string();
+        b.node_share_sats = Some(node_share);
+        b.slashed_reason = Some(BondSlashReason::LostDispute.to_string());
+        b.slashed_at = Some(slashed_at);
+        b.payout_invoice = invoice.map(|s| s.to_string());
+        b.last_invoice_request_at = last_request;
+        b
+    }
+
+    #[test]
+    fn resolve_recipient_sell_order_taker_buyer_slashed() {
+        // Sell-order: maker=seller, taker=buyer. Bond is on the
+        // taker (buyer). Recipient = seller (the non-slashed side).
+        let order = Order {
+            kind: Kind::Sell.to_string(),
+            seller_pubkey: Some(maker_pk().to_string()),
+            buyer_pubkey: Some(taker_pk().to_string()),
+            ..Order::default()
+        };
+        let bond = pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, 5_000, 0, None, None);
+        let r = resolve_recipient(&order, &bond, BondSlashReason::LostDispute).unwrap();
+        assert_eq!(r.unwrap().to_string(), maker_pk());
+    }
+
+    #[test]
+    fn resolve_recipient_buy_order_taker_seller_slashed() {
+        let order = Order {
+            kind: Kind::Buy.to_string(),
+            buyer_pubkey: Some(maker_pk().to_string()),
+            seller_pubkey: Some(taker_pk().to_string()),
+            ..Order::default()
+        };
+        let bond = pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, 5_000, 0, None, None);
+        let r = resolve_recipient(&order, &bond, BondSlashReason::LostDispute).unwrap();
+        assert_eq!(r.unwrap().to_string(), maker_pk());
+    }
+
+    #[test]
+    fn resolve_recipient_missing_buyer_returns_none() {
+        let order = Order {
+            kind: Kind::Sell.to_string(),
+            seller_pubkey: Some(maker_pk().to_string()),
+            buyer_pubkey: None,
+            ..Order::default()
+        };
+        let bond = pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, 5_000, 0, None, None);
+        let r = resolve_recipient(&order, &bond, BondSlashReason::LostDispute).unwrap();
+        assert!(r.is_none());
+    }
+
+    #[tokio::test]
+    async fn request_payout_invoice_respects_cadence_window() {
+        // A request issued within `invoice_window_seconds` of the
+        // previous one must no-op. This is the load-bearing guard
+        // against spamming the counterparty on every 60s tick.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            None,
+            Some(now - 10), // 10s ago, well within 300s window
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        request_payout_invoice(&pool, &bond, 300, 86_400)
+            .await
+            .unwrap();
+
+        let row: (i64, Option<i64>) = sqlx::query_as(
+            "SELECT invoice_request_attempts, last_invoice_request_at FROM bonds WHERE id = ?",
+        )
+        .bind(bond.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        // Counter must NOT have advanced and timestamp must be
+        // untouched.
+        assert_eq!(row.0, 0);
+        assert_eq!(row.1, Some(now - 10));
+    }
+
+    #[tokio::test]
+    async fn forfeit_bond_transitions_to_forfeited_without_preimage() {
+        // The forfeit path normally calls settle_hold_invoice. In the
+        // unit-test harness there's no LND, so we exercise the
+        // `preimage = None` branch which skips the LND call and just
+        // marks the row Forfeited. Real-world bonds always have a
+        // preimage (set by `request_taker_bond`), but the no-preimage
+        // branch is the documented behaviour for rows that never
+        // received an HTLC.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let mut bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
+        bond.preimage = None;
+        bond.hash = None;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        // We can't easily call `forfeit_bond` without an LndConnector,
+        // so exercise the SQL transition path used inside it directly
+        // — this is the load-bearing piece of the forfeit branch.
+        let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
+            .bind(BondState::Forfeited.to_string())
+            .bind(bond.id)
+            .bind(BondState::PendingPayout.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(result.rows_affected(), 1);
+        let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.0, BondState::Forfeited.to_string());
+    }
+
+    #[tokio::test]
+    async fn send_payment_failure_increments_attempts_and_flips_to_failed() {
+        // After `max_retries` consecutive `send_payment` failures the
+        // row must transition `PendingPayout -> Failed`. Exercises
+        // `on_send_payment_failure` with a tight retry budget.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some("lnbc1pSOMETHING"),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        // First failure: attempts 0 -> 1, still PendingPayout.
+        on_send_payment_failure(&pool, &bond, 3, "transient")
+            .await
+            .unwrap();
+        let bond_after_1: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(bond_after_1.payout_attempts, 1);
+        assert_eq!(bond_after_1.state, BondState::PendingPayout.to_string());
+
+        // Second + third failures use the *fresh* row each time so the
+        // counter math is exercised end-to-end. Third must flip Failed.
+        on_send_payment_failure(&pool, &bond_after_1, 3, "transient")
+            .await
+            .unwrap();
+        let bond_after_2: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(bond_after_2.payout_attempts, 2);
+
+        on_send_payment_failure(&pool, &bond_after_2, 3, "transient")
+            .await
+            .unwrap();
+        let bond_after_3: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(bond_after_3.payout_attempts, 3);
+        assert_eq!(bond_after_3.state, BondState::Failed.to_string());
+    }
+
+    #[tokio::test]
+    async fn pending_payout_no_counterparty_share_is_node_only() {
+        // `slash_node_share_pct = 1.0` style row: counterparty share
+        // is 0. `process_one_bond` must route to the node-only branch
+        // (settle_node_only) and not enqueue an AddBondInvoice. We
+        // can't easily exercise the LND call here, but we can verify
+        // the state filter on the SQL transition.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            10_000, // node_share == amount → counterparty_share = 0
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        bond.preimage = None;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        // Direct CAS that node-only path issues post-settle.
+        let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
+            .bind(BondState::Slashed.to_string())
+            .bind(bond.id)
+            .bind(BondState::PendingPayout.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(result.rows_affected(), 1);
+    }
+}

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -601,14 +601,51 @@ fn resolve_recipient(
 
 // ── Inbound action handler ──────────────────────────────────────────────
 
+/// Outcome of [`apply_payout_invoice`]: distinguishes the three terminal
+/// branches so the caller can log appropriately without re-reading the
+/// row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InvoiceApplyOutcome {
+    /// CAS persisted the invoice onto a `PendingPayout` row that had
+    /// `payout_invoice IS NULL`. The scheduler will route on its next
+    /// tick.
+    Persisted,
+    /// CAS flipped a `Failed` row back to `PendingPayout`, overwriting
+    /// the stale `payout_invoice` and resetting both attempt counters.
+    /// The scheduler will retry `send_payment` against the fresh
+    /// invoice on its next tick.
+    Resurrected,
+    /// CAS did not apply: either the bond's state changed under us
+    /// (forfeited, slashed, or another concurrent submission landed
+    /// first), `payout_invoice` was already set on a `PendingPayout`
+    /// row, or the `Failed` resurrection request landed past the
+    /// claim window. The caller maps this to
+    /// `CantDo(NotAllowedByStatus)` uniformly.
+    Rejected,
+}
+
 /// `Action::AddBondInvoice` handler: the counterparty replies with the
-/// payout bolt11. Persists `payout_invoice` and resets
-/// `invoice_request_attempts` to 0 in the same UPDATE.
+/// payout bolt11. Validates the bolt11 against the counterparty share,
+/// then routes to one of two CAS branches:
 ///
-/// Rejects with `CantDo(NotAllowedByStatus)` if the bond has already
-/// moved out of `PendingPayout` — most importantly the `Forfeited`
-/// case, which is the "claim window expired" path. The CAS predicate
-/// is the arbiter; no clocks are read here.
+/// - **`PendingPayout` + no `payout_invoice` yet.** The first-time
+///   submission. Persists the invoice and resets
+///   `invoice_request_attempts` to 0.
+/// - **`Failed` (within `payout_claim_window_days`).** Resurrection:
+///   flips the row back to `PendingPayout`, overwrites the stale
+///   `payout_invoice`, resets `payout_attempts` and
+///   `invoice_request_attempts` to 0. Gives the user another full
+///   retry budget against the fresh bolt11.
+///
+/// Rejects with `CantDo(NotAllowedByStatus)` for `Forfeited`,
+/// `Slashed`, `Released`, or `Failed`-past-claim-window — all the
+/// states from which we cannot accept further user-side recovery. The
+/// CAS predicate is the arbiter for the in-window cases; the
+/// claim-window check is the only piece of clock logic, and it is
+/// asymmetric: PendingPayout still admits a late invoice that beats
+/// the scheduler's forfeit CAS (§8.2), but `Failed` resurrection is
+/// strictly inside the window — `Failed` past the window is operator
+/// territory.
 pub async fn add_bond_invoice_action(
     ctx: &AppContext,
     msg: Message,
@@ -624,16 +661,17 @@ pub async fn add_bond_invoice_action(
     };
 
     let sender = event.sender;
-    let bond = find_active_bond_in_pending_payout(pool, order_id, &sender.to_string()).await?;
+    let bond = find_recoverable_bond_for_recipient(pool, order_id, &sender.to_string()).await?;
     let bond = match bond {
         Some(b) => b,
         None => {
-            // No `PendingPayout` bond for this sender on this order.
-            // Two natural reasons: the bond was never slashed (and so
-            // there is nothing to invoice for), or the claim window
-            // already expired and the row moved to `Forfeited`. From
-            // the user's perspective both look the same — they sent
-            // us an invoice we cannot route.
+            // No bond on this order is in a state that accepts an
+            // invoice from this sender. Could be: the bond was never
+            // slashed (nothing to invoice for); the claim window
+            // already expired with no invoice and the row moved to
+            // `Forfeited`; the bond was already paid (`Slashed`); or
+            // some other state. From the user's perspective they look
+            // the same — we cannot route their bolt11.
             return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
         }
     };
@@ -661,54 +699,172 @@ pub async fn add_bond_invoice_action(
         return Err(MostroCantDo(CantDoReason::InvalidInvoice));
     }
 
-    // CAS the row: only persist the invoice if the bond is *still* in
-    // `PendingPayout` and *still* has no `payout_invoice`. Both
-    // predicates close the obvious races (the scheduler racing to
-    // Forfeited; a concurrent duplicate AddBondInvoice).
-    let result = sqlx::query(
-        "UPDATE bonds \
-           SET payout_invoice = ?, invoice_request_attempts = 0 \
-         WHERE id = ? AND state = ? AND payout_invoice IS NULL",
-    )
-    .bind(&payment_request)
-    .bind(bond.id)
-    .bind(BondState::PendingPayout.to_string())
-    .execute(pool)
-    .await
-    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    let cfg = Settings::get_bond();
+    let claim_window_seconds = cfg
+        .map(|c| c.payout_claim_window_days as i64 * 86_400)
+        .unwrap_or(15 * 86_400);
+    let now = Utc::now().timestamp();
 
-    if result.rows_affected() == 0 {
-        return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+    match apply_payout_invoice(pool, &bond, &payment_request, now, claim_window_seconds).await? {
+        InvoiceApplyOutcome::Persisted => {
+            info!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                sender = %sender,
+                "bond payout: invoice accepted; awaiting scheduler tick for payout"
+            );
+            Ok(())
+        }
+        InvoiceApplyOutcome::Resurrected => {
+            info!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                sender = %sender,
+                "bond payout: Failed -> PendingPayout (user submitted fresh invoice within claim window); payout_attempts reset, awaiting scheduler tick for payout"
+            );
+            Ok(())
+        }
+        InvoiceApplyOutcome::Rejected => Err(MostroCantDo(CantDoReason::NotAllowedByStatus)),
     }
-
-    info!(
-        bond_id = %bond.id,
-        order_id = %bond.order_id,
-        sender = %sender,
-        "bond payout: invoice accepted; awaiting scheduler tick for payout"
-    );
-
-    Ok(())
 }
 
-/// Find a `PendingPayout` bond on `order_id` whose recipient (the
-/// non-slashed side) matches `sender_pubkey`.
+/// Persist `invoice` onto `bond` via one of two state-specific CAS
+/// branches. See [`InvoiceApplyOutcome`] for the result shape.
+///
+/// Race-safety: every transition is a single guarded `UPDATE` against
+/// the state column. Two concurrent callers can race, but at most one
+/// `UPDATE` matches.
+///
+/// - `PendingPayout` path uses `WHERE state = 'pending-payout' AND
+///   payout_invoice IS NULL`. A second caller that found the row
+///   `PendingPayout` but lost the race will see `rows_affected = 0`
+///   (either because the invoice is now set or because the row moved
+///   on) and gets `Rejected`.
+/// - `Failed` path uses `WHERE state = 'failed'`. A second caller that
+///   found the row `Failed` but lost the resurrection race will see
+///   the row as `PendingPayout` at CAS time, so the predicate fails
+///   and they get `Rejected`. The claim-window check is in Rust
+///   *before* the CAS; a tiny window-edge race is benign because the
+///   CAS itself does not gate on time.
+async fn apply_payout_invoice(
+    pool: &Pool<Sqlite>,
+    bond: &Bond,
+    invoice: &str,
+    now: i64,
+    claim_window_seconds: i64,
+) -> Result<InvoiceApplyOutcome, MostroError> {
+    let state = match BondState::from_str(&bond.state) {
+        Ok(s) => s,
+        Err(_) => return Ok(InvoiceApplyOutcome::Rejected),
+    };
+
+    match state {
+        BondState::PendingPayout => {
+            let result = sqlx::query(
+                "UPDATE bonds \
+                   SET payout_invoice = ?, invoice_request_attempts = 0 \
+                 WHERE id = ? AND state = ? AND payout_invoice IS NULL",
+            )
+            .bind(invoice)
+            .bind(bond.id)
+            .bind(BondState::PendingPayout.to_string())
+            .execute(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+            if result.rows_affected() == 0 {
+                Ok(InvoiceApplyOutcome::Rejected)
+            } else {
+                Ok(InvoiceApplyOutcome::Persisted)
+            }
+        }
+        BondState::Failed => {
+            // `slashed_at` is the anchor for the claim window. A
+            // `Failed` row that reached this state via the normal
+            // flow always has `slashed_at` set (Phase 2's slash CAS
+            // writes it atomically with the transition to
+            // `PendingPayout`, and the row never leaves that anchor
+            // afterwards). A `None` here would be an invariant
+            // violation; reject conservatively rather than treat it
+            // as "infinitely recoverable".
+            let slashed_at = match bond.slashed_at {
+                Some(t) => t,
+                None => return Ok(InvoiceApplyOutcome::Rejected),
+            };
+            if now.saturating_sub(slashed_at) >= claim_window_seconds {
+                return Ok(InvoiceApplyOutcome::Rejected);
+            }
+
+            // Resurrection CAS. The `state = 'failed'` predicate is
+            // the arbiter: two concurrent calls can both pass the
+            // Rust claim-window check, but only one matches `state =
+            // 'failed'` at execution time. The loser sees
+            // `rows_affected = 0` and gets `Rejected`. The scheduler
+            // does not race here because it only enumerates
+            // `PendingPayout` (Failed is invisible to it), and the
+            // row reads consistent on the next tick because we set
+            // state + invoice + counters in the same UPDATE.
+            let result = sqlx::query(
+                "UPDATE bonds \
+                   SET state = ?, \
+                       payout_invoice = ?, \
+                       payout_attempts = 0, \
+                       invoice_request_attempts = 0 \
+                 WHERE id = ? AND state = ?",
+            )
+            .bind(BondState::PendingPayout.to_string())
+            .bind(invoice)
+            .bind(bond.id)
+            .bind(BondState::Failed.to_string())
+            .execute(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+            if result.rows_affected() == 0 {
+                Ok(InvoiceApplyOutcome::Rejected)
+            } else {
+                Ok(InvoiceApplyOutcome::Resurrected)
+            }
+        }
+        // Any other state — `Requested`, `Locked`, `Released`,
+        // `Slashed`, `Forfeited` — is not user-recoverable via this
+        // path. The finder normally never returns these (it filters
+        // on `pending-payout` / `failed`), but we treat unexpected
+        // input defensively.
+        _ => Ok(InvoiceApplyOutcome::Rejected),
+    }
+}
+
+/// Find a bond on `order_id` whose recipient (the non-slashed side)
+/// matches `sender_pubkey` *and* whose state still accepts a new
+/// payout invoice from the user.
+///
+/// "Accepts a new invoice" means either:
+/// - `PendingPayout` — the normal path, the user is responding to an
+///   `AddBondInvoice` request for the first time (or replacing a
+///   submission that hadn't yet landed against a CAS-set row).
+/// - `Failed` — the user-recoverable resurrection path. The row's
+///   `payout_invoice` is set from a prior failed delivery; the
+///   handler will overwrite it and reset the retry counters, subject
+///   to the claim window enforced at CAS time.
 ///
 /// The bond row stores `bond.pubkey` = slashed user's trade pubkey,
 /// not the recipient's. So we look up the order, compute the
 /// recipient via [`resolve_recipient`], and confirm it matches the
 /// sender of the AddBondInvoice reply.
-async fn find_active_bond_in_pending_payout(
+async fn find_recoverable_bond_for_recipient(
     pool: &Pool<Sqlite>,
     order_id: Uuid,
     sender_pubkey: &str,
 ) -> Result<Option<Bond>, MostroError> {
     let bonds: Vec<Bond> = sqlx::query_as::<_, Bond>(
-        "SELECT * FROM bonds WHERE order_id = ? AND state = ? \
-         ORDER BY slashed_at DESC",
+        "SELECT * FROM bonds \
+          WHERE order_id = ? AND (state = ? OR state = ?) \
+          ORDER BY slashed_at DESC",
     )
     .bind(order_id)
     .bind(BondState::PendingPayout.to_string())
+    .bind(BondState::Failed.to_string())
     .fetch_all(pool)
     .await
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
@@ -1039,5 +1195,377 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(after.0, BondState::Slashed.to_string());
+    }
+
+    // ── apply_payout_invoice / resurrection ───────────────────────────
+
+    const CLAIM_WINDOW_SECONDS: i64 = 15 * 86_400;
+
+    #[tokio::test]
+    async fn apply_payout_invoice_persists_on_pending_payout_null_invoice() {
+        // First-time submission: PendingPayout with no prior invoice.
+        // CAS lands, invoice is persisted, invoice_request_attempts
+        // reset to 0.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let mut bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
+        bond.invoice_request_attempts = 2;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pNEW", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Persisted);
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.state, BondState::PendingPayout.to_string());
+        assert_eq!(after.payout_invoice.as_deref(), Some("lnbc1pNEW"));
+        assert_eq!(after.invoice_request_attempts, 0);
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_rejects_pending_payout_when_invoice_already_set() {
+        // PendingPayout with `payout_invoice` already populated: the
+        // CAS `AND payout_invoice IS NULL` guard fires and the helper
+        // returns `Rejected`. No clobbering of the existing bolt11.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            Some("lnbc1pOLD"),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pNEW", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Rejected);
+
+        let after: (String, Option<String>) =
+            sqlx::query_as("SELECT state, payout_invoice FROM bonds WHERE id = ?")
+                .bind(bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(after.0, BondState::PendingPayout.to_string());
+        assert_eq!(after.1.as_deref(), Some("lnbc1pOLD"));
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_resurrects_failed_within_window() {
+        // Failed bond, slash anchor 1 day ago, fresh invoice: the
+        // resurrection CAS flips state back to PendingPayout,
+        // overwrites the stale bolt11, and resets *both* attempt
+        // counters so the user gets a full retry budget against the
+        // new invoice.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let slashed_at = now - 86_400; // 1 day ago
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            slashed_at,
+            Some("lnbc1pBAD"),
+            None,
+        );
+        bond.state = BondState::Failed.to_string();
+        bond.payout_attempts = 5;
+        bond.invoice_request_attempts = 3;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pFRESH", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Resurrected);
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.state, BondState::PendingPayout.to_string());
+        assert_eq!(after.payout_invoice.as_deref(), Some("lnbc1pFRESH"));
+        assert_eq!(after.payout_attempts, 0);
+        assert_eq!(after.invoice_request_attempts, 0);
+        // Slash anchor is *not* extended — the claim window remains
+        // bounded by the original slash time.
+        assert_eq!(after.slashed_at, Some(slashed_at));
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_rejects_failed_past_claim_window() {
+        // 1 second past the window: rejected. Row stays Failed with
+        // the original counters intact (no clobber of operator
+        // diagnostics).
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let slashed_at = now - CLAIM_WINDOW_SECONDS - 1;
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            slashed_at,
+            Some("lnbc1pBAD"),
+            None,
+        );
+        bond.state = BondState::Failed.to_string();
+        bond.payout_attempts = 5;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pFRESH", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Rejected);
+
+        let after: (String, Option<String>, i64) =
+            sqlx::query_as("SELECT state, payout_invoice, payout_attempts FROM bonds WHERE id = ?")
+                .bind(bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(after.0, BondState::Failed.to_string());
+        assert_eq!(after.1.as_deref(), Some("lnbc1pBAD"));
+        assert_eq!(after.2, 5);
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_rejects_failed_at_exact_window_boundary() {
+        // Exactly at the window edge (`now - slashed_at ==
+        // claim_window_seconds`): rejected. The check is `>=`, not
+        // `>`, so the boundary belongs to operator territory.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let slashed_at = now - CLAIM_WINDOW_SECONDS;
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            slashed_at,
+            Some("lnbc1pBAD"),
+            None,
+        );
+        bond.state = BondState::Failed.to_string();
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pFRESH", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Rejected);
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_rejects_failed_without_slashed_at() {
+        // Defensive guard against an invariant violation: a `Failed`
+        // row with NULL `slashed_at` has no claim-window anchor and
+        // must not be treated as infinitely recoverable. Reject and
+        // leave for operator inspection.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            Some("lnbc1pBAD"),
+            None,
+        );
+        bond.state = BondState::Failed.to_string();
+        bond.slashed_at = None;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pFRESH", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Rejected);
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_concurrent_resurrections_only_one_wins() {
+        // Models two concurrent resurrection attempts on a Failed
+        // bond. Both callers hold the same stale snapshot (state =
+        // Failed). The first CAS wins; the second sees `state =
+        // 'pending-payout'` at execution time, predicate misses,
+        // `rows_affected = 0` → `Rejected`. The winner's invoice is
+        // the one that persists.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            Some("lnbc1pBAD"),
+            None,
+        );
+        bond.state = BondState::Failed.to_string();
+        bond.payout_attempts = 5;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome_a =
+            apply_payout_invoice(&pool, &bond, "lnbc1pFRESH_A", now, CLAIM_WINDOW_SECONDS)
+                .await
+                .unwrap();
+        assert_eq!(outcome_a, InvoiceApplyOutcome::Resurrected);
+
+        // Second call operates on the *same* stale `Bond` snapshot
+        // (state still reads Failed in this Rust struct).
+        let outcome_b =
+            apply_payout_invoice(&pool, &bond, "lnbc1pFRESH_B", now, CLAIM_WINDOW_SECONDS)
+                .await
+                .unwrap();
+        assert_eq!(outcome_b, InvoiceApplyOutcome::Rejected);
+
+        let after: (String, Option<String>) =
+            sqlx::query_as("SELECT state, payout_invoice FROM bonds WHERE id = ?")
+                .bind(bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(after.0, BondState::PendingPayout.to_string());
+        assert_eq!(after.1.as_deref(), Some("lnbc1pFRESH_A"));
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_resurrects_after_re_failure() {
+        // End-to-end cycle: Failed → resurrect with B → drive back to
+        // Failed via on_send_payment_failure → resurrect with C. Each
+        // resurrection independently resets the retry budget; the
+        // user can absorb multiple bad invoices so long as they are
+        // still inside the claim window.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            Some("lnbc1pA"),
+            None,
+        );
+        bond.state = BondState::Failed.to_string();
+        bond.payout_attempts = 5;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        // First resurrection.
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pB", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Resurrected);
+
+        let bond_after_b: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(bond_after_b.state, BondState::PendingPayout.to_string());
+        assert_eq!(bond_after_b.payout_attempts, 0);
+
+        // Drive back to Failed via three consecutive send_payment
+        // failures with retry budget = 3. Each call re-reads the row
+        // so the counter math is exercised against fresh state.
+        let mut current = bond_after_b;
+        for _ in 0..3 {
+            on_send_payment_failure(&pool, &current, 3, "transient")
+                .await
+                .unwrap();
+            current = sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE id = ?")
+                .bind(bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        }
+        assert_eq!(current.state, BondState::Failed.to_string());
+
+        // Second resurrection with a different invoice.
+        let outcome = apply_payout_invoice(&pool, &current, "lnbc1pC", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Resurrected);
+
+        let final_bond: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(final_bond.state, BondState::PendingPayout.to_string());
+        assert_eq!(final_bond.payout_invoice.as_deref(), Some("lnbc1pC"));
+        assert_eq!(final_bond.payout_attempts, 0);
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_rejects_other_states() {
+        // Defensive guard for the unexpected-input case: the finder
+        // already filters to {PendingPayout, Failed}, but if a caller
+        // hands the helper a row in any other state we must refuse
+        // to mutate it.
+        let pool = setup_pool().await;
+        let now = Utc::now().timestamp();
+
+        for state in [
+            BondState::Slashed,
+            BondState::Released,
+            BondState::Forfeited,
+            BondState::Locked,
+            BondState::Requested,
+        ] {
+            let order_id = Uuid::new_v4();
+            insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+            let mut bond = pending_payout_bond(
+                order_id,
+                taker_pk(),
+                10_000,
+                5_000,
+                now,
+                Some("lnbc1p"),
+                None,
+            );
+            bond.state = state.to_string();
+            let bond = create_bond(&pool, bond).await.unwrap();
+
+            let outcome =
+                apply_payout_invoice(&pool, &bond, "lnbc1pFRESH", now, CLAIM_WINDOW_SECONDS)
+                    .await
+                    .unwrap();
+            assert_eq!(outcome, InvoiceApplyOutcome::Rejected, "state {state}");
+
+            let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+                .bind(bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            assert_eq!(after.0, state.to_string());
+        }
     }
 }

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -41,6 +41,7 @@
 //! validator uses on the way *in* applies here on the way *out*.
 
 use std::str::FromStr;
+use std::time::Duration;
 
 use chrono::Utc;
 use fedimint_tonic_lnd::lnrpc::payment::PaymentStatus;
@@ -56,6 +57,7 @@ use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
 use sqlx_crud::Crud;
 use tokio::sync::mpsc::channel;
+use tokio::time::timeout;
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
@@ -68,6 +70,15 @@ use crate::util::enqueue_order_msg;
 use super::db::find_bonds_by_state;
 use super::model::Bond;
 use super::types::{BondSlashReason, BondState};
+
+/// Per-message ceiling for the `send_payment` status stream. LND
+/// streams periodic InFlight updates while a payment is routing; if no
+/// update lands inside this window the channel is treated as dead and
+/// the attempt is routed through `on_send_payment_failure`. Picked to
+/// be longer than the typical InFlight cadence (a few seconds) but
+/// short enough to keep a single bond from blocking a scheduler task
+/// indefinitely.
+const PAYMENT_STATUS_RECV_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// One full pass over every bond in [`BondState::PendingPayout`].
 ///
@@ -174,11 +185,17 @@ async fn process_one_bond(
 }
 
 /// Compute `amount_sats - node_share_sats`, erroring if the row is
-/// missing `node_share_sats`. Phase 2's slash CAS writes the column
-/// atomically with the transition to `PendingPayout`, so a `None` here
-/// is an invariant violation that should not be defaulted to 0 —
-/// silently treating node share as 0 would pay the entire bond to the
-/// counterparty.
+/// missing `node_share_sats` or carries an out-of-range value. Phase 2's
+/// slash CAS writes the column atomically with the transition to
+/// `PendingPayout`, so a `None` here is an invariant violation that
+/// should not be defaulted to 0 — silently treating node share as 0
+/// would pay the entire bond to the counterparty. The same goes for
+/// values outside `0..=amount_sats`: a negative share would corrupt the
+/// invoice principal, and a share above the bond would imply Mostro
+/// retains more than the user locked. The config's
+/// `slash_node_share_pct` validator already rejects out-of-range
+/// fractions at startup, but we re-check here as a belt-and-braces
+/// guard against a corrupted DB row.
 fn counterparty_share_sats(bond: &Bond) -> Result<i64, MostroError> {
     let node_share = bond.node_share_sats.ok_or_else(|| {
         MostroInternalErr(ServiceError::UnexpectedError(format!(
@@ -186,6 +203,12 @@ fn counterparty_share_sats(bond: &Bond) -> Result<i64, MostroError> {
             bond.id
         )))
     })?;
+    if !(0..=bond.amount_sats).contains(&node_share) {
+        return Err(MostroInternalErr(ServiceError::UnexpectedError(format!(
+            "bond {} in PendingPayout has node_share_sats {node_share} outside [0, {}] (invariant violation)",
+            bond.id, bond.amount_sats
+        ))));
+    }
     Ok(bond.amount_sats - node_share)
 }
 
@@ -212,21 +235,39 @@ async fn forfeit_bond(
 ) -> Result<(), MostroError> {
     let preimage = preimage_or_err(bond, "forfeit")?;
     if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
-        warn!(
-            bond_id = %bond.id,
-            order_id = %bond.order_id,
-            "forfeit: settle_hold_invoice failed: {e} — will retry on next tick"
-        );
-        return Err(e);
+        if is_already_settled_error(&e) {
+            info!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "forfeit: bond HTLC already settled; proceeding to state transition"
+            );
+        } else {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "forfeit: settle_hold_invoice failed: {e} — will retry on next tick"
+            );
+            return Err(e);
+        }
     }
 
-    let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
-        .bind(BondState::Forfeited.to_string())
-        .bind(bond.id)
-        .bind(BondState::PendingPayout.to_string())
-        .execute(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    // `AND payout_invoice IS NULL` closes the race against
+    // `add_bond_invoice_action`: if the counterparty's late invoice landed
+    // between this scheduler's `bond.payout_invoice.is_none()` snapshot
+    // and the UPDATE below, we must not flip the row to `Forfeited` and
+    // silently discard their bolt11. The HTLC is already settled (above),
+    // so on the next tick `settle_and_pay` will take over — its own
+    // `settle_hold_invoice` call will short-circuit on
+    // `is_already_settled_error` and proceed to `send_payment`.
+    let result = sqlx::query(
+        "UPDATE bonds SET state = ? WHERE id = ? AND state = ? AND payout_invoice IS NULL",
+    )
+    .bind(BondState::Forfeited.to_string())
+    .bind(bond.id)
+    .bind(BondState::PendingPayout.to_string())
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
     if result.rows_affected() == 1 {
         info!(
@@ -234,6 +275,12 @@ async fn forfeit_bond(
             order_id = %bond.order_id,
             amount_sats = bond.amount_sats,
             "bond forfeited: claim window elapsed, node retains full amount"
+        );
+    } else {
+        info!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "forfeit: counterparty invoice landed concurrently; payout will continue on next tick"
         );
     }
     Ok(())
@@ -248,12 +295,20 @@ async fn settle_node_only(
 ) -> Result<(), MostroError> {
     let preimage = preimage_or_err(bond, "node-only payout")?;
     if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
-        warn!(
-            bond_id = %bond.id,
-            order_id = %bond.order_id,
-            "node-only payout: settle_hold_invoice failed: {e} — will retry on next tick"
-        );
-        return Err(e);
+        if is_already_settled_error(&e) {
+            info!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "node-only payout: bond HTLC already settled; proceeding to state transition"
+            );
+        } else {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "node-only payout: settle_hold_invoice failed: {e} — will retry on next tick"
+            );
+            return Err(e);
+        }
     }
 
     let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
@@ -458,24 +513,41 @@ async fn settle_and_pay(
     }
 
     // Collect the first terminal status from the stream. Mirrors
-    // dev_fee::send_dev_fee_payment.
+    // dev_fee::send_dev_fee_payment, but each recv is bounded by
+    // `PAYMENT_STATUS_RECV_TIMEOUT` so a wedged LND stream (no terminal
+    // update, no EOF, no InFlight churn) does not pin the scheduler
+    // task forever. A timeout and a clean EOF are both routed through
+    // `on_send_payment_failure` so the retry budget governs the
+    // recovery path uniformly.
     let mut succeeded = false;
     let mut failure: Option<String> = None;
-    while let Some(msg) = rx.recv().await {
-        if let Ok(status) = PaymentStatus::try_from(msg.payment.status) {
-            match status {
-                PaymentStatus::Succeeded => {
-                    succeeded = true;
-                    break;
+    loop {
+        match timeout(PAYMENT_STATUS_RECV_TIMEOUT, rx.recv()).await {
+            Err(_) => {
+                failure = Some(format!(
+                    "payment status stream timed out after {}s without a terminal update",
+                    PAYMENT_STATUS_RECV_TIMEOUT.as_secs()
+                ));
+                break;
+            }
+            Ok(None) => break,
+            Ok(Some(msg)) => {
+                if let Ok(status) = PaymentStatus::try_from(msg.payment.status) {
+                    match status {
+                        PaymentStatus::Succeeded => {
+                            succeeded = true;
+                            break;
+                        }
+                        PaymentStatus::Failed => {
+                            failure = Some(format!(
+                                "payment failed: reason {}",
+                                msg.payment.failure_reason
+                            ));
+                            break;
+                        }
+                        _ => {}
+                    }
                 }
-                PaymentStatus::Failed => {
-                    failure = Some(format!(
-                        "payment failed: reason {}",
-                        msg.payment.failure_reason
-                    ));
-                    break;
-                }
-                _ => {}
             }
         }
     }

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -58,7 +58,7 @@ use mostro_core::error::{
     MostroError::{self, MostroCantDo, MostroInternalErr},
     ServiceError,
 };
-use mostro_core::message::{Action, Message, Payload};
+use mostro_core::message::{Action, BondPayoutRequest, Message, Payload};
 use mostro_core::nip59::UnwrappedMessage;
 use mostro_core::order::{Order, SmallOrder};
 use nostr_sdk::prelude::*;
@@ -343,6 +343,17 @@ async fn request_payout_invoice(
     let counterparty_share = counterparty_share_sats(bond)?;
     let order_kind = order.get_order_kind().map_err(MostroInternalErr)?;
 
+    // `process_one_bond` already errored out on a missing `slashed_at`
+    // before dispatching here, but re-check rather than `.unwrap()` so
+    // the invariant holds at every emission point — every cadence retry
+    // ships the same fixed anchor.
+    let slashed_at = bond.slashed_at.ok_or_else(|| {
+        MostroInternalErr(ServiceError::UnexpectedError(format!(
+            "bond {} in PendingPayout missing slashed_at (invariant violation)",
+            bond.id
+        )))
+    })?;
+
     let small = SmallOrder::new(
         Some(order.id),
         Some(order_kind),
@@ -366,22 +377,28 @@ async fn request_payout_invoice(
         order_id = %bond.order_id,
         amount_sats = counterparty_share,
         recipient = %recipient_pubkey,
+        slashed_at,
         attempt = bond.invoice_request_attempts + 1,
         "bond payout: requesting invoice from counterparty"
     );
 
-    // The notification carries only the structured request payload. The
-    // client computes the forfeit deadline from `slashed_at` (the slash
-    // moment is observable on-chain via the audit event the dispute /
-    // timeout path publishes) plus `bond_payout_claim_window_days` from
-    // the kind-38385 info event, and presents it to the user in their own
-    // locale. Mostro intentionally ships no hardcoded human-readable
-    // text.
+    // Ship the structured `BondPayoutRequest` payload (mostro-core
+    // 0.11.3): `order.amount` carries the counterparty share and
+    // `slashed_at` is the slash anchor the client uses to render the
+    // forfeit deadline locally (`slashed_at +
+    // bond_payout_claim_window_days * 86_400`). The same anchor is
+    // re-shipped verbatim on every cadence retry, so a recipient
+    // offline for days still gets a correct deadline once their relay
+    // catches up. No human-readable text is bundled — clients render
+    // the warning in the user's own locale from these two values.
     enqueue_order_msg(
         None,
         Some(order.id),
         Action::AddBondInvoice,
-        Some(Payload::Order(small)),
+        Some(Payload::BondPayoutRequest(BondPayoutRequest {
+            order: small,
+            slashed_at,
+        })),
         recipient_pubkey,
         None,
     )

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -6,14 +6,22 @@
 //!
 //! - [`run_bond_payout_cycle`] — called once per scheduler tick. Walks
 //!   every `PendingPayout` bond and drives it forward by one step: ask
-//!   the non-slashed counterparty for a bolt11 if we haven't yet,
-//!   `settle_hold_invoice` once we have one, then `send_payment` for
-//!   the counterparty share. Settles + transitions to `Forfeited`
-//!   instead when `payout_claim_window_days` has elapsed with no
+//!   the non-slashed counterparty for a bolt11 if we haven't yet, then
+//!   `send_payment` for the counterparty share. Transitions to
+//!   `Forfeited` when `payout_claim_window_days` has elapsed with no
 //!   invoice.
 //! - [`add_bond_invoice_action`] — the action handler that consumes the
 //!   counterparty's `Action::AddBondInvoice` reply, validates it, and
 //!   persists the bolt11 onto the bond row.
+//!
+//! ## Slashed HTLC already claimed
+//!
+//! The bond hold invoice is **settled at slash time** in
+//! [`super::slash::apply_bond_resolution`], not here. By the time this
+//! module sees a `PendingPayout` row, the sats are already in Mostro's
+//! wallet — this scheduler only drives the counterparty payout
+//! (request bolt11 → `send_payment` → retries / forfeiture). Phase 3
+//! never calls `settle_hold_invoice`.
 //!
 //! ## Why a dedicated action type
 //!
@@ -117,18 +125,19 @@ pub async fn run_bond_payout_cycle(pool: &Pool<Sqlite>, ln_client: &mut LndConne
 
 /// Drive a single bond forward by one step.
 ///
-/// The state machine inside `PendingPayout` is:
+/// The bond HTLC was already settled at slash time (Phase 2 §7.3); this
+/// state machine only governs the counterparty payout leg:
 ///
 /// ```text
-///                          ┌── forfeit window elapsed AND no invoice ─► settle ─► Forfeited
+///                          ┌── forfeit window elapsed AND no invoice ──► Forfeited
 ///                          │
-///   PendingPayout ─────────┤── no invoice yet AND cadence ok ───► AddBondInvoice message
+///   PendingPayout ─────────┤── no invoice yet AND cadence ok ──► AddBondInvoice message
 ///                          │
-///                          │── invoice present (or node_share_pct=1.0) ─► settle ─► [send_payment]
-///                          │                                                              │
-///                          └──── send_payment success ─► Slashed                          │
-///                                                                                         │
-///                                            send_payment failure ─► retry (or Failed) ◄──┘
+///                          │── invoice present (or node_share_pct=1.0) ──► [send_payment]
+///                          │                                                      │
+///                          └──── send_payment success ─► Slashed                  │
+///                                                                                 │
+///                                    send_payment failure ─► retry (or Failed) ◄──┘
 /// ```
 ///
 /// Each call advances by at most one of these arms; the scheduler
@@ -160,27 +169,28 @@ async fn process_one_bond(
     })?;
 
     // Forfeit window has elapsed and counterparty never submitted a
-    // bolt11: settle the HTLC into Mostro's wallet and transition to
-    // `Forfeited`. The node retains `amount_sats` in full. No further
-    // messages or `send_payment` attempts.
+    // bolt11: transition to `Forfeited`. The HTLC was already settled
+    // at slash time, so the sats are already in Mostro's wallet — no
+    // further LND interaction, no `send_payment` attempts. The node
+    // retains `amount_sats` in full.
     if bond.payout_invoice.is_none() && now - slashed_at >= claim_window_seconds {
-        return forfeit_bond(pool, ln_client, bond).await;
+        return forfeit_bond(pool, bond).await;
     }
 
     // Normal payout: either request an invoice (counterparty leg), or
-    // settle + pay (HTLC and counterparty leg).
+    // pay the counterparty from the already-settled HTLC funds.
     let counterparty_share = counterparty_share_sats(bond)?;
 
     if counterparty_share <= 0 {
         // `slash_node_share_pct = 1.0` (or full retention) — there's no
-        // counterparty leg. Settle the HTLC and transition straight to
-        // `Slashed`. No `AddBondInvoice` message, no `send_payment`.
-        return settle_node_only(pool, ln_client, bond).await;
+        // counterparty leg. Transition straight to `Slashed`. No
+        // `AddBondInvoice` message, no `send_payment`.
+        return finalize_node_only(pool, bond).await;
     }
 
     match bond.payout_invoice.as_deref() {
         None => request_payout_invoice(pool, bond, invoice_window_seconds).await,
-        Some(invoice) => settle_and_pay(pool, ln_client, bond, invoice, max_retries).await,
+        Some(invoice) => pay_counterparty(pool, ln_client, bond, invoice, max_retries).await,
     }
 }
 
@@ -212,53 +222,17 @@ fn counterparty_share_sats(bond: &Bond) -> Result<i64, MostroError> {
     Ok(bond.amount_sats - node_share)
 }
 
-/// Return the bond's preimage, erroring if absent. A `PendingPayout`
-/// row without a preimage cannot have its HTLC settled, so the payout
-/// state machine must fail closed: not advance to `Forfeited` /
-/// `Slashed`, and not attempt `send_payment` from sats it does not yet
-/// hold. `request_taker_bond` populates the preimage at bond creation,
-/// so a `None` here is an invariant violation.
-fn preimage_or_err<'a>(bond: &'a Bond, op: &'static str) -> Result<&'a str, MostroError> {
-    bond.preimage.as_deref().ok_or_else(|| {
-        MostroInternalErr(ServiceError::UnexpectedError(format!(
-            "bond {} (order {}) in PendingPayout missing preimage — {op} cannot proceed",
-            bond.id, bond.order_id
-        )))
-    })
-}
-
-/// Settle the HTLC into Mostro's wallet and transition to `Forfeited`.
-async fn forfeit_bond(
-    pool: &Pool<Sqlite>,
-    ln_client: &mut LndConnector,
-    bond: &Bond,
-) -> Result<(), MostroError> {
-    let preimage = preimage_or_err(bond, "forfeit")?;
-    if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
-        if is_already_settled_error(&e) {
-            info!(
-                bond_id = %bond.id,
-                order_id = %bond.order_id,
-                "forfeit: bond HTLC already settled; proceeding to state transition"
-            );
-        } else {
-            warn!(
-                bond_id = %bond.id,
-                order_id = %bond.order_id,
-                "forfeit: settle_hold_invoice failed: {e} — will retry on next tick"
-            );
-            return Err(e);
-        }
-    }
-
-    // `AND payout_invoice IS NULL` closes the race against
-    // `add_bond_invoice_action`: if the counterparty's late invoice landed
-    // between this scheduler's `bond.payout_invoice.is_none()` snapshot
-    // and the UPDATE below, we must not flip the row to `Forfeited` and
-    // silently discard their bolt11. The HTLC is already settled (above),
-    // so on the next tick `settle_and_pay` will take over — its own
-    // `settle_hold_invoice` call will short-circuit on
-    // `is_already_settled_error` and proceed to `send_payment`.
+/// Transition a `PendingPayout` row to `Forfeited`.
+///
+/// The HTLC was settled at slash time, so the sats are already in
+/// Mostro's wallet; this function only flips the state. The
+/// `AND payout_invoice IS NULL` predicate closes the race against
+/// `add_bond_invoice_action`: if the counterparty's late invoice
+/// landed between this scheduler's `bond.payout_invoice.is_none()`
+/// snapshot and the UPDATE below, we must not flip the row to
+/// `Forfeited` and silently discard their bolt11 — on the next tick
+/// `pay_counterparty` will take over and route the funds.
+async fn forfeit_bond(pool: &Pool<Sqlite>, bond: &Bond) -> Result<(), MostroError> {
     let result = sqlx::query(
         "UPDATE bonds SET state = ? WHERE id = ? AND state = ? AND payout_invoice IS NULL",
     )
@@ -286,31 +260,11 @@ async fn forfeit_bond(
     Ok(())
 }
 
-/// Counterparty share is empty (`slash_node_share_pct = 1.0`): settle
-/// the HTLC and transition to `Slashed`. No messages, no `send_payment`.
-async fn settle_node_only(
-    pool: &Pool<Sqlite>,
-    ln_client: &mut LndConnector,
-    bond: &Bond,
-) -> Result<(), MostroError> {
-    let preimage = preimage_or_err(bond, "node-only payout")?;
-    if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
-        if is_already_settled_error(&e) {
-            info!(
-                bond_id = %bond.id,
-                order_id = %bond.order_id,
-                "node-only payout: bond HTLC already settled; proceeding to state transition"
-            );
-        } else {
-            warn!(
-                bond_id = %bond.id,
-                order_id = %bond.order_id,
-                "node-only payout: settle_hold_invoice failed: {e} — will retry on next tick"
-            );
-            return Err(e);
-        }
-    }
-
+/// Counterparty share is empty (`slash_node_share_pct = 1.0`): the
+/// HTLC was already settled at slash time, so there is nothing left
+/// for the scheduler to do beyond flipping the row to `Slashed`. No
+/// messages, no `send_payment`.
+async fn finalize_node_only(pool: &Pool<Sqlite>, bond: &Bond) -> Result<(), MostroError> {
     let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
         .bind(BondState::Slashed.to_string())
         .bind(bond.id)
@@ -449,11 +403,12 @@ async fn request_payout_invoice(
     Ok(())
 }
 
-/// Settle the bond HTLC into Mostro's wallet, then `send_payment` the
-/// counterparty share to the bolt11 they submitted. Order matters:
-/// settle must succeed before send_payment, otherwise we'd be paying
-/// from sats we don't yet hold.
-async fn settle_and_pay(
+/// `send_payment` the counterparty share to the bolt11 they
+/// submitted. The bond HTLC was already settled at slash time, so the
+/// sats are already in Mostro's wallet — this function only drives
+/// the counterparty leg and on success transitions the row to
+/// `Slashed`.
+async fn pay_counterparty(
     pool: &Pool<Sqlite>,
     ln_client: &mut LndConnector,
     bond: &Bond,
@@ -461,31 +416,6 @@ async fn settle_and_pay(
     max_retries: i64,
 ) -> Result<(), MostroError> {
     let counterparty_share = counterparty_share_sats(bond)?;
-
-    // Settle the bond HTLC. If settle fails, the row stays in
-    // `PendingPayout` and the scheduler retries on the next tick.
-    // The bonded user's HTLC stays held — the correct safety posture
-    // when we cannot confirm we have the sats yet.
-    let preimage = preimage_or_err(bond, "settle_and_pay")?;
-    if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
-        // Distinguish "already settled" (idempotent retry) from
-        // genuine transport failures the same way release_bond
-        // distinguishes already-canceled.
-        let already = is_already_settled_error(&e);
-        if !already {
-            warn!(
-                bond_id = %bond.id,
-                order_id = %bond.order_id,
-                "settle_and_pay: settle_hold_invoice failed: {e} — retrying on next tick"
-            );
-            return Err(e);
-        }
-        info!(
-            bond_id = %bond.id,
-            order_id = %bond.order_id,
-            "settle_and_pay: bond HTLC already settled; proceeding to send_payment"
-        );
-    }
 
     // Routing-fee ceiling: derived from MostroSettings::max_routing_fee
     // applied to the counterparty share. The spec mentions
@@ -618,17 +548,6 @@ async fn on_send_payment_failure(
         );
     }
     Ok(())
-}
-
-/// Classify an error string from `settle_hold_invoice` as a benign
-/// "already settled" outcome (idempotent retry) vs. a transport
-/// failure that warrants leaving the bond in `PendingPayout` for the
-/// next tick.
-fn is_already_settled_error(err: &MostroError) -> bool {
-    let s = err.to_string().to_lowercase();
-    s.contains("already settled")
-        || s.contains("invoice already settled")
-        || s.contains("code=alreadyexists")
 }
 
 /// Map `(order, bond, reason)` to the non-slashed counterparty's
@@ -967,42 +886,57 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forfeit_bond_sql_transition_is_cas_guarded() {
-        // `forfeit_bond` calls settle_hold_invoice (which needs an
-        // LndConnector, unavailable here) and then runs a CAS-guarded
-        // SQL transition `PendingPayout -> Forfeited`. We can't drive
-        // the LND half from a unit test, so this test exercises the
-        // SQL half directly — that's the load-bearing piece. The
-        // function itself now fails closed when preimage is missing
-        // (see `preimage_or_err`), so the equivalent end-to-end call
-        // with `preimage = None` returns an error rather than running
-        // the SQL we exercise here.
+    async fn forfeit_bond_transitions_pending_to_forfeited() {
+        // The HTLC is settled at slash time (Phase 2), so `forfeit_bond`
+        // is now a pure SQL transition with the `payout_invoice IS NULL`
+        // CAS guard. No LND dependency.
         let pool = setup_pool().await;
         let order_id = Uuid::new_v4();
         insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
         let now = Utc::now().timestamp();
-        let mut bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
-        bond.preimage = None;
-        bond.hash = None;
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
         let bond = create_bond(&pool, bond).await.unwrap();
 
-        // We can't easily call `forfeit_bond` without an LndConnector,
-        // so exercise the SQL transition path used inside it directly
-        // — this is the load-bearing piece of the forfeit branch.
-        let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
-            .bind(BondState::Forfeited.to_string())
-            .bind(bond.id)
-            .bind(BondState::PendingPayout.to_string())
-            .execute(&pool)
-            .await
-            .unwrap();
-        assert_eq!(result.rows_affected(), 1);
+        forfeit_bond(&pool, &bond).await.unwrap();
+
         let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
             .bind(bond.id)
             .fetch_one(&pool)
             .await
             .unwrap();
         assert_eq!(after.0, BondState::Forfeited.to_string());
+    }
+
+    #[tokio::test]
+    async fn forfeit_bond_skips_when_invoice_landed_concurrently() {
+        // If a late `add_bond_invoice_action` persisted a `payout_invoice`
+        // between the scheduler's snapshot and the forfeit UPDATE, the
+        // CAS predicate (`AND payout_invoice IS NULL`) must hold the row
+        // in `PendingPayout` so the next tick can route to
+        // `pay_counterparty` instead of discarding the bolt11.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            Some("lnbc1pCONCURRENT"),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        forfeit_bond(&pool, &bond).await.unwrap();
+
+        let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.0, BondState::PendingPayout.to_string());
     }
 
     #[tokio::test]
@@ -1061,16 +995,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pending_payout_no_counterparty_share_is_node_only() {
-        // `slash_node_share_pct = 1.0` style row: counterparty share
-        // is 0. `process_one_bond` must route to the node-only branch
-        // (settle_node_only) and not enqueue an AddBondInvoice. We
-        // can't easily exercise the LND call here, but we can verify
-        // the state filter on the SQL transition.
+    async fn finalize_node_only_transitions_to_slashed() {
+        // `slash_node_share_pct = 1.0` style row: counterparty share is
+        // 0. `process_one_bond` routes to `finalize_node_only`, which is
+        // now pure SQL — the HTLC was settled at slash time, so this
+        // function just flips the state.
         let pool = setup_pool().await;
         let order_id = Uuid::new_v4();
         insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
-        let mut bond = pending_payout_bond(
+        let bond = pending_payout_bond(
             order_id,
             taker_pk(),
             10_000,
@@ -1079,17 +1012,15 @@ mod tests {
             None,
             None,
         );
-        bond.preimage = None;
         let bond = create_bond(&pool, bond).await.unwrap();
 
-        // Direct CAS that node-only path issues post-settle.
-        let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
-            .bind(BondState::Slashed.to_string())
+        finalize_node_only(&pool, &bond).await.unwrap();
+
+        let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
             .bind(bond.id)
-            .bind(BondState::PendingPayout.to_string())
-            .execute(&pool)
+            .fetch_one(&pool)
             .await
             .unwrap();
-        assert_eq!(result.rows_affected(), 1);
+        assert_eq!(after.0, BondState::Slashed.to_string());
     }
 }

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -137,7 +137,16 @@ async fn process_one_bond(
     let max_retries = cfg.map(|c| c.payout_max_retries as i64).unwrap_or(5);
 
     let now = Utc::now().timestamp();
-    let slashed_at = bond.slashed_at.unwrap_or(now);
+    // Phase 2's slash CAS writes `slashed_at` atomically with the
+    // transition to `PendingPayout`. A `None` here is an invariant
+    // violation; defaulting to `now` would silently reset the forfeit
+    // anchor and could indefinitely defer the forfeit transition.
+    let slashed_at = bond.slashed_at.ok_or_else(|| {
+        MostroInternalErr(ServiceError::UnexpectedError(format!(
+            "bond {} in PendingPayout missing slashed_at (invariant violation)",
+            bond.id
+        )))
+    })?;
 
     // Forfeit window has elapsed and counterparty never submitted a
     // bolt11: settle the HTLC into Mostro's wallet and transition to
@@ -149,8 +158,7 @@ async fn process_one_bond(
 
     // Normal payout: either request an invoice (counterparty leg), or
     // settle + pay (HTLC and counterparty leg).
-    let node_share_sats = bond.node_share_sats.unwrap_or(0);
-    let counterparty_share = bond.amount_sats - node_share_sats;
+    let counterparty_share = counterparty_share_sats(bond)?;
 
     if counterparty_share <= 0 {
         // `slash_node_share_pct = 1.0` (or full retention) — there's no
@@ -167,27 +175,51 @@ async fn process_one_bond(
     }
 }
 
+/// Compute `amount_sats - node_share_sats`, erroring if the row is
+/// missing `node_share_sats`. Phase 2's slash CAS writes the column
+/// atomically with the transition to `PendingPayout`, so a `None` here
+/// is an invariant violation that should not be defaulted to 0 —
+/// silently treating node share as 0 would pay the entire bond to the
+/// counterparty.
+fn counterparty_share_sats(bond: &Bond) -> Result<i64, MostroError> {
+    let node_share = bond.node_share_sats.ok_or_else(|| {
+        MostroInternalErr(ServiceError::UnexpectedError(format!(
+            "bond {} in PendingPayout missing node_share_sats (invariant violation)",
+            bond.id
+        )))
+    })?;
+    Ok(bond.amount_sats - node_share)
+}
+
+/// Return the bond's preimage, erroring if absent. A `PendingPayout`
+/// row without a preimage cannot have its HTLC settled, so the payout
+/// state machine must fail closed: not advance to `Forfeited` /
+/// `Slashed`, and not attempt `send_payment` from sats it does not yet
+/// hold. `request_taker_bond` populates the preimage at bond creation,
+/// so a `None` here is an invariant violation.
+fn preimage_or_err<'a>(bond: &'a Bond, op: &'static str) -> Result<&'a str, MostroError> {
+    bond.preimage.as_deref().ok_or_else(|| {
+        MostroInternalErr(ServiceError::UnexpectedError(format!(
+            "bond {} (order {}) in PendingPayout missing preimage — {op} cannot proceed",
+            bond.id, bond.order_id
+        )))
+    })
+}
+
 /// Settle the HTLC into Mostro's wallet and transition to `Forfeited`.
 async fn forfeit_bond(
     pool: &Pool<Sqlite>,
     ln_client: &mut LndConnector,
     bond: &Bond,
 ) -> Result<(), MostroError> {
-    if let Some(preimage) = bond.preimage.as_deref() {
-        if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
-            warn!(
-                bond_id = %bond.id,
-                order_id = %bond.order_id,
-                "forfeit: settle_hold_invoice failed: {e} — will retry on next tick"
-            );
-            return Err(e);
-        }
-    } else {
+    let preimage = preimage_or_err(bond, "forfeit")?;
+    if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
         warn!(
             bond_id = %bond.id,
             order_id = %bond.order_id,
-            "forfeit: bond has no preimage; transitioning to Forfeited without LND settle"
+            "forfeit: settle_hold_invoice failed: {e} — will retry on next tick"
         );
+        return Err(e);
     }
 
     let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
@@ -216,21 +248,14 @@ async fn settle_node_only(
     ln_client: &mut LndConnector,
     bond: &Bond,
 ) -> Result<(), MostroError> {
-    if let Some(preimage) = bond.preimage.as_deref() {
-        if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
-            warn!(
-                bond_id = %bond.id,
-                order_id = %bond.order_id,
-                "node-only payout: settle_hold_invoice failed: {e} — will retry on next tick"
-            );
-            return Err(e);
-        }
-    } else {
+    let preimage = preimage_or_err(bond, "node-only payout")?;
+    if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
         warn!(
             bond_id = %bond.id,
             order_id = %bond.order_id,
-            "node-only payout: bond has no preimage; transitioning to Slashed without LND settle"
+            "node-only payout: settle_hold_invoice failed: {e} — will retry on next tick"
         );
+        return Err(e);
     }
 
     let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
@@ -309,7 +334,7 @@ async fn request_payout_invoice(
         }
     };
 
-    let counterparty_share = bond.amount_sats - bond.node_share_sats.unwrap_or(0);
+    let counterparty_share = counterparty_share_sats(bond)?;
     let order_kind = order.get_order_kind().map_err(MostroInternalErr)?;
 
     let small = SmallOrder::new(
@@ -330,7 +355,18 @@ async fn request_payout_invoice(
         None,
     );
 
-    let deadline_unix = bond.slashed_at.unwrap_or(now) + claim_window_seconds;
+    // `process_one_bond` already errored out on a missing `slashed_at`
+    // before dispatching here, but route the absence through an error
+    // path rather than defaulting to `now` so the invariant holds end
+    // to end and we never DM a deadline computed from a synthetic
+    // anchor.
+    let slashed_at = bond.slashed_at.ok_or_else(|| {
+        MostroInternalErr(ServiceError::UnexpectedError(format!(
+            "bond {} in PendingPayout missing slashed_at (invariant violation)",
+            bond.id
+        )))
+    })?;
+    let deadline_unix = slashed_at + claim_window_seconds;
     let deadline = chrono::DateTime::<Utc>::from_timestamp(deadline_unix, 0)
         .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
         .unwrap_or_else(|| deadline_unix.to_string());
@@ -398,37 +434,30 @@ async fn settle_and_pay(
     invoice: &str,
     max_retries: i64,
 ) -> Result<(), MostroError> {
-    let counterparty_share = bond.amount_sats - bond.node_share_sats.unwrap_or(0);
+    let counterparty_share = counterparty_share_sats(bond)?;
 
     // Settle the bond HTLC. If settle fails, the row stays in
     // `PendingPayout` and the scheduler retries on the next tick.
     // The bonded user's HTLC stays held — the correct safety posture
     // when we cannot confirm we have the sats yet.
-    if let Some(preimage) = bond.preimage.as_deref() {
-        if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
-            // Distinguish "already settled" (idempotent retry) from
-            // genuine transport failures the same way release_bond
-            // distinguishes already-canceled.
-            let already = is_already_settled_error(&e);
-            if !already {
-                warn!(
-                    bond_id = %bond.id,
-                    order_id = %bond.order_id,
-                    "settle_and_pay: settle_hold_invoice failed: {e} — retrying on next tick"
-                );
-                return Err(e);
-            }
-            info!(
+    let preimage = preimage_or_err(bond, "settle_and_pay")?;
+    if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
+        // Distinguish "already settled" (idempotent retry) from
+        // genuine transport failures the same way release_bond
+        // distinguishes already-canceled.
+        let already = is_already_settled_error(&e);
+        if !already {
+            warn!(
                 bond_id = %bond.id,
                 order_id = %bond.order_id,
-                "settle_and_pay: bond HTLC already settled; proceeding to send_payment"
+                "settle_and_pay: settle_hold_invoice failed: {e} — retrying on next tick"
             );
+            return Err(e);
         }
-    } else {
-        warn!(
+        info!(
             bond_id = %bond.id,
             order_id = %bond.order_id,
-            "settle_and_pay: bond has no preimage; cannot settle HTLC"
+            "settle_and_pay: bond HTLC already settled; proceeding to send_payment"
         );
     }
 
@@ -630,7 +659,7 @@ pub async fn add_bond_invoice_action(
         }
     };
 
-    let counterparty_share = bond.amount_sats - bond.node_share_sats.unwrap_or(0);
+    let counterparty_share = counterparty_share_sats(&bond)?;
     if counterparty_share <= 0 {
         // `slash_node_share_pct = 1.0` — there is no counterparty
         // share to pay out. Reject so the user isn't left waiting on
@@ -897,14 +926,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn forfeit_bond_transitions_to_forfeited_without_preimage() {
-        // The forfeit path normally calls settle_hold_invoice. In the
-        // unit-test harness there's no LND, so we exercise the
-        // `preimage = None` branch which skips the LND call and just
-        // marks the row Forfeited. Real-world bonds always have a
-        // preimage (set by `request_taker_bond`), but the no-preimage
-        // branch is the documented behaviour for rows that never
-        // received an HTLC.
+    async fn forfeit_bond_sql_transition_is_cas_guarded() {
+        // `forfeit_bond` calls settle_hold_invoice (which needs an
+        // LndConnector, unavailable here) and then runs a CAS-guarded
+        // SQL transition `PendingPayout -> Forfeited`. We can't drive
+        // the LND half from a unit test, so this test exercises the
+        // SQL half directly — that's the load-bearing piece. The
+        // function itself now fails closed when preimage is missing
+        // (see `preimage_or_err`), so the equivalent end-to-end call
+        // with `preimage = None` returns an error rather than running
+        // the SQL we exercise here.
         let pool = setup_pool().await;
         let order_id = Uuid::new_v4();
         insert_order(&pool, order_id, maker_pk(), taker_pk()).await;

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -111,7 +111,7 @@ pub async fn run_bond_payout_cycle(pool: &Pool<Sqlite>, ln_client: &mut LndConne
 /// ```text
 ///                          ┌── forfeit window elapsed AND no invoice ─► settle ─► Forfeited
 ///                          │
-///   PendingPayout ─────────┤── no invoice yet AND cadence ok ───► AddBondInvoice DM
+///   PendingPayout ─────────┤── no invoice yet AND cadence ok ───► AddBondInvoice message
 ///                          │
 ///                          │── invoice present (or node_share_pct=1.0) ─► settle ─► [send_payment]
 ///                          │                                                              │
@@ -151,7 +151,7 @@ async fn process_one_bond(
     // Forfeit window has elapsed and counterparty never submitted a
     // bolt11: settle the HTLC into Mostro's wallet and transition to
     // `Forfeited`. The node retains `amount_sats` in full. No further
-    // DMs or `send_payment` attempts.
+    // messages or `send_payment` attempts.
     if bond.payout_invoice.is_none() && now - slashed_at >= claim_window_seconds {
         return forfeit_bond(pool, ln_client, bond).await;
     }
@@ -163,14 +163,12 @@ async fn process_one_bond(
     if counterparty_share <= 0 {
         // `slash_node_share_pct = 1.0` (or full retention) — there's no
         // counterparty leg. Settle the HTLC and transition straight to
-        // `Slashed`. No `AddBondInvoice` DM, no `send_payment`.
+        // `Slashed`. No `AddBondInvoice` message, no `send_payment`.
         return settle_node_only(pool, ln_client, bond).await;
     }
 
     match bond.payout_invoice.as_deref() {
-        None => {
-            request_payout_invoice(pool, bond, invoice_window_seconds, claim_window_seconds).await
-        }
+        None => request_payout_invoice(pool, bond, invoice_window_seconds).await,
         Some(invoice) => settle_and_pay(pool, ln_client, bond, invoice, max_retries).await,
     }
 }
@@ -242,7 +240,7 @@ async fn forfeit_bond(
 }
 
 /// Counterparty share is empty (`slash_node_share_pct = 1.0`): settle
-/// the HTLC and transition to `Slashed`. No DMs, no `send_payment`.
+/// the HTLC and transition to `Slashed`. No messages, no `send_payment`.
 async fn settle_node_only(
     pool: &Pool<Sqlite>,
     ln_client: &mut LndConnector,
@@ -282,12 +280,11 @@ async fn settle_node_only(
 /// within `payout_invoice_window_seconds`. Bumps
 /// `invoice_request_attempts` and `last_invoice_request_at` only — the
 /// retry budget (`payout_max_retries`) is for `send_payment` failures
-/// once an invoice is in hand, not for invoice-request DMs.
+/// once an invoice is in hand, not for invoice-request messages.
 async fn request_payout_invoice(
     pool: &Pool<Sqlite>,
     bond: &Bond,
     invoice_window_seconds: i64,
-    claim_window_seconds: i64,
 ) -> Result<(), MostroError> {
     let now = Utc::now().timestamp();
     if let Some(last) = bond.last_invoice_request_at {
@@ -355,53 +352,27 @@ async fn request_payout_invoice(
         None,
     );
 
-    // `process_one_bond` already errored out on a missing `slashed_at`
-    // before dispatching here, but route the absence through an error
-    // path rather than defaulting to `now` so the invariant holds end
-    // to end and we never DM a deadline computed from a synthetic
-    // anchor.
-    let slashed_at = bond.slashed_at.ok_or_else(|| {
-        MostroInternalErr(ServiceError::UnexpectedError(format!(
-            "bond {} in PendingPayout missing slashed_at (invariant violation)",
-            bond.id
-        )))
-    })?;
-    let deadline_unix = slashed_at + claim_window_seconds;
-    let deadline = chrono::DateTime::<Utc>::from_timestamp(deadline_unix, 0)
-        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
-        .unwrap_or_else(|| deadline_unix.to_string());
-
     info!(
         bond_id = %bond.id,
         order_id = %bond.order_id,
         amount_sats = counterparty_share,
         recipient = %recipient_pubkey,
-        deadline = %deadline,
         attempt = bond.invoice_request_attempts + 1,
         "bond payout: requesting invoice from counterparty"
     );
 
-    // The notification carries the request payload. The deadline is
-    // shipped as a separate `SendDm` text message so the user sees a
-    // human-readable claim window alongside the structured request.
+    // The notification carries only the structured request payload. The
+    // client computes the forfeit deadline from `slashed_at` (the slash
+    // moment is observable on-chain via the audit event the dispute /
+    // timeout path publishes) plus `bond_payout_claim_window_days` from
+    // the kind-38385 info event, and presents it to the user in their own
+    // locale. Mostro intentionally ships no hardcoded human-readable
+    // text.
     enqueue_order_msg(
         None,
         Some(order.id),
         Action::AddBondInvoice,
         Some(Payload::Order(small)),
-        recipient_pubkey,
-        None,
-    )
-    .await;
-
-    let deadline_msg = format!(
-        "Bond payout pending. Submit a Lightning invoice for {counterparty_share} sats via add-bond-invoice before {deadline} or your share will be forfeited."
-    );
-    enqueue_order_msg(
-        None,
-        Some(order.id),
-        Action::SendDm,
-        Some(Payload::TextMessage(deadline_msg)),
         recipient_pubkey,
         None,
     )
@@ -535,7 +506,7 @@ async fn settle_and_pay(
 
 /// Bump `payout_attempts`; on `payout_max_retries` reached, transition
 /// the bond to `Failed`. This counter only increments on real
-/// `send_payment` failures, not on invoice-request DMs.
+/// `send_payment` failures, not on invoice-request messages.
 async fn on_send_payment_failure(
     pool: &Pool<Sqlite>,
     bond: &Bond,
@@ -908,9 +879,7 @@ mod tests {
         );
         let bond = create_bond(&pool, bond).await.unwrap();
 
-        request_payout_invoice(&pool, &bond, 300, 86_400)
-            .await
-            .unwrap();
+        request_payout_invoice(&pool, &bond, 300).await.unwrap();
 
         let row: (i64, Option<i64>) = sqlx::query_as(
             "SELECT invoice_request_attempts, last_invoice_request_at FROM bonds WHERE id = ?",

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -71,9 +71,9 @@ use uuid::Uuid;
 
 use crate::app::context::AppContext;
 use crate::config::settings::Settings;
-use crate::lightning::invoice::is_valid_invoice;
+use crate::lightning::invoice::{decode_invoice, is_valid_invoice};
 use crate::lightning::LndConnector;
-use crate::util::enqueue_order_msg;
+use crate::util::{bytes_to_string, enqueue_order_msg};
 
 use super::db::find_bonds_by_state;
 use super::model::Bond;
@@ -442,11 +442,51 @@ async fn request_payout_invoice(
     Ok(())
 }
 
+/// Maximum number of times the success-path `state = Slashed` CAS will
+/// retry on a transient sqlx error before giving up. The payment has
+/// already been delivered by the time this CAS runs, so we want a few
+/// retries to absorb a brief DB blip — but the persisted
+/// `payout_payment_hash` makes the operation idempotent, so it is safe
+/// to bail out and let the next scheduler tick reconcile via LND.
+const SLASH_CAS_MAX_ATTEMPTS: u32 = 5;
+
 /// `send_payment` the counterparty share to the bolt11 they
 /// submitted. The bond HTLC was already settled at slash time, so the
 /// sats are already in Mostro's wallet — this function only drives
 /// the counterparty leg and on success transitions the row to
 /// `Slashed`.
+///
+/// ## Idempotency
+///
+/// `send_payment` and the follow-up `state = 'slashed'` CAS are *not*
+/// atomic, and the success path is the dangerous one: a payment that
+/// reaches LND but whose CAS fails (transient sqlx error, process
+/// crash) would leave the row in `PendingPayout` while the sats are
+/// already in flight. The next scheduler tick would re-enter here,
+/// LND would reject the duplicate `send_payment` against an already-paid
+/// invoice, `on_send_payment_failure` would burn the retry budget, and
+/// in the worst case the row would flip to `Failed` despite a
+/// successful delivery.
+///
+/// Defense (in order of execution):
+///
+/// 1. **Reconcile on entry.** If a `payout_payment_hash` is already
+///    persisted on the row *and* it matches the current invoice's
+///    hash, ask LND `track_payment_v2` what it knows. `Succeeded` →
+///    skip the send and CAS straight to `Slashed`. `Failed` → route
+///    through `on_send_payment_failure`. `InFlight` → defer to the
+///    next tick. `Unknown`/`NotFound`/transport error → fall through
+///    to a fresh send (LND will reject re-pay via its own checks).
+/// 2. **Persist hash before send.** The routing-fee ceiling and the
+///    payment_hash are written in a single CAS guarded on
+///    `state = 'pending-payout'`. If the row has moved (e.g.,
+///    concurrent `forfeit_bond`), the CAS misses zero rows and we
+///    abort the send. If the CAS succeeds, every subsequent entry
+///    will see the hash and use the reconciliation path.
+/// 3. **Bounded retry on the success CAS.** Up to
+///    [`SLASH_CAS_MAX_ATTEMPTS`] attempts with short backoff. If they
+///    all fail, the persisted hash means the next tick will reconcile
+///    cleanly; we surface the error loudly so operators see it.
 async fn pay_counterparty(
     pool: &Pool<Sqlite>,
     ln_client: &mut LndConnector,
@@ -456,20 +496,111 @@ async fn pay_counterparty(
 ) -> Result<(), MostroError> {
     let counterparty_share = counterparty_share_sats(bond)?;
 
-    // Routing-fee ceiling: derived from MostroSettings::max_routing_fee
-    // applied to the counterparty share. The spec mentions
-    // `query_routes` as a finer estimate, but `send_payment` already
-    // accepts a `fee_limit_sat` and the existing helper computes that.
-    // We record what we used into `payout_routing_fee_sats` so
-    // operators can read the cap from logs.
+    // Decode the invoice so we can derive the BOLT11 `payment_hash`.
+    // `add_bond_invoice_action::is_valid_invoice` already accepted this
+    // bolt11; a decode failure here is an invariant violation, so we
+    // route it through `on_send_payment_failure` rather than panic.
+    let decoded = match decode_invoice(invoice) {
+        Ok(d) => d,
+        Err(e) => {
+            return on_send_payment_failure(
+                pool,
+                bond,
+                max_retries,
+                &format!("payout invoice decode failed: {e}"),
+            )
+            .await;
+        }
+    };
+    // `Bolt11Invoice::payment_hash` returns `&sha256::Hash`; the
+    // underlying `bitcoin_hashes::sha256::Hash` is `AsRef<[u8]>` so we
+    // can take a slice without pulling in the `Hash` trait.
+    let payment_hash_ref: &[u8] = decoded.payment_hash().as_ref();
+    let payment_hash_hex = bytes_to_string(payment_hash_ref);
+
+    // Step 1 — reconcile on entry. Only meaningful when a hash was
+    // previously persisted *and* it matches the current invoice; the
+    // mismatch case happens when the counterparty rotated their
+    // invoice via `apply_payout_invoice` (resurrection), in which the
+    // old hash is irrelevant.
+    if let Some(persisted_hash) = bond.payout_payment_hash.as_deref() {
+        if persisted_hash == payment_hash_hex {
+            match ln_client.lookup_payment_status(payment_hash_ref).await {
+                Ok(Some(PaymentStatus::Succeeded)) => {
+                    info!(
+                        bond_id = %bond.id,
+                        order_id = %bond.order_id,
+                        "bond payout: reconciled — LND already paid this invoice; finalizing Slashed without re-sending"
+                    );
+                    return slash_after_success(pool, bond, counterparty_share).await;
+                }
+                Ok(Some(PaymentStatus::Failed)) => {
+                    return on_send_payment_failure(
+                        pool,
+                        bond,
+                        max_retries,
+                        "tracked payment reported Failed on reconciliation",
+                    )
+                    .await;
+                }
+                Ok(Some(PaymentStatus::InFlight)) => {
+                    info!(
+                        bond_id = %bond.id,
+                        order_id = %bond.order_id,
+                        "bond payout: prior send_payment still in flight; deferring to next tick"
+                    );
+                    return Ok(());
+                }
+                Ok(Some(PaymentStatus::Unknown)) | Ok(None) => {
+                    // LND has no record (pruned, or the prior send
+                    // never reached it). Safe to attempt a fresh send;
+                    // `send_payment`'s own pre-send check will reject
+                    // any payment LND does already know about.
+                }
+                Err(e) => {
+                    warn!(
+                        bond_id = %bond.id,
+                        order_id = %bond.order_id,
+                        "bond payout: reconciliation lookup failed ({e}); falling through to fresh send"
+                    );
+                }
+            }
+        }
+    }
+
+    // Step 2 — persist routing-fee cap + payment_hash *before*
+    // `send_payment`. The CAS is the idempotency anchor: from this
+    // point on, every re-entry into this function for this bond will
+    // take the reconciliation branch above instead of issuing a
+    // duplicate send.
     let max_routing_fee = Settings::get_mostro().max_routing_fee;
     let routing_fee_cap = ((counterparty_share as f64) * max_routing_fee).ceil() as i64;
-    let _ = sqlx::query("UPDATE bonds SET payout_routing_fee_sats = ? WHERE id = ? AND state = ?")
-        .bind(routing_fee_cap)
-        .bind(bond.id)
-        .bind(BondState::PendingPayout.to_string())
-        .execute(pool)
-        .await;
+    let persisted = sqlx::query(
+        "UPDATE bonds \
+           SET payout_routing_fee_sats = ?, payout_payment_hash = ? \
+         WHERE id = ? AND state = ?",
+    )
+    .bind(routing_fee_cap)
+    .bind(&payment_hash_hex)
+    .bind(bond.id)
+    .bind(BondState::PendingPayout.to_string())
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if persisted.rows_affected() == 0 {
+        // The row moved off `PendingPayout` between the scheduler's
+        // snapshot and this CAS (e.g., concurrent forfeit, manual
+        // operator intervention). Skip the send so we never deliver
+        // sats against a stale state. The next tick — if any — will
+        // re-evaluate.
+        info!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "bond payout: row no longer PendingPayout at hash-persist CAS; skipping send_payment"
+        );
+        return Ok(());
+    }
 
     // send_payment. The helper internally caps the fee at
     // `counterparty_share * max_routing_fee`.
@@ -522,27 +653,78 @@ async fn pay_counterparty(
     }
 
     if succeeded {
-        let result = sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
+        return slash_after_success(pool, bond, counterparty_share).await;
+    }
+
+    let msg = failure.unwrap_or_else(|| "payment stream ended without terminal status".to_string());
+    on_send_payment_failure(pool, bond, max_retries, &msg).await
+}
+
+/// Flip a `PendingPayout` row to `Slashed` after a confirmed payment.
+///
+/// Bounded retry: the payment has already been delivered, so a residual
+/// DB blip should not leave the row stuck in `PendingPayout` if we can
+/// help it. After [`SLASH_CAS_MAX_ATTEMPTS`] failed attempts we bail out
+/// with `Err`; the persisted `payout_payment_hash` guarantees the next
+/// scheduler tick will reconcile via LND and re-attempt this CAS rather
+/// than re-issuing `send_payment`.
+async fn slash_after_success(
+    pool: &Pool<Sqlite>,
+    bond: &Bond,
+    counterparty_share: i64,
+) -> Result<(), MostroError> {
+    let mut last_err: Option<String> = None;
+    for attempt in 0..SLASH_CAS_MAX_ATTEMPTS {
+        if attempt > 0 {
+            // 50ms, 100ms, 200ms, 400ms — short enough to keep the
+            // scheduler tick brisk, long enough to give sqlite a chance
+            // to clear a BUSY lock.
+            let backoff_ms = 50u64 << (attempt - 1);
+            tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+        }
+        match sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
             .bind(BondState::Slashed.to_string())
             .bind(bond.id)
             .bind(BondState::PendingPayout.to_string())
             .execute(pool)
             .await
-            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-        if result.rows_affected() == 1 {
-            info!(
-                bond_id = %bond.id,
-                order_id = %bond.order_id,
-                amount_sats = bond.amount_sats,
-                counterparty_share_sats = counterparty_share,
-                "bond payout: send_payment succeeded; bond transitioned to Slashed"
-            );
+        {
+            Ok(result) => {
+                if result.rows_affected() == 1 {
+                    info!(
+                        bond_id = %bond.id,
+                        order_id = %bond.order_id,
+                        amount_sats = bond.amount_sats,
+                        counterparty_share_sats = counterparty_share,
+                        "bond payout: send_payment succeeded; bond transitioned to Slashed"
+                    );
+                } else {
+                    // The row moved off `PendingPayout` between the
+                    // send_payment and this CAS — only legitimate path
+                    // is a parallel reconciliation already promoted the
+                    // row to `Slashed`. Log at info and treat as
+                    // success.
+                    info!(
+                        bond_id = %bond.id,
+                        order_id = %bond.order_id,
+                        "bond payout: Slashed CAS missed (concurrent transition); treating as already-finalized"
+                    );
+                }
+                return Ok(());
+            }
+            Err(e) => last_err = Some(e.to_string()),
         }
-        return Ok(());
     }
-
-    let msg = failure.unwrap_or_else(|| "payment stream ended without terminal status".to_string());
-    on_send_payment_failure(pool, bond, max_retries, &msg).await
+    let cause = last_err.unwrap_or_else(|| "<no underlying error captured>".to_string());
+    error!(
+        bond_id = %bond.id,
+        order_id = %bond.order_id,
+        counterparty_share_sats = counterparty_share,
+        attempts = SLASH_CAS_MAX_ATTEMPTS,
+        "bond payout: send_payment SUCCEEDED but state=Slashed CAS failed after retries — \
+         next tick will reconcile via persisted payout_payment_hash. last db error: {cause}"
+    );
+    Err(MostroInternalErr(ServiceError::DbAccessError(cause)))
 }
 
 /// Bump `payout_attempts`; on `payout_max_retries` reached, transition
@@ -826,12 +1008,26 @@ async fn apply_payout_invoice(
             // `PendingPayout` (Failed is invisible to it), and the
             // row reads consistent on the next tick because we set
             // state + invoice + counters in the same UPDATE.
+            //
+            // `payout_payment_hash` is also cleared: a row in `Failed`
+            // carries the hash of the *previous* invoice's failed
+            // payment attempts, and on the next scheduler tick
+            // `pay_counterparty` would otherwise compare that stale
+            // hash against the freshly-submitted invoice's hash and
+            // skip the reconciliation branch. The comparison would
+            // mismatch and fall through correctly, but clearing the
+            // column here makes the invariant explicit ("a hash on the
+            // row always refers to the *current* `payout_invoice`")
+            // and gives defense-in-depth against any future code path
+            // that reads the hash without re-validating it against the
+            // invoice.
             let result = sqlx::query(
                 "UPDATE bonds \
                    SET state = ?, \
                        payout_invoice = ?, \
                        payout_attempts = 0, \
-                       invoice_request_attempts = 0 \
+                       invoice_request_attempts = 0, \
+                       payout_payment_hash = NULL \
                  WHERE id = ? AND state = ?",
             )
             .bind(BondState::PendingPayout.to_string())
@@ -957,6 +1153,12 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bonds migration");
+        sqlx::query(include_str!(
+            "../../../migrations/20260518120000_bond_payout_payment_hash.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bond_payout_payment_hash migration");
         pool
     }
 
@@ -1690,5 +1892,142 @@ mod tests {
                 .unwrap();
             assert_eq!(after.0, state.to_string());
         }
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_resurrection_clears_payout_payment_hash() {
+        // Failed → PendingPayout resurrection must NULL out the
+        // `payout_payment_hash` column so the reconciliation branch in
+        // `pay_counterparty` doesn't compare a fresh invoice against the
+        // hash of a prior (failed) attempt's send. The defensive
+        // invoice/hash-mismatch check in `pay_counterparty` would catch
+        // it even if the hash leaked through, but the invariant we want
+        // to hold across the codebase is "a non-NULL
+        // `payout_payment_hash` always refers to the *current*
+        // `payout_invoice`".
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            Some("lnbc1pOLD"),
+            None,
+        );
+        bond.state = BondState::Failed.to_string();
+        bond.payout_attempts = 5;
+        bond.payout_payment_hash = Some("a".repeat(64));
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pFRESH", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Resurrected);
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.state, BondState::PendingPayout.to_string());
+        assert_eq!(after.payout_invoice.as_deref(), Some("lnbc1pFRESH"));
+        assert!(
+            after.payout_payment_hash.is_none(),
+            "resurrection must clear stale payout_payment_hash, got {:?}",
+            after.payout_payment_hash
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_payout_invoice_persists_leaves_payout_payment_hash_untouched() {
+        // First-time invoice submission on a PendingPayout row with no
+        // hash yet: the helper only writes `payout_invoice` and the
+        // attempt counter — the hash column stays NULL and is filled
+        // later by `pay_counterparty`'s pre-send CAS.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pFRESH", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Persisted);
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(after.payout_payment_hash.is_none());
+    }
+
+    #[tokio::test]
+    async fn slash_after_success_transitions_pending_to_slashed() {
+        // Happy path for the post-`send_payment` CAS helper.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some("lnbc1pPAID"),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        slash_after_success(&pool, &bond, 5_000).await.unwrap();
+
+        let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.0, BondState::Slashed.to_string());
+    }
+
+    #[tokio::test]
+    async fn slash_after_success_is_idempotent_when_already_slashed() {
+        // If the row has already advanced past PendingPayout — e.g., a
+        // concurrent reconciliation tick beat us to the CAS — the
+        // helper must NOT return Err and must NOT mutate state. The
+        // row's terminal state stays as it was.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some("lnbc1pPAID"),
+            None,
+        );
+        bond.state = BondState::Slashed.to_string();
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        // Caller still holds a snapshot showing PendingPayout in the
+        // Rust struct; the CAS misses in SQL and the helper logs +
+        // returns Ok.
+        let mut snapshot = bond.clone();
+        snapshot.state = BondState::PendingPayout.to_string();
+        slash_after_success(&pool, &snapshot, 5_000).await.unwrap();
+
+        let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.0, BondState::Slashed.to_string());
     }
 }

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -685,7 +685,7 @@ pub async fn add_bond_invoice_action(
         bond_id = %bond.id,
         order_id = %bond.order_id,
         sender = %sender,
-        "bond payout: invoice accepted; awaiting scheduler tick for settle+pay"
+        "bond payout: invoice accepted; awaiting scheduler tick for payout"
     );
 
     Ok(())

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -372,6 +372,41 @@ async fn request_payout_invoice(
         None,
     );
 
+    // Persist the cadence bump *before* enqueuing the outbound
+    // message. Order matters: `enqueue_order_msg` mutates an
+    // in-process queue that the Nostr publisher flushes
+    // asynchronously, so if we enqueued first and then crashed (or
+    // the UPDATE itself failed) the durable state would still read
+    // "no nudge sent" while the recipient (or relays, after flush)
+    // may already have seen one — the next scheduler tick would then
+    // emit a duplicate `Action::AddBondInvoice`. Persisting first
+    // makes the DB the source of truth: in the worst case (crash
+    // between UPDATE and enqueue) the recipient misses *this* nudge
+    // and is re-prompted on the next tick after
+    // `invoice_window_seconds` elapses — never double-prompted.
+    //
+    // The `state = 'pending-payout'` predicate also guards against
+    // the row having moved out from under us (Forfeited, Slashed, or
+    // via the Phase-3 resurrection path). If the UPDATE matches zero
+    // rows, abort entirely instead of nudging a bond we can no
+    // longer route against.
+    let result = sqlx::query(
+        "UPDATE bonds \
+           SET invoice_request_attempts = invoice_request_attempts + 1, \
+               last_invoice_request_at = ? \
+         WHERE id = ? AND state = ?",
+    )
+    .bind(now)
+    .bind(bond.id)
+    .bind(BondState::PendingPayout.to_string())
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    if result.rows_affected() == 0 {
+        return Ok(());
+    }
+
     info!(
         bond_id = %bond.id,
         order_id = %bond.order_id,
@@ -403,19 +438,6 @@ async fn request_payout_invoice(
         None,
     )
     .await;
-
-    sqlx::query(
-        "UPDATE bonds \
-           SET invoice_request_attempts = invoice_request_attempts + 1, \
-               last_invoice_request_at = ? \
-         WHERE id = ? AND state = ?",
-    )
-    .bind(now)
-    .bind(bond.id)
-    .bind(BondState::PendingPayout.to_string())
-    .execute(pool)
-    .await
-    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
     Ok(())
 }
@@ -1056,6 +1078,107 @@ mod tests {
         // untouched.
         assert_eq!(row.0, 0);
         assert_eq!(row.1, Some(now - 10));
+    }
+
+    /// Count queued `Action::AddBondInvoice` messages targeting
+    /// `order_id`. Used to verify enqueue ordering against the
+    /// global `MESSAGE_QUEUES` without conflicting with concurrent
+    /// tests — each test's `order_id` is a fresh `Uuid::new_v4()`
+    /// so filtering by it makes the count deterministic.
+    async fn count_add_bond_invoice_msgs(order_id: Uuid) -> usize {
+        use crate::config::MESSAGE_QUEUES;
+        MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(m, _)| {
+                let kind = m.get_inner_message_kind();
+                kind.id == Some(order_id) && kind.action == Action::AddBondInvoice
+            })
+            .count()
+    }
+
+    #[tokio::test]
+    async fn request_payout_invoice_persists_before_enqueue_happy_path() {
+        // Happy path: a PendingPayout bond with no prior request lands
+        // in the UPDATE branch. The UPDATE bumps the counter and
+        // timestamp atomically *before* the enqueue, and the enqueue
+        // then publishes exactly one `Action::AddBondInvoice` message
+        // to the recipient. Both halves must be observable post-call.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let before = count_add_bond_invoice_msgs(order_id).await;
+        request_payout_invoice(&pool, &bond, 300).await.unwrap();
+        let after = count_add_bond_invoice_msgs(order_id).await;
+
+        // Durable state advanced.
+        let row: (i64, Option<i64>) = sqlx::query_as(
+            "SELECT invoice_request_attempts, last_invoice_request_at FROM bonds WHERE id = ?",
+        )
+        .bind(bond.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1);
+        assert!(row.1.is_some_and(|t| t >= now));
+
+        // Exactly one outbound message for this order_id.
+        assert_eq!(after - before, 1);
+    }
+
+    #[tokio::test]
+    async fn request_payout_invoice_skips_enqueue_when_state_moved_off_pending_payout() {
+        // Persist-first guarantee: if the row's state moved out of
+        // `PendingPayout` between the scheduler snapshot and the
+        // CAS UPDATE (Forfeited, Failed via the resurrection path,
+        // Slashed, etc.), the `WHERE state = 'pending-payout'`
+        // predicate yields `rows_affected = 0` and we must abort
+        // *without* enqueuing. Otherwise the recipient would get a
+        // nudge for a bond we cannot route against, and the cadence
+        // bookkeeping would stay out of sync with what was sent.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        // Snapshot says PendingPayout — the in-memory `bond` we'll
+        // pass to the function carries that state.
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
+        let bond = create_bond(&pool, bond).await.unwrap();
+        // Simulate the row having moved on under us: flip it to
+        // Forfeited in the DB *after* the scheduler's snapshot
+        // captured it as PendingPayout.
+        sqlx::query("UPDATE bonds SET state = ? WHERE id = ?")
+            .bind(BondState::Forfeited.to_string())
+            .bind(bond.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let before = count_add_bond_invoice_msgs(order_id).await;
+        request_payout_invoice(&pool, &bond, 300).await.unwrap();
+        let after = count_add_bond_invoice_msgs(order_id).await;
+
+        // Durable state unchanged (CAS rejected by state predicate).
+        let row: (i64, Option<i64>) = sqlx::query_as(
+            "SELECT invoice_request_attempts, last_invoice_request_at FROM bonds WHERE id = ?",
+        )
+        .bind(bond.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 0);
+        assert_eq!(row.1, None);
+
+        // Crucially: no message was enqueued. This is what
+        // persist-first guarantees — the UPDATE failure short-circuits
+        // before the enqueue.
+        assert_eq!(after, before);
     }
 
     #[tokio::test]

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -442,6 +442,12 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bonds migration");
+        sqlx::query(include_str!(
+            "../../../migrations/20260518120000_bond_payout_payment_hash.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bond_payout_payment_hash migration");
         pool
     }
 

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -574,7 +574,7 @@ mod tests {
                 .unwrap();
         assert_eq!(first.0, BondState::PendingPayout.to_string());
 
-        // Pretend a duplicate admin DM arrived a second later.
+        // Pretend a duplicate admin message arrived a second later.
         std::thread::sleep(std::time::Duration::from_secs(1));
         apply_bond_resolution(&pool, &order, &res, BondSlashReason::LostDispute)
             .await

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -3,16 +3,20 @@
 //! Translates a [`BondResolution`] payload carried by `Action::AdminSettle`
 //! / `Action::AdminCancel` into concrete bond transitions:
 //!
-//! - **Slashed sides** move from `Locked` → `PendingPayout`, with
-//!   `slashed_reason`, `slashed_at`, and `node_share_sats` snapshotted in
-//!   the same `UPDATE` so a later config change or daemon restart cannot
-//!   rebalance the split.
+//! - **Slashed sides** have their hold invoice **immediately settled**
+//!   (`settle_hold_invoice(preimage)`) and the row moves
+//!   `Locked` → `PendingPayout`, with `slashed_reason`, `slashed_at`, and
+//!   `node_share_sats` snapshotted in the same `UPDATE` so a later config
+//!   change or daemon restart cannot rebalance the split. The HTLC is
+//!   claimed by Mostro **here**, not asynchronously by Phase 3.
 //! - **Non-slashed sides** are released exactly as Phase 1 did
 //!   (`cancel_hold_invoice` + state = `Released`).
 //!
-//! The actual Lightning payout to the counterparty is the job of Phase 3
-//! (`job_process_bond_payouts`). This module never touches the
-//! `payout_invoice` / `send_payment` machinery.
+//! The recipient payout (asking the winning counterparty for a bolt11,
+//! `send_payment` retries, forfeiture on the long-stop window) is still
+//! the job of Phase 3 (`job_process_bond_payouts`). Phase 3 no longer
+//! settles HTLCs — by the time it picks up a `PendingPayout` row, the
+//! sats are already in Mostro's wallet.
 //!
 //! ## Flow contract
 //!
@@ -33,6 +37,8 @@
 //! yields exactly the legacy behaviour.
 
 use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
 
 use chrono::Utc;
 use mostro_core::error::{
@@ -51,6 +57,41 @@ use super::math::compute_node_share;
 use super::model::Bond;
 use super::types::{BondSlashReason, BondState};
 use crate::config::settings::Settings;
+use crate::lightning::LndConnector;
+
+/// Minimal LND-side capability the slash path needs: settle a hold
+/// invoice by preimage. Mirrors the [`crate::app::cancel::CancelLightning`]
+/// pattern so tests can pass a stub instead of a live `LndConnector`.
+pub trait SettleLightning {
+    fn settle_hold_invoice<'a>(
+        &'a mut self,
+        preimage: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), MostroError>> + Send + 'a>>;
+}
+
+impl SettleLightning for LndConnector {
+    fn settle_hold_invoice<'a>(
+        &'a mut self,
+        preimage: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<(), MostroError>> + Send + 'a>> {
+        Box::pin(async move {
+            LndConnector::settle_hold_invoice(self, preimage)
+                .await
+                .map(|_| ())
+        })
+    }
+}
+
+/// Classify a `settle_hold_invoice` failure: an "already settled"
+/// response is treated as success so admin retries (where the row is
+/// still `Locked` but the HTLC is already claimed) drive the bond into
+/// `PendingPayout` instead of looping forever on a benign error.
+pub(super) fn is_already_settled_error(err: &MostroError) -> bool {
+    let s = err.to_string().to_lowercase();
+    s.contains("already settled")
+        || s.contains("invoice already settled")
+        || s.contains("code=alreadyexists")
+}
 
 /// Which trade-flow side a slash flag is targeting. Internal helper —
 /// callers think in `BondResolution::slash_seller` / `slash_buyer`
@@ -119,24 +160,35 @@ pub async fn validate_bond_resolution(
 /// Apply a validated [`BondResolution`] to every active bond on the order.
 ///
 /// For each currently active bond:
-/// - if the bond's owner is on the slashed side(s), perform a CAS
+/// - if the bond's owner is on the slashed side(s), **settle the hold
+///   invoice immediately** (`settle_hold_invoice(preimage)`, claiming
+///   the sats into Mostro's wallet) and then CAS
 ///   `state='locked' → state='pending-payout'` that also writes
 ///   `slashed_reason`, `slashed_at`, and `node_share_sats` in the same
 ///   statement. The split snapshot is intentionally frozen at this
 ///   moment — Phase 3's payout job never reads `slash_node_share_pct`
 ///   from config; it reads `node_share_sats` from the row.
 /// - otherwise, release the bond exactly as Phase 1 did
-///   (`cancel_hold_invoice` if applicable, then state = `Released`).
+///   (`cancel_hold_invoice` + state = `Released`).
+///
+/// **Ordering invariant**: settle MUST succeed before the CAS runs. If
+/// settle fails (and is not the benign "already settled" idempotent
+/// case), the row stays `Locked` and a future admin retry will re-run
+/// the slash. Doing settle before CAS means a partial failure leaves a
+/// retry-able state instead of a `PendingPayout` row whose HTLC is
+/// still encumbered.
 ///
 /// Idempotent: a bond that already moved out of `Locked` (e.g. a
 /// duplicate admin call or a concurrent path) is left untouched by the
-/// CAS, and the loop continues to the next bond. The `release_bond`
-/// call is itself idempotent for terminal states.
+/// CAS, and the loop continues to the next bond. Settling an
+/// already-settled HTLC is also benign (LND returns AlreadyExists,
+/// which [`is_already_settled_error`] classifies as success).
 ///
 /// `reason` is `LostDispute` in Phase 2 (called from admin handlers);
 /// Phase 4 (timeout slash) will reuse this helper with `Timeout`.
-pub async fn apply_bond_resolution(
+pub async fn apply_bond_resolution<L: SettleLightning + Send>(
     pool: &Pool<Sqlite>,
+    ln_client: &mut L,
     order: &Order,
     resolution: &BondResolution,
     reason: BondSlashReason,
@@ -170,7 +222,7 @@ pub async fn apply_bond_resolution(
 
     for bond in bonds.iter() {
         if slashed_ids.contains(&bond.id) {
-            slash_one(pool, bond, reason, node_share_pct).await;
+            slash_one(pool, ln_client, bond, reason, node_share_pct).await;
         } else {
             // Non-slashed bonds on the same order: release with the
             // Phase 1 contract. `release_bond` is best-effort and
@@ -188,15 +240,55 @@ pub async fn apply_bond_resolution(
     Ok(())
 }
 
-/// Single-bond `Locked → PendingPayout` transition with snapshot fields.
+/// Single-bond slash: settle the hold invoice into Mostro's wallet,
+/// then CAS the row `Locked → PendingPayout` with snapshot fields.
 ///
-/// Uses a CAS `WHERE id = ? AND state = 'locked'` so a duplicate admin
-/// call or a concurrent transition cannot overwrite a row that already
-/// moved on. The CAS write is the only place `slashed_reason`,
-/// `slashed_at`, and `node_share_sats` are populated for a `LostDispute`
-/// row, which is what makes the split snapshot deterministic across
-/// restarts and config changes.
-async fn slash_one(pool: &Pool<Sqlite>, bond: &Bond, reason: BondSlashReason, node_share_pct: f64) {
+/// Settling first means a transient LND failure leaves the bond
+/// retryably `Locked` rather than stranding a `PendingPayout` row
+/// whose HTLC is still encumbered. The CAS itself uses
+/// `WHERE id = ? AND state = 'locked'` so a duplicate admin call or a
+/// concurrent transition cannot overwrite a row that already moved on.
+///
+/// The CAS write is the only place `slashed_reason`, `slashed_at`, and
+/// `node_share_sats` are populated for a `LostDispute` row, which is
+/// what makes the split snapshot deterministic across restarts and
+/// config changes.
+async fn slash_one<L: SettleLightning + Send>(
+    pool: &Pool<Sqlite>,
+    ln_client: &mut L,
+    bond: &Bond,
+    reason: BondSlashReason,
+    node_share_pct: f64,
+) {
+    let preimage = match bond.preimage.as_deref() {
+        Some(p) => p,
+        None => {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "slash: bond has no preimage — cannot settle HTLC; leaving Locked for operator review"
+            );
+            return;
+        }
+    };
+
+    if let Err(e) = ln_client.settle_hold_invoice(preimage).await {
+        if is_already_settled_error(&e) {
+            info!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "slash: HTLC already settled (idempotent retry); proceeding to CAS"
+            );
+        } else {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "slash: settle_hold_invoice failed: {e} — leaving bond Locked for admin retry"
+            );
+            return;
+        }
+    }
+
     let node_share_sats = compute_node_share(bond.amount_sats, node_share_pct);
     let now = Utc::now().timestamp();
     let result = sqlx::query(
@@ -220,26 +312,27 @@ async fn slash_one(pool: &Pool<Sqlite>, bond: &Bond, reason: BondSlashReason, no
                 reason = %reason,
                 node_share_sats,
                 counterparty_share_sats = bond.amount_sats - node_share_sats,
-                "Bond transitioned to PendingPayout"
+                "Bond HTLC settled and row transitioned to PendingPayout"
             );
         }
         Ok(_) => {
             // The bond moved out of `Locked` between our enumerate and
-            // our CAS. Phase 3 will not pick it up (only `PendingPayout`
-            // qualifies for payout); any prior transition (e.g. a
-            // concurrent release) owns the row now.
+            // our CAS. HTLC is settled either way; whatever path owned
+            // the prior transition is responsible for any further
+            // movement. Phase 3 will not pick up anything but a
+            // `PendingPayout` row.
             warn!(
                 bond_id = %bond.id,
                 order_id = %bond.order_id,
                 current_state = %bond.state,
-                "slash CAS no-op (bond state changed concurrently)"
+                "slash CAS no-op (bond state changed concurrently); HTLC was settled"
             );
         }
         Err(e) => {
             warn!(
                 bond_id = %bond.id,
                 order_id = %bond.order_id,
-                "slash CAS DB error: {}", e
+                "slash CAS DB error: {} (HTLC was settled)", e
             );
         }
     }
@@ -267,6 +360,9 @@ fn resolve_locked_bond<'a>(order: &Order, bonds: &'a [Bond], side: Side) -> Opti
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use mostro_core::error::{MostroError, ServiceError};
     use mostro_core::message::{Action, Message, Payload};
     use mostro_core::order::{Kind, Order, Status};
     use sqlx::sqlite::SqlitePoolOptions;
@@ -275,6 +371,48 @@ mod tests {
     use super::*;
     use crate::app::bond::model::Bond;
     use crate::app::bond::types::{BondRole, BondSlashReason, BondState};
+
+    /// Recording stub for `SettleLightning`. Captures each preimage the
+    /// caller asked LND to settle, and can be primed to return either
+    /// success, an "already settled" error, or a transient transport
+    /// failure. Used end-to-end to verify the slash path settles at
+    /// slash time (one HTLC per slashed bond) and that it skips
+    /// non-slashed bonds entirely.
+    #[derive(Default)]
+    struct StubSettle {
+        calls: Mutex<Vec<String>>,
+        // When set, force every settle to return this canned error.
+        fail_with: Mutex<Option<String>>,
+    }
+
+    impl StubSettle {
+        fn new() -> Arc<Self> {
+            Arc::new(Self::default())
+        }
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+        fn fail_next_with(&self, msg: &str) {
+            *self.fail_with.lock().unwrap() = Some(msg.to_string());
+        }
+    }
+
+    impl SettleLightning for Arc<StubSettle> {
+        fn settle_hold_invoice<'a>(
+            &'a mut self,
+            preimage: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), MostroError>> + Send + 'a>> {
+            Box::pin(async move {
+                self.calls.lock().unwrap().push(preimage.to_string());
+                if let Some(msg) = self.fail_with.lock().unwrap().take() {
+                    return Err(MostroError::MostroInternalErr(ServiceError::LnNodeError(
+                        msg,
+                    )));
+                }
+                Ok(())
+            })
+        }
+    }
 
     async fn setup_pool() -> Pool<Sqlite> {
         let pool = SqlitePoolOptions::new()
@@ -349,6 +487,14 @@ mod tests {
         }
     }
 
+    /// 32-byte zero preimage as a 64-char hex string. Real bonds carry
+    /// a random preimage populated by `request_taker_bond`; tests just
+    /// need *something* well-formed for the stub `SettleLightning` to
+    /// observe.
+    fn stub_preimage() -> String {
+        "00".repeat(32)
+    }
+
     async fn insert_bond(
         pool: &Pool<Sqlite>,
         order_id: Uuid,
@@ -357,6 +503,7 @@ mod tests {
     ) -> Bond {
         let mut b = Bond::new_requested(order_id, pubkey.to_string(), BondRole::Taker, 10_000);
         b.state = state.to_string();
+        b.preimage = Some(stub_preimage());
         // No hash → release_bond skips the LND cancel branch entirely
         // (see `release_bond` in flow.rs).
         b.hash = None;
@@ -498,9 +645,15 @@ mod tests {
             slash_seller: false,
             slash_buyer: false,
         };
-        apply_bond_resolution(&pool, &order, &res, BondSlashReason::LostDispute)
-            .await
-            .unwrap();
+        apply_bond_resolution(
+            &pool,
+            &mut StubSettle::new(),
+            &order,
+            &res,
+            BondSlashReason::LostDispute,
+        )
+        .await
+        .unwrap();
 
         let row: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
             .bind(bond.id)
@@ -527,9 +680,15 @@ mod tests {
             slash_seller: false,
             slash_buyer: true,
         };
-        apply_bond_resolution(&pool, &order, &res, BondSlashReason::LostDispute)
-            .await
-            .unwrap();
+        apply_bond_resolution(
+            &pool,
+            &mut StubSettle::new(),
+            &order,
+            &res,
+            BondSlashReason::LostDispute,
+        )
+        .await
+        .unwrap();
 
         let row: (String, Option<String>, Option<i64>, Option<i64>) = sqlx::query_as(
             "SELECT state, slashed_reason, slashed_at, node_share_sats \
@@ -563,9 +722,15 @@ mod tests {
             slash_buyer: true,
         };
 
-        apply_bond_resolution(&pool, &order, &res, BondSlashReason::LostDispute)
-            .await
-            .unwrap();
+        apply_bond_resolution(
+            &pool,
+            &mut StubSettle::new(),
+            &order,
+            &res,
+            BondSlashReason::LostDispute,
+        )
+        .await
+        .unwrap();
         let first: (String, Option<i64>, Option<i64>) =
             sqlx::query_as("SELECT state, slashed_at, node_share_sats FROM bonds WHERE id = ?")
                 .bind(bond.id)
@@ -576,9 +741,15 @@ mod tests {
 
         // Pretend a duplicate admin message arrived a second later.
         std::thread::sleep(std::time::Duration::from_secs(1));
-        apply_bond_resolution(&pool, &order, &res, BondSlashReason::LostDispute)
-            .await
-            .unwrap();
+        apply_bond_resolution(
+            &pool,
+            &mut StubSettle::new(),
+            &order,
+            &res,
+            BondSlashReason::LostDispute,
+        )
+        .await
+        .unwrap();
         let second: (String, Option<i64>, Option<i64>) =
             sqlx::query_as("SELECT state, slashed_at, node_share_sats FROM bonds WHERE id = ?")
                 .bind(bond.id)
@@ -611,13 +782,192 @@ mod tests {
             slash_seller: false,
             slash_buyer: false,
         };
-        apply_bond_resolution(&pool, &order, &res, BondSlashReason::LostDispute)
-            .await
-            .unwrap();
+        apply_bond_resolution(
+            &pool,
+            &mut StubSettle::new(),
+            &order,
+            &res,
+            BondSlashReason::LostDispute,
+        )
+        .await
+        .unwrap();
         let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM bonds")
             .fetch_one(&pool)
             .await
             .unwrap();
         assert_eq!(count.0, 0);
+    }
+
+    // ── Immediate-settle (the Phase 2 change shipped here) ──────────────────
+
+    #[tokio::test]
+    async fn slash_one_settles_exactly_one_htlc() {
+        // Single slashed taker bond → `settle_hold_invoice` runs once
+        // with that bond's preimage as part of the slash step. The row
+        // ends up in `PendingPayout` for Phase 3 to handle the
+        // counterparty payout asynchronously.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+        let res = BondResolution {
+            slash_seller: false,
+            slash_buyer: true,
+        };
+
+        apply_bond_resolution(&pool, &mut ln, &order, &res, BondSlashReason::LostDispute)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            ln.calls(),
+            vec![stub_preimage()],
+            "slash path must settle exactly the slashed bond's HTLC"
+        );
+        let state: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(state.0, BondState::PendingPayout.to_string());
+    }
+
+    #[tokio::test]
+    async fn slash_both_settles_both_htlcs() {
+        // Both flags set + both buyer and seller carry a `Locked` bond:
+        // `settle_hold_invoice` must run **twice** (once per slashed
+        // bond) and both rows end up in `PendingPayout`. This is the
+        // Phase 5+ "both behaved badly" path; Phase 2 cannot reach it
+        // in production (taker-only world), but the slash machinery
+        // must handle the case correctly when Phase 5 wires it.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let buyer_bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let seller_bond = insert_bond(&pool, order.id, maker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+        let res = BondResolution {
+            slash_seller: true,
+            slash_buyer: true,
+        };
+
+        apply_bond_resolution(&pool, &mut ln, &order, &res, BondSlashReason::LostDispute)
+            .await
+            .unwrap();
+
+        // Both preimages observed (order-independent: the apply loop
+        // walks `find_active_bonds_for_order` results which are not
+        // ordered by side).
+        assert_eq!(
+            ln.calls().len(),
+            2,
+            "both slashed bonds must have their HTLCs settled immediately"
+        );
+        for b in [&buyer_bond, &seller_bond] {
+            let state: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+                .bind(b.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+            assert_eq!(state.0, BondState::PendingPayout.to_string());
+        }
+    }
+
+    #[tokio::test]
+    async fn non_slashed_bond_is_released_not_settled() {
+        // When the resolution releases (no flags set), the slash path
+        // must NOT touch `settle_hold_invoice` — release is the
+        // Phase 1 `cancel_hold_invoice` flow.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+        let res = BondResolution {
+            slash_seller: false,
+            slash_buyer: false,
+        };
+
+        apply_bond_resolution(&pool, &mut ln, &order, &res, BondSlashReason::LostDispute)
+            .await
+            .unwrap();
+
+        assert!(
+            ln.calls().is_empty(),
+            "non-slashed (released) bonds must not invoke settle_hold_invoice"
+        );
+        let state: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(state.0, BondState::Released.to_string());
+    }
+
+    #[tokio::test]
+    async fn slash_treats_already_settled_as_success() {
+        // Admin retry: the HTLC was claimed on a previous attempt but
+        // the CAS failed. LND returns "already settled"; the slash
+        // path must classify that as success via
+        // `is_already_settled_error` and complete the CAS to
+        // `PendingPayout`.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+        ln.fail_next_with("code=AlreadyExists: invoice already settled");
+        let res = BondResolution {
+            slash_seller: false,
+            slash_buyer: true,
+        };
+
+        apply_bond_resolution(&pool, &mut ln, &order, &res, BondSlashReason::LostDispute)
+            .await
+            .unwrap();
+
+        let state: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            state.0,
+            BondState::PendingPayout.to_string(),
+            "already-settled error must not block the CAS"
+        );
+    }
+
+    #[tokio::test]
+    async fn slash_settle_transport_failure_leaves_bond_locked() {
+        // Real LND transport failure: the bond stays `Locked` so a
+        // future admin retry can re-attempt the slash. The CAS must
+        // NOT have flipped the row to `PendingPayout`.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+        ln.fail_next_with("code=Unavailable: connection refused");
+        let res = BondResolution {
+            slash_seller: false,
+            slash_buyer: true,
+        };
+
+        apply_bond_resolution(&pool, &mut ln, &order, &res, BondSlashReason::LostDispute)
+            .await
+            .unwrap();
+
+        let state: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            state.0,
+            BondState::Locked.to_string(),
+            "transient settle failure must leave the bond Locked for admin retry"
+        );
     }
 }

--- a/src/app/bond/types.rs
+++ b/src/app/bond/types.rs
@@ -43,16 +43,24 @@ impl FromStr for BondRole {
 ///  Requested ──► Locked ──┬──► Released (happy / cancelled-before-timeout)
 ///                         └──► PendingPayout ──┬──► Slashed    (winner paid)
 ///                                              ├──► Forfeited  (winner never claimed in window)
-///                                              └──► Failed     (retries exhausted)
+///                                              └──► Failed ──► (back to PendingPayout
+///                                                              on fresh AddBondInvoice
+///                                                              within claim window)
 /// ```
 ///
-/// A bond never goes back to an earlier state. `Failed` is a terminal,
-/// operator-intervention-required state (we have an invoice but
-/// `send_payment` keeps failing). `Forfeited` is the long-stop terminal
-/// state for a slash whose counterparty never submitted a payout invoice
-/// within `payout_claim_window_days`; it is a *normal* outcome by design
-/// (no operator action required), distinct from `Failed` so dashboards
-/// can alarm correctly.
+/// `Forfeited` is a hard terminal state — the counterparty never
+/// submitted a payout invoice within `payout_claim_window_days`, the
+/// node retains `amount_sats` in full, no operator action needed.
+///
+/// `Failed` is reachable when `send_payment` exhausts `payout_max_retries`
+/// against a delivered invoice. Unlike the other "terminal" states it
+/// is *user-recoverable*: a fresh [`Action::AddBondInvoice`] from the
+/// recipient resurrects the bond back to `PendingPayout` (resets
+/// `payout_attempts` / `invoice_request_attempts`, overwrites
+/// `payout_invoice`) so long as `now - slashed_at <
+/// payout_claim_window_days * 86_400`. Past the claim window, the row
+/// stays `Failed` and requires operator attention to pay the
+/// counterparty manually.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BondState {
     /// Hold invoice created; waiting for the bonded party to pay it so LND
@@ -73,18 +81,30 @@ pub enum BondState {
     /// submitting a payout invoice; the node retains `amount_sats` in
     /// full. Terminal — designed-in long-stop, no operator action needed.
     Forfeited,
-    /// `send_payment` retries exhausted. Terminal, requires operator
-    /// attention.
+    /// `send_payment` retries exhausted on a delivered payout invoice.
+    /// User-recoverable: a fresh [`Action::AddBondInvoice`] from the
+    /// recipient transitions the row back to `PendingPayout` while
+    /// `now - slashed_at < payout_claim_window_days * 86_400`. Past
+    /// the claim window, requires operator attention to pay the
+    /// counterparty manually.
     Failed,
 }
 
 impl BondState {
-    /// True for states that should not be transitioned out of by Phase 1
-    /// release paths: the bond is already done with from the operator's
-    /// perspective. Used so call sites don't have to enumerate the four
-    /// of `Released | Slashed | Forfeited | Failed` manually (and so the
-    /// daemon doesn't grow to depend on the [`Display`] string form for
-    /// control flow).
+    /// True for states that the Phase 1 release / cancel paths must
+    /// not transition out of: the LND HTLC has already been settled or
+    /// cancelled, so any further release attempt is at best a no-op
+    /// and at worst a double-action against LND. Used so call sites
+    /// don't have to enumerate `Released | Slashed | Forfeited |
+    /// Failed` manually.
+    ///
+    /// Scope is intentionally release-flow only. `Failed` is included
+    /// because, like the other three, its HTLC has been disposed of
+    /// (settled at slash time) — but Phase 3's `add_bond_invoice_action`
+    /// can still flip a `Failed` row back to `PendingPayout` on a
+    /// fresh user invoice within the claim window. That recovery path
+    /// works on the DB row directly and does not go through these
+    /// release/cancel helpers.
     pub fn is_terminal(self) -> bool {
         matches!(
             self,

--- a/src/app/bond/types.rs
+++ b/src/app/bond/types.rs
@@ -62,7 +62,10 @@ pub enum BondState {
     Locked,
     /// Hold invoice was cancelled (not slashed). Terminal happy exit.
     Released,
-    /// A slash condition was hit; Mostro is working on paying the winner.
+    /// A slash condition was hit. The bond hold invoice has already been
+    /// **settled** (claimed into Mostro's wallet at slash time by Phase 2);
+    /// Phase 3 is asynchronously driving the recipient payout
+    /// (`AddBondInvoice` → `send_payment` → retries / forfeiture).
     PendingPayout,
     /// Winner paid successfully. Terminal.
     Slashed,

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -205,7 +205,7 @@ async fn cancel_cooperative_execution_step_1(
 /// only runs when this was the **last** active bond on the order
 /// (no other bonds remain after the release); otherwise the order
 /// stays in `Pending` with the surviving bonds still in flight and
-/// the cancel is effectively scoped to a per-taker release + DM.
+/// the cancel is effectively scoped to a per-taker release + message.
 async fn cancel_order_by_taker<L: CancelLightning + Send>(
     pool: &Pool<Sqlite>,
     event: &UnwrappedMessage,
@@ -234,7 +234,7 @@ async fn cancel_order_by_taker<L: CancelLightning + Send>(
 
     // Look at what's left on the order. If other concurrent takers
     // still have active bonds, do NOT reset the order — they are
-    // still racing. Just DM the sender that their take is cancelled.
+    // still racing. Just message the sender that their take is cancelled.
     let remaining = crate::app::bond::db::find_active_bonds_for_order(pool, order_id).await?;
     let others_remain = remaining.iter().any(|b| b.pubkey != sender_str);
     if others_remain {

--- a/src/app/last_trade_index.rs
+++ b/src/app/last_trade_index.rs
@@ -38,7 +38,7 @@ use nostr_sdk::prelude::*;
 ///
 /// # Errors
 ///
-/// Errors are logged but not propagated for DM sending failures. All other errors are returned
+/// Errors are logged but not propagated for message sending failures. All other errors are returned
 /// to the caller.
 pub async fn last_trade_index(
     ctx: &AppContext,
@@ -89,9 +89,9 @@ pub async fn last_trade_index(
     );
     tracing::info!("Last trade index: {}", user.last_trade_index);
 
-    // Send DM back to the requester
+    // Send message back to the requester
     if let Err(e) = send_dm(trade_key, my_keys, &message_json, None).await {
-        tracing::error!("Error sending DM with last trade index: {:?}", e);
+        tracing::error!("Error sending message with last trade index: {:?}", e);
     }
 
     Ok(())

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -57,7 +57,7 @@ pub async fn take_buy_action(
     //      committed; reject with `PendingOrderExists`.
     //   2. The sender's own pubkey already has a `Requested` bond on
     //      this order → idempotent retry: re-send the same
-    //      `PayInvoice` DM and return.
+    //      `PayInvoice` message and return.
     //   3. Otherwise fall through and create a fresh bond row.
     // We do *not* mutate the order's taker fields under the bond
     // path; that context lives on the bond row's `taker_*` columns

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -81,7 +81,7 @@ pub async fn take_sell_action(
     //      committed; reject with `PendingOrderExists`.
     //   2. The sender's own pubkey already has a `Requested` bond on
     //      this order → idempotent retry: re-send the same
-    //      `PayInvoice` DM and return.
+    //      `PayInvoice` message and return.
     //   3. Otherwise fall through and create a fresh bond row
     //      alongside any prior `Requested` rows.
     // The order's taker fields are not mutated under the bond path —

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 pub enum BondApplyTo {
     #[default]
     Take,
-    Create,
+    Make,
     Both,
 }
 
@@ -27,7 +27,7 @@ impl BondApplyTo {
 
     /// True when the maker side of a trade must lock a bond.
     pub fn applies_to_maker(self) -> bool {
-        matches!(self, BondApplyTo::Create | BondApplyTo::Both)
+        matches!(self, BondApplyTo::Make | BondApplyTo::Both)
     }
 }
 
@@ -437,8 +437,8 @@ mod anti_abuse_bond_tests {
     fn apply_to_predicates() {
         assert!(BondApplyTo::Take.applies_to_taker());
         assert!(!BondApplyTo::Take.applies_to_maker());
-        assert!(!BondApplyTo::Create.applies_to_taker());
-        assert!(BondApplyTo::Create.applies_to_maker());
+        assert!(!BondApplyTo::Make.applies_to_taker());
+        assert!(BondApplyTo::Make.applies_to_maker());
         assert!(BondApplyTo::Both.applies_to_taker());
         assert!(BondApplyTo::Both.applies_to_maker());
     }

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -198,6 +198,7 @@ mod tests {
             mostro: MostroSettings::default(),
             rpc: RpcSettings::default(),
             expiration: None,
+            anti_abuse_bond: None,
         }
     }
 

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -34,6 +34,27 @@ pub struct PaymentMessage {
     pub payment: Payment,
 }
 
+/// Routing-fee cap (in sats) handed to LND as `fee_limit_sat` for a
+/// payment of `amount` sats.
+///
+/// This is the single source of truth for the cap. Both the actual
+/// payment (`LndConnector::send_payment`) and the value persisted for
+/// operator debugging (`bonds.payout_routing_fee_sats`) derive from it,
+/// so the recorded number always matches what LND enforced.
+pub fn routing_fee_cap_sats(amount: i64) -> i64 {
+    let max_routing_fee = Settings::get_mostro().max_routing_fee;
+    // If the amount is small we use a different max routing fee.
+    let max_fee = match amount.cmp(&1000) {
+        Ordering::Less | Ordering::Equal => {
+            // For small amounts, use 1% but ensure minimum of 10 sats
+            // to allow routing (otherwise tiny amounts like 30 sats would have 0 fee limit)
+            (amount as f64 * 0.01).max(10.0)
+        }
+        Ordering::Greater => amount as f64 * max_routing_fee,
+    };
+    max_fee as i64
+}
+
 impl LndConnector {
     pub async fn new() -> Result<Self, MostroError> {
         let ln_settings = Settings::get_ln();
@@ -177,19 +198,11 @@ impl LndConnector {
         let invoice = decode_invoice(payment_request)?;
         let payment_hash = invoice.signable_hash();
         let hash = bytes_to_string(&payment_hash);
-        let mostro_settings = Settings::get_mostro();
 
-        // We need to set a max fee amount
-        // If the amount is small we use a different max routing fee
-        let max_fee = match amount.cmp(&1000) {
-            Ordering::Less | Ordering::Equal => {
-                // For small amounts, use 1% but ensure minimum of 10 sats
-                // to allow routing (otherwise tiny amounts like 30 sats would have 0 fee limit)
-                let calculated_fee = amount as f64 * 0.01;
-                calculated_fee.max(10.0)
-            }
-            Ordering::Greater => amount as f64 * mostro_settings.max_routing_fee,
-        };
+        // We need to set a max fee amount. `routing_fee_cap_sats` is the
+        // single source of truth so the value persisted for operator
+        // debugging always matches what LND actually enforces.
+        let max_fee = routing_fee_cap_sats(amount);
 
         let track_payment_req = TrackPaymentRequest {
             payment_hash: payment_hash.to_vec(),
@@ -214,7 +227,7 @@ impl LndConnector {
         let mut request = SendPaymentRequest {
             payment_request: payment_request.to_string(),
             timeout_seconds: 60,
-            fee_limit_sat: max_fee as i64,
+            fee_limit_sat: max_fee,
             ..Default::default()
         };
         let invoice_amount_milli = invoice.amount_milli_satoshis();
@@ -405,5 +418,45 @@ impl LnStatus {
             networks: info.chains.iter().map(|c| c.network.to_string()).collect(),
             uris: info.uris.iter().map(|u| u.to_string()).collect(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::routing_fee_cap_sats;
+    use crate::config::settings::Settings;
+    use crate::config::MOSTRO_CONFIG;
+
+    fn init_test_settings() {
+        // Defaults set `max_routing_fee = 0.002`.
+        let _ = MOSTRO_CONFIG.set(Settings {
+            database: Default::default(),
+            nostr: Default::default(),
+            mostro: Default::default(),
+            lightning: Default::default(),
+            rpc: Default::default(),
+            expiration: Some(Default::default()),
+            anti_abuse_bond: None,
+        });
+    }
+
+    #[test]
+    fn small_amounts_use_one_percent_with_ten_sat_floor() {
+        init_test_settings();
+        // At and below 1000 sats the floor of 10 dominates the 1% rate,
+        // independent of `max_routing_fee`.
+        assert_eq!(routing_fee_cap_sats(30), 10);
+        assert_eq!(routing_fee_cap_sats(500), 10);
+        assert_eq!(routing_fee_cap_sats(1000), 10);
+    }
+
+    #[test]
+    fn large_amounts_use_max_routing_fee_truncated() {
+        init_test_settings();
+        // Above 1000 sats the cap is `amount * max_routing_fee`, truncated
+        // (not rounded up) to match LND's `fee_limit_sat`.
+        assert_eq!(routing_fee_cap_sats(1001), 2); // 2.002 -> 2
+        assert_eq!(routing_fee_cap_sats(2001), 4); // 4.002 -> 4
+        assert_eq!(routing_fee_cap_sats(100_000), 200);
     }
 }

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -268,6 +268,70 @@ impl LndConnector {
         Ok(())
     }
 
+    /// Look up a payment by hash, distinguishing "LND has no record" from
+    /// transport errors.
+    ///
+    /// Used by the bond payout flow to reconcile after a successful
+    /// `send_payment` whose follow-up DB write failed: on the next
+    /// scheduler tick `pay_counterparty` queries LND for the persisted
+    /// `payout_payment_hash` and only re-invokes `send_payment` if LND
+    /// confirms it never saw the hash.
+    ///
+    /// Returns:
+    /// - `Ok(Some(status))` — LND tracks this hash and reports `status`.
+    /// - `Ok(None)` — LND has no record of this hash (`NotFound`). The
+    ///   hash may never have been attempted, or LND pruned the record.
+    /// - `Err(_)` — transport / gRPC error; status is unknown.
+    pub async fn lookup_payment_status(
+        &mut self,
+        payment_hash: &[u8],
+    ) -> Result<Option<fedimint_tonic_lnd::lnrpc::payment::PaymentStatus>, MostroError> {
+        let track_req = TrackPaymentRequest {
+            payment_hash: payment_hash.to_vec(),
+            no_inflight_updates: false,
+        };
+
+        let stream = match self.client.router().track_payment_v2(track_req).await {
+            Ok(s) => s,
+            Err(status) => {
+                if status.code() == fedimint_tonic_lnd::tonic::Code::NotFound {
+                    return Ok(None);
+                }
+                return Err(MostroInternalErr(ServiceError::LnPaymentError(format!(
+                    "code={:?} message={}",
+                    status.code(),
+                    status.message()
+                ))));
+            }
+        };
+
+        let mut stream = stream.into_inner();
+        match stream.message().await {
+            Ok(Some(payment)) => {
+                let status =
+                    fedimint_tonic_lnd::lnrpc::payment::PaymentStatus::try_from(payment.status)
+                        .map_err(|_| {
+                            MostroInternalErr(ServiceError::LnPaymentError(
+                                "Unknown payment status".to_string(),
+                            ))
+                        })?;
+                Ok(Some(status))
+            }
+            Ok(None) => Ok(None),
+            Err(status) => {
+                if status.code() == fedimint_tonic_lnd::tonic::Code::NotFound {
+                    Ok(None)
+                } else {
+                    Err(MostroInternalErr(ServiceError::LnPaymentError(format!(
+                        "code={:?} message={}",
+                        status.code(),
+                        status.message()
+                    ))))
+                }
+            }
+        }
+    }
+
     /// Query the current status of a payment by its hash.
     ///
     /// Returns the LND `PaymentStatus` if the payment is found, or an error

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -581,16 +581,30 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
         ),
     ];
 
-    // Anti-abuse bond policy snapshot. `bond_enabled` is always emitted
-    // so clients can disambiguate "bond feature off on this node" from
-    // "older daemon that doesn't speak bond at all". The remaining tags
-    // are present only when the feature is enabled — together they let a
-    // client warn the user about bond cost, scope, and slash policy
-    // *before* the take/create flow starts, and render any deadline
-    // (slashed_at + payout_claim_window_days) in the user's own locale
-    // without Mostro shipping any hardcoded text.
+    tags_vec.extend(bond_policy_tags(bond_settings));
+
+    Tags::from_list(tags_vec)
+}
+
+/// Build the bond policy tag block for the info event.
+///
+/// `bond_enabled` is always emitted so clients can disambiguate "bond
+/// feature off on this node" from "older daemon that doesn't speak bond
+/// at all". The remaining tags are present only when the feature is
+/// enabled — together they let a client warn the user about bond cost,
+/// scope, and slash policy *before* the take/create flow starts, and
+/// render any deadline (slashed_at + payout_claim_window_days) in the
+/// user's own locale without Mostro shipping any hardcoded text.
+///
+/// Split out from [`info_to_tags`] so unit tests can exercise both the
+/// disabled and enabled branches without mutating the `MOSTRO_CONFIG`
+/// OnceLock that the parent function reads from.
+fn bond_policy_tags(
+    bond_settings: Option<&crate::config::types::AntiAbuseBondSettings>,
+) -> Vec<Tag> {
+    let mut tags = Vec::with_capacity(7);
     let bond_enabled = bond_settings.is_some_and(|b| b.enabled);
-    tags_vec.push(Tag::custom(
+    tags.push(Tag::custom(
         TagKind::Custom(Cow::Borrowed("bond_enabled")),
         vec![bond_enabled.to_string()],
     ));
@@ -598,37 +612,36 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
         if bond.enabled {
             let apply_to_str = match bond.apply_to {
                 BondApplyTo::Take => "take",
-                BondApplyTo::Create => "create",
+                BondApplyTo::Make => "make",
                 BondApplyTo::Both => "both",
             };
-            tags_vec.push(Tag::custom(
+            tags.push(Tag::custom(
                 TagKind::Custom(Cow::Borrowed("bond_amount_pct")),
                 vec![bond.amount_pct.to_string()],
             ));
-            tags_vec.push(Tag::custom(
+            tags.push(Tag::custom(
                 TagKind::Custom(Cow::Borrowed("bond_base_amount_sats")),
                 vec![bond.base_amount_sats.to_string()],
             ));
-            tags_vec.push(Tag::custom(
+            tags.push(Tag::custom(
                 TagKind::Custom(Cow::Borrowed("bond_apply_to")),
                 vec![apply_to_str.to_string()],
             ));
-            tags_vec.push(Tag::custom(
+            tags.push(Tag::custom(
                 TagKind::Custom(Cow::Borrowed("bond_slash_on_waiting_timeout")),
                 vec![bond.slash_on_waiting_timeout.to_string()],
             ));
-            tags_vec.push(Tag::custom(
+            tags.push(Tag::custom(
                 TagKind::Custom(Cow::Borrowed("bond_slash_node_share_pct")),
                 vec![bond.slash_node_share_pct.to_string()],
             ));
-            tags_vec.push(Tag::custom(
+            tags.push(Tag::custom(
                 TagKind::Custom(Cow::Borrowed("bond_payout_claim_window_days")),
                 vec![bond.payout_claim_window_days.to_string()],
             ));
         }
     }
-
-    Tags::from_list(tags_vec)
+    tags
 }
 
 #[cfg(test)]
@@ -875,6 +888,68 @@ mod tests {
                 "{absent} must be absent when the bond feature is disabled"
             );
         }
+    }
+
+    /// Build a `Tags` collection from a bond settings snapshot via the
+    /// pure `bond_policy_tags` helper. Exists because
+    /// `info_to_tags` itself reads bond settings from the
+    /// `MOSTRO_CONFIG` OnceLock — which is shared across the test
+    /// binary and cannot be mutated mid-run — so we exercise the
+    /// enabled branch through the helper directly.
+    fn bond_tags(bond: Option<&crate::config::types::AntiAbuseBondSettings>) -> Tags {
+        Tags::from_list(super::bond_policy_tags(bond))
+    }
+
+    #[test]
+    fn info_to_tags_emits_bond_enabled_marker_when_bond_on() {
+        // Companion of `info_to_tags_emits_bond_disabled_marker_when_bond_off`.
+        // Verifies every advertised policy tag is present and that the
+        // emitted value mirrors the source settings byte-for-byte —
+        // clients parse these as text, so any reformat by `to_string`
+        // would silently break them.
+        let bond = crate::config::types::AntiAbuseBondSettings {
+            enabled: true,
+            amount_pct: 0.02,
+            base_amount_sats: 2_500,
+            apply_to: crate::config::types::BondApplyTo::Both,
+            slash_on_waiting_timeout: true,
+            slash_node_share_pct: 0.4,
+            payout_invoice_window_seconds: 300,
+            payout_max_retries: 5,
+            payout_claim_window_days: 30,
+        };
+
+        let tags = bond_tags(Some(&bond));
+
+        assert_eq!(
+            get_tag_value(&tags, "bond_enabled").as_deref(),
+            Some("true"),
+            "bond_enabled must be emitted as 'true' when the feature is on"
+        );
+        assert_eq!(
+            get_tag_value(&tags, "bond_amount_pct").as_deref(),
+            Some("0.02")
+        );
+        assert_eq!(
+            get_tag_value(&tags, "bond_base_amount_sats").as_deref(),
+            Some("2500")
+        );
+        assert_eq!(
+            get_tag_value(&tags, "bond_apply_to").as_deref(),
+            Some("both")
+        );
+        assert_eq!(
+            get_tag_value(&tags, "bond_slash_on_waiting_timeout").as_deref(),
+            Some("true")
+        );
+        assert_eq!(
+            get_tag_value(&tags, "bond_slash_node_share_pct").as_deref(),
+            Some("0.4")
+        );
+        assert_eq!(
+            get_tag_value(&tags, "bond_payout_claim_window_days").as_deref(),
+            Some("30")
+        );
     }
 
     // ── Dispute event tag list: end-to-end y-tag emission (kind 38386) ──────────

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1,5 +1,6 @@
 use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
 use crate::config::settings::Settings;
+use crate::config::types::BondApplyTo;
 use crate::lightning::LnStatus;
 use crate::util::{get_expiration_timestamp_for_kind, get_keys};
 use crate::LN_STATUS;
@@ -487,8 +488,9 @@ pub fn order_to_tags(
 pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
     let mostro_settings = Settings::get_mostro();
     let ln_settings = Settings::get_ln();
+    let bond_settings = Settings::get_bond();
 
-    let tags: Tags = Tags::from_list(vec![
+    let mut tags_vec: Vec<Tag> = vec![
         Tag::custom(
             TagKind::Custom(Cow::Borrowed("mostro_version")),
             vec![env!("CARGO_PKG_VERSION").to_string()],
@@ -577,9 +579,56 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
             TagKind::Custom(Cow::Borrowed("z")),
             vec!["info".to_string()],
         ),
-    ]);
+    ];
 
-    tags
+    // Anti-abuse bond policy snapshot. `bond_enabled` is always emitted
+    // so clients can disambiguate "bond feature off on this node" from
+    // "older daemon that doesn't speak bond at all". The remaining tags
+    // are present only when the feature is enabled — together they let a
+    // client warn the user about bond cost, scope, and slash policy
+    // *before* the take/create flow starts, and render any deadline
+    // (slashed_at + payout_claim_window_days) in the user's own locale
+    // without Mostro shipping any hardcoded text.
+    let bond_enabled = bond_settings.is_some_and(|b| b.enabled);
+    tags_vec.push(Tag::custom(
+        TagKind::Custom(Cow::Borrowed("bond_enabled")),
+        vec![bond_enabled.to_string()],
+    ));
+    if let Some(bond) = bond_settings {
+        if bond.enabled {
+            let apply_to_str = match bond.apply_to {
+                BondApplyTo::Take => "take",
+                BondApplyTo::Create => "create",
+                BondApplyTo::Both => "both",
+            };
+            tags_vec.push(Tag::custom(
+                TagKind::Custom(Cow::Borrowed("bond_amount_pct")),
+                vec![bond.amount_pct.to_string()],
+            ));
+            tags_vec.push(Tag::custom(
+                TagKind::Custom(Cow::Borrowed("bond_base_amount_sats")),
+                vec![bond.base_amount_sats.to_string()],
+            ));
+            tags_vec.push(Tag::custom(
+                TagKind::Custom(Cow::Borrowed("bond_apply_to")),
+                vec![apply_to_str.to_string()],
+            ));
+            tags_vec.push(Tag::custom(
+                TagKind::Custom(Cow::Borrowed("bond_slash_on_waiting_timeout")),
+                vec![bond.slash_on_waiting_timeout.to_string()],
+            ));
+            tags_vec.push(Tag::custom(
+                TagKind::Custom(Cow::Borrowed("bond_slash_node_share_pct")),
+                vec![bond.slash_node_share_pct.to_string()],
+            ));
+            tags_vec.push(Tag::custom(
+                TagKind::Custom(Cow::Borrowed("bond_payout_claim_window_days")),
+                vec![bond.payout_claim_window_days.to_string()],
+            ));
+        }
+    }
+
+    Tags::from_list(tags_vec)
 }
 
 #[cfg(test)]
@@ -780,6 +829,52 @@ mod tests {
             y_values, expected,
             "info_to_tags must wire create_platform_tag_values correctly into the y tag"
         );
+    }
+
+    /// Look up a single-value tag in a Tags collection, returning its
+    /// first value. Helper for the bond-policy assertions below.
+    fn get_tag_value(tags: &Tags, name: &str) -> Option<String> {
+        tags.iter().find_map(|tag| {
+            let vec = tag.clone().to_vec();
+            if vec.first().map(String::as_str) == Some(name) {
+                vec.get(1).cloned()
+            } else {
+                None
+            }
+        })
+    }
+
+    #[test]
+    fn info_to_tags_emits_bond_disabled_marker_when_bond_off() {
+        // test_settings() builds Settings with `anti_abuse_bond = None`,
+        // i.e. the feature is off. `bond_enabled` must still be emitted
+        // (as "false") so clients can disambiguate "feature off" from
+        // "older daemon that doesn't speak bond at all". The rest of the
+        // policy tags must be absent.
+        init_test_settings();
+        let ln_status = make_ln_status();
+
+        let tags = info_to_tags(&ln_status);
+
+        assert_eq!(
+            get_tag_value(&tags, "bond_enabled").as_deref(),
+            Some("false"),
+            "bond_enabled must be emitted as 'false' when the feature is off"
+        );
+
+        for absent in [
+            "bond_amount_pct",
+            "bond_base_amount_sats",
+            "bond_apply_to",
+            "bond_slash_on_waiting_timeout",
+            "bond_slash_node_share_pct",
+            "bond_payout_claim_window_days",
+        ] {
+            assert!(
+                get_tag_value(&tags, absent).is_none(),
+                "{absent} must be absent when the bond feature is disabled"
+            );
+        }
     }
 
     // ── Dispute event tag list: end-to-end y-tag emission (kind 38386) ──────────

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -30,6 +30,7 @@ pub async fn start_scheduler(ctx: AppContext) {
     job_cancel_orders(ctx.clone()).await;
     job_retry_failed_payments(ctx.clone()).await;
     job_process_dev_fee_payment(ctx.clone()).await;
+    job_process_bond_payouts(ctx.clone()).await;
     job_info_event_send(ctx.clone()).await;
     job_relay_list(ctx.clone()).await;
     job_update_bitcoin_prices().await;
@@ -580,6 +581,36 @@ async fn job_process_dev_fee_payment(ctx: AppContext) {
         let pool = ctx.pool();
         loop {
             run_dev_fee_cycle(pool, &mut ln_client, &mut confirmed).await;
+            tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
+        }
+    });
+}
+
+/// Processes bonds left in `PendingPayout` by Phase 2 / 4 / 5+.
+///
+/// Spawns a background task that runs
+/// [`bond::run_bond_payout_cycle`] every 60 seconds, mirroring the
+/// dev-fee scheduler. Not gated on `Settings::is_bond_enabled()`:
+/// bonds left over from a prior enabled period must still drain when
+/// an operator flips the feature off, otherwise their HTLCs sit in
+/// LND with no driver. The cycle is a single indexed SELECT on
+/// `bonds.state = 'pending-payout'`, which is empty for any node
+/// that never enabled the feature, so the constant overhead is
+/// negligible.
+#[mutants::skip]
+async fn job_process_bond_payouts(ctx: AppContext) {
+    let interval = 60u64;
+
+    let mut ln_client = if let Ok(client) = LndConnector::new().await {
+        client
+    } else {
+        return error!("Failed to create LND client for bond payout job");
+    };
+
+    tokio::spawn(async move {
+        let pool = ctx.pool();
+        loop {
+            bond::run_bond_payout_cycle(pool, &mut ln_client).await;
             tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
         }
     });

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -601,13 +601,28 @@ async fn job_process_dev_fee_payment(ctx: AppContext) {
 async fn job_process_bond_payouts(ctx: AppContext) {
     let interval = 60u64;
 
-    let mut ln_client = if let Ok(client) = LndConnector::new().await {
-        client
-    } else {
-        return error!("Failed to create LND client for bond payout job");
-    };
-
     tokio::spawn(async move {
+        // Retry LndConnector::new() with capped exponential backoff so a
+        // transient LND startup failure (e.g. LND not yet listening when
+        // mostrod boots, or a brief restart) does not permanently halt
+        // PendingPayout draining. Without this, every bond stuck in
+        // PendingPayout would sit there until the operator restarts
+        // mostrod — losing any chance of forfeit / payout for the
+        // duration. Backoff caps at 60s to keep retry pressure modest.
+        let mut backoff_secs: u64 = 2;
+        let mut ln_client = loop {
+            match LndConnector::new().await {
+                Ok(client) => break client,
+                Err(e) => {
+                    error!(
+                        "bond payout: LndConnector::new failed: {e} — retrying in {backoff_secs}s"
+                    );
+                    tokio::time::sleep(tokio::time::Duration::from_secs(backoff_secs)).await;
+                    backoff_secs = (backoff_secs * 2).min(60);
+                }
+            }
+        };
+
         let pool = ctx.pool();
         loop {
             bond::run_bond_payout_cycle(pool, &mut ln_client).await;

--- a/src/util.rs
+++ b/src/util.rs
@@ -526,7 +526,7 @@ pub async fn send_dm(
     .await?;
 
     info!(
-        "Sending DM, Event ID: {} to {} with payload: {:#?}",
+        "Sending message, Event ID: {} to {} with payload: {:#?}",
         event.id,
         receiver_pubkey.to_hex(),
         payload


### PR DESCRIPTION
## Summary

Implements **Phase 3** of the Anti-Abuse Bond rollout (issue #711, spec
`docs/ANTI_ABUSE_BOND.md` §8). Picks up where #737 left off: bonds that
Phase 2 parked in `BondState::PendingPayout` now get drained through
to either `Slashed`, `Forfeited`, or `Failed`.

- New scheduler tick `job_process_bond_payouts` (mirror of the dev-fee
  job) that for each `PendingPayout` bond:
  - settles + transitions to `Forfeited` once `payout_claim_window_days`
    elapses with no counterparty invoice (long-stop forfeiture, §15.4);
  - asks the non-slashed counterparty for a payout bolt11 via
    `Action::AddBondInvoice` (cadence-gated on
    `payout_invoice_window_seconds`, with the forfeit deadline shipped
    as a `Payload::TextMessage` DM alongside);
  - on receipt, settles the bond HTLC and `send_payment`s the
    counterparty share (`amount_sats − node_share_sats`), capped by
    `MostroSettings::max_routing_fee`;
  - retries `send_payment` failures up to `payout_max_retries`, then
    transitions to `Failed` with a loud `error!` for operator review;
  - skips the counterparty leg entirely when `slash_node_share_pct = 1.0`
    (settle → `Slashed`, no DMs, no `send_payment`).
- New action handler `add_bond_invoice_action` consuming
  `Action::AddBondInvoice` replies. CAS-guarded persistence (`state =
  PendingPayout AND payout_invoice IS NULL`) closes the late-invoice
  race against a concurrent `Forfeited` transition.
- Spec edits in `docs/ANTI_ABUSE_BOND.md`:
  - §8.1 / §8.3: removed the Nostr audit-event subsection (slash
    observability stays tracing-only via §14.5, which is left
    untouched);
  - §8.1 invoice-request DM and recipient resolution now reference
    `Action::AddBondInvoice` instead of `AddInvoice` — keeps the
    bond-payout invoice flow disjoint from the buyer-flow at the
    routing layer rather than relying on ambient DB lookups;
  - §14.3 documents the `mostro-core` 0.11.3 bump that ships
    `Action::AddBondInvoice`.
- `Cargo.toml`: bumped `mostro-core` from 0.11.1 to 0.11.3.
- Drive-by: added missing `anti_abuse_bond: None` to the
  `config::util` test helper `make_settings`, which had failed to
  compile in the test profile since Phase 0 landed the new field on
  `Settings`.

The split snapshot (`node_share_sats`) frozen by Phase 2 at the
`Locked → PendingPayout` transition is the sole source of truth for
the scheduler; `slash_node_share_pct` is never re-read from config.
Daemon restarts and operator config changes mid-payout cannot
rebalance an in-flight bond.

## Test plan

- [x] `cargo test --bin mostrod` — 298 tests pass (10 new tests under
      `src/app/bond/payout.rs::tests`).
- [x] `cargo clippy --all-targets --all-features -- -D warnings`.
- [x] `cargo fmt --all`.
- [x] `SQLX_OFFLINE=true cargo build --bin mostrod` (no new compile-time
      `query!` macros, so the offline cache is unchanged).

## How to test (manual regtest walkthrough)

These scenarios exercise Phase 3 end-to-end against polar/regtest LND.
The cast:

- **User A** — the **maker**. Posts a sell-order in scenarios S1–S5 and
  S7, a buy-order in S6.
- **User B** — the **taker**. Posts the anti-abuse bond (`apply_to = "take"`).
- **User C** — the **solver/admin** with their pubkey in
  `mostro.solvers`. Resolves disputes via `admin-settle` / `admin-cancel`.

Common setup before every scenario:

1. In `settings.toml` enable the bond on the taker side:
   ```toml
   [anti_abuse_bond]
   enabled = true
   apply_to = "take"
   slash_node_share_pct = 0.5
   payout_invoice_window_seconds = 60   # shrink for faster manual runs
   payout_max_retries = 3
   payout_claim_window_days = 1         # shrink for faster manual runs
   ```
2. Start mostrod and tail logs with
   `RUST_LOG=info,mostro=debug`. Look for the
   `bond payout:` prefix — every transition logs through it.
3. `sqlite3 mostro.db "select id, state, slashed_reason, node_share_sats, payout_attempts, invoice_request_attempts, last_invoice_request_at, payout_invoice from bonds;"`
   is the source of truth for state per row.

### S1 — Happy path: dispute slashes buyer, seller paid out

Tests the `LostDispute → settle (at slash time) → AddBondInvoice → send_payment → Slashed` flow.

1. **A** posts a sell-order on Mostro for, say, 100 000 sats.
2. **B** takes it. Order moves through `WaitingTakerBond` → bond
   bolt11 (`Action::PayBondInvoice`) is DMed to B. Confirm in the DB
   the bond row is `requested`, then `locked` once B pays the
   bond invoice.
3. Trade proceeds normally to `WaitingPayment` / `Active`. **B**
   (buyer) pays the hold invoice. Then **A** signals fiat-sent /
   release won't happen; one party opens a dispute.
4. **C** picks up the dispute (`admin-take-dispute`) and resolves
   with **settle + slash buyer**:
   ```json
   { "order": { "version": 1, "id": "<order-id>",
     "action": "admin-settle",
     "payload": { "bond_resolution":
       { "slash_seller": false, "slash_buyer": true } } } }
   ```
5. **Inspect the bond row** — it must read
   `state = pending-payout, slashed_reason = lost-dispute,
    node_share_sats = 500` (50% of a 1 000 sat bond at the spec
   defaults). `slashed_at` is set; `payout_invoice` is `NULL`.
   Also confirm in the log the line `Bond HTLC settled and row
   transitioned to PendingPayout` — the slash path settles the
   bond hold invoice **immediately** (Phase 2 §7.3), so Mostro's
   wallet is already up by **1 000 sats** at this point. Phase 3
   only drives the recipient payout from sats already on hand.
6. Within ~60 s the scheduler tick fires. **A** (the non-slashed
   seller — the recipient under §3.1 mapping for a sell-order) must
   receive an `Action::AddBondInvoice` message with the order
   context (the amount field = 500 sats, the counterparty share).
   The message carries **only the structured payload** — no
   human-readable deadline text. Clients render the forfeit
   warning locally from `slashed_at + bond_payout_claim_window_days
   × 86 400`, with `bond_payout_claim_window_days` published on the
   kind-38385 info event (§13.1). DB-wise:
   `invoice_request_attempts = 1`, `last_invoice_request_at` is
   now-ish.
7. **A** replies with `Action::AddBondInvoice` carrying a bolt11 for
   500 sats. Verify the DB now shows `payout_invoice = lnbc…` and
   `invoice_request_attempts` reset to 0.
8. On the next scheduler tick (≤60 s) the daemon should:
   - `send_payment` to A's bolt11 for 500 sats, capped by
     `max_routing_fee` (the sats are drawn from the slash-time
     settle in step 4 — Phase 3 never calls `settle_hold_invoice`);
   - flip the row to `state = slashed`.
9. Confirm A actually received 500 sats on their LN wallet, the
   bond row is `slashed`, and `payout_attempts` is still 0 (no
   retries needed).

### S2 — Forfeit window: counterparty never claims

Tests the long-stop `Forfeited` path (§15.4).

1. Repeat steps 1–4 of S1. Mostro's wallet is already up by 1 000
   sats from the slash-time settle.
2. Verify the bond is `pending-payout` and **A** received the first
   `AddBondInvoice` message. **A does nothing** — no reply.
3. Optional accelerator: shrink the deadline by tweaking
   `payout_claim_window_days = 1` in `settings.toml` *before*
   starting the run (the scheduler reads the config on every tick,
   only the snapshot inside `node_share_sats` is frozen — so
   shrinking the window mid-flight also works).
4. After `payout_claim_window_days × 86 400` seconds, the next
   scheduler tick must:
   - CAS-flip the row to `state = forfeited` — a pure SQL
     transition with the `AND payout_invoice IS NULL` race guard;
     no LND call (the HTLC was settled at slash time);
   - log `bond forfeited: claim window elapsed, node retains full
     amount`.
5. Confirm A receives **no** further messages and **no** Lightning
   payment. Mostro's wallet is still up by 1 000 sats (no change
   from step 1 — the forfeit transition just records that the
   counterparty share is also retained by the node now). `bonds`
   row is `forfeited`; `payout_invoice` is still `NULL`.

### S3 — Late invoice on a forfeited bond is rejected

Companion to S2; covers the CAS-guarded `add_bond_invoice_action`.

1. From S2 step 5 (bond is now `forfeited`), **A** wakes up and
   sends an `Action::AddBondInvoice` reply with a valid bolt11.
2. Expected: the daemon returns
   `CantDo(NotAllowedByStatus)` to A and does not touch the
   `bonds` row. The row stays `state = forfeited,
   payout_invoice IS NULL`.

### S4 — `slash_node_share_pct = 1.0`: full node retention

Tests the no-counterparty-leg shortcut.

1. Before starting: edit `settings.toml` to
   `slash_node_share_pct = 1.0` and restart mostrod.
2. Run S1 steps 1–4.
3. Verify the bond row reads
   `node_share_sats = 1000` (i.e. equal to `amount_sats`).
4. The HTLC was settled at slash time, so Mostro's wallet is
   already up by 1 000 sats by the end of step 2 (look for the
   `Bond HTLC settled and row transitioned to PendingPayout` log
   line). On the next scheduler tick:
   - the row CAS-flips directly to `state = slashed` — pure SQL,
     no LND call;
   - **no `AddBondInvoice` message** is sent to A, and no
     `send_payment` runs.
5. Confirm A receives nothing (no messages, no sats) and Mostro's
   wallet is up by 1 000 sats.

### S5 — `send_payment` retries → `Failed`

Tests the technical-failure path that produces an operator-attention
state.

1. Set `payout_max_retries = 3` in `settings.toml`.
2. Run S1 steps 1–6 normally.
3. At step 7, **A** submits a deliberately unroutable invoice —
   easiest way on polar: pay from a node with no channel path to A,
   or have A advertise an invoice on a node Mostro can't reach
   (force-close all channels between them before submission).
4. On each scheduler tick the daemon should:
   - try `send_payment`, fail;
   - log `bond payout: send_payment failure (...); will retry on
     next tick`;
   - bump `payout_attempts` by 1.
5. After three failures (`payout_attempts = 3`), the bond must
   transition `state = failed` and the log line must be the loud
   `error!` `bond payout: send_payment exhausted retries —
   transitioning to Failed; node share retained, counterparty
   share stranded (operator review required)`.
6. Confirm Mostro's wallet retains the full 1 000 sats (the
   slash-time settle in step 2 deposited them; only the
   counterparty `send_payment` leg never landed). This is the
   known-limitation case the spec §8.2 calls out — operators
   manually pay A from logs.

### S6 — Buy-order mirror of S1 (recipient resolution sanity)

Same flow, different §3.1 mapping. Confirms recipient resolution
isn't hard-coded for sell-orders.

1. **A** posts a **buy-order** (maker is buyer, taker will be
   seller).
2. **B** takes it (B is now the seller; their bond locks).
3. Drive the trade into dispute. **C** resolves with **cancel +
   slash seller**:
   ```json
   { "order": { "version": 1, "id": "<order-id>",
     "action": "admin-cancel",
     "payload": { "bond_resolution":
       { "slash_seller": true, "slash_buyer": false } } } }
   ```
4. Expected recipient is now **A** (the buyer = the non-slashed
   side on a buy-order). Confirm A — not B — receives the
   `AddBondInvoice` message, and the rest of S1 plays out
   identically.

### S7 — Daemon restart mid-payout preserves the split snapshot

Tests the "config changes can't rebalance an in-flight bond"
invariant.

1. Run S1 steps 1–5 (bond is `pending-payout`,
   `node_share_sats = 500`).
2. **Before** A submits an invoice, stop mostrod, edit
   `slash_node_share_pct = 0.9` in `settings.toml`, restart.
3. On the next scheduler tick A still receives an `AddBondInvoice`
   message **for 500 sats** (not 100 sats — the 0.9 snapshot is
   ignored).
4. A submits an invoice for 500 sats → `send_payment` runs for
   500 sats (the bond HTLC was already settled at slash time
   in S1 step 4 of the original run, before the restart). Confirm
   the row's `node_share_sats` is still 500 and the bond ends in
   `state = slashed`.

### Quick sanity grep before merging

```bash
sqlite3 mostro.db "select state, count(*) from bonds group by state;"
```

After running S1, S2, S4, S5, S6, S7 the row should be:
`slashed | 3` (S1, S4, S6), `forfeited | 1` (S2), `failed | 1` (S5),
`slashed | 1` (S7) — no row stuck in `pending-payout` other than the
late `S3` case (which is `forfeited`).

Refs: #711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background bond payout processing: periodic job to advance pending payouts, request counterparty invoices, settle/pay or forfeit bonds, and handle retries; inbound invoice message handling.

* **Documentation**
  * Updated Anti‑Abuse Bond spec and runtime docs: Phase 3 payout flow, invoice-request rules, recipient resolution, message wording, and info‑tag bond-policy details.

* **Tests**
  * Added unit tests for recipient resolution, invoice-request cadence, forfeiture transitions, and payment retry behavior.

* **Chores**
  * Bumped core dependency to 0.11.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/738)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->