### PR TITLE
fix: let daemon finalize disputes without solver row

### DIFF
--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -4,8 +4,8 @@ use std::str::FromStr;
 use crate::app::bond::{self, BondSlashReason};
 use crate::app::context::AppContext;
 use crate::db::{
-    find_dispute_by_order_id, is_assigned_solver, is_dispute_taken_by_admin,
-    solver_has_write_permission,
+    ensure_dispute_finalize_permission, find_dispute_by_order_id, is_assigned_solver,
+    is_dispute_taken_by_admin,
 };
 use crate::lightning::LndConnector;
 use crate::nip33::{create_platform_tag_values, new_dispute_event};
@@ -75,9 +75,13 @@ pub async fn admin_cancel_action(
         _ => {}
     }
 
-    if !solver_has_write_permission(pool, &event.identity.to_string(), order.id).await? {
-        return Err(MostroCantDo(CantDoReason::NotAuthorized));
-    }
+    ensure_dispute_finalize_permission(
+        pool,
+        &event.identity.to_string(),
+        &my_keys.public_key().to_string(),
+        order.id,
+    )
+    .await?;
 
     // Was order cooperatively cancelled?
     if order.check_status(Status::CooperativelyCanceled).is_ok() {

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -1,8 +1,8 @@
 use crate::app::bond::{self, BondSlashReason};
 use crate::app::context::AppContext;
 use crate::db::{
-    find_dispute_by_order_id, is_assigned_solver, is_dispute_taken_by_admin,
-    solver_has_write_permission,
+    ensure_dispute_finalize_permission, find_dispute_by_order_id, is_assigned_solver,
+    is_dispute_taken_by_admin,
 };
 use crate::lightning::LndConnector;
 use crate::nip33::{create_platform_tag_values, new_dispute_event};
@@ -50,9 +50,13 @@ pub async fn admin_settle_action(
         _ => {}
     }
 
-    if !solver_has_write_permission(pool, &event.identity.to_string(), order.id).await? {
-        return Err(MostroCantDo(CantDoReason::NotAuthorized));
-    }
+    ensure_dispute_finalize_permission(
+        pool,
+        &event.identity.to_string(),
+        &my_keys.public_key().to_string(),
+        order.id,
+    )
+    .await?;
 
     // Was order cooperatively cancelled?
     if order.check_status(Status::CooperativelyCanceled).is_ok() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1002,6 +1002,29 @@ pub async fn solver_has_write_permission(
     Ok(result)
 }
 
+/// Ensures the caller may finalize a dispute (`admin-settle` / `admin-cancel`).
+///
+/// The Mostro daemon identity (`caller_pubkey == admin_pubkey`) bypasses solver
+/// category checks, matching `admin_take_dispute`. Human solvers must have
+/// read-write permission on the assigned dispute.
+///
+/// Callers must already have passed `is_assigned_solver`.
+pub async fn ensure_dispute_finalize_permission(
+    pool: &SqlitePool,
+    caller_pubkey: &str,
+    admin_pubkey: &str,
+    order_id: Uuid,
+) -> Result<(), MostroError> {
+    if caller_pubkey == admin_pubkey {
+        return Ok(());
+    }
+    if solver_has_write_permission(pool, caller_pubkey, order_id).await? {
+        Ok(())
+    } else {
+        Err(MostroCantDo(CantDoReason::NotAuthorized))
+    }
+}
+
 /// Returns true when `pubkey` corresponds to a solver user with read-write
 /// permission (`users.is_solver = true` and `users.category = 2`), independent
 /// of any dispute assignment. Use this when the caller is a prospective taker

--- a/src/db.rs
+++ b/src/db.rs
@@ -1004,17 +1004,19 @@ pub async fn solver_has_write_permission(
 
 /// Ensures the caller may finalize a dispute (`admin-settle` / `admin-cancel`).
 ///
-/// The Mostro daemon identity (`caller_pubkey == admin_pubkey`) bypasses solver
-/// category checks, matching `admin_take_dispute`. Human solvers must have
+/// Requires the caller to be the assigned solver (`is_assigned_solver`). The
+/// Mostro daemon identity (`caller_pubkey == admin_pubkey`) then bypasses solver
+/// category checks, matching `admin_take_dispute`. Human solvers must also have
 /// read-write permission on the assigned dispute.
-///
-/// Callers must already have passed `is_assigned_solver`.
 pub async fn ensure_dispute_finalize_permission(
     pool: &SqlitePool,
     caller_pubkey: &str,
     admin_pubkey: &str,
     order_id: Uuid,
 ) -> Result<(), MostroError> {
+    if !is_assigned_solver(pool, caller_pubkey, order_id).await? {
+        return Err(MostroCantDo(CantDoReason::IsNotYourDispute));
+    }
     if caller_pubkey == admin_pubkey {
         return Ok(());
     }
@@ -1271,6 +1273,8 @@ impl RestoreSessionManager {
 // Add this cfg attribute if the code is *only* for testing
 #[cfg(test)]
 mod tests {
+    use mostro_core::error::CantDoReason;
+    use mostro_core::prelude::MostroError;
     use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
     use sqlx::Error;
     use std::collections::HashSet;
@@ -1927,7 +1931,89 @@ mod tests {
             .unwrap();
     }
 
+    async fn setup_finalize_permission_db() -> Result<SqlitePool, Error> {
+        let pool = setup_users_db().await?;
+        sqlx::query(
+            r#"CREATE TABLE IF NOT EXISTS disputes (
+                id char(36) primary key not null,
+                order_id char(36) unique not null,
+                status varchar(10) not null,
+                order_previous_status varchar(10) not null,
+                solver_pubkey char(64),
+                created_at integer not null,
+                taken_at integer default 0
+            )"#,
+        )
+        .execute(&pool)
+        .await?;
+        Ok(pool)
+    }
+
+    async fn insert_assigned_dispute(pool: &SqlitePool, order_id: uuid::Uuid, solver_pubkey: &str) {
+        sqlx::query(
+            "INSERT INTO disputes (id, order_id, status, order_previous_status, solver_pubkey, created_at)
+             VALUES (?1, ?2, 'in-progress', 'dispute', ?3, 1700000000)",
+        )
+        .bind(uuid::Uuid::new_v4().to_string())
+        .bind(order_id)
+        .bind(solver_pubkey)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_read_only_solver(pool: &SqlitePool, pubkey: &str) {
+        sqlx::query(
+            "INSERT INTO users (pubkey, is_solver, category, created_at) VALUES (?1, 1, 1, 1700000000)",
+        )
+        .bind(pubkey)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
     const VALID_PUBKEY: &str = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    const DAEMON_PUBKEY: &str = "b1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    const HUMAN_SOLVER_PUBKEY: &str =
+        "c1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+
+    #[tokio::test]
+    async fn ensure_dispute_finalize_permission_daemon_without_user_row() {
+        let pool = setup_finalize_permission_db().await.unwrap();
+        let order_id = uuid::Uuid::new_v4();
+        insert_assigned_dispute(&pool, order_id, DAEMON_PUBKEY).await;
+
+        let result = super::ensure_dispute_finalize_permission(
+            &pool,
+            DAEMON_PUBKEY,
+            DAEMON_PUBKEY,
+            order_id,
+        )
+        .await;
+
+        assert!(result.is_ok(), "assigned daemon must finalize without a users row");
+    }
+
+    #[tokio::test]
+    async fn ensure_dispute_finalize_permission_human_solver_denied() {
+        let pool = setup_finalize_permission_db().await.unwrap();
+        let order_id = uuid::Uuid::new_v4();
+        insert_read_only_solver(&pool, HUMAN_SOLVER_PUBKEY).await;
+        insert_assigned_dispute(&pool, order_id, HUMAN_SOLVER_PUBKEY).await;
+
+        let result = super::ensure_dispute_finalize_permission(
+            &pool,
+            HUMAN_SOLVER_PUBKEY,
+            DAEMON_PUBKEY,
+            order_id,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroError::MostroCantDo(CantDoReason::NotAuthorized))
+        ));
+    }
 
     #[tokio::test]
     async fn test_update_user_trade_index_valid() {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1991,7 +1991,10 @@ mod tests {
         )
         .await;
 
-        assert!(result.is_ok(), "assigned daemon must finalize without a users row");
+        assert!(
+            result.is_ok(),
+            "assigned daemon must finalize without a users row"
+        );
     }
 
     #[tokio::test]

--- a/src/rpc/service.rs
+++ b/src/rpc/service.rs
@@ -63,12 +63,10 @@ impl AdminServiceImpl {
 
         // Admin RPC flows synthesize the inbound event with the node's own
         // pubkey in both `identity` and `sender` slots. Authorization is then
-        // enforced downstream by the handlers, which check `event.identity`
-        // against `is_assigned_solver` / `solver_has_write_permission` (and
-        // for cancel/settle, fall back to `is_dispute_taken_by_admin`). For
-        // these flows to succeed, the operator must register the daemon's own
-        // pubkey as an admin/solver with write permission. Authentication of
-        // the gRPC caller itself happens at the transport layer, not here.
+        // enforced downstream: the caller must be the assigned solver
+        // (`is_assigned_solver`), with `ensure_dispute_finalize_permission`
+        // bypassing solver category checks for the daemon key (same as
+        // `admin_take_dispute`). gRPC transport authenticates the operator.
         let event = UnwrappedMessage {
             message: msg.clone(),
             signature: None,


### PR DESCRIPTION
## Summary

`admin-settle` and `admin-cancel` rejected the Mostro daemon with `NotAuthorized` after it took a dispute, because `solver_has_write_permission` required a `users` row with `is_solver` and `category = 2`. That was inconsistent with `admin_take_dispute`, which already allows the daemon key without DB registration.

This PR adds `ensure_dispute_finalize_permission`: the daemon identity bypasses solver category checks; human solvers still need read-write permission on the assigned dispute.

## Changes

- Add `ensure_dispute_finalize_permission` in `src/db.rs`
- Use it from `admin_settle_action` and `admin_cancel_action`
- Update RPC service comment (no longer requires registering daemon as solver)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized authorization for dispute finalization (cancel and settle); admin daemon identity bypasses solver checks while other callers must meet solver write permission.

* **Documentation**
  * Clarified how admin RPC authorization is enforced for dispute cancellation.

* **Tests**
  * Added unit tests covering the new permission behavior, including daemon bypass and denial scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/746?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->