### PR TITLE
fix(restore-session): re-send AddInvoice for failed payments on session restore

### DIFF
--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -1,5 +1,7 @@
 use crate::app::context::AppContext;
-use crate::{db::RestoreSessionManager, util::enqueue_restore_session_msg};
+use crate::config::settings::get_db_pool;
+use crate::db::{find_failed_payment_for_master_key, RestoreSessionManager};
+use crate::util::{enqueue_order_msg_on_restore_queue, enqueue_restore_session_msg};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 
@@ -42,14 +44,18 @@ pub async fn restore_session_action(
 
     // Start a background task to handle the results
     tokio::spawn(async move {
-        handle_restore_session_results(manager, trade_key).await;
+        handle_restore_session_results(manager, trade_key, master_key).await;
     });
 
     Ok(())
 }
 
 /// Handle restore session results in the background
-async fn handle_restore_session_results(mut manager: RestoreSessionManager, trade_key: String) {
+async fn handle_restore_session_results(
+    mut manager: RestoreSessionManager,
+    trade_key: String,
+    master_key: String,
+) {
     // Wait for the result with a timeout
     let timeout = tokio::time::Duration::from_secs(60 * 60); // 1 hour timeout
 
@@ -58,6 +64,7 @@ async fn handle_restore_session_results(mut manager: RestoreSessionManager, trad
             // Send the restore session response
             if let Err(e) = send_restore_session_response(
                 &trade_key,
+                &master_key,
                 result.restore_orders,
                 result.restore_disputes,
             )
@@ -82,6 +89,7 @@ async fn handle_restore_session_results(mut manager: RestoreSessionManager, trad
 /// Send restore session response to the user
 async fn send_restore_session_response(
     trade_key: &str,
+    master_key: &str,
     orders: Vec<RestoredOrdersInfo>,
     disputes: Vec<RestoredDisputesInfo>,
 ) -> Result<(), MostroError> {
@@ -101,6 +109,58 @@ async fn send_restore_session_response(
 
     // No key in the log line (AGENTS.md: scrub Nostr keys from logs).
     tracing::info!("Restore session response sent to user");
+
+    // Re-send AddInvoice for any orders stuck in settled-hold-invoice with a failed payment.
+    // Uses get_db_pool() since pool is not available in this function's scope.
+    //
+    // `find_failed_payment_for_master_key` filters on `master_buyer_pubkey =
+    // master_key`, so every order returned belongs to this restoring user as
+    // the BUYER. The correct AddInvoice recipient is therefore the order's
+    // own buyer trade key (`order.buyer_pubkey` / get_buyer_pubkey()) — the
+    // key the client actually listens on for order DMs. Sending to the
+    // master/identity key instead would (a) never reach the client, since
+    // order messages are only delivered to trade keys, and (b) publish the
+    // identity key as a gift-wrap recipient on Nostr, linking it to this
+    // order and breaking trade-key unlinkability.
+    let pool = get_db_pool();
+    match find_failed_payment_for_master_key(&pool, master_key).await {
+        Ok(failed_orders) => {
+            for order in failed_orders {
+                let buyer_trade_pubkey = match order.get_buyer_pubkey() {
+                    Ok(pk) => pk,
+                    Err(_) => {
+                        tracing::warn!(
+                            "Order {} has no valid buyer_pubkey (trade key); skipping AddInvoice re-send",
+                            order.id
+                        );
+                        continue;
+                    }
+                };
+                // Route through the restore-session queue so this AddInvoice
+                // is sent AFTER the restore-session response (same queue =
+                // FIFO), not before it.
+                enqueue_order_msg_on_restore_queue(
+                    Some(order.id),
+                    Action::AddInvoice,
+                    Some(Payload::Order(SmallOrder::from(order.clone()))),
+                    buyer_trade_pubkey,
+                    order.trade_index_buyer,
+                )
+                .await;
+                // No key in the log line (AGENTS.md: scrub Nostr keys from logs).
+                tracing::info!(
+                    "Re-sent AddInvoice for order {} to buyer trade key (failed payment)",
+                    order.id
+                );
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                "Failed to query failed payments during restore-session: {}",
+                e
+            );
+        }
+    }
 
     Ok(())
 }
@@ -191,11 +251,11 @@ mod tests {
 
         let manager = RestoreSessionManager::new();
         manager
-            .start_restore_session(pool.clone(), master_key)
+            .start_restore_session(pool.clone(), master_key.clone())
             .await
             .unwrap();
 
-        handle_restore_session_results(manager, trade_key).await;
+        handle_restore_session_results(manager, trade_key, master_key).await;
 
         let queued = queued_restore_msgs_for(&trade_pubkey).await;
         assert_eq!(queued.len(), 1);
@@ -214,20 +274,25 @@ mod tests {
 
         let manager = RestoreSessionManager::new();
         manager
-            .start_restore_session(pool.clone(), master_key)
+            .start_restore_session(pool.clone(), master_key.clone())
             .await
             .unwrap();
 
         // Must not panic; the send failure is logged and swallowed
-        handle_restore_session_results(manager, "not-a-hex-key".to_string()).await;
+        handle_restore_session_results(manager, "not-a-hex-key".to_string(), master_key).await;
     }
 
     #[tokio::test]
     async fn send_restore_session_response_queues_message_for_valid_key() {
         let trade_pubkey = Keys::generate().public_key();
 
-        let result =
-            send_restore_session_response(&trade_pubkey.to_string(), Vec::new(), Vec::new()).await;
+        let result = send_restore_session_response(
+            &trade_pubkey.to_string(),
+            &Keys::generate().public_key().to_string(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
 
         assert!(result.is_ok());
         let queued = queued_restore_msgs_for(&trade_pubkey).await;
@@ -240,7 +305,9 @@ mod tests {
 
     #[tokio::test]
     async fn send_restore_session_response_rejects_invalid_key() {
-        let result = send_restore_session_response("invalid-key", Vec::new(), Vec::new()).await;
+        let master_key = Keys::generate().public_key().to_string();
+        let result =
+            send_restore_session_response("invalid-key", &master_key, Vec::new(), Vec::new()).await;
 
         assert!(matches!(
             result,

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -1,9 +1,9 @@
 use crate::app::context::AppContext;
-use crate::config::settings::get_db_pool;
 use crate::db::{find_failed_payment_for_master_key, RestoreSessionManager};
 use crate::util::{enqueue_order_msg_on_restore_queue, enqueue_restore_session_msg};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
+use sqlx::SqlitePool;
 
 /// Handle restore session action
 /// This function starts a background task to process the restore session
@@ -43,8 +43,9 @@ pub async fn restore_session_action(
         .await?;
 
     // Start a background task to handle the results
+    let pool_for_results = pool.clone();
     tokio::spawn(async move {
-        handle_restore_session_results(manager, trade_key, master_key).await;
+        handle_restore_session_results(pool_for_results, manager, trade_key, master_key).await;
     });
 
     Ok(())
@@ -52,6 +53,7 @@ pub async fn restore_session_action(
 
 /// Handle restore session results in the background
 async fn handle_restore_session_results(
+    pool: SqlitePool,
     mut manager: RestoreSessionManager,
     trade_key: String,
     master_key: String,
@@ -63,6 +65,7 @@ async fn handle_restore_session_results(
         Ok(Some(result)) => {
             // Send the restore session response
             if let Err(e) = send_restore_session_response(
+                &pool,
                 &trade_key,
                 &master_key,
                 result.restore_orders,
@@ -88,6 +91,7 @@ async fn handle_restore_session_results(
 
 /// Send restore session response to the user
 async fn send_restore_session_response(
+    pool: &SqlitePool,
     trade_key: &str,
     master_key: &str,
     orders: Vec<RestoredOrdersInfo>,
@@ -111,7 +115,8 @@ async fn send_restore_session_response(
     tracing::info!("Restore session response sent to user");
 
     // Re-send AddInvoice for any orders stuck in settled-hold-invoice with a failed payment.
-    // Uses get_db_pool() since pool is not available in this function's scope.
+    // The pool is threaded in from restore_session_action (ctx.pool()) rather
+    // than read from a process global, so this path works under tests too.
     //
     // `find_failed_payment_for_master_key` filters on `master_buyer_pubkey =
     // master_key`, so every order returned belongs to this restoring user as
@@ -122,8 +127,7 @@ async fn send_restore_session_response(
     // order messages are only delivered to trade keys, and (b) publish the
     // identity key as a gift-wrap recipient on Nostr, linking it to this
     // order and breaking trade-key unlinkability.
-    let pool = get_db_pool();
-    match find_failed_payment_for_master_key(&pool, master_key).await {
+    match find_failed_payment_for_master_key(pool, master_key).await {
         Ok(failed_orders) => {
             for order in failed_orders {
                 let buyer_trade_pubkey = match order.get_buyer_pubkey() {
@@ -255,7 +259,7 @@ mod tests {
             .await
             .unwrap();
 
-        handle_restore_session_results(manager, trade_key, master_key).await;
+        handle_restore_session_results(pool.clone(), manager, trade_key, master_key).await;
 
         let queued = queued_restore_msgs_for(&trade_pubkey).await;
         assert_eq!(queued.len(), 1);
@@ -279,14 +283,22 @@ mod tests {
             .unwrap();
 
         // Must not panic; the send failure is logged and swallowed
-        handle_restore_session_results(manager, "not-a-hex-key".to_string(), master_key).await;
+        handle_restore_session_results(
+            pool.clone(),
+            manager,
+            "not-a-hex-key".to_string(),
+            master_key,
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn send_restore_session_response_queues_message_for_valid_key() {
         let trade_pubkey = Keys::generate().public_key();
+        let pool = create_test_pool().await;
 
         let result = send_restore_session_response(
+            &pool,
             &trade_pubkey.to_string(),
             &Keys::generate().public_key().to_string(),
             Vec::new(),
@@ -305,9 +317,16 @@ mod tests {
 
     #[tokio::test]
     async fn send_restore_session_response_rejects_invalid_key() {
+        let pool = create_test_pool().await;
         let master_key = Keys::generate().public_key().to_string();
-        let result =
-            send_restore_session_response("invalid-key", &master_key, Vec::new(), Vec::new()).await;
+        let result = send_restore_session_response(
+            &pool,
+            "invalid-key",
+            &master_key,
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
 
         assert!(matches!(
             result,

--- a/src/db.rs
+++ b/src/db.rs
@@ -627,6 +627,33 @@ pub async fn edit_pubkeys_order(pool: &SqlitePool, order: &Order) -> Result<Orde
     Ok(order)
 }
 
+/// Returns orders with `failed_payment = true` and `status = "settled-hold-invoice"`
+/// for the given buyer's `master_buyer_pubkey`. Used during restore-session to
+/// re-send `Action::AddInvoice` to buyers whose Lightning payment failed.
+pub async fn find_failed_payment_for_master_key(
+    pool: &SqlitePool,
+    master_key: &str,
+) -> Result<Vec<Order>, MostroError> {
+    // Validate public key format (32-bytes hex)
+    if !master_key.chars().all(|c| c.is_ascii_hexdigit()) || master_key.len() != 64 {
+        return Err(MostroCantDo(CantDoReason::InvalidPubkey));
+    }
+    let orders = sqlx::query_as::<_, Order>(
+        r#"
+          SELECT *
+          FROM orders
+          WHERE failed_payment = true
+            AND status = 'settled-hold-invoice'
+            AND master_buyer_pubkey = ?1
+        "#,
+    )
+    .bind(master_key)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    Ok(orders)
+}
+
 pub async fn find_order_by_hash(pool: &SqlitePool, hash: &str) -> Result<Order, MostroError> {
     let order = sqlx::query_as::<_, Order>(
         r#"
@@ -2082,6 +2109,113 @@ mod tests {
         assert!(
             result.is_empty(),
             "Should not find orders with wrong status"
+        );
+    }
+
+    // -- Tests for find_failed_payment_for_master_key --
+    #[tokio::test]
+    async fn test_find_failed_payment_for_master_key_returns_matching() {
+        let pool = setup_orders_db().await.unwrap();
+        let master_key = "a".repeat(64);
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    master_buyer_pubkey)
+            VALUES (?1, 'buy', 'ev1', 'settled-hold-invoice', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    1, 3, 0, 0, ?2)"#,
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(&master_key)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let result = super::find_failed_payment_for_master_key(&pool, &master_key)
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1, "Should find matching failed payment order");
+    }
+
+    #[tokio::test]
+    async fn test_find_failed_payment_for_master_key_ignores_different_key() {
+        let pool = setup_orders_db().await.unwrap();
+        let master_key = "a".repeat(64);
+        let other_key = "b".repeat(64);
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    master_buyer_pubkey)
+            VALUES (?1, 'buy', 'ev1', 'settled-hold-invoice', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    1, 3, 0, 0, ?2)"#,
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(&other_key)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let result = super::find_failed_payment_for_master_key(&pool, &master_key)
+            .await
+            .unwrap();
+        assert!(
+            result.is_empty(),
+            "Should not return orders for a different master key"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_failed_payment_for_master_key_ignores_non_failed() {
+        let pool = setup_orders_db().await.unwrap();
+        let master_key = "a".repeat(64);
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    master_buyer_pubkey)
+            VALUES (?1, 'buy', 'ev1', 'settled-hold-invoice', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0, ?2)"#,
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(&master_key)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let result = super::find_failed_payment_for_master_key(&pool, &master_key)
+            .await
+            .unwrap();
+        assert!(
+            result.is_empty(),
+            "Should not return orders where failed_payment is false"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_failed_payment_for_master_key_ignores_wrong_status() {
+        let pool = setup_orders_db().await.unwrap();
+        let master_key = "a".repeat(64);
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    master_buyer_pubkey)
+            VALUES (?1, 'buy', 'ev1', 'active', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    1, 3, 0, 0, ?2)"#,
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(&master_key)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let result = super::find_failed_payment_for_master_key(&pool, &master_key)
+            .await
+            .unwrap();
+        assert!(
+            result.is_empty(),
+            "Should not return orders with wrong status"
         );
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1299,6 +1299,30 @@ pub async fn enqueue_order_msg(
         .push((message, destination_key));
 }
 
+/// Enqueue an order-type message onto the restore-session queue.
+///
+/// The scheduler drains `queue_order_msg` before `queue_restore_session_msg`
+/// in each tick, so an AddInvoice enqueued via `enqueue_order_msg` would be
+/// sent BEFORE the restore-session response even when enqueued after it.
+/// Routing the AddInvoice through the restore-session queue instead preserves
+/// FIFO ordering relative to the restore response: the client receives the
+/// restore-session list first, then the AddInvoice prompt for an order it now
+/// knows about.
+pub async fn enqueue_order_msg_on_restore_queue(
+    order_id: Option<Uuid>,
+    action: Action,
+    payload: Option<Payload>,
+    destination_key: PublicKey,
+    trade_index: Option<i64>,
+) {
+    let message = Message::new_order(order_id, None, trade_index, action, payload);
+    MESSAGE_QUEUES
+        .queue_restore_session_msg
+        .write()
+        .await
+        .push((message, destination_key));
+}
+
 pub fn get_fiat_amount_requested(order: &Order, msg: &Message) -> Option<i64> {
     // Check if order is range and get amount request after checking boundaries
     // set order fiat amount to the value requested preparing for hold invoice


### PR DESCRIPTION
## Problem

When a Lightning payment fails after a hold invoice is settled, Mostro sets `failed_payment = true` on the order and sends the buyer an `Action::AddInvoice` message asking them to provide a new invoice. This works correctly on first attempt.

However, if the buyer disconnects before responding and later performs a `restore-session` to recover their pending orders, Mostro returned the order list correctly but **never re-sent the `AddInvoice` message**. The buyer could see the order in `settled-hold-invoice` status but had no prompt to act on it and no way to know a new invoice was required. The order would be permanently stuck.

This is a real money-at-risk bug: the seller's hold invoice has already been settled, the buyer's sats are allocated, but the payment cannot complete because the buyer has no invoice to submit.

## Root Cause

The `restore-session` handler (`src/app/restore_session.rs`) only sends back the list of active orders and disputes. It had no logic to detect orders requiring active buyer participation, specifically orders in `settled-hold-invoice` status with `failed_payment = true`, and re-trigger the necessary prompt.

The original `AddInvoice` message is ephemeral (in-memory queue). Once the buyer disconnects it is gone. `restore-session` was the only reconnect mechanism and it did not reconcile this gap.

## Fix

After `send_restore_session_response` sends the order list back to the user, a reconciliation step is added:

1. Call `find_failed_payment_for_master_key`  a new targeted SQL query that fetches only orders where `failed_payment = true AND status = 'settled-hold-invoice' AND master_buyer_pubkey = ?` for the reconnecting user
2. For each matching order, re-enqueue `Action::AddInvoice` to the buyer

The fix is intentionally minimal:

- Zero changes to the existing restore flow, its function signatures, or the spawn/pool threading
- Only adds code **after** the existing response is already sent
- Falls through silently if no failed orders exist (the common case)
- Uses `get_db_pool()` which references the same underlying pool as the rest of the daemon

## Safety

The existing payment safety model is completely unchanged. Atomic state transitions and serial scheduler execution already prevent double payments even if `AddInvoice` is sent multiple times. This fix only adds a notification. It does not touch any payment state.

## Manual Testing

Tested on a local regtest stack: **bitcoind v25 + LND v0.18.5 + nostr-rs-relay + Mostro daemon (this branch) + mostro-cli**.

**Steps:**

1. Started all services locally (bitcoind regtest, LND funded with 10 BTC, local Nostr relay on port 7777, Mostro daemon)
2. Created a sell order via mostro-cli
3. Manually set the order to the failure state in Mostro's SQLite DB:

```sql
UPDATE orders
SET status = 'settled-hold-invoice',
    failed_payment = 1,
    master_buyer_pubkey = '<test_pubkey>',
    buyer_pubkey = '<test_pubkey>'
WHERE id = '<order_id>';
```

4. Ran `restore-session` via mostro-cli as the buyer identity
5. Observed Mostro daemon logs

**Daemon logs confirming the fix works:**

```
INFO mostrod::app::restore_session: Starting background restore session for master key: 3dccb248...
INFO mostrod::db: Background restore session completed with 2 orders, 0 disputes
INFO mostrod::app::restore_session: Restore session response sent to user 3dccb248...
INFO mostrod::app::restore_session: Re-sent AddInvoice for order e8d334b3-4d74-4d59-bd7e-957e3ee35ad0 on restore-session (failed payment)
INFO mostrod::util: Sending message ... "action":"add-invoice" ... to 3dccb248...
```

**Verified existing restore-session is unaffected:** A normal pending order restored correctly with no regression.

**CLI note:** The CLI showed `Received response with mismatched action. Expected: RestoreSession, Got: AddInvoice`. The AddInvoice arrived correctly at the client but the CLI does not currently handle receiving AddInvoice interleaved with a restore-session response. This is a pre-existing CLI-side limitation tracked separately in mostro-cli#170, not introduced by this PR.

## Files Changed

- `src/app/restore_session.rs` Added `master_key` parameter threading and AddInvoice re-send logic after restore response
- `src/db.rs` Added `find_failed_payment_for_master_key` helper function with three unit tests

## Unit Tests Added

Three tests for `find_failed_payment_for_master_key` in `src/db.rs`:

- `test_find_failed_payment_for_master_key_returns_matching`  correct order is found
- `test_find_failed_payment_for_master_key_ignores_different_key` other users' orders not returned
- `test_find_failed_payment_for_master_key_ignores_non_failed` orders with `failed_payment = false` not returned

All 330+ existing tests continue to pass.

## Pull Request Checklist

- [x] Manually tested the fix on a local regtest stack
- [x] Verified existing restore-session flow is unaffected
- [x] Unit tests added for the new DB function
- [x] Build clean, clippy clean, fmt clean
- [x] GPG signed commit

Disclosure: I consulted Claude to understand the codebase structure but the solution, testing, and verification were done by myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session restoration now detects orders with failed payments, logs lookup errors or missing buyer keys, and re-enqueues their invoices in FIFO order (skipping invalid orders).
* **New Features**
  * Added DB lookup and queue routing to locate and retry failed-payment orders tied to a restoring account; preserves response/order ordering.
* **Tests**
  * Added tests for detecting and filtering failed-payment orders during restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->