### PR TITLE
feat(bond): Phase 4 — timeout slash for the taker bond

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d84611d5f96e2aa8310633c00763615f12ca46e331b4dd42c184a6329ca1eb"
+checksum = "964e2810ab700532c3e6677615123372bf9a0ef3fbba4e36b9d65e98f3734ef0"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.11.4", features = ["sqlx"] }
+mostro-core = { version = "0.11.5", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 clap = { version = "4.5.45", features = ["derive"] }

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -190,7 +190,7 @@ slash path.
 | 2 | Solver-directed dispute slash via `BondResolution` payload (taker bond) | 1.5 | pending |
 | 3 | Payout flow: `Action::AddBondInvoice` to winner, routing-fee estimation, retries | 2 | pending |
 | 3.5 | Payout confirmation to the winner: `BondInvoiceAccepted` (receipt) + `BondPayoutCompleted` (paid) + explicit "already paid" refusal | 3 | proposed |
-| 4 | Timeout slash for taker bond (`slash_on_waiting_timeout`) | 3 | pending |
+| 4 | Timeout slash for taker bond (`slash_on_waiting_timeout`) + `Action::BondSlashed` forfeiture notice | 3 | ✅ shipped (mostro-core 0.11.5) |
 | 5 | Maker bond (non-range): lock + dispute slash reusing Phase 2/3 | 3 | pending |
 | 6 | Maker bond for **range orders** with proportional slashes | 5 | pending |
 | 7 | Timeout slash for maker bond | 5 | pending |
@@ -1516,6 +1516,17 @@ adding maker bond rows to the lookup.
 
 ### 9.3 Scope
 
+**Implemented (as shipped):** the timeout-slash dispatch lives in
+`bond::slash_or_release_on_timeout` (`src/app/bond/slash.rs`), called
+from `scheduler::job_cancel_orders` in the persist-success branch that
+previously did an unconditional Phase 1 release. It reuses the Phase 2
+`apply_bond_resolution` primitive, deriving a `BondResolution` from the
+§9.2 responsibility table; the §3.1 buyer/seller → bond mapping baked
+into that primitive resolves the responsible party's bond row. The bond
+config is passed in (the scheduler hands it `Settings::get_bond()`)
+rather than read from the global, so the gate is unit-testable. The
+slash notice uses `Action::BondSlashed` (mostro-core **0.11.5**).
+
 - Modify `scheduler::job_cancel_orders`: when the waiting-state timeout
   elapses on an order in `WaitingBuyerInvoice` / `WaitingPayment`, run
   the §9.2 lookup. If a bond exists for the responsible party, reuse
@@ -1528,7 +1539,17 @@ adding maker bond rows to the lookup.
   §8.1: `slashed_reason = Timeout` plus the §9.2 responsibility entry
   uniquely names the non-slashed counterparty (`WaitingBuyerInvoice`
   → seller; `WaitingPayment` → buyer).
-- Localised message to the slashed user explaining forfeiture.
+- Localised forfeiture notice to the slashed user via the dedicated
+  `Action::BondSlashed` (mostro-core 0.11.5; Mostro → slashed user,
+  `Payload::Order` with `amount` = the slashed bond amount). It carries
+  no human-readable text — the client renders the forfeiture message in
+  the user's locale. The notice is **best-effort and complements** the
+  `Action::Canceled` the slashed user already receives for the order; a
+  dropped notice never rolls back the slash. It is sent **only after the
+  slash is confirmed to have landed** (the bond row re-reads as
+  `PendingPayout`), so a transient `settle_hold_invoice` failure — which
+  leaves the bond `Locked` for retry — can never produce a false "your
+  bond was slashed" message.
 - Tests:
   - "Cancel at minute 5 of a 15-minute timeout" → bond released, no
     slash.
@@ -1842,6 +1863,19 @@ these requires a compatibility statement:
   confirmation — no funds at risk. No new `CantDoReason` is needed: the
   "already paid / in progress" refusals reuse
   `CantDoReason::NotAllowedByStatus`.
+- `Action::BondSlashed` in mostro-core (Phase 4). **Released in
+  `mostro-core` 0.11.5.** Mostro → slashed-user forfeiture notice for a
+  waiting-state timeout slash; carries `Payload::Order` (`amount` = the
+  slashed bond amount). Earlier drafts of this spec assumed Phase 4 was
+  daemon-only with no protocol change and reused the existing
+  `Action::Canceled`; the dedicated action was added so the slashed
+  user's client can render an explicit, localised forfeiture message
+  rather than inferring it. Serde-additive: a client that doesn't know
+  the variant ignores the message and falls back to the
+  `Action::Canceled` it already receives for the order — no funds at
+  risk. `MessageKind::verify` accepts it like the other Mostro → user
+  notifications (id required; `BondResolution` / `BondPayoutRequest`
+  payloads rejected). No new `CantDoReason` is needed.
 - `Status::WaitingMakerBond` (Phase 5). Not yet shipped upstream;
   needs a follow-up `mostro-core` minor release before Phase 5 can
   land here.

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -1546,10 +1546,14 @@ slash notice uses `Action::BondSlashed` (mostro-core **0.11.5**).
   the user's locale. The notice is **best-effort and complements** the
   `Action::Canceled` the slashed user already receives for the order; a
   dropped notice never rolls back the slash. It is sent **only after the
-  slash is confirmed to have landed** (the bond row re-reads as
-  `PendingPayout`), so a transient `settle_hold_invoice` failure — which
-  leaves the bond `Locked` for retry — can never produce a false "your
-  bond was slashed" message.
+  slash is confirmed to have landed** — confirmed via the bond row's
+  durable `slashed_reason = Timeout` metadata (which the concurrent
+  Phase 3 payout scheduler never clears as it moves the row
+  `PendingPayout → Slashed | Forfeited | Failed`), not a transient
+  `state = PendingPayout` check that the scheduler could invalidate
+  within the race window. A transient `settle_hold_invoice` failure
+  leaves the bond `Locked` with no slash metadata, so it can never
+  produce a false "your bond was slashed" message.
 - Tests:
   - "Cancel at minute 5 of a 15-minute timeout" → bond released, no
     slash.

--- a/src/app/bond/mod.rs
+++ b/src/app/bond/mod.rs
@@ -24,5 +24,8 @@ pub use flow::{
 pub use math::{compute_bond_amount, compute_node_share};
 pub use model::Bond;
 pub use payout::{add_bond_invoice_action, run_bond_payout_cycle};
-pub use slash::{apply_bond_resolution, extract_bond_resolution, validate_bond_resolution};
+pub use slash::{
+    apply_bond_resolution, extract_bond_resolution, notify_bond_slashed,
+    slash_or_release_on_timeout, validate_bond_resolution,
+};
 pub use types::{BondRole, BondSlashReason, BondState};

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -39,25 +39,30 @@
 use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
+use std::str::FromStr;
 
 use chrono::Utc;
 use mostro_core::error::{
     CantDoReason,
-    MostroError::{self, MostroCantDo},
+    MostroError::{self, MostroCantDo, MostroInternalErr},
+    ServiceError,
 };
-use mostro_core::message::{BondResolution, Message, Payload};
-use mostro_core::order::Order;
+use mostro_core::message::{Action, BondResolution, Message, Payload};
+use mostro_core::order::{Order, SmallOrder, Status};
+use nostr_sdk::prelude::PublicKey;
 use sqlx::{Pool, Sqlite};
 use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::db::find_active_bonds_for_order;
-use super::flow::release_bond;
+use super::flow::{release_bond, release_bonds_for_order_or_warn};
 use super::math::compute_node_share;
 use super::model::Bond;
 use super::types::{BondSlashReason, BondState};
 use crate::config::settings::Settings;
+use crate::config::types::AntiAbuseBondSettings;
 use crate::lightning::LndConnector;
+use crate::util::enqueue_order_msg;
 
 /// Minimal LND-side capability the slash path needs: settle a hold
 /// invoice by preimage. Mirrors the [`crate::app::cancel::CancelLightning`]
@@ -238,6 +243,207 @@ pub async fn apply_bond_resolution<L: SettleLightning + Send>(
     }
 
     Ok(())
+}
+
+/// Phase 4 — timeout-slash dispatch for the scheduler's
+/// `job_cancel_orders`.
+///
+/// Given the **pre-cancel** snapshot of an order whose waiting-state
+/// deadline elapsed, decide — from the waiting state alone (the §9.2
+/// responsibility table) and the node's bond policy — whether the
+/// responsible party's bond is slashed with `BondSlashReason::Timeout`,
+/// or every bond on the order is simply released (the Phase 1 "always
+/// release" behaviour).
+///
+/// Responsibility maps directly from the waiting state:
+/// `WaitingBuyerInvoice → buyer`, `WaitingPayment → seller`. The
+/// buyer/seller → bond-row resolution then reuses the §3.1 order-kind
+/// mapping baked into [`apply_bond_resolution`] (a slash flag is matched
+/// against `order.buyer_pubkey` / `order.seller_pubkey`, which equal the
+/// bonded taker's trade pubkey). So under `apply_to = "take"` only the
+/// taker side ever carries a bond, and the maker-responsible rows of the
+/// §9.2 table fall through to release.
+///
+/// A slash happens **only** when all of the following hold:
+/// - the feature is enabled, `slash_on_waiting_timeout = true`, and
+///   `apply_to` covers the taker;
+/// - the order is in a waiting state;
+/// - the responsible party holds a `Locked` bond.
+///
+/// Otherwise every active bond is released. This preserves today's
+/// behaviour when the feature is off, when the bond belongs to the
+/// non-responsible party, or when no bond exists — and it is the path
+/// that drains stray bonds left over from a previously-enabled period,
+/// so it is **not** gated on the current feature flag.
+///
+/// Returns `Ok(Some(bond))` with the slashed bond row when a timeout
+/// slash actually landed (HTLC settled + row in `PendingPayout`), so the
+/// caller can notify the slashed user; `Ok(None)` otherwise. The slash is
+/// confirmed by re-reading the row: [`apply_bond_resolution`] is
+/// best-effort and leaves the bond `Locked` on a transient settle
+/// failure, so a `Some` return guarantees the bond was really forfeited
+/// and the notice is truthful.
+///
+/// `order` MUST carry the pre-cancel waiting status and the trade
+/// pubkeys; call this from the persist-success branch that replaces the
+/// Phase 1 release call. `bond_cfg` is the node's `[anti_abuse_bond]`
+/// config (the scheduler passes `Settings::get_bond()`); it is taken as a
+/// parameter rather than read from the global so the gate is unit-testable
+/// without mutating process-wide state.
+pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
+    pool: &Pool<Sqlite>,
+    ln_client: &mut L,
+    order: &Order,
+    bond_cfg: Option<&AntiAbuseBondSettings>,
+) -> Result<Option<Bond>, MostroError> {
+    // Responsible side from the waiting state. Anything else is not a
+    // Phase 4 trigger — release defensively and bail. (The scheduler only
+    // calls this for waiting-state orders, but we never assume it.)
+    let side = match order.get_order_status() {
+        Ok(Status::WaitingBuyerInvoice) => Side::Buyer,
+        Ok(Status::WaitingPayment) => Side::Seller,
+        _ => {
+            release_bonds_for_order_or_warn(pool, order.id, "scheduler_timeout").await;
+            return Ok(None);
+        }
+    };
+
+    // Gate the slash. `apply_to` is a posting-timing switch; Phase 4 is
+    // taker-only, so we check `applies_to_taker` (Phase 7 widens this to
+    // the maker). When the gate is closed we still release — bonds left
+    // over from a prior enabled period must drain regardless.
+    let slash_armed = bond_cfg
+        .is_some_and(|c| c.enabled && c.slash_on_waiting_timeout && c.apply_to.applies_to_taker());
+    if !slash_armed {
+        release_bonds_for_order_or_warn(pool, order.id, "scheduler_timeout").await;
+        return Ok(None);
+    }
+
+    // Does the responsible party hold a `Locked` bond?
+    let bonds = find_active_bonds_for_order(pool, order.id).await?;
+    let Some(responsible) = resolve_locked_bond(order, &bonds, side).cloned() else {
+        // Responsible party has no bond (e.g. the maker under
+        // `apply_to = take`), or the bond already moved out of `Locked`.
+        // No slash; release whatever is still active on the order.
+        release_bonds_for_order_or_warn(pool, order.id, "scheduler_timeout").await;
+        return Ok(None);
+    };
+
+    // Reuse the Phase 2 primitive. The `BondResolution` names the
+    // responsible side; `apply_bond_resolution` settles that bond's HTLC
+    // + CAS → PendingPayout(Timeout) and releases every other active bond
+    // on the order (the Phase 1 cancel path).
+    let resolution = match side {
+        Side::Buyer => BondResolution {
+            slash_seller: false,
+            slash_buyer: true,
+        },
+        Side::Seller => BondResolution {
+            slash_seller: true,
+            slash_buyer: false,
+        },
+    };
+    apply_bond_resolution(
+        pool,
+        ln_client,
+        order,
+        &resolution,
+        BondSlashReason::Timeout,
+    )
+    .await?;
+
+    // Confirm the slash actually landed before claiming it: a transient
+    // settle failure leaves the bond `Locked` (apply_bond_resolution is
+    // best-effort), and we must never tell a user their bond was forfeited
+    // while the HTLC is still theirs.
+    if bond_is_pending_payout(pool, responsible.id).await? {
+        info!(
+            bond_id = %responsible.id,
+            order_id = %order.id,
+            role = %responsible.role,
+            "Bond slashed on waiting-state timeout"
+        );
+        Ok(Some(responsible))
+    } else {
+        warn!(
+            bond_id = %responsible.id,
+            order_id = %order.id,
+            "timeout slash did not land (bond not in PendingPayout); no forfeiture notice sent"
+        );
+        Ok(None)
+    }
+}
+
+/// Re-read a bond row's state and report whether it reached
+/// `PendingPayout`. Used to confirm a timeout slash truly landed before
+/// notifying the slashed user.
+async fn bond_is_pending_payout(pool: &Pool<Sqlite>, bond_id: Uuid) -> Result<bool, MostroError> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+        .bind(bond_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    Ok(row
+        .map(|(s,)| s == BondState::PendingPayout.to_string())
+        .unwrap_or(false))
+}
+
+/// Phase 4 — best-effort forfeiture notice to the slashed user
+/// (`Action::BondSlashed`). Mirrors the Phase 3.5 payout acks: a dropped
+/// message must never roll back the slash, so failures are logged, not
+/// propagated. The slashed user also receives the order's
+/// `Action::Canceled` from the scheduler's normal cancel notification;
+/// this message is the bond-specific complement explaining the
+/// forfeiture. The `SmallOrder` carries the slashed bond amount in
+/// `amount` so the client can render the figure in the user's locale.
+pub async fn notify_bond_slashed(order: &Order, slashed: &Bond) {
+    let recipient = match PublicKey::from_str(&slashed.pubkey) {
+        Ok(pk) => pk,
+        Err(e) => {
+            warn!(
+                bond_id = %slashed.id,
+                order_id = %order.id,
+                "bond slash: unparseable bonded pubkey ({e}); skipping BondSlashed notice"
+            );
+            return;
+        }
+    };
+    let order_kind = match order.get_order_kind() {
+        Ok(k) => k,
+        Err(e) => {
+            warn!(
+                order_id = %order.id,
+                "bond slash: cannot resolve order kind ({e:?}); skipping BondSlashed notice"
+            );
+            return;
+        }
+    };
+    let small = SmallOrder::new(
+        Some(order.id),
+        Some(order_kind),
+        None,
+        slashed.amount_sats,
+        order.fiat_code.clone(),
+        order.min_amount,
+        order.max_amount,
+        order.fiat_amount,
+        order.payment_method.clone(),
+        order.premium,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    enqueue_order_msg(
+        None,
+        Some(order.id),
+        Action::BondSlashed,
+        Some(Payload::Order(small)),
+        recipient,
+        None,
+    )
+    .await;
 }
 
 /// Single-bond slash: settle the hold invoice into Mostro's wallet,
@@ -974,6 +1180,332 @@ mod tests {
             state.0,
             BondState::Locked.to_string(),
             "transient settle failure must leave the bond Locked for admin retry"
+        );
+    }
+
+    // ── Phase 4 — timeout-slash dispatch ────────────────────────────────────
+
+    use crate::config::types::{AntiAbuseBondSettings, BondApplyTo};
+
+    /// Bond config for the Phase 4 gate. `Default` is `enabled = false`;
+    /// override only the three flags `slash_or_release_on_timeout`
+    /// inspects.
+    fn timeout_cfg(
+        enabled: bool,
+        slash_on_waiting_timeout: bool,
+        apply_to: BondApplyTo,
+    ) -> AntiAbuseBondSettings {
+        AntiAbuseBondSettings {
+            enabled,
+            slash_on_waiting_timeout,
+            apply_to,
+            ..AntiAbuseBondSettings::default()
+        }
+    }
+
+    /// `fixture_order` parks the order in `Dispute`; the Phase 4 dispatch
+    /// keys off the waiting state, so override it.
+    fn waiting_order(kind: Kind, seller_pk: &str, buyer_pk: &str, status: Status) -> Order {
+        let mut o = fixture_order(kind, seller_pk, buyer_pk);
+        o.status = status.to_string();
+        o
+    }
+
+    async fn read_bond_state(pool: &Pool<Sqlite>, id: Uuid) -> String {
+        let row: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+        row.0
+    }
+
+    #[tokio::test]
+    async fn timeout_slash_disabled_releases_without_slashing() {
+        // slash_on_waiting_timeout = false: even with the responsible
+        // taker holding a Locked bond on a timed-out waiting state, the
+        // bond is released (Phase 1 behaviour), never slashed, and the
+        // HTLC is never settled.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, false, BondApplyTo::Take);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "disabled timeout slash must not report a slash"
+        );
+        assert!(
+            ln.calls().is_empty(),
+            "release path must not settle the HTLC"
+        );
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::Released.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_slash_sell_buyer_silent_slashes_taker_bond() {
+        // sell order, WaitingBuyerInvoice: the buyer is responsible and on
+        // a sell order the buyer is the taker. Gate armed → the taker bond
+        // is slashed with reason=Timeout and the HTLC is settled exactly
+        // once. The dispatch reports the slashed bond.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Take);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.map(|b| b.id),
+            Some(bond.id),
+            "must report the slashed bond for notification"
+        );
+        assert_eq!(
+            ln.calls(),
+            vec![stub_preimage()],
+            "slash settles exactly the responsible bond's HTLC"
+        );
+        let row: (String, Option<String>, Option<i64>) =
+            sqlx::query_as("SELECT state, slashed_reason, slashed_at FROM bonds WHERE id = ?")
+                .bind(bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, BondState::PendingPayout.to_string());
+        assert_eq!(row.1.as_deref(), Some("timeout"));
+        assert!(row.2.unwrap() > 0, "slashed_at must be set");
+    }
+
+    #[tokio::test]
+    async fn timeout_slash_buy_seller_silent_slashes_taker_bond() {
+        // buy order, WaitingPayment: the seller is responsible and on a
+        // buy order the seller is the taker. (For a buy order the maker is
+        // the buyer, so the taker's trade pubkey lives in `seller_pubkey`.)
+        // Gate armed → taker bond slashed with reason=Timeout.
+        let pool = setup_pool().await;
+        let order = waiting_order(Kind::Buy, taker_pk(), maker_pk(), Status::WaitingPayment);
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Take);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert_eq!(result.map(|b| b.id), Some(bond.id));
+        assert_eq!(ln.calls(), vec![stub_preimage()]);
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::PendingPayout.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_no_slash_when_responsible_party_is_maker_sell_order() {
+        // sell order, WaitingPayment: the seller is responsible, and on a
+        // sell order the seller is the *maker*, who holds no bond under
+        // apply_to=take. The taker (buyer) bond exists but belongs to the
+        // non-responsible party — it must be released, never slashed.
+        // This is the load-bearing money-safety case: a counterparty
+        // going silent must not cost the *other* party their bond.
+        let pool = setup_pool().await;
+        let order = waiting_order(Kind::Sell, maker_pk(), taker_pk(), Status::WaitingPayment);
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Take);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "maker-responsible row must not slash the taker's bond"
+        );
+        assert!(ln.calls().is_empty());
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::Released.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_no_slash_when_responsible_party_is_maker_buy_order() {
+        // buy order, WaitingBuyerInvoice: the buyer is responsible, and on
+        // a buy order the buyer is the maker (no bond under apply_to=take).
+        // The taker (seller) bond is released, not slashed.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Buy,
+            taker_pk(),
+            maker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Take);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+        assert!(ln.calls().is_empty());
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::Released.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_slash_skipped_when_apply_to_make_only() {
+        // apply_to=make: the taker side posts no bond, so the timeout path
+        // must not slash a taker bond even with an otherwise-armed config.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Make);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+        assert!(ln.calls().is_empty());
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::Released.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_no_config_releases_bond() {
+        // No [anti_abuse_bond] block (cfg = None): the dispatch still
+        // drains any active bond (release), and never slashes. This is the
+        // path that cleans up bonds left over from a previously-enabled
+        // period.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, None)
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+        assert!(ln.calls().is_empty());
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::Released.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_slash_transient_settle_failure_leaves_bond_locked_and_no_notice() {
+        // A transient settle failure leaves the bond Locked (the apply
+        // primitive is best-effort). The dispatch must re-read the row and
+        // report None, so the caller never sends a forfeiture notice for a
+        // bond whose HTLC is still the user's.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+        ln.fail_next_with("code=Unavailable: connection refused");
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Take);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "an unconfirmed slash must not be reported to the caller"
+        );
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::Locked.to_string(),
+            "transient settle failure must leave the bond Locked for retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_bond_slashed_targets_the_slashed_user() {
+        // The forfeiture notice goes to the bonded (slashed) taker,
+        // carrying Action::BondSlashed scoped to the order.
+        use crate::config::MESSAGE_QUEUES;
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::PendingPayout).await;
+
+        notify_bond_slashed(&order, &bond).await;
+
+        let recipients: Vec<String> = MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(m, _)| {
+                let k = m.get_inner_message_kind();
+                k.id == Some(order.id) && k.action == Action::BondSlashed
+            })
+            .map(|(_, pk)| pk.to_string())
+            .collect();
+        assert_eq!(
+            recipients,
+            vec![taker_pk().to_string()],
+            "BondSlashed must be enqueued to the slashed taker only"
         );
     }
 }

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -277,12 +277,15 @@ pub async fn apply_bond_resolution<L: SettleLightning + Send>(
 /// so it is **not** gated on the current feature flag.
 ///
 /// Returns `Ok(Some(bond))` with the slashed bond row when a timeout
-/// slash actually landed (HTLC settled + row in `PendingPayout`), so the
-/// caller can notify the slashed user; `Ok(None)` otherwise. The slash is
-/// confirmed by re-reading the row: [`apply_bond_resolution`] is
-/// best-effort and leaves the bond `Locked` on a transient settle
-/// failure, so a `Some` return guarantees the bond was really forfeited
-/// and the notice is truthful.
+/// slash actually landed, so the caller can notify the slashed user;
+/// `Ok(None)` otherwise. The slash is confirmed by re-reading the row's
+/// durable `slashed_reason = Timeout` metadata (see
+/// [`timeout_slash_confirmed`]) rather than a transient
+/// `state = PendingPayout` check — the concurrent payout scheduler can
+/// move a just-slashed row onward within the confirmation window.
+/// [`apply_bond_resolution`] is best-effort and leaves the bond `Locked`
+/// (no slash metadata) on a transient settle failure, so a `Some` return
+/// guarantees the bond was really forfeited and the notice is truthful.
 ///
 /// `order` MUST carry the pre-cancel waiting status and the trade
 /// pubkeys; call this from the persist-success branch that replaces the
@@ -356,7 +359,7 @@ pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
     // settle failure leaves the bond `Locked` (apply_bond_resolution is
     // best-effort), and we must never tell a user their bond was forfeited
     // while the HTLC is still theirs.
-    if bond_is_pending_payout(pool, responsible.id).await? {
+    if timeout_slash_confirmed(pool, responsible.id).await? {
         info!(
             bond_id = %responsible.id,
             order_id = %order.id,
@@ -368,24 +371,45 @@ pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
         warn!(
             bond_id = %responsible.id,
             order_id = %order.id,
-            "timeout slash did not land (bond not in PendingPayout); no forfeiture notice sent"
+            "timeout slash did not land (bond still Locked); no forfeiture notice sent"
         );
         Ok(None)
     }
 }
 
-/// Re-read a bond row's state and report whether it reached
-/// `PendingPayout`. Used to confirm a timeout slash truly landed before
-/// notifying the slashed user.
-async fn bond_is_pending_payout(pool: &Pool<Sqlite>, bond_id: Uuid) -> Result<bool, MostroError> {
-    let row: Option<(String,)> = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
-        .bind(bond_id)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-    Ok(row
-        .map(|(s,)| s == BondState::PendingPayout.to_string())
-        .unwrap_or(false))
+/// Confirm a timeout slash actually landed on `bond_id`, regardless of
+/// where the concurrent payout scheduler has since moved the row.
+///
+/// The slash CAS in [`slash_one`] writes `slashed_reason = Timeout`
+/// atomically with the `Locked → PendingPayout` transition, and **no**
+/// later transition clears it: the payout job's state changes
+/// (`PendingPayout → Slashed | Forfeited | Failed`, and the
+/// `Failed → PendingPayout` resurrection) only ever rewrite `state`, never
+/// `slashed_reason` / `slashed_at`. So `slashed_reason = Timeout` is a
+/// stable witness that *this* slash succeeded.
+///
+/// A point-in-time `state = PendingPayout` check would be racy: the payout
+/// scheduler runs every 60s and can move a just-slashed row off
+/// `PendingPayout` within the confirmation window (e.g. `finalize_node_only`
+/// flips a node-only slash, `slash_node_share_pct = 1.0`, straight to
+/// `Slashed`). Keying on the durable slash metadata instead means the
+/// forfeiture notice is never lost to that race.
+///
+/// A transient settle failure leaves the bond `Locked` with
+/// `slashed_reason` NULL, so this still returns `false` and no false
+/// forfeiture notice is sent. Dispute slashes write
+/// `slashed_reason = LostDispute`, so a (vanishingly unlikely) concurrent
+/// dispute slash that won the CAS first does not trigger a *timeout*
+/// notice here — the dispute path owns its own messaging.
+async fn timeout_slash_confirmed(pool: &Pool<Sqlite>, bond_id: Uuid) -> Result<bool, MostroError> {
+    let row: Option<(Option<String>,)> =
+        sqlx::query_as("SELECT slashed_reason FROM bonds WHERE id = ?")
+            .bind(bond_id)
+            .fetch_optional(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    let timeout = BondSlashReason::Timeout.to_string();
+    Ok(row.and_then(|(reason,)| reason).as_deref() == Some(timeout.as_str()))
 }
 
 /// Phase 4 — best-effort forfeiture notice to the slashed user
@@ -1471,6 +1495,69 @@ mod tests {
             read_bond_state(&pool, bond.id).await,
             BondState::Locked.to_string(),
             "transient settle failure must leave the bond Locked for retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_slash_confirmed_survives_concurrent_payout_progression() {
+        // Regression: the payout scheduler runs concurrently (every 60s)
+        // and can move a just-slashed `PendingPayout` row onward — e.g. a
+        // node-only slash flips straight to `Slashed` via
+        // `finalize_node_only` — before the dispatch re-reads it. The
+        // confirmation must key off the durable `slashed_reason = Timeout`
+        // metadata, not the transient `PendingPayout` state, so the
+        // forfeiture notice is never lost to that race. Every post-slash
+        // state must confirm.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+
+        for state in [
+            BondState::PendingPayout,
+            BondState::Slashed,
+            BondState::Forfeited,
+            BondState::Failed,
+        ] {
+            let bond = insert_bond(&pool, order.id, taker_pk(), state).await;
+            // Stamp the timeout slash metadata that `slash_one` writes
+            // atomically with the Locked → PendingPayout CAS.
+            sqlx::query("UPDATE bonds SET slashed_reason = ? WHERE id = ?")
+                .bind(BondSlashReason::Timeout.to_string())
+                .bind(bond.id)
+                .execute(&pool)
+                .await
+                .unwrap();
+            assert!(
+                timeout_slash_confirmed(&pool, bond.id).await.unwrap(),
+                "post-slash state {state:?} with slashed_reason=Timeout must confirm the slash"
+            );
+        }
+
+        // A still-Locked bond (transient settle failure) carries no slash
+        // metadata and must NOT confirm — no false forfeiture notice.
+        let locked = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        assert!(
+            !timeout_slash_confirmed(&pool, locked.id).await.unwrap(),
+            "a Locked bond with no slash metadata must not confirm"
+        );
+
+        // A dispute slash (LostDispute) must not be mistaken for a timeout
+        // slash, so the timeout notice is not sent for it.
+        let dispute = insert_bond(&pool, order.id, taker_pk(), BondState::PendingPayout).await;
+        sqlx::query("UPDATE bonds SET slashed_reason = ? WHERE id = ?")
+            .bind(BondSlashReason::LostDispute.to_string())
+            .bind(dispute.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(
+            !timeout_slash_confirmed(&pool, dispute.id).await.unwrap(),
+            "a LostDispute slash must not confirm as a timeout slash"
         );
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -386,10 +386,26 @@ async fn job_cancel_orders(ctx: AppContext) {
                             }
                             Ok(None) => {}
                             Err(e) => {
+                                // `Err` from `slash_or_release_on_timeout` is a DB-read
+                                // failure (e.g. `find_active_bonds_for_order` /
+                                // `timeout_slash_confirmed` couldn't read the bond
+                                // rows), so we don't yet know whether the slash
+                                // applies. Falling through to cancel/republish
+                                // would persist the order out of
+                                // `find_order_by_seconds`'s waiting-state
+                                // eligibility window, and the next tick would
+                                // never re-evaluate it — losing the slash whose
+                                // applicability we couldn't even determine.
+                                // `continue` keeps the order eligible so the
+                                // next tick re-runs the full path (the slash
+                                // primitive is idempotent on a settled HTLC and
+                                // a `PendingPayout` bond, so a retry that
+                                // finds the work already done is a no-op).
                                 tracing::warn!(
-                                    "scheduler_timeout: bond slash/release failed for {} ({}); proceeding with cancel/republish — next tick re-attempts the slash",
+                                    "scheduler_timeout: bond slash/release errored for {} ({}); skipping cancel/republish so next tick retries",
                                     order.id, e
                                 );
+                                continue;
                             }
                         }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -425,16 +425,39 @@ async fn job_cancel_orders(ctx: AppContext) {
                             // net.
                             match order_updated.update(pool).await {
                                 Ok(_) => {
-                                    // Phase 1: scheduler-driven cancels
-                                    // (waiting-state timeouts) always
-                                    // release the bond. Slashing on
-                                    // timeout lands in Phase 4.
-                                    bond::release_bonds_for_order_or_warn(
+                                    // Phase 4: a waiting-state timeout may
+                                    // slash the responsible party's bond
+                                    // (gated by `slash_on_waiting_timeout`
+                                    // + `apply_to`). The dispatch reuses
+                                    // the Phase 2 slash primitive (settle
+                                    // the bond HTLC + CAS to
+                                    // PendingPayout(Timeout)) and releases
+                                    // every other bond; when no slash
+                                    // applies it falls back to releasing
+                                    // all bonds, exactly as Phase 1 did.
+                                    // `order` is the pre-cancel snapshot —
+                                    // its waiting status and trade pubkeys
+                                    // are intact, which the §3.1
+                                    // buyer/seller → bond mapping needs.
+                                    match bond::slash_or_release_on_timeout(
                                         pool,
-                                        order_id,
-                                        "scheduler_timeout",
+                                        &mut ln_client,
+                                        &order,
+                                        Settings::get_bond(),
                                     )
-                                    .await;
+                                    .await
+                                    {
+                                        Ok(Some(slashed)) => {
+                                            bond::notify_bond_slashed(&order, &slashed).await;
+                                        }
+                                        Ok(None) => {}
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                "scheduler_timeout: bond slash/release failed for {} ({})",
+                                                order_id, e
+                                            );
+                                        }
+                                    }
                                 }
                                 Err(e) => {
                                     tracing::warn!(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -346,6 +346,53 @@ async fn job_cancel_orders(ctx: AppContext) {
                                 }
                             };
 
+                        // Phase 4: run the bond slash/release **before** any
+                        // DB mutation that takes the order out of
+                        // `find_order_by_seconds`'s
+                        // `status ∈ {WaitingBuyerInvoice, WaitingPayment}`
+                        // eligibility window — both `update_order_to_initial_state`
+                        // (republish path) and `order_updated.update`
+                        // (cancel path) below are such mutations. A
+                        // transient `settle_hold_invoice` failure inside
+                        // `slash_one` leaves the bond `Locked`; with the
+                        // slash gated on persist success (the original
+                        // Phase 4 layout) that means the slash is dropped
+                        // entirely, because the order has already moved
+                        // out of the eligible set and the next tick never
+                        // re-picks it up. Running it here means a
+                        // transient LND hiccup just defers the cancel to
+                        // the next tick, at which point the slash is
+                        // idempotent (HTLC's "already settled" path
+                        // proceeds to a CAS no-op and returns `Ok(None)`,
+                        // so neither the bond nor the user are touched
+                        // twice). The notification fires immediately on
+                        // first success so a later persist failure
+                        // doesn't lose it — by next tick `slash_or_release_on_timeout`
+                        // sees no `Locked` bond and returns `Ok(None)`,
+                        // so the notice never duplicates either.
+                        // `order` is the pre-mutation snapshot — its
+                        // waiting status and trade pubkeys are intact,
+                        // which the §3.1 buyer/seller → bond mapping needs.
+                        match bond::slash_or_release_on_timeout(
+                            pool,
+                            &mut ln_client,
+                            &order,
+                            Settings::get_bond(),
+                        )
+                        .await
+                        {
+                            Ok(Some(slashed)) => {
+                                bond::notify_bond_slashed(&order, &slashed).await;
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                tracing::warn!(
+                                    "scheduler_timeout: bond slash/release failed for {} ({}); proceeding with cancel/republish — next tick re-attempts the slash",
+                                    order.id, e
+                                );
+                            }
+                        }
+
                         let (maker_action, new_status, edited_order) =
                             match (order_status, order_kind) {
                                 (Status::WaitingBuyerInvoice, Kind::Sell)
@@ -413,58 +460,18 @@ async fn job_cancel_orders(ctx: AppContext) {
                                 new_status
                             );
                             let order_id = order_updated.id;
-                            // Persist the new status before releasing
-                            // bonds: a release on top of a failed
-                            // persist would leave the order in its
-                            // pre-cancel status while the bond is
-                            // gone, so the next scheduler tick keeps
-                            // re-publishing cancels with no funds to
-                            // refund. Skip release on persist failure
-                            // — the next tick retries persist, and
-                            // the bond's CLTV expiry is the safety
-                            // net.
-                            match order_updated.update(pool).await {
-                                Ok(_) => {
-                                    // Phase 4: a waiting-state timeout may
-                                    // slash the responsible party's bond
-                                    // (gated by `slash_on_waiting_timeout`
-                                    // + `apply_to`). The dispatch reuses
-                                    // the Phase 2 slash primitive (settle
-                                    // the bond HTLC + CAS to
-                                    // PendingPayout(Timeout)) and releases
-                                    // every other bond; when no slash
-                                    // applies it falls back to releasing
-                                    // all bonds, exactly as Phase 1 did.
-                                    // `order` is the pre-cancel snapshot —
-                                    // its waiting status and trade pubkeys
-                                    // are intact, which the §3.1
-                                    // buyer/seller → bond mapping needs.
-                                    match bond::slash_or_release_on_timeout(
-                                        pool,
-                                        &mut ln_client,
-                                        &order,
-                                        Settings::get_bond(),
-                                    )
-                                    .await
-                                    {
-                                        Ok(Some(slashed)) => {
-                                            bond::notify_bond_slashed(&order, &slashed).await;
-                                        }
-                                        Ok(None) => {}
-                                        Err(e) => {
-                                            tracing::warn!(
-                                                "scheduler_timeout: bond slash/release failed for {} ({})",
-                                                order_id, e
-                                            );
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::warn!(
-                                        "scheduler_timeout: persist failed for order {} ({}); skipping bond release — will retry next tick",
-                                        order_id, e
-                                    );
-                                }
+                            // Persist the new status. The bond slash/release
+                            // has already run above (before any DB mutation
+                            // that strips eligibility) — on persist failure
+                            // the next tick retries this branch only; the
+                            // slash is durable in `bonds.slashed_reason` and
+                            // a re-entry sees no `Locked` bond, so it is a
+                            // no-op (no duplicate notify).
+                            if let Err(e) = order_updated.update(pool).await {
+                                tracing::warn!(
+                                    "scheduler_timeout: persist failed for order {} ({}); will retry next tick",
+                                    order_id, e
+                                );
                             }
                         }
                     }


### PR DESCRIPTION
## What

Implements **Phase 4** of the anti-abuse bond ([`docs/ANTI_ABUSE_BOND.md`](docs/ANTI_ABUSE_BOND.md) §9, issue #711): when a waiting-state timeout **actually elapses**, the responsible party's bond is **slashed** instead of always released.

## Gate flags

`enabled && slash_on_waiting_timeout && apply_to ∈ { take, both }`. With any of these off, behaviour is identical to today (bonds released).

## How

- **`bond::slash_or_release_on_timeout`** (`src/app/bond/slash.rs`): derives the responsible side from the waiting state alone (§9.2: `WaitingBuyerInvoice → buyer`, `WaitingPayment → seller`). When armed and the responsible party holds a `Locked` bond, it reuses the Phase 2 `apply_bond_resolution` primitive with `BondSlashReason::Timeout` — settling the bond HTLC + CAS to `PendingPayout` and releasing every other bond. Otherwise it falls back to releasing all bonds (Phase 1 behaviour), which also drains stray bonds left from a previously-enabled period.
- The §3.1 buyer/seller → bond-row mapping is the one already baked into the reused primitive; `bond.pubkey` equals the order's `buyer_pubkey`/`seller_pubkey`, so under `apply_to = take` only the taker side ever resolves a bond and the maker-responsible §9.2 rows fall through to release.
- The bond config is **passed in** (the scheduler hands it `Settings::get_bond()`) instead of read from the global `OnceLock`, so the gate is unit-testable.
- Wired into **`scheduler::job_cancel_orders`**, replacing the unconditional Phase 1 release in the persist-success branch. The pre-cancel order snapshot (waiting status + trade pubkeys intact) is passed so the resolution matches the bonded party.
- **`bond::notify_bond_slashed`** sends the slashed user an `Action::BondSlashed` (mostro-core **0.11.5**) forfeiture notice, carrying `Payload::Order` (amount = slashed bond amount). Best-effort, and sent **only after the slash is confirmed to have landed** — confirmed via the durable `slashed_reason = Timeout` metadata (written atomically with the slash CAS and never cleared by the concurrent Phase 3 payout job), not a transient `state = PendingPayout` check the scheduler could invalidate. A transient `settle_hold_invoice` failure leaves the bond `Locked` with no slash metadata, so it never produces a false "your bond was slashed" message.

## Safety invariants

- **§9.1 honoured:** only the elapsed-timeout scheduler path can slash. Cooperative / unilateral / admin cancels still go through the Phase 1 `release_bonds_for_order_or_warn` helpers, untouched (verified: single non-test call site).
- **No mis-slash:** a counterparty going silent never costs the *other* party their bond — the responsible-side resolution is keyed on the waiting state, and the maker-responsible rows release rather than slash (covered by tests).
- **No false forfeiture notice:** the notice is gated on a re-read of the durable `slashed_reason = Timeout` metadata, so a transient settle failure (bond stays `Locked`) or a concurrent payout-job transition (`PendingPayout → Slashed`) can neither suppress a true notice nor fabricate a false one.

## mostro-core dependency

Bumps the pin `0.11.4 → 0.11.5`, which adds the additive `Action::BondSlashed` (released upstream in [mostro-core#149](https://github.com/MostroP2P/mostro-core/pull/149)). Serde-additive: clients that don't know the variant ignore it and fall back to the `Action::Canceled` they already receive for the order. The spec (§9.3, §14.3, phase table) is updated to reflect this — earlier drafts assumed Phase 4 was daemon-only.

## Tests

`cargo test` (337 passed), `cargo clippy --all-targets --all-features` clean, `cargo fmt` clean. **10 new unit tests** in `bond::slash`:

- all four §9.2 worked rows (sell+`WaitingBuyerInvoice`→slash, buy+`WaitingPayment`→slash, sell+`WaitingPayment`→no slash/maker, buy+`WaitingBuyerInvoice`→no slash/maker);
- `slash_on_waiting_timeout = false` → release, no slash;
- `apply_to = make` → no taker slash;
- no `[anti_abuse_bond]` config → release;
- transient settle failure → bond stays `Locked`, no notice;
- timeout-slash confirmation survives the concurrent payout-job progression (all post-slash states with `slashed_reason = timeout` confirm; `Locked`/no-metadata and `LostDispute` do not);
- `Action::BondSlashed` targets the slashed taker only.

## How to test (manual regtest walkthrough)

These scenarios exercise Phase 4 end-to-end against polar/regtest LND.
The cast:

- **User A** — the **maker**. Posts a sell-order in S1, S3–S6; a buy-order in S2.
- **User B** — the **taker**. Posts the anti-abuse bond (`apply_to = "take"`).

No solver is involved: Phase 4 slashes are **automatic on timeout**, not
solver-directed (those are Phase 2). The recipient payout reuses the
Phase 3 machinery unchanged.

Common setup before every scenario:

1. In `settings.toml`, shrink the waiting-state timeout and enable the
   bond on the taker side:
   ```toml
   [mostro]
   # Waiting-state deadline (default 900 = 15 min). Shrink it so the
   # scheduler fires in ~1–2 min instead of 15.
   expiration_seconds = 60

   [anti_abuse_bond]
   enabled = true
   apply_to = "take"
   slash_on_waiting_timeout = true      # the Phase 4 gate
   slash_node_share_pct = 0.5
   payout_invoice_window_seconds = 60   # Phase 3 payout; shrink for faster runs
   payout_max_retries = 3
   payout_claim_window_days = 1
   ```
2. Start mostrod with `RUST_LOG=info,mostro=debug`. Watch for
   `Bond slashed on waiting-state timeout` (the Phase 4 slash) and the
   `bond payout:` prefix (the Phase 3 drain).
3. `sqlite3 mostro.db "select id, state, slashed_reason, node_share_sats, payout_invoice from bonds;"`
   is the source of truth per row.

**Timing note:** an order becomes eligible for the timeout once
`taken_at + expiration_seconds` has passed, and `job_cancel_orders` ticks
every 60 s — so allow up to `expiration_seconds + 60 s` after the order
parks in its waiting state.

### S1 — Buyer silent past `WaitingBuyerInvoice` (sell-order): slash taker, republish, pay seller

The main happy-path slash + Phase 3 payout. §9.2 row
`sell / WaitingBuyerInvoice → buyer = taker → slash`.

1. **A** posts a sell-order for, say, 100 000 sats.
2. **B** takes it **without** including a payout invoice. The bond bolt11
   arrives as `Action::PayBondInvoice`; B pays it. Confirm the bond row
   goes `requested → locked` and the order moves to `waiting-buyer-invoice`.
3. **B goes silent** — never sends the payout invoice. Wait
   `expiration_seconds` + up to one 60 s tick.
4. On the tick, confirm the log line `Bond slashed on waiting-state
   timeout`. DB: bond row `state = pending-payout, slashed_reason =
   timeout, node_share_sats = 500` (50 % of a 1 000 sat bond at these
   defaults), `slashed_at` set. The bond HTLC is settled **at slash
   time**, so Mostro's wallet is already up by the bond amount.
5. **B** (the slashed buyer/taker) receives **two** messages:
   `Action::Canceled` (the order) and `Action::BondSlashed` (the
   forfeiture notice; `amount` = the slashed bond amount). The order is
   republished to **A** as `Action::NewOrder` and returns to `pending`
   (still takeable by others).
6. Phase 3 takes over (reuse): the non-slashed counterparty for
   `WaitingBuyerInvoice` is the **seller = A**. Within ~60 s **A**
   receives an `Action::AddBondInvoice` for 500 sats. A replies with a
   bolt11 → `send_payment` → bond row `state = slashed`. Confirm A
   actually received 500 sats.

### S2 — Seller silent past `WaitingPayment` (buy-order): slash taker, pay buyer

§9.2 row `buy / WaitingPayment → seller = taker → slash`. Confirms
recipient resolution lands on the buyer, not hard-coded for sell-orders.

1. **A** posts a **buy-order** (maker = buyer; taker will be seller).
2. **B** takes it. B pays the bond (`Action::PayBondInvoice`) → bond
   locks → order moves to `waiting-payment` and B receives the trade
   hold invoice (`Action::PayInvoice`). B pays the **bond** but **not**
   the trade hold invoice.
3. **B goes silent.** Wait for the timeout + tick.
4. Confirm bond → `pending-payout / timeout`; **B** receives
   `Action::Canceled` + `Action::BondSlashed`; the order republishes to
   `pending`.
5. Phase 3: the recipient for `WaitingPayment` is the **buyer = A**.
   Confirm **A** — not B — receives `Action::AddBondInvoice`, and the
   payout completes as in S1.

### S3 — Cancel before the timeout never slashes (attack invariant, §9.1)

1. **A** posts a sell-order; **B** takes it (no invoice), pays the bond →
   `waiting-buyer-invoice`.
2. **Before** `expiration_seconds` elapses, one party cancels (e.g. B
   initiates a cooperative cancel and A co-signs).
3. Confirm: the bond row → `released` (HTLC cancelled, funds back to B).
   **No** `slashed_reason`, **no** `Action::BondSlashed`, **no**
   `Action::AddBondInvoice`. This is the anti-theft invariant — a
   counterparty cannot cancel at minute N−1 to steal a bond.

### S4 — Responsible party is the maker → no slash

§9.2 "no slash" row. The taker holds a bond but is not the responsible
party.

1. **A** posts a sell-order. **B** takes it **with** a payout invoice, so
   the order skips `waiting-buyer-invoice` and parks at `waiting-payment`,
   awaiting the **seller = A = maker** to pay the trade hold invoice. B
   pays the bond → locks.
2. **A** (the seller/maker) never pays the hold invoice. Wait for the
   timeout + tick.
3. Responsible party = seller = maker, who holds no bond under
   `apply_to = take`. Confirm: **no slash** — B's bond is **released**,
   the order is **canceled** (`(WaitingPayment, Sell)` → `Canceled`), and
   B receives **no** `Action::BondSlashed`.
   - *Buy-order mirror:* a buy-order stuck in `waiting-buyer-invoice`
     (buyer = maker responsible) behaves identically — no slash, order
     canceled.

### S5 — `slash_on_waiting_timeout = false` → no slash

1. Set `slash_on_waiting_timeout = false`; restart mostrod.
2. Repeat S1 steps 1–3 (B silent at `waiting-buyer-invoice`).
3. On the timeout tick, confirm the bond is **released**, not slashed:
   no `slashed_reason`, no `Action::BondSlashed`, no
   `Action::AddBondInvoice`. The gate is off, so Phase 4 falls back to
   the Phase 1 always-release behaviour.

### S6 — `slash_node_share_pct = 1.0`: node-only slash still notifies (race regression)

Targets the concurrency fix: the Phase 3 payout job can flip a node-only
slash straight `pending-payout → slashed` within the confirmation
window, so the notice must key off the durable `slashed_reason = timeout`
metadata, not the transient state.

1. Set `slash_node_share_pct = 1.0`; restart.
2. Run S1 steps 1–4 (B silent → slash). Bond → `pending-payout /
   timeout`, `node_share_sats` = the full bond amount.
3. The next Phase 3 tick flips the row directly to `slashed`
   (`finalize_node_only`), with **no** `Action::AddBondInvoice` and **no**
   `send_payment` (the node keeps everything).
4. Confirm **B still receives `Action::BondSlashed`**, even though the
   row may already read `slashed` by the time you inspect it. (Before the
   fix, the notice would be silently dropped in this race.)

### Quick sanity grep

```bash
sqlite3 mostro.db "select state, slashed_reason, count(*) from bonds group by state, slashed_reason;"
```

After S1, S2, S6 you should see rows in `slashed | timeout`; after S3,
S4, S5, rows in `released` with NULL `slashed_reason`. No timeout-slashed
row should be stuck in `pending-payout` once Phase 3 has drained it.

Refs: #711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orders stuck in waiting state can now trigger bond slashing on timeout when anti‑abuse bond settings apply
  * Slashed users receive a forfeiture notification showing the amount

* **Reliability**
  * Scheduler runs timeout slash/release before cancelling orders, avoiding duplicate notifications and leaving orders eligible for retry on transient errors

* **Dependencies**
  * Core runtime bumped to v0.11.5

* **Documentation**
  * Anti‑abuse bond spec updated to document Phase 4 timeout‑slash rollout and notifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
