### PR TITLE
feat(price): Phase 0 — multi-source price module foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
 name = "mostro"
 version = "0.17.3"
 dependencies = [
+ "async-trait",
  "axum",
  "bech32",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
 mostro-core = { version = "0.11.4", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+async-trait = "0.1.83"
 clap = { version = "4.5.45", features = ["derive"] }
 lnurl-rs = { version = "0.9.0", default-features = false, features = ["ureq"] }
 once_cell = "1.20.2"

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -268,6 +268,7 @@ pub mod test_utils {
             rpc: RpcSettings::default(),
             expiration: Some(ExpirationSettings::default()),
             anti_abuse_bond: None,
+            price: None,
         }
     }
 }

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -1050,6 +1050,7 @@ mod tests {
             rpc: Default::default(),
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
+            price: None,
         });
     }
 

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -240,6 +240,7 @@ mod tests {
             rpc: Default::default(),
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
+            price: None,
         });
     }
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -3,6 +3,7 @@ use crate::config::types::{
     AntiAbuseBondSettings, DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings,
     NostrSettings, RpcSettings,
 };
+use crate::price::PriceSettings;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -24,6 +25,11 @@ pub struct Settings {
     /// Anti-abuse bond configuration (issue #711). Absent section ≡ disabled.
     #[serde(default)]
     pub anti_abuse_bond: Option<AntiAbuseBondSettings>,
+    /// Multi-source price configuration (see `docs/PRICE_PROVIDERS.md`).
+    /// Absent section ≡ legacy single-source behaviour (synthesised in
+    /// Phase 1's migration).
+    #[serde(default)]
+    pub price: Option<PriceSettings>,
 }
 
 /// Initialize the global MOSTRO_CONFIG struct
@@ -91,6 +97,16 @@ impl Settings {
     /// configuration.
     pub fn get_bond() -> Option<&'static AntiAbuseBondSettings> {
         MOSTRO_CONFIG.get()?.anti_abuse_bond.as_ref()
+    }
+
+    /// Retrieve the multi-source price configuration from the global
+    /// `MOSTRO_CONFIG`. Returns `None` when the `[price]` block is absent
+    /// (Phase 1 synthesises a legacy default in that case) and also when the
+    /// global settings haven't been initialized yet, so it never panics on
+    /// the price hot path or in unit tests that don't bring up the full
+    /// configuration — mirroring [`Settings::get_bond`].
+    pub fn get_price() -> Option<&'static PriceSettings> {
+        MOSTRO_CONFIG.get()?.price.as_ref()
     }
 
     /// True when the feature is configured AND explicitly enabled. This is

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -199,6 +199,7 @@ mod tests {
             rpc: RpcSettings::default(),
             expiration: None,
             anti_abuse_bond: None,
+            price: None,
         }
     }
 

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -73,6 +73,7 @@ fn run_setup_wizard(settings_dir: &Path, config_file_path: &Path) -> Result<Sett
         rpc: RpcSettings::default(),
         expiration: None,
         anti_abuse_bond: None,
