### PR TITLE
feat(bond): Phase 3.5 — payout confirmation to the winner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1304,7 +1304,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b972de34af6574c8fbb2a6e8fd6a8e478fd45875ef4eae45165668b30246cf0"
+checksum = "58d84611d5f96e2aa8310633c00763615f12ca46e331b4dd42c184a6329ca1eb"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1906,7 +1906,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2302,7 +2302,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -2339,9 +2339,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2559,7 +2559,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3122,7 +3122,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.11.3", features = ["sqlx"] }
+mostro-core = { version = "0.11.4", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.45", features = ["derive"] }

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -1374,8 +1374,8 @@ explicit refusal message.
 
 ### 8.5.1 Scope
 
-- **Two additive `Action` variants in `mostro-core`** (target a future
-  release, e.g. 0.11.4 — not yet shipped). Both are Mostro → winner and
+- **Two additive `Action` variants in `mostro-core`** (released in
+  0.11.4). Both are Mostro → winner and
   carry `Payload::Order` (the same `SmallOrder` shape the client already
   renders for other order-bearing actions), so older clients that ignore
   unknown actions degrade gracefully:
@@ -1833,8 +1833,8 @@ these requires a compatibility statement:
   must land together. `MessageKind::verify` accepts this variant only
   on `Action::AddBondInvoice`.
 - `Action::BondInvoiceAccepted` + `Action::BondPayoutCompleted` in
-  mostro-core (Phase 3.5). **Not yet released** — target a future minor
-  (e.g. 0.11.4). Mostro → winner acknowledgements (payout-invoice
+  mostro-core (Phase 3.5). **Released in `mostro-core` 0.11.4.** Mostro →
+  winner acknowledgements (payout-invoice
   receipt and terminal payout success); duals of the existing
   `Action::BuyerInvoiceAccepted` / `Action::PurchaseCompleted`. Both are
   serde-additive and carry `Payload::Order`, so a client that doesn't

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -341,7 +341,6 @@ async fn request_payout_invoice(
     };
 
     let counterparty_share = counterparty_share_sats(bond)?;
-    let order_kind = order.get_order_kind().map_err(MostroInternalErr)?;
 
     // `process_one_bond` already errored out on a missing `slashed_at`
     // before dispatching here, but re-check rather than `.unwrap()` so
@@ -354,23 +353,7 @@ async fn request_payout_invoice(
         )))
     })?;
 
-    let small = SmallOrder::new(
-        Some(order.id),
-        Some(order_kind),
-        None,
-        counterparty_share,
-        order.fiat_code.clone(),
-        order.min_amount,
-        order.max_amount,
-        order.fiat_amount,
-        order.payment_method.clone(),
-        order.premium,
-        None,
-        None,
-        None,
-        None,
-        None,
-    );
+    let small = build_payout_small_order(&order, counterparty_share)?;
 
     // Persist the cadence bump *before* enqueuing the outbound
     // message. Order matters: `enqueue_order_msg` mutates an
@@ -701,6 +684,10 @@ async fn slash_after_success(
                         counterparty_share_sats = counterparty_share,
                         "bond payout: send_payment succeeded; bond transitioned to Slashed"
                     );
