### PR TITLE
fix: surface InvalidOrderId to clients as CantDo(NotFound)

### DIFF
--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -180,11 +180,11 @@ pub async fn admin_take_dispute_action(
     // Get order from db using the dispute order id
     let order = if let Some(order) = Order::by_id(pool, dispute.order_id)
         .await
-        .map_err(|_| MostroInternalErr(ServiceError::InvalidOrderId))?
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?
     {
         order
     } else {
-        return Err(MostroInternalErr(ServiceError::InvalidOrderId));
+        return Err(MostroCantDo(CantDoReason::NotFound));
     };
 
     // Update dispute fields

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -159,7 +159,7 @@ pub async fn dispute_action(
     let order_id = if let Some(order_id) = msg.get_inner_message_kind().id {
         order_id
     } else {
-        return Err(MostroInternalErr(ServiceError::InvalidOrderId));
+        return Err(MostroCantDo(CantDoReason::NotFound));
     };
     // Check dispute for this order id is yet present.
     if find_dispute_by_order_id(pool, order_id).await.is_ok() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1170,14 +1170,14 @@ pub async fn get_order(msg: &Message, pool: &Pool<Sqlite>) -> Result<Order, Most
     let order_msg = msg.get_inner_message_kind();
     let order_id = order_msg
         .id
-        .ok_or(MostroInternalErr(ServiceError::InvalidOrderId))?;
+        .ok_or(MostroCantDo(CantDoReason::NotFound))?;
     let order = Order::by_id(pool, order_id)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
     if let Some(order) = order {
         Ok(order)
     } else {
-        Err(MostroInternalErr(ServiceError::InvalidOrderId))
+        Err(MostroCantDo(CantDoReason::NotFound))
     }
 }
 
@@ -1583,6 +1583,65 @@ mod tests {
             .unwrap();
 
         assert!(orders.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_order_returns_not_found_when_id_missing() {
+        initialize();
+        let pool = setup_orders_pool().await;
+        let message = Message::Order(MessageKind::new(
+            None,
+            None,
+            None,
+            Action::AdminSettle,
+            None,
+        ));
+
+        let err = get_order(&message, &pool).await.unwrap_err();
+        assert!(matches!(
+            err,
+            MostroError::MostroCantDo(CantDoReason::NotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_returns_not_found_when_order_absent() {
+        initialize();
+        let pool = setup_orders_pool().await;
+        let missing_id = Uuid::new_v4();
+        let message = Message::Order(MessageKind::new(
+            Some(missing_id),
+            None,
+            None,
+            Action::AdminSettle,
+            None,
+        ));
+
+        let err = get_order(&message, &pool).await.unwrap_err();
+        assert!(matches!(
+            err,
+            MostroError::MostroCantDo(CantDoReason::NotFound)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_order_returns_order_when_found() {
+        initialize();
+        let pool = setup_orders_pool().await;
+        let user_pubkey = "a".repeat(64);
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, Some(&user_pubkey), None, &user_pubkey).await;
+
+        let message = Message::Order(MessageKind::new(
+            Some(order_id),
+            None,
+            None,
+            Action::AdminSettle,
+            None,
+        ));
+
+        let order = get_order(&message, &pool).await.unwrap();
+        assert_eq!(order.id, order_id);
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1168,9 +1168,7 @@ pub async fn get_dispute(msg: &Message, pool: &Pool<Sqlite>) -> Result<Dispute, 
 
 pub async fn get_order(msg: &Message, pool: &Pool<Sqlite>) -> Result<Order, MostroError> {
     let order_msg = msg.get_inner_message_kind();
-    let order_id = order_msg
-        .id
-        .ok_or(MostroCantDo(CantDoReason::NotFound))?;
+    let order_id = order_msg.id.ok_or(MostroCantDo(CantDoReason::NotFound))?;
     let order = Order::by_id(pool, order_id)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;


### PR DESCRIPTION
## Summary

Closes #751.

Admin actions (`AdminSettle`, `AdminCancel`) — and any handler that called `get_order` — used to return `MostroInternalErr(ServiceError::InvalidOrderId)` when the message lacked an `id` or the order was not present in the database. That error was routed to `manage_errors`, which only calls `warning_msg` and never enqueues a DM back to the sender. The client therefore never learned the action failed and timed out.

This change promotes the user-facing path of `InvalidOrderId` to `MostroCantDo(CantDoReason::NotFound)`, so the sender receives a `CantDo` DM. It matches the existing `CantDo` pattern already used in `last_trade_index_action` and `orders_action`, and is the option recommended in the issue.

## Changes

- `util.rs::get_order`: return `CantDo(NotFound)` when the message lacks an `id` and when the order is not present in the database.
- `app/dispute.rs::dispute_action`: return `CantDo(NotFound)` when the message lacks an `order_id`.
- `app/admin_take_dispute.rs::admin_take_dispute_action`:
  - Preserve `DbAccessError` semantics on real database failures (previously silently mapped to `InvalidOrderId`).
  - Return `CantDo(NotFound)` when the dispute's referenced order is missing, so the admin gets feedback.
- Unit tests for the three `get_order` branches: missing id, order not found, order found.

## Affected actions

`AdminSettle`, `AdminCancel`, `Dispute`, `AdminTakeDispute`, and any other handler that resolves an order through `get_order` (`FiatSent`, `TakeBuy`, `TakeSell`, `AddInvoice`, `Cancel`, `Release`, `RateUser`, `TradePubkey`).

## Test plan

- [x] `cargo build --tests -p mostro` — clean.
- [x] `cargo test -p mostro --bin mostrod` — 334 passed, 0 failed (3 new tests added).
- [x] `cargo clippy -p mostro --bin mostrod --tests` — no new warnings.
- [x] Manual: send `AdminSettle` with a non-existent `order_id` and verify the admin receives a `CantDo(NotFound)` DM instead of a timeout.

## Related

- CLI side: MostroP2P/mostro-cli#170