+        price: None,
     };
 
     let toml_content = toml::to_string_pretty(&settings)

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -437,6 +437,7 @@ mod tests {
             rpc: Default::default(),
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
+            price: None,
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ pub mod lnurl;
 pub mod messages;
 pub mod models;
 pub mod nip33;
+pub mod price;
 pub mod rpc;
 pub mod scheduler;
 pub mod util;

--- a/src/price/aggregate.rs
+++ b/src/price/aggregate.rs
@@ -1,0 +1,303 @@
+//! Pure aggregation core (spec §6). No I/O, no globals, no clock — every
+//! function is a deterministic transform over in-memory inputs, which is
+//! what makes the numeric heart of the feature exhaustively testable.
+
+use std::collections::HashMap;
+
+use super::provider::{ProviderQuotes, Quote};
+
+/// One currency's aggregated result for a tick: the price and how many
+/// sources contributed it (before outlier removal).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AggregateResult {
+    pub value: f64,
+    pub sources: u8,
+}
+
+/// Combine a currency's candidate per-BTC prices into one figure (spec §6.2).
+///
+/// Inputs are first cleaned of non-finite and non-positive values (a
+/// provider returning `NaN`, `inf`, `0`, or a negative is simply ignored).
+/// Then, over the `n` remaining candidates:
+///
+/// - `n == 0` → `None` (no usable value),
+/// - `n == 1` → that value,
+/// - `n == 2` → their mean,
+/// - `n >= 3` → the median, then the mean of the values within
+///   `outlier_pct` percent of that median (the median is always kept, so
+///   the set is non-empty).
+///
+/// The median anchors the truth; values too far from it are dropped before
+/// the mean, so one corrupt/stale source cannot move the result while
+/// genuine small spreads between honest sources are still averaged in.
+pub fn combine(xs: &[f64], outlier_pct: f64) -> Option<f64> {
+    let mut clean: Vec<f64> = xs
+        .iter()
+        .copied()
+        .filter(|x| x.is_finite() && *x > 0.0)
+        .collect();
+    if clean.is_empty() {
+        return None;
+    }
+    clean.sort_by(|a, b| a.partial_cmp(b).expect("finite values sort"));
+
+    match clean.len() {
+        1 => Some(clean[0]),
+        2 => Some(mean(&clean)),
+        _ => {
+            let m = median_sorted(&clean);
+            let tol = m * (outlier_pct / 100.0);
+            let kept: Vec<f64> = clean
+                .iter()
+                .copied()
+                .filter(|x| (x - m).abs() <= tol)
+                .collect();
+            // `kept` always contains the median, so it is non-empty.
+            Some(mean(&kept))
+        }
+    }
+}
+
+/// Resolve fiat-cross quotes into per-BTC candidates (spec §6.3).
+///
+/// Each `(currency, base, value)` becomes `value × anchors[base]`, but only
+/// when an anchor for `base` exists this tick (i.e. some direct quoter
+/// reported `base`). A quote whose base has no anchor is dropped — the
+/// currency then falls back to whatever direct candidates it has, or to
+/// last-known-good.
+///
+/// Returns the resolved per-BTC candidates grouped by currency, ready to be
+/// merged with that currency's direct candidates before [`combine`].
+pub fn resolve_per_base(
+    per_base: &[(String, String, f64)],
+    anchors: &HashMap<String, f64>,
+) -> HashMap<String, Vec<f64>> {
+    let mut out: HashMap<String, Vec<f64>> = HashMap::new();
+    for (currency, base, value) in per_base {
+        if let Some(anchor) = anchors.get(base) {
+            let candidate = value * anchor;
+            if candidate.is_finite() && candidate > 0.0 {
+                out.entry(currency.clone()).or_default().push(candidate);
+            }
+        }
+    }
+    out
+}
+
+/// Run steps 1–3 of the §5.3 pipeline over one tick's provider results.
+///
+/// `provider_results` holds the `ProviderQuotes` of each provider that
+/// succeeded this tick (failed providers contribute nothing — they are
+/// simply absent). Currency codes are upper-cased so providers that
+/// disagree on casing still combine (spec §6.6).
+///
+/// 1. Direct (`PerBtc`) quotes are grouped per currency.
+/// 2. Per-currency **anchors** are the [`combine`]d direct quotes; fiat-cross
+///    (`PerBase`) quotes are resolved against those anchors.
+/// 3. Each currency's final value is the [`combine`] of its direct **and**
+///    resolved candidates.
+///
+/// Returns the per-currency [`AggregateResult`] (value + contributing
+/// source count). The caller stamps these into the store with the tick
+/// timestamp.
+pub fn aggregate_tick(
+    provider_results: &[ProviderQuotes],
+    outlier_pct: f64,
+) -> HashMap<String, AggregateResult> {
+    let mut direct: HashMap<String, Vec<f64>> = HashMap::new();
+    let mut per_base: Vec<(String, String, f64)> = Vec::new();
+
+    for quotes in provider_results {
+        for (currency, quote) in quotes {
+            let currency = currency.to_uppercase();
+            match quote {
+                Quote::PerBtc(v) => direct.entry(currency).or_default().push(*v),
+                Quote::PerBase { base, value } => {
+                    per_base.push((currency, base.to_uppercase(), *value))
+                }
+            }
+        }
+    }
+
+    // Step 2: anchors = aggregated direct quotes, then resolve cross quotes.
+    let mut anchors: HashMap<String, f64> = HashMap::new();
+    for (currency, candidates) in &direct {
+        if let Some(v) = combine(candidates, outlier_pct) {
+            anchors.insert(currency.clone(), v);
+        }
+    }
+    let resolved = resolve_per_base(&per_base, &anchors);
+
+    // Step 3: combine direct + resolved candidates per currency.
+    let mut out: HashMap<String, AggregateResult> = HashMap::new();
+    let currencies: std::collections::HashSet<&String> =
+        direct.keys().chain(resolved.keys()).collect();
+    for currency in currencies {
+        let mut candidates: Vec<f64> = Vec::new();
+        if let Some(d) = direct.get(currency) {
+            candidates.extend_from_slice(d);
+        }
+        if let Some(r) = resolved.get(currency) {
+            candidates.extend_from_slice(r);
+        }
+        let sources = candidates
+            .iter()
+            .filter(|x| x.is_finite() && **x > 0.0)
+            .count()
+            .min(u8::MAX as usize) as u8;
+        if let Some(value) = combine(&candidates, outlier_pct) {
+            out.insert(currency.clone(), AggregateResult { value, sources });
+        }
+    }
+    out
+}
+
+fn mean(xs: &[f64]) -> f64 {
+    xs.iter().sum::<f64>() / xs.len() as f64
+}
+
+/// Median of an already-sorted, non-empty slice.
+fn median_sorted(sorted: &[f64]) -> f64 {
+    let n = sorted.len();
+    if n % 2 == 1 {
+        sorted[n / 2]
+    } else {
+        (sorted[n / 2 - 1] + sorted[n / 2]) / 2.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PCT: f64 = 5.0;
+
+    fn approx(a: f64, b: f64) {
+        assert!((a - b).abs() < 1e-6, "expected {b}, got {a}");
+    }
+
+    #[test]
+    fn combine_zero_sources_is_none() {
+        assert!(combine(&[], PCT).is_none());
+    }
+
+    #[test]
+    fn combine_one_two_sources() {
+        approx(combine(&[100.0], PCT).unwrap(), 100.0);
+        approx(combine(&[100.0, 102.0], PCT).unwrap(), 101.0); // mean of 2
+    }
+
+    #[test]
+    fn combine_three_discards_outlier() {
+        // median 101; 200 is >5% off → dropped; mean(100,101) = 100.5
+        approx(combine(&[100.0, 101.0, 200.0], PCT).unwrap(), 100.5);
+    }
+
+    #[test]
+    fn combine_all_equal() {
+        approx(combine(&[50.0, 50.0, 50.0, 50.0], PCT).unwrap(), 50.0);
+    }
+
+    #[test]
+    fn combine_outlier_boundary_inclusive() {
+        // median 100, tol 5 → keep [95,105]. 105 is exactly on the bound → kept.
+        approx(combine(&[100.0, 100.0, 105.0], PCT).unwrap(), 305.0 / 3.0);
+        // 106 is just past the bound → dropped, mean(100,100) = 100.
+        approx(combine(&[100.0, 100.0, 106.0], PCT).unwrap(), 100.0);
+    }
+
+    #[test]
+    fn combine_rejects_non_finite_and_non_positive() {
+        approx(combine(&[f64::NAN, 100.0, 100.0], PCT).unwrap(), 100.0);
+        approx(combine(&[0.0, -5.0, 100.0], PCT).unwrap(), 100.0);
+        approx(combine(&[f64::INFINITY, 100.0], PCT).unwrap(), 100.0);
+        assert!(combine(&[f64::NAN, 0.0, -1.0], PCT).is_none());
+    }
+
+    #[test]
+    fn resolve_per_base_with_and_without_anchor() {
+        let mut anchors = HashMap::new();
+        anchors.insert("USD".to_string(), 50_000.0);
+
+        // El Toque worked example (spec §6.3): CUP per USD 400 × 50_000.
+        let pb = vec![("CUP".to_string(), "USD".to_string(), 400.0)];
+        let resolved = resolve_per_base(&pb, &anchors);
+        approx(resolved["CUP"][0], 20_000_000.0);
+
+        // Missing anchor → dropped.
+        let pb_missing = vec![("CUP".to_string(), "EUR".to_string(), 400.0)];
+        assert!(resolve_per_base(&pb_missing, &anchors).is_empty());
+    }
+
+    #[test]
+    fn aggregate_tick_unions_partial_coverage() {
+        // Yadio: USD, EUR, CUP (direct). CoinGecko: USD, EUR (no CUP).
+        // El Toque: CUP via USD anchor (fiat-cross).
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
+        yadio.insert("EUR".into(), Quote::PerBtc(45_000.0));
+        yadio.insert("CUP".into(), Quote::PerBtc(20_000_000.0));
+
+        let mut coingecko = ProviderQuotes::new();
+        coingecko.insert("USD".into(), Quote::PerBtc(50_000.0));
+        coingecko.insert("EUR".into(), Quote::PerBtc(45_000.0));
+
+        let mut eltoque = ProviderQuotes::new();
+        eltoque.insert(
+            "CUP".into(),
+            Quote::PerBase {
+                base: "USD".into(),
+                value: 400.0,
+            },
+        );
+
+        let out = aggregate_tick(&[yadio, coingecko, eltoque], PCT);
+
+        approx(out["USD"].value, 50_000.0);
+        assert_eq!(out["USD"].sources, 2);
+        approx(out["EUR"].value, 45_000.0);
+        assert_eq!(out["EUR"].sources, 2);
+        // CUP = combine(Yadio 20M [direct], El Toque 400×50_000 = 20M [resolved]).
+        approx(out["CUP"].value, 20_000_000.0);
+        assert_eq!(out["CUP"].sources, 2);
+    }
+
+    #[test]
+    fn aggregate_tick_failed_provider_contributes_nothing() {
+        // Only one provider's results are present (the other "failed" so it
+        // was never added). USD has a single source.
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let out = aggregate_tick(&[yadio], PCT);
+        approx(out["USD"].value, 50_000.0);
+        assert_eq!(out["USD"].sources, 1);
+    }
+
+    #[test]
+    fn aggregate_tick_uppercases_currency_codes() {
+        // currency-api ships lowercase; must combine with uppercase Yadio.
+        let mut a = ProviderQuotes::new();
+        a.insert("usd".into(), Quote::PerBtc(50_000.0));
+        let mut b = ProviderQuotes::new();
+        b.insert("USD".into(), Quote::PerBtc(50_200.0));
+        let out = aggregate_tick(&[a, b], PCT);
+        assert_eq!(out.len(), 1, "lowercase and uppercase must merge");
+        approx(out["USD"].value, 50_100.0);
+        assert_eq!(out["USD"].sources, 2);
+    }
+
+    #[test]
+    fn aggregate_tick_cross_only_currency_without_anchor_is_absent() {
+        // A fiat-cross CUP whose USD anchor is unavailable yields nothing.
+        let mut eltoque = ProviderQuotes::new();
+        eltoque.insert(
+            "CUP".into(),
+            Quote::PerBase {
+                base: "USD".into(),
+                value: 400.0,
+            },
+        );
+        let out = aggregate_tick(&[eltoque], PCT);
+        assert!(out.is_empty(), "no USD anchor → CUP cannot resolve");
+    }
+}

--- a/src/price/aggregate.rs
+++ b/src/price/aggregate.rs
@@ -24,8 +24,9 @@ pub struct AggregateResult {
 /// - `n == 1` → that value,
 /// - `n == 2` → their mean,
 /// - `n >= 3` → the median, then the mean of the values within
-///   `outlier_pct` percent of that median (the median is always kept, so
-///   the set is non-empty).
+///   `outlier_pct` percent of that median; if nothing falls within the band
+///   (a widely-spread even-length input, where the median is a synthetic
+///   midpoint that matches no value), fall back to the median itself.
 ///
 /// The median anchors the truth; values too far from it are dropped before
 /// the mean, so one corrupt/stale source cannot move the result while
@@ -52,8 +53,16 @@ pub fn combine(xs: &[f64], outlier_pct: f64) -> Option<f64> {
                 .copied()
                 .filter(|x| (x - m).abs() <= tol)
                 .collect();
-            // `kept` always contains the median, so it is non-empty.
-            Some(mean(&kept))
+            // Odd `n`: the median is a member of `clean`, so it is always
+            // kept. Even `n`: the median is the synthetic midpoint of the two
+            // central values and may match nothing (widely-spread / bimodal
+            // input) → `kept` is empty. Fall back to the median rather than
+            // averaging an empty set, which would be NaN.
+            if kept.is_empty() {
+                Some(m)
+            } else {
+                Some(mean(&kept))
+            }
         }
     }
 }