+                    // Phase 3.5: confirm the payout to the winner so
+                    // their client can close the claim (best-effort —
+                    // never blocks or rolls back the slash).
+                    notify_payout_completed(pool, bond, counterparty_share).await;
                 } else {
                     // The row moved off `PendingPayout` between the
                     // send_payment and this CAS — only legitimate path
@@ -804,6 +791,170 @@ fn resolve_recipient(
         .transpose()
         .map_err(|e| MostroInternalErr(ServiceError::UnexpectedError(e.to_string())))?;
     Ok(pk)
+}
+
+/// Build the `SmallOrder` carried by bond-payout messages
+/// (`AddBondInvoice`, `BondInvoiceAccepted`, `BondPayoutCompleted`).
+/// `order.amount` carries the **counterparty share** — the figure the
+/// winner's client renders — not the trade amount.
+fn build_payout_small_order(
+    order: &Order,
+    counterparty_share: i64,
+) -> Result<SmallOrder, MostroError> {
+    let order_kind = order.get_order_kind().map_err(MostroInternalErr)?;
+    Ok(SmallOrder::new(
+        Some(order.id),
+        Some(order_kind),
+        None,
+        counterparty_share,
+        order.fiat_code.clone(),
+        order.min_amount,
+        order.max_amount,
+        order.fiat_amount,
+        order.payment_method.clone(),
+        order.premium,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ))
+}
+
+/// Phase 3.5 — best-effort outbound acknowledgement to the winning
+/// counterparty. Enqueues `action` (`BondInvoiceAccepted` or
+/// `BondPayoutCompleted`) carrying the order as a `SmallOrder`
+/// (amount = counterparty share) to `recipient`.
+///
+/// Deliberately infallible: a failure to *notify* must never roll back
+/// the bond state transition that triggered it. The winner still
+/// receives the sats over Lightning; the worst case of a dropped ack is
+/// a missing confirmation message, which a later user action or the
+/// generic `CantDo` backstop surfaces anyway. Failures are logged, not
+/// propagated.
+async fn enqueue_payout_ack(
+    order: &Order,
+    action: Action,
+    recipient: PublicKey,
+    counterparty_share: i64,
+) {
+    let small = match build_payout_small_order(order, counterparty_share) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                order_id = %order.id,
+                "bond payout: cannot build SmallOrder for {action} ack ({e:?}); skipping notification"
+            );
+            return;
+        }
+    };
+    enqueue_order_msg(
+        None,
+        Some(order.id),
+        action,
+        Some(Payload::Order(small)),
+        recipient,
+        None,
+    )
+    .await;
+}
+
+/// Phase 3.5 — tell the winner their payout bolt11 was received and the
+/// payment is now pending (`Action::BondInvoiceAccepted`). Sent to the
+/// submitter (`recipient`) right after the invoice is persisted, so the
+/// client stops prompting the user for another invoice. Best-effort.
+async fn notify_invoice_received(
+    pool: &Pool<Sqlite>,
+    bond: &Bond,
+    recipient: PublicKey,
+    counterparty_share: i64,
+) {
+    match Order::by_id(pool, bond.order_id).await {
+        Ok(Some(order)) => {
+            enqueue_payout_ack(
+                &order,
+                Action::BondInvoiceAccepted,
+                recipient,
+                counterparty_share,
+            )
+            .await;
+        }
+        Ok(None) => warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "bond payout: order row missing; skipping BondInvoiceAccepted ack"
+        ),
+        Err(e) => warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "bond payout: order load failed ({e}); skipping BondInvoiceAccepted ack"
+        ),
+    }
+}
+
+/// Phase 3.5 — tell the winner the payout succeeded and the claim is
+/// closed (`Action::BondPayoutCompleted`). Sent after the
+/// `PendingPayout → Slashed` CAS lands. Resolves the recipient the same
+/// way the invoice request does (the non-slashed counterparty).
+/// Best-effort. **Not** sent on the node-only
+/// (`slash_node_share_pct = 1.0`) path — there is no counterparty leg
+/// and the winner was never asked for an invoice.
+async fn notify_payout_completed(pool: &Pool<Sqlite>, bond: &Bond, counterparty_share: i64) {
+    let order = match Order::by_id(pool, bond.order_id).await {
+        Ok(Some(o)) => o,
+        Ok(None) => {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "bond payout: order row missing; skipping BondPayoutCompleted notification"
+            );
+            return;
+        }
+        Err(e) => {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "bond payout: order load failed ({e}); skipping BondPayoutCompleted notification"
+            );
+            return;
+        }
+    };
+    let reason = match bond
+        .slashed_reason
+        .as_deref()
+        .and_then(|s| BondSlashReason::from_str(s).ok())
+    {
+        Some(r) => r,
+        None => {
+            warn!(
+                bond_id = %bond.id,
+                "bond payout: unparseable slashed_reason {:?}; skipping BondPayoutCompleted notification",
+                bond.slashed_reason
+            );
+            return;
+        }
+    };
+    match resolve_recipient(&order, bond, reason) {
+        Ok(Some(recipient)) => {
+            enqueue_payout_ack(
+                &order,
+                Action::BondPayoutCompleted,
+                recipient,
+                counterparty_share,
+            )
+            .await;
+        }
+        Ok(None) => warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "bond payout: cannot resolve recipient; skipping BondPayoutCompleted notification"
+        ),
+        Err(e) => warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "bond payout: recipient resolution failed ({e:?}); skipping BondPayoutCompleted notification"
+        ),
+    }
 }
 
 // ── Inbound action handler ──────────────────────────────────────────────
