### PR TITLE
fix(price): tolerate null rates in Yadio /exrates/BTC response

### DIFF
--- a/src/bitcoin_price.rs
+++ b/src/bitcoin_price.rs
@@ -13,8 +13,13 @@ use tracing::{error, info};
 
 #[derive(Debug, Deserialize)]
 struct YadioResponse {
+    // Yadio reports `null` for currencies it currently has no rate for
+    // (observed: `"BGN": null`). A strict `HashMap<String, f64>` makes serde
+    // reject the *entire* response on the first null, taking every currency
+    // down with it. Parse leniently as `Option<f64>` and drop the bad
+    // entries in `update_prices`.
     #[serde(rename = "BTC")]
-    btc: HashMap<String, f64>,
+    btc: HashMap<String, Option<f64>>,
 }
 
 static BITCOIN_PRICES: Lazy<RwLock<HashMap<String, f64>>> =
@@ -35,13 +40,22 @@ impl BitcoinPriceManager {
             .json()
             .await
             .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
+
+        // Keep only currencies with a usable rate: drop `null` (currencies
+        // Yadio has no price for) and any non-finite / non-positive value.
+        let rates_clone: HashMap<String, f64> = yadio_response
+            .btc
+            .into_iter()
+            .filter_map(|(code, value)| match value {
+                Some(v) if v.is_finite() && v > 0.0 => Some((code, v)),
+                _ => None,
+            })
+            .collect();
+
         info!(
             "Bitcoin prices updated. Got BTC price in {} fiat currencies",
-            yadio_response.btc.keys().collect::<Vec<&String>>().len()
+            rates_clone.len()
         );
-
-        // Clone rates before acquiring lock to avoid holding it across await
-        let rates_clone = yadio_response.btc.clone();
 
         {
             let mut prices_write = BITCOIN_PRICES
@@ -201,10 +215,42 @@ mod tests {
         assert!(result.is_ok());
 
         let response = result.unwrap();
-        assert_eq!(response.btc.get("USD"), Some(&50000.0));
-        assert_eq!(response.btc.get("EUR"), Some(&45000.0));
-        assert_eq!(response.btc.get("GBP"), Some(&40000.0));
+        assert_eq!(response.btc.get("USD"), Some(&Some(50000.0)));
+        assert_eq!(response.btc.get("EUR"), Some(&Some(45000.0)));
+        assert_eq!(response.btc.get("GBP"), Some(&Some(40000.0)));
         assert_eq!(response.btc.len(), 3);
+    }
+
+    #[test]
+    fn test_yadio_response_with_null_rate_is_parsed_and_filtered() {
+        // Regression: Yadio now returns `null` for currencies it has no rate
+        // for (e.g. "BGN": null). The lenient `Option<f64>` parse must accept
+        // the whole payload, and the same filter `update_prices` applies must
+        // drop the null while keeping the good currencies.
+        let json_response = r#"
+        {
+            "BTC": { "USD": 75899.55, "EUR": 65393.99, "BGN": null },
+            "base": "BTC",
+            "timestamp": 1779480604069
+        }
+        "#;
+
+        let response: YadioResponse = serde_json::from_str(json_response).expect("must parse");
+        assert_eq!(response.btc.get("BGN"), Some(&None));
+
+        let rates: HashMap<String, f64> = response
+            .btc
+            .into_iter()
+            .filter_map(|(code, value)| match value {
+                Some(v) if v.is_finite() && v > 0.0 => Some((code, v)),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(rates.len(), 2, "null BGN must be dropped");
+        assert_eq!(rates.get("USD"), Some(&75899.55));
+        assert_eq!(rates.get("EUR"), Some(&65393.99));
+        assert!(!rates.contains_key("BGN"));
     }
 
     #[test]

--- a/src/bitcoin_price.rs
+++ b/src/bitcoin_price.rs
@@ -9,7 +9,7 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::sync::RwLock;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[derive(Debug, Deserialize)]
 struct YadioResponse {
@@ -51,6 +51,15 @@ impl BitcoinPriceManager {
                 _ => None,
             })
             .collect();
+
+        // A response with zero usable rates (everything null/invalid, or an
+        // empty BTC object) must NOT overwrite the cache — that would turn a
+        // transient provider hiccup into total price unavailability for every
+        // currency. Keep the last known prices and try again next tick.
+        if rates_clone.is_empty() {
+            warn!("Yadio returned no usable BTC rates; keeping previously cached prices");
+            return Ok(());
+        }
 
         info!(
             "Bitcoin prices updated. Got BTC price in {} fiat currencies",
@@ -251,6 +260,28 @@ mod tests {
         assert_eq!(rates.get("USD"), Some(&75899.55));
         assert_eq!(rates.get("EUR"), Some(&65393.99));
         assert!(!rates.contains_key("BGN"));
+    }
+
+    #[test]
+    fn test_yadio_response_all_null_filters_to_empty() {
+        // When every rate is null/invalid the payload still parses, but the
+        // filter yields an empty map — the condition under which
+        // `update_prices` preserves the previously cached prices instead of
+        // overwriting them with nothing.
+        let json_response = r#"{ "BTC": { "BGN": null, "ZZZ": null }, "base": "BTC" }"#;
+        let response: YadioResponse = serde_json::from_str(json_response).expect("must parse");
+        let rates: HashMap<String, f64> = response
+            .btc
+            .into_iter()
+            .filter_map(|(code, value)| match value {
+                Some(v) if v.is_finite() && v > 0.0 => Some((code, v)),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            rates.is_empty(),
+            "all-null response must filter to an empty rate set"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Diagnosis

Running `mostrod` on `main` logs every tick:

```
ERROR mostrod::scheduler: Failed to update Bitcoin prices: Error caused by Error serializing message
```

Yadio's `GET /exrates/BTC` now returns a **`null`** value for at least one currency:

```json
{ "BTC": { "USD": 75899.55, "EUR": 65393.99, "BGN": null, ... }, "base": "BTC", "timestamp": 1779480604069 }
```

`BitcoinPriceManager::update_prices` parses that into `YadioResponse { btc: HashMap<String, f64> }`. serde cannot deserialize `null` into `f64`, so the **whole** response is rejected — mapped to `ServiceError::MessageSerializationError` (Display: "Error serializing message"). A single unpriced currency (BGN) takes down BTC prices for **all** 100+ currencies, leaving clients on stale data.

## Fix

Parse leniently as `HashMap<String, Option<f64>>` and keep only currencies with a usable rate — dropping `null` and any non-finite / non-positive value — before storing in `BITCOIN_PRICES` and publishing to Nostr. The unpriced currency is simply absent until Yadio prices it again; everything else updates normally.

Minimal and targeted: only `src/bitcoin_price.rs` (the `/exrates/BTC` cached path). The per-take `/convert` path in `get_market_quote` queries a single currency and is unaffected.

## Tests

- New regression test `test_yadio_response_with_null_rate_is_parsed_and_filtered` using the exact payload shape (USD, EUR, `BGN: null`): the lenient parse accepts it and the filter drops only BGN.
- Existing deserialization tests updated for the `Option<f64>` shape; the malformed-JSON / null-map / string-value error tests still reject as before.
- `cargo build`, `cargo test` (bitcoin_price: 11 pass), `cargo clippy --all-targets --all-features`, `cargo fmt` all clean.

## Note

This is the immediate hotfix for the Yadio single point of failure. The in-progress multi-source price module (spec `docs/PRICE_PROVIDERS.md`, Phase 0 in #747) removes the dependency on Yadio alone and its Yadio adapter will carry the same lenient parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing exchange rate data. The price system now gracefully processes incomplete currency rate information, filtering out invalid values while maintaining stability and accuracy of available rates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->