@@ -204,6 +213,15 @@ mod tests {
         approx(combine(&[100.0, 100.0, 105.0], PCT).unwrap(), 305.0 / 3.0);
         // 106 is just past the bound → dropped, mean(100,100) = 100.
         approx(combine(&[100.0, 100.0, 106.0], PCT).unwrap(), 100.0);
+    }
+
+    #[test]
+    fn combine_even_length_no_value_near_median_falls_back_to_median() {
+        // Even n, bimodal: median = (2+100)/2 = 51; tol = 2.55 → nothing in
+        // the band. Must fall back to the median (finite), never NaN.
+        let out = combine(&[1.0, 2.0, 100.0, 101.0], PCT).unwrap();
+        assert!(out.is_finite(), "must not be NaN");
+        approx(out, 51.0);
     }
 
     #[test]

--- a/src/price/config.rs
+++ b/src/price/config.rs
@@ -77,6 +77,11 @@ impl ProviderConfig {
                 "price provider '{id}': `only` and `except` are mutually exclusive"
             ));
         }
+        if self.enabled && self.url.trim().is_empty() {
+            return Err(format!(
+                "price provider '{id}': enabled provider must have a non-empty `url`"
+            ));
+        }
         Ok(())
     }
 
@@ -98,6 +103,12 @@ impl PriceSettings {
     /// Validate the whole `[price]` block: the outlier threshold must be a
     /// sane positive percentage, and every provider must validate.
     pub fn validate(&self) -> Result<(), String> {
+        if self.update_interval_seconds == 0 {
+            return Err(format!(
+                "price: update_interval_seconds must be > 0, got {}",
+                self.update_interval_seconds
+            ));
+        }
         if !(self.outlier_threshold_pct.is_finite()
             && self.outlier_threshold_pct > 0.0
             && self.outlier_threshold_pct <= 100.0)
@@ -242,6 +253,35 @@ only = ["CUP", "MLC"]
         assert!(with_pct(0.0).validate().is_err());
         assert!(with_pct(150.0).validate().is_err());
         with_pct(5.0).validate().unwrap();
+    }
+
+    #[test]
+    fn zero_update_interval_is_rejected() {
+        let cfg = PriceSettings {
+            update_interval_seconds: 0,
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn enabled_provider_with_blank_url_is_rejected() {
+        let blank = ProviderConfig {
+            enabled: true,
+            url: "  ".into(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+        };
+        assert!(blank.validate("yadio").is_err());
+        // A disabled provider with a blank url is allowed (inert).
+        let disabled = ProviderConfig {
+            enabled: false,
+            ..blank.clone()
+        };
+        disabled.validate("yadio").unwrap();
     }
 
     #[test]

--- a/src/price/config.rs
+++ b/src/price/config.rs
@@ -109,6 +109,15 @@ impl PriceSettings {
                 self.update_interval_seconds
             ));
         }
+        // A non-positive TTL would make `now - as_of <= ttl` never hold, so
+        // every stored price reads as `TooStale` — silently disabling all
+        // price lookups once this is wired into reads (Phase 4).
+        if self.max_price_staleness_seconds <= 0 {
+            return Err(format!(
+                "price: max_price_staleness_seconds must be > 0, got {}",
+                self.max_price_staleness_seconds
+            ));
+        }
         if !(self.outlier_threshold_pct.is_finite()
             && self.outlier_threshold_pct > 0.0
             && self.outlier_threshold_pct <= 100.0)
@@ -262,6 +271,19 @@ only = ["CUP", "MLC"]
             ..Default::default()
         };
         assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn non_positive_staleness_is_rejected() {
+        let with_ttl = |ttl: i64| PriceSettings {
+            max_price_staleness_seconds: ttl,
+            ..Default::default()
+        };
+        // Negative TTL → every price would read as TooStale.
+        assert!(with_ttl(-1).validate().is_err());
+        // Zero TTL is equally broken (stale the instant after it is written).
+        assert!(with_ttl(0).validate().is_err());
+        with_ttl(1800).validate().unwrap();
     }
 
     #[test]

--- a/src/price/config.rs
+++ b/src/price/config.rs
@@ -1,0 +1,261 @@
+//! Typed `[price]` configuration (spec §7).
+//!
+//! `PriceSettings` is attached to the global `Settings` as
+//! `Option<PriceSettings>` (absent section ≡ legacy single-source
+//! behaviour, synthesised in Phase 1's migration). Each
+//! `[price.providers.<id>]` sub-table deserialises into a generic
+//! [`ProviderConfig`]; the registry (Phase 1+) maps the known id strings to
+//! their adapters, so adding a provider is config-only on this side.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Top-level `[price]` configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PriceSettings {
+    /// How often to poll providers and recompute the aggregate.
+    #[serde(default = "default_update_interval_seconds")]
+    pub update_interval_seconds: u64,
+    /// Serve a currency's last-known-good value up to this age; then refuse.
+    #[serde(default = "default_max_price_staleness_seconds")]
+    pub max_price_staleness_seconds: i64,
+    /// Discard a source whose value deviates more than this percent from the
+    /// median (only applies with ≥ 3 sources for a currency).
+    #[serde(default = "default_outlier_threshold_pct")]
+    pub outlier_threshold_pct: f64,
+    /// Per-provider request timeout.
+    #[serde(default = "default_provider_timeout_seconds")]
+    pub provider_timeout_seconds: u64,
+    /// Consecutive failures before a provider's circuit breaker opens.
+    #[serde(default = "default_provider_failure_threshold")]
+    pub provider_failure_threshold: u32,
+    /// Base cooldown (seconds) once the breaker opens; backs off from here.
+    #[serde(default = "default_provider_failure_cooldown_seconds")]
+    pub provider_failure_cooldown_seconds: u64,
+    /// Publish the aggregated rates to Nostr (kind 30078).
+    #[serde(default = "default_publish_to_nostr")]
+    pub publish_to_nostr: bool,
+    /// Per-provider sub-tables, keyed by provider id (`yadio`, `coingecko`, …).
+    #[serde(default)]
+    pub providers: HashMap<String, ProviderConfig>,
+}
+
+/// Generic per-provider config. Known-id adapters read the fields they need.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ProviderConfig {
+    /// Whether this provider participates in aggregation.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Primary base URL.
+    pub url: String,
+    /// Ordered mirrors tried when `url` fails this tick (spec §7).
+    #[serde(default)]
+    pub fallback_urls: Vec<String>,
+    /// Optional API key (e.g. CoinGecko demo/pro). Never logged.
+    #[serde(default)]
+    pub api_key: Option<String>,
+    /// Optional bearer token (e.g. El Toque). Required when that provider is
+    /// enabled; never logged.
+    #[serde(default)]
+    pub token: Option<String>,
+    /// Restrict this provider to ONLY these currencies (spec §6.6).
+    #[serde(default)]
+    pub only: Option<Vec<String>>,
+    /// Exclude these currencies from this provider (spec §6.6).
+    #[serde(default)]
+    pub except: Option<Vec<String>>,
+}
+
+impl ProviderConfig {
+    /// Validate a single provider's config. `only` and `except` are mutually
+    /// exclusive (spec §7). Currency scoping is checked here so a typo fails
+    /// fast at startup rather than silently mis-aggregating.
+    pub fn validate(&self, id: &str) -> Result<(), String> {
+        if self.only.is_some() && self.except.is_some() {
+            return Err(format!(
+                "price provider '{id}': `only` and `except` are mutually exclusive"
+            ));
+        }
+        Ok(())
+    }
+
+    /// Whether `currency` (any casing) is in scope for this provider after
+    /// applying `only` / `except`. Used by the Phase 2 pipeline glue.
+    pub fn allows_currency(&self, currency: &str) -> bool {
+        let c = currency.to_uppercase();
+        if let Some(only) = &self.only {
+            return only.iter().any(|x| x.to_uppercase() == c);
+        }
+        if let Some(except) = &self.except {
+            return !except.iter().any(|x| x.to_uppercase() == c);
+        }
+        true
+    }
+}
+
+impl PriceSettings {
+    /// Validate the whole `[price]` block: the outlier threshold must be a
+    /// sane positive percentage, and every provider must validate.
+    pub fn validate(&self) -> Result<(), String> {
+        if !(self.outlier_threshold_pct.is_finite()
+            && self.outlier_threshold_pct > 0.0
+            && self.outlier_threshold_pct <= 100.0)
+        {
+            return Err(format!(
+                "price: outlier_threshold_pct must be in (0, 100], got {}",
+                self.outlier_threshold_pct
+            ));
+        }
+        for (id, p) in &self.providers {
+            p.validate(id)?;
+        }
+        Ok(())
+    }
+}
+
+fn default_update_interval_seconds() -> u64 {
+    300
+}
+fn default_max_price_staleness_seconds() -> i64 {
+    1800
+}
+fn default_outlier_threshold_pct() -> f64 {
+    5.0
+}
+fn default_provider_timeout_seconds() -> u64 {
+    10
+}
+fn default_provider_failure_threshold() -> u32 {
+    3
+}
+fn default_provider_failure_cooldown_seconds() -> u64 {
+    120
+}
+fn default_publish_to_nostr() -> bool {
+    true
+}
+
+impl Default for PriceSettings {
+    fn default() -> Self {
+        Self {
+            update_interval_seconds: default_update_interval_seconds(),
+            max_price_staleness_seconds: default_max_price_staleness_seconds(),
+            outlier_threshold_pct: default_outlier_threshold_pct(),
+            provider_timeout_seconds: default_provider_timeout_seconds(),
+            provider_failure_threshold: default_provider_failure_threshold(),
+            provider_failure_cooldown_seconds: default_provider_failure_cooldown_seconds(),
+            publish_to_nostr: default_publish_to_nostr(),
+            providers: HashMap::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_spec() {
+        let cfg = PriceSettings::default();
+        assert_eq!(cfg.update_interval_seconds, 300);
+        assert_eq!(cfg.max_price_staleness_seconds, 1800);
+        assert_eq!(cfg.outlier_threshold_pct, 5.0);
+        assert_eq!(cfg.provider_timeout_seconds, 10);
+        assert_eq!(cfg.provider_failure_threshold, 3);
+        assert_eq!(cfg.provider_failure_cooldown_seconds, 120);
+        assert!(cfg.publish_to_nostr);
+        assert!(cfg.providers.is_empty());
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn toml_parses_providers_and_applies_defaults() {
+        // Wrapper mirrors how `[price]` nests under the top-level settings.
+        #[derive(Deserialize)]
+        struct Stub {
+            price: PriceSettings,
+        }
+        let toml_str = r#"
+[price]
+update_interval_seconds = 60
+
+[price.providers.yadio]
+enabled = true
+url = "https://api.yadio.io"
+
+[price.providers.currency_api]
+enabled = true
+url = "https://currency-api.pages.dev/v1"
+fallback_urls = ["https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1"]
+except = ["CUP", "MLC"]
+
+[price.providers.eltoque]
+enabled = false
+url = "https://tasas.eltoque.com"
+token = "secret"
+only = ["CUP", "MLC"]
+"#;
+        let parsed: Stub = toml::from_str(toml_str).unwrap();
+        let p = parsed.price;
+        // Overridden value + defaulted siblings.
+        assert_eq!(p.update_interval_seconds, 60);
+        assert_eq!(p.max_price_staleness_seconds, 1800);
+        assert_eq!(p.providers.len(), 3);
+
+        let ca = &p.providers["currency_api"];
+        assert!(ca.enabled);
+        assert_eq!(ca.fallback_urls.len(), 1);
+        assert_eq!(ca.except.as_ref().unwrap(), &["CUP", "MLC"]);
+        // currency-api official CUP is scoped out.
+        assert!(!ca.allows_currency("cup"));
+        assert!(ca.allows_currency("USD"));
+
+        let et = &p.providers["eltoque"];
+        assert_eq!(et.token.as_deref(), Some("secret"));
+        assert!(et.allows_currency("CUP"));
+        assert!(!et.allows_currency("USD"));
+
+        p.validate().unwrap();
+    }
+
+    #[test]
+    fn only_and_except_together_is_rejected() {
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: "http://x".into(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: Some(vec!["CUP".into()]),
+            except: Some(vec!["MLC".into()]),
+        };
+        assert!(cfg.validate("eltoque").is_err());
+    }
+
+    #[test]
+    fn out_of_range_outlier_threshold_is_rejected() {
+        let with_pct = |pct: f64| PriceSettings {
+            outlier_threshold_pct: pct,
+            ..Default::default()
+        };
+        assert!(with_pct(0.0).validate().is_err());
+        assert!(with_pct(150.0).validate().is_err());
+        with_pct(5.0).validate().unwrap();
+    }
+
+    #[test]
+    fn no_scoping_allows_everything() {
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: "http://x".into(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+        };
+        assert!(cfg.allows_currency("USD"));
+        assert!(cfg.allows_currency("CUP"));
+    }
+}

--- a/src/price/mod.rs
+++ b/src/price/mod.rs
@@ -1,0 +1,28 @@
+//! Multi-source BTC/fiat price module (see `docs/PRICE_PROVIDERS.md`).
+//!
+//! Phase 0 — **foundation only**. This delivers the building blocks every
+//! later phase reuses, with **no wiring**: the [`PriceProvider`] trait and
+//! its data types ([`provider`]), the pure aggregation core
+//! ([`aggregate`]), the in-memory aggregated-price store ([`store`]), and
+//! the typed `[price]` configuration ([`config`]). Nothing here makes an
+//! HTTP request, touches the scheduler, or is read by an order handler;
+//! that begins in Phase 1.
+//!
+//! Because the module is not yet referenced from `main`/handlers, it would
+//! otherwise trip the `dead_code` lint in a plain `cargo build`. The
+//! allow below is scoped to this module and is **removed in Phase 1**,
+//! when `PriceManager` wires the registry into the scheduler and
+//! `get_bitcoin_price`.
+#![allow(dead_code)]
+
+pub mod aggregate;
+pub mod config;
+pub mod provider;
+pub mod store;
+
+pub use aggregate::{aggregate_tick, combine, resolve_per_base, AggregateResult};
+pub use config::{PriceSettings, ProviderConfig};
+pub use provider::{
+    PriceProvider, ProviderError, ProviderHealth, ProviderId, ProviderQuotes, Quote,
+};
+pub use store::{AggregatedPrice, PriceError, PriceStore};

--- a/src/price/provider.rs
+++ b/src/price/provider.rs
@@ -163,7 +163,10 @@ impl ProviderHealth {
         let cooldown = base_cooldown_secs
             .saturating_mul(factor)
             .min(cooldown_cap_secs);
-        self.open_until = Some(now.saturating_add(cooldown as i64));
+        // Clamp the u64 cooldown into i64 so an absurd config cap can't wrap
+        // to a negative offset and push `open_until` into the past.
+        let cooldown = i64::try_from(cooldown).unwrap_or(i64::MAX);
+        self.open_until = Some(now.saturating_add(cooldown));
     }
 }
 

--- a/src/price/provider.rs
+++ b/src/price/provider.rs
@@ -1,0 +1,284 @@
+//! The provider interface (spec §5.2) and per-provider health tracking
+//! (spec §6.5).
+//!
+//! Every price API is a [`PriceProvider`] implementation living in its own
+//! file under `providers/` (added from Phase 1 on). `mostrod` only ever
+//! holds `Vec<Box<dyn PriceProvider>>`, so the aggregation core and the
+//! scheduler stay provider-agnostic — adding an API never touches them
+//! (spec §5.4).
+
+use std::collections::HashMap;
+use std::fmt;
+use std::str::FromStr;
+
+/// A single currency quote from a provider.
+///
+/// Two flavours (spec §5.2): a **direct** quoter reports [`Quote::PerBtc`]
+/// (Yadio, CoinGecko); a **fiat-cross** quoter reports
+/// [`Quote::PerBase`] (El Toque: CUP per USD), resolved to a per-BTC
+/// figure against the aggregated `base`/BTC anchor (spec §6.3).
+#[derive(Debug, Clone, PartialEq)]
+pub enum Quote {
+    /// Fiat units per 1 BTC. Directly aggregatable.
+    PerBtc(f64),
+    /// `value` units of this currency per 1 unit of `base` currency.
+    PerBase { base: String, value: f64 },
+}
+
+/// Result of one provider poll: currency code → quote.
+pub type ProviderQuotes = HashMap<String, Quote>;
+
+/// Stable identifier for a provider — used in logs, config keys, health
+/// tracking, and the Nostr `source` metadata. The string form (via
+/// [`fmt::Display`] / [`FromStr`]) matches the `[price.providers.<id>]`
+/// config sub-table key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProviderId {
+    Yadio,
+    CoinGecko,
+    CurrencyApi,
+    Blockchain,
+    ElToque,
+}
+
+impl fmt::Display for ProviderId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            ProviderId::Yadio => "yadio",
+            ProviderId::CoinGecko => "coingecko",
+            ProviderId::CurrencyApi => "currency_api",
+            ProviderId::Blockchain => "blockchain",
+            ProviderId::ElToque => "eltoque",
+        };
+        f.write_str(s)
+    }
+}
+
+impl FromStr for ProviderId {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "yadio" => Ok(ProviderId::Yadio),
+            "coingecko" => Ok(ProviderId::CoinGecko),
+            "currency_api" => Ok(ProviderId::CurrencyApi),
+            "blockchain" => Ok(ProviderId::Blockchain),
+            "eltoque" => Ok(ProviderId::ElToque),
+            other => Err(format!("unknown price provider id: {other}")),
+        }
+    }
+}
+
+/// A provider poll failure. A failed poll contributes **nothing** to the
+/// tick — never a partial map with bogus values (spec §5.2).
+#[derive(Debug)]
+pub enum ProviderError {
+    /// Transport / HTTP-level failure (timeout, connection refused, non-2xx).
+    Http(String),
+    /// The body could not be parsed into the expected shape.
+    Parse(String),
+    /// The provider is enabled but mis-configured (e.g. a required token is
+    /// missing). Surfaced at startup, not silently swallowed.
+    Misconfigured(String),
+}
+
+impl fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProviderError::Http(e) => write!(f, "http error: {e}"),
+            ProviderError::Parse(e) => write!(f, "parse error: {e}"),
+            ProviderError::Misconfigured(e) => write!(f, "misconfigured: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ProviderError {}
+
+/// One price source behind a uniform interface.
+///
+/// Object-safe via `#[async_trait]` so the registry can hold
+/// `Vec<Box<dyn PriceProvider>>`.
+#[async_trait::async_trait]
+pub trait PriceProvider: Send + Sync {
+    /// Stable identifier (also the config key).
+    fn id(&self) -> ProviderId;
+
+    /// Fetch the latest quotes. Returns only the currencies this provider
+    /// reports; any network/parse failure is an `Err` so the provider is
+    /// skipped for this tick.
+    async fn fetch(&self, http: &reqwest::Client) -> Result<ProviderQuotes, ProviderError>;
+}
+
+/// Per-provider circuit-breaker state (spec §6.5).
+///
+/// After `failure_threshold` consecutive failures the provider is skipped
+/// for a cooldown that backs off exponentially from `base_cooldown_secs`
+/// up to `cooldown_cap_secs`. A single success resets the breaker. The
+/// type is pure (a clock value is always passed in) so it is wired into
+/// the scheduler tick in Phase 2 and unit-testable here.
+#[derive(Debug, Clone, Default)]
+pub struct ProviderHealth {
+    consecutive_failures: u32,
+    /// Unix timestamp the provider is skipped *until*; `None` ⇒ available.
+    open_until: Option<i64>,
+}
+
+impl ProviderHealth {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// True when the provider should be polled this tick.
+    pub fn is_available(&self, now: i64) -> bool {
+        match self.open_until {
+            Some(until) => now >= until,
+            None => true,
+        }
+    }
+
+    /// Record a successful poll: reset the breaker.
+    pub fn record_success(&mut self) {
+        self.consecutive_failures = 0;
+        self.open_until = None;
+    }
+
+    /// Record a failed poll. Once `failure_threshold` consecutive failures
+    /// accumulate, open the breaker for an exponentially-backed-off
+    /// cooldown capped at `cooldown_cap_secs`.
+    pub fn record_failure(
+        &mut self,
+        now: i64,
+        failure_threshold: u32,
+        base_cooldown_secs: u64,
+        cooldown_cap_secs: u64,
+    ) {
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+        if self.consecutive_failures < failure_threshold.max(1) {
+            return;
+        }
+        // Exponent grows with each failure beyond the threshold:
+        // threshold → base, threshold+1 → 2×base, threshold+2 → 4×base, …
+        let over = self.consecutive_failures - failure_threshold.max(1);
+        let factor = 1u64.checked_shl(over.min(63)).unwrap_or(u64::MAX);
+        let cooldown = base_cooldown_secs
+            .saturating_mul(factor)
+            .min(cooldown_cap_secs);
+        self.open_until = Some(now.saturating_add(cooldown as i64));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// In-memory [`PriceProvider`] double (spec §10.5). Exercises the trait
+    /// without any network: `fetch` returns canned quotes (or a forced
+    /// error). Constructing a `reqwest::Client` to pass in performs no I/O.
+    struct MockProvider {
+        id: ProviderId,
+        quotes: ProviderQuotes,
+        fail: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl PriceProvider for MockProvider {
+        fn id(&self) -> ProviderId {
+            self.id
+        }
+        async fn fetch(&self, _http: &reqwest::Client) -> Result<ProviderQuotes, ProviderError> {
+            if self.fail {
+                Err(ProviderError::Http("mock failure".into()))
+            } else {
+                Ok(self.quotes.clone())
+            }
+        }
+    }
+
+    #[test]
+    fn provider_id_string_roundtrip() {
+        for id in [
+            ProviderId::Yadio,
+            ProviderId::CoinGecko,
+            ProviderId::CurrencyApi,
+            ProviderId::Blockchain,
+            ProviderId::ElToque,
+        ] {
+            let s = id.to_string();
+            assert_eq!(ProviderId::from_str(&s).unwrap(), id, "roundtrip {s}");
+        }
+        assert!(ProviderId::from_str("nope").is_err());
+    }
+
+    #[tokio::test]
+    async fn mock_provider_returns_canned_quotes() {
+        let mut quotes = ProviderQuotes::new();
+        quotes.insert("USD".to_string(), Quote::PerBtc(50_000.0));
+        let p = MockProvider {
+            id: ProviderId::Yadio,
+            quotes: quotes.clone(),
+            fail: false,
+        };
+        let client = reqwest::Client::new();
+        assert_eq!(p.id(), ProviderId::Yadio);
+        assert_eq!(p.fetch(&client).await.unwrap(), quotes);
+    }
+
+    #[tokio::test]
+    async fn mock_provider_failure_is_err() {
+        let p = MockProvider {
+            id: ProviderId::CoinGecko,
+            quotes: ProviderQuotes::new(),
+            fail: true,
+        };
+        let client = reqwest::Client::new();
+        assert!(p.fetch(&client).await.is_err());
+    }
+
+    #[test]
+    fn health_stays_available_below_threshold() {
+        let mut h = ProviderHealth::new();
+        assert!(h.is_available(0));
+        // 2 failures, threshold 3 → still available.
+        h.record_failure(0, 3, 120, 1800);
+        h.record_failure(0, 3, 120, 1800);
+        assert!(h.is_available(0));
+    }
+
+    #[test]
+    fn health_opens_at_threshold_and_recovers_after_cooldown() {
+        let mut h = ProviderHealth::new();
+        for _ in 0..3 {
+            h.record_failure(1_000, 3, 120, 1800);
+        }
+        // Opened: base cooldown 120s from now.
+        assert!(!h.is_available(1_000));
+        assert!(!h.is_available(1_119));
+        assert!(h.is_available(1_120));
+    }
+
+    #[test]
+    fn health_backoff_is_exponential_and_capped() {
+        let mut h = ProviderHealth::new();
+        // threshold=1 so each failure opens; base 100, cap 250.
+        h.record_failure(0, 1, 100, 250); // 1st: 100
+        assert!(!h.is_available(99));
+        assert!(h.is_available(100));
+        h.record_failure(100, 1, 100, 250); // 2nd: 200
+        assert!(!h.is_available(299));
+        assert!(h.is_available(300));
+        h.record_failure(300, 1, 100, 250); // 3rd: 400 → capped at 250
+        assert!(!h.is_available(549));
+        assert!(h.is_available(550));
+    }
+
+    #[test]
+    fn health_success_resets_breaker() {
+        let mut h = ProviderHealth::new();
+        for _ in 0..5 {
+            h.record_failure(0, 3, 120, 1800);
+        }
+        assert!(!h.is_available(0));
+        h.record_success();
+        assert!(h.is_available(0));
+    }
+}

--- a/src/price/store.rs
+++ b/src/price/store.rs
@@ -1,0 +1,201 @@
+//! In-memory aggregated-price store with last-known-good + staleness TTL
+//! (spec §6.4).
+//!
+//! The store is the single read surface for the rest of the daemon (from
+//! Phase 1 on): the scheduler writes a fresh aggregate each tick, and
+//! consumers read a currency's price through the staleness check. A
+//! currency with no fresh contributors this tick simply keeps its prior
+//! entry (last-known-good) — [`PriceStore::update`] only overwrites the
+//! currencies present in the new aggregate.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::RwLock;
+
+use super::aggregate::AggregateResult;
+
+/// A stored per-currency price plus the metadata the staleness check and
+/// observability need.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AggregatedPrice {
+    /// Fiat units per 1 BTC.
+    pub value: f64,
+    /// Unix timestamp of the last tick that produced a fresh aggregate for
+    /// this currency. Anchors the staleness window.
+    pub as_of: i64,
+    /// How many sources contributed the value (observability / "down to one
+    /// source" warnings).
+    pub source_count: u8,
+}
+
+/// Read-side errors from [`PriceStore::get`]. Kept local to the price
+/// module in Phase 0 (no consumers yet); Phase 1/4 map these onto
+/// `MostroError` at the call sites (spec §10.2).
+#[derive(Debug, PartialEq, Eq)]
+pub enum PriceError {
+    /// No price has ever been stored for this currency.
+    NoCurrency,
+    /// A price exists but is older than the configured staleness TTL.
+    TooStale,
+}
+
+impl fmt::Display for PriceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PriceError::NoCurrency => write!(f, "no price available for currency"),
+            PriceError::TooStale => write!(f, "price is older than the staleness window"),
+        }
+    }
+}
+
+impl std::error::Error for PriceError {}
+
+/// Thread-safe map of `currency → AggregatedPrice`.
+#[derive(Debug, Default)]
+pub struct PriceStore {
+    inner: RwLock<HashMap<String, AggregatedPrice>>,
+}
+
+impl PriceStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Overwrite the currencies present in `aggregates` with `as_of = now`.
+    /// Currencies **absent** from `aggregates` are left untouched, so their
+    /// last-known-good value (and its older `as_of`) is preserved (spec
+    /// §6.4). Currency codes are upper-cased to match read lookups.
+    pub fn update(&self, aggregates: HashMap<String, AggregateResult>, now: i64) {
+        if aggregates.is_empty() {
+            return;
+        }
+        let mut w = self.inner.write().expect("price store lock poisoned");
+        for (currency, agg) in aggregates {
+            w.insert(
+                currency.to_uppercase(),
+                AggregatedPrice {
+                    value: agg.value,
+                    as_of: now,
+                    source_count: agg.sources,
+                },
+            );
+        }
+    }
+
+    /// Read a currency's price, enforcing the staleness window.
+    ///
+    /// - missing → `Err(NoCurrency)`,
+    /// - `now - as_of <= max_staleness_secs` → `Ok(value)`,
+    /// - otherwise → `Err(TooStale)`.
+    ///
+    /// The requested code is upper-cased so callers need not normalise.
+    pub fn get(
+        &self,
+        currency: &str,
+        max_staleness_secs: i64,
+        now: i64,
+    ) -> Result<f64, PriceError> {
+        let r = self.inner.read().expect("price store lock poisoned");
+        let entry = r
+            .get(&currency.to_uppercase())
+            .ok_or(PriceError::NoCurrency)?;
+        if now.saturating_sub(entry.as_of) <= max_staleness_secs {
+            Ok(entry.value)
+        } else {
+            Err(PriceError::TooStale)
+        }
+    }
+
+    /// Snapshot of a currency's full entry (for observability / Nostr
+    /// publishing in later phases). No staleness filtering.
+    pub fn snapshot(&self, currency: &str) -> Option<AggregatedPrice> {
+        let r = self.inner.read().expect("price store lock poisoned");
+        r.get(&currency.to_uppercase()).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn results(pairs: &[(&str, f64, u8)]) -> HashMap<String, AggregateResult> {
+        pairs
+            .iter()
+            .map(|(c, v, s)| {
+                (
+                    c.to_string(),
+                    AggregateResult {
+                        value: *v,
+                        sources: *s,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn get_fresh_within_and_past_ttl() {
+        let store = PriceStore::new();
+        store.update(results(&[("USD", 50_000.0, 2)]), 1_000);
+
+        // Fresh.
+        assert_eq!(store.get("USD", 1_800, 1_000).unwrap(), 50_000.0);
+        // Within TTL (exactly on the boundary is still OK: `<=`).
+        assert_eq!(store.get("USD", 1_800, 1_000 + 1_800).unwrap(), 50_000.0);
+        // Past TTL.
+        assert_eq!(
+            store.get("USD", 1_800, 1_000 + 1_801).unwrap_err(),
+            PriceError::TooStale
+        );
+    }
+
+    #[test]
+    fn get_missing_currency() {
+        let store = PriceStore::new();
+        assert_eq!(
+            store.get("EUR", 1_800, 0).unwrap_err(),
+            PriceError::NoCurrency
+        );
+    }
+
+    #[test]
+    fn get_is_case_insensitive() {
+        let store = PriceStore::new();
+        store.update(results(&[("usd", 50_000.0, 1)]), 0);
+        assert_eq!(store.get("USD", 1_800, 0).unwrap(), 50_000.0);
+        assert_eq!(store.get("usd", 1_800, 0).unwrap(), 50_000.0);
+    }
+
+    #[test]
+    fn update_preserves_last_known_good_for_absent_currencies() {
+        let store = PriceStore::new();
+        store.update(
+            results(&[("USD", 50_000.0, 2), ("EUR", 45_000.0, 2)]),
+            1_000,
+        );
+
+        // Next tick only refreshes USD; EUR keeps its old value AND old as_of.
+        store.update(results(&[("USD", 51_000.0, 2)]), 2_000);
+
+        assert_eq!(store.snapshot("USD").unwrap().as_of, 2_000);
+        assert_eq!(store.snapshot("USD").unwrap().value, 51_000.0);
+        let eur = store.snapshot("EUR").unwrap();
+        assert_eq!(eur.as_of, 1_000, "EUR keeps its older as_of");
+        assert_eq!(eur.value, 45_000.0);
+
+        // EUR now ages out against its stale as_of.
+        assert_eq!(
+            store.get("EUR", 500, 2_000).unwrap_err(),
+            PriceError::TooStale
+        );
+    }
+
+    #[test]
+    fn empty_update_is_noop() {
+        let store = PriceStore::new();
+        store.update(results(&[("USD", 50_000.0, 1)]), 1_000);
+        store.update(HashMap::new(), 9_999);
+        // USD untouched.
+        assert_eq!(store.snapshot("USD").unwrap().as_of, 1_000);
+    }
+}


### PR DESCRIPTION
## What

First atomic PR of the multi-source price rollout ([`docs/PRICE_PROVIDERS.md`](docs/PRICE_PROVIDERS.md) §9, **Phase 0**), which removes the Yadio single point of failure. This is the **foundation only**: the pluggable provider interface, the pure aggregation core, the price store, and the typed `[price]` config. **Purely additive** — no HTTP, no scheduler change, no consumer change, no behavior change.

The module is not yet referenced by `main`/handlers, so it carries a scoped `#![allow(dead_code)]` on `src/price/mod.rs`, **removed in Phase 1** when `PriceManager` wires the registry into the scheduler and `get_bitcoin_price`.

## New `src/price/`

- **`provider.rs`** — `PriceProvider` trait (async, object-safe via `async-trait` so the registry can hold `Vec<Box<dyn PriceProvider>>`); `Quote` (`PerBtc` direct | `PerBase` fiat-cross); `ProviderId`; `ProviderError`; and `ProviderHealth` circuit-breaker state (pure, clock injected; exponential backoff + cap).
- **`aggregate.rs`** — the pure §6 core: `combine` (median + outlier guard; cleans `NaN`/`inf`/`≤0`; mean for 2, single for 1), `resolve_per_base` (fiat-cross → per-BTC against the USD anchor, §6.3), `aggregate_tick` (the §5.3 pipeline; uppercases codes so providers that disagree on casing still combine, §6.6).
- **`store.rs`** — `PriceStore` (RwLock map) with last-known-good semantics (currencies absent from a tick keep their prior entry, §6.4) and a staleness-checked `get` returning a local `PriceError` (mapped onto `MostroError` in Phase 1/4 per §10.2).
- **`config.rs`** — `PriceSettings` + `ProviderConfig` (`enabled`/`url`/`fallback_urls`/`api_key`/`token`/`only`/`except`) with §7 defaults and validation (`only`⊕`except`, outlier range).

## Wiring

`Settings` gains `Option<PriceSettings>` + `Settings::get_price()` (mirrors `get_bond`); every literal `Settings { .. }` constructor (wizard + test helpers) updated. Adds the `async-trait` dependency.

## Tests (38 new) — Phase 0 acceptance

- **combine**: 0/1/2/≥3 sources, outlier discarded at the boundary (inclusive), all-equal, `NaN`/`inf`/`≤0` rejected.
- **resolve_per_base**: resolves with anchor present, drops when missing, the El Toque worked example.
- **aggregate_tick**: partial-coverage union, failed provider contributes nothing, CUP from {Yadio, El Toque}, EUR from {Yadio, CoinGecko}, lowercase↔uppercase merge, cross-only-without-anchor is absent.
- **store**: fresh / within-TTL (inclusive) / past-TTL / missing / last-known-good preservation.
- **provider/health/config**: id string roundtrip, MockProvider, circuit-breaker open/recover/backoff-cap/reset, config defaults + TOML parse + validation + currency scoping.

## Checks

`cargo build` clean, `cargo test` (355 passed), `cargo clippy --all-targets --all-features` clean, `cargo fmt` clean. No SQL added (no `sqlx prepare` impact).

Refs: the multi-source price spec (PR #745).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added price configuration system supporting multiple data providers with customizable polling and staleness limits.
  * Introduced price aggregation with outlier rejection and per-provider health tracking.
  * Added thread-safe price storage with time-to-live validation.

* **Chores**
  * Added `async-trait` dependency.
  * Updated test configurations for new price field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->