@@ -920,7 +1071,6 @@ pub async fn add_bond_invoice_action(
                 sender = %sender,
                 "bond payout: invoice accepted; awaiting scheduler tick for payout"
             );
-            Ok(())
         }
         InvoiceApplyOutcome::Resurrected => {
             info!(
@@ -929,10 +1079,18 @@ pub async fn add_bond_invoice_action(
                 sender = %sender,
                 "bond payout: Failed -> PendingPayout (user submitted fresh invoice within claim window); payout_attempts reset, awaiting scheduler tick for payout"
             );
-            Ok(())
         }
-        InvoiceApplyOutcome::Rejected => Err(MostroCantDo(CantDoReason::NotAllowedByStatus)),
+        InvoiceApplyOutcome::Rejected => {
+            return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+        }
     }
+
+    // Phase 3.5: acknowledge receipt to the winner (best-effort) so the
+    // client marks the invoice as received and stops prompting the user
+    // for another one. The bolt11 is already persisted at this point;
+    // a failed ack never affects the payout.
+    notify_invoice_received(pool, &bond, sender, counterparty_share).await;
+    Ok(())
 }
 
 /// Persist `invoice` onto `bond` via one of two state-specific CAS
@@ -2032,5 +2190,131 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(after.0, BondState::Slashed.to_string());
+    }
+
+    /// Recipient pubkeys (hex) of queued messages matching `order_id` +
+    /// `action`. Lets a test assert both the count and the destination
+    /// of Phase 3.5 acks against the global `MESSAGE_QUEUES`.
+    async fn ack_recipients(order_id: Uuid, action: Action) -> Vec<String> {
+        use crate::config::MESSAGE_QUEUES;
+        MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(m, _)| {
+                let k = m.get_inner_message_kind();
+                k.id == Some(order_id) && k.action == action
+            })
+            .map(|(_, pk)| pk.to_string())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn notify_invoice_received_acks_submitter() {
+        // Phase 3.5: when the winner's payout bolt11 is accepted, an
+        // `Action::BondInvoiceAccepted` is enqueued back to the
+        // submitter so their client stops prompting for an invoice.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let recipient = PublicKey::from_str(maker_pk()).unwrap();
+        let before = ack_recipients(order_id, Action::BondInvoiceAccepted)
+            .await
+            .len();
+        notify_invoice_received(&pool, &bond, recipient, 5_000).await;
+        let after = ack_recipients(order_id, Action::BondInvoiceAccepted).await;
+
+        assert_eq!(after.len() - before, 1);
+        assert!(after.contains(&maker_pk().to_string()));
+    }
+
+    #[tokio::test]
+    async fn notify_payout_completed_acks_counterparty() {
+        // Phase 3.5: after the payout settles, the non-slashed
+        // counterparty (here the seller/maker, since the bond is on the
+        // buyer/taker of a sell order) receives BondPayoutCompleted.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, now, None, None);
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let before = ack_recipients(order_id, Action::BondPayoutCompleted)
+            .await
+            .len();
+        notify_payout_completed(&pool, &bond, 5_000).await;
+        let after = ack_recipients(order_id, Action::BondPayoutCompleted).await;
+
+        assert_eq!(after.len() - before, 1);
+        assert!(after.contains(&maker_pk().to_string()));
+    }
+
+    #[tokio::test]
+    async fn slash_after_success_notifies_winner() {
+        // The success CAS that flips PendingPayout -> Slashed also
+        // enqueues exactly one BondPayoutCompleted to the counterparty.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            Some("lnbc1pPAID"),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let before = ack_recipients(order_id, Action::BondPayoutCompleted)
+            .await
+            .len();
+        slash_after_success(&pool, &bond, 5_000).await.unwrap();
+        let after = ack_recipients(order_id, Action::BondPayoutCompleted).await;
+
+        let state: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(state.0, BondState::Slashed.to_string());
+        assert_eq!(after.len() - before, 1);
+        assert!(after.contains(&maker_pk().to_string()));
+    }
+
+    #[tokio::test]
+    async fn finalize_node_only_does_not_notify_winner() {
+        // slash_node_share_pct = 1.0: the whole bond is the node share,
+        // there is no counterparty leg, and the winner was never asked
+        // for an invoice — so no BondPayoutCompleted must be sent.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        // node_share == amount → counterparty share is 0.
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 10_000, now, None, None);
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let before = ack_recipients(order_id, Action::BondPayoutCompleted)
+            .await
+            .len();
+        finalize_node_only(&pool, &bond).await.unwrap();
+        let after = ack_recipients(order_id, Action::BondPayoutCompleted).await;
+
+        let state: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(state.0, BondState::Slashed.to_string());
+        assert_eq!(after.len(), before); // no new notification
     }
 }


