### PR TITLE
fix: include created_at on AddInvoice SmallOrder

### DIFF
--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -198,7 +198,6 @@ mod tests {
             mostro: MostroSettings::default(),
             rpc: RpcSettings::default(),
             expiration: None,
-            anti_abuse_bond: None,
         }
     }
 

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -198,6 +198,7 @@ mod tests {
             mostro: MostroSettings::default(),
             rpc: RpcSettings::default(),
             expiration: None,
+            anti_abuse_bond: None,
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -971,7 +971,7 @@ pub async fn set_waiting_invoice_status(
         None,
         None,
         None,
-        None,
+        Some(order.created_at),
         None,
     );
     // We create a Message


### PR DESCRIPTION
## Summary

- Set `SmallOrder.created_at` from `order.created_at` in `set_waiting_invoice_status` when sending `Action::AddInvoice` to the buyer, matching the payload shape used in `flow::hold_invoice_paid` so clients (e.g. Mostrix) can show order creation time after a take-sell flow without an invoice in the take message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Buyer invoice notifications now include the order creation timestamp.

* **Tests**
  * Test helpers updated to include the anti-abuse bond field for environment-variable override scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->