### PR DESCRIPTION
## What

Implements **Phase 3.5** of the anti-abuse bond (`docs/ANTI_ABUSE_BOND.md` §8.5): the daemon now confirms the bond-payout flow to the winning counterparty, using the two new `Action` variants shipped in **`mostro-core` 0.11.4**.

## Why

Field testing surfaced a gap in the Phase 3 payout flow: once the winner submits their payout bolt11, Mostro told them **nothing**. The `send_payment` retry loop is silent and the `PendingPayout → Slashed` success transition enqueued no message, so the client couldn't tell whether the invoice was received, paid, or still pending — and the user kept re-submitting invoices that would never be paid.

> _Reported by a user testing the bond rollout: "estaría bueno avisarle al ganador del bond que su invoice ya fue pagada, o cuando fue recibida, porque sino los clientes no saben y el user va a poder seguir mandando invoices."_

## Changes

- **`Action::BondInvoiceAccepted`** — sent to the winner right after their payout bolt11 is persisted (both the first-time `Persisted` and the `Failed`-resurrection paths), so the client stops prompting for an invoice.
- **`Action::BondPayoutCompleted`** — sent to the winner when the `PendingPayout → Slashed` CAS lands (`send_payment` succeeded), so the client closes the claim. **Not** sent on the node-only (`slash_node_share_pct = 1.0`) path.
- Both are **best-effort**: a dropped ack never rolls back the slash (the sats already arrived over Lightning). They share a new `build_payout_small_order` helper (also folded into `request_payout_invoice`).
- The redundant-invoice refusals already return `CantDo(NotAllowedByStatus)` from Phase 3, matching the spec — no change needed there.
- Bumps the `mostro-core` pin to **0.11.4** and marks the Phase 3.5 entries in `docs/ANTI_ABUSE_BOND.md` as released.

## Tests

New unit tests: receipt ack to submitter, completion ack to counterparty, the `slash_after_success` wiring, and the node-only no-notification case.

- `cargo fmt --check` ✓
- `cargo clippy --all-targets --all-features` ✓
- `cargo test` → **327 passed** ✓ (against published `mostro-core` 0.11.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bond payout notifications with enhanced counterparty communication and state tracking

* **Bug Fixes**
  * Enhanced error handling in bond invoice submission and processing workflows

* **Improvements**
  * Optimized payout flow structure for improved reliability

* **Chores**
  * Updated core dependency to v0.11.4

* **Documentation**
  * Updated anti-abuse bond documentation to reflect current feature availability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->