### PR TITLE
feat(bond): Phase 4.5 — re-prompt winner for payout invoice on payment failure

### DIFF
--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -1667,15 +1667,35 @@ and **while the claim window is still open**, Mostro should:
 All changes are in `src/app/bond/payout.rs` and the scheduler cadence;
 no `mostro-core` variant, no migration.
 
-- **Stale invoice on retry exhaustion is discarded, not terminal.**
-  Change `on_send_payment_failure` so that when
-  `payout_attempts >= payout_max_retries`:
+- **Only a *terminal* failure abandons the invoice (double-payout
+  guard).** Abandoning the current invoice — whether by re-arming for a
+  fresh one or by flipping to `Failed` — clears `payout_payment_hash`,
+  which disables the §8.1 reconciliation branch in `pay_counterparty`
+  (the branch that looks the payment up in LND before re-sending). If the
+  in-flight `send_payment` for the current invoice could still settle,
+  abandoning it would let a freshly-prompted invoice be paid while the
+  original later succeeds — a **double payout**. So
+  `on_send_payment_failure` distinguishes two failure kinds:
+  - **Terminal** — LND reported the payment `Failed` (via the status
+    stream or reconciliation), or the invoice is structurally unusable.
+    No payment is or will be in flight, so the invoice may be abandoned.
+  - **Indeterminate** — status-stream timeout, stream EOF, or a
+    `send_payment` RPC error. The payment may still be in flight. The
+    invoice and its `payout_payment_hash` are **kept**; the row stays in
+    `PendingPayout` and the next tick's reconciliation branch polls LND
+    to a definitive `Succeeded` / `Failed` before anything new is paid.
+    `payout_attempts` saturates at `payout_max_retries` so a long LND
+    outage cannot grow it without bound.
+- **Stale invoice on *terminal* retry exhaustion is discarded, not
+  terminal-`Failed`.** When `payout_attempts >= payout_max_retries`
+  after a **terminal** failure:
   - **If `now - slashed_at < payout_claim_window_days * 86_400`** (claim
     window still open): instead of transitioning to `Failed`, CAS the row
     *back into the invoice-request phase* — clear `payout_invoice`,
     `payout_routing_fee_sats`, and `payout_payment_hash` to `NULL`, reset
-    `payout_attempts = 0`, and **leave `state = PendingPayout`** and
-    `slashed_at` untouched. The guard is `WHERE id = ? AND state =
+    `payout_attempts = 0`, clear `last_invoice_request_at` (so the
+    re-prompt fires immediately), and **leave `state = PendingPayout`**
+    and `slashed_at` untouched. The guard is `WHERE id = ? AND state =
     'pending-payout'` so a row that raced to another state in the
     meantime is left alone.
   - **Else** (claim window already elapsed): transition to `Failed` as
@@ -1731,14 +1751,22 @@ ever observed after the claim window has elapsed.
 
 ### 9.5.5 Tests
 
-- **Re-request after exhaustion, in window.** Bond in `PendingPayout`
-  with a submitted-but-unroutable `payout_invoice`, day 2 of a 15-day
-  window. Drive `send_payment` failures up to `payout_max_retries`. The
-  row stays `PendingPayout`, `payout_invoice` / `payout_routing_fee_sats`
-  / `payout_payment_hash` are cleared, `payout_attempts` resets to 0, and
-  `slashed_at` is unchanged. On the next scheduler tick (cadence window
-  elapsed) a fresh `Action::AddBondInvoice` is enqueued to the winner and
+- **Re-request after *terminal* exhaustion, in window.** Bond in
+  `PendingPayout` with a submitted-but-unroutable `payout_invoice`, day 2
+  of a 15-day window. Drive **terminal** `send_payment` failures up to
+  `payout_max_retries`. The row stays `PendingPayout`, `payout_invoice` /
+  `payout_routing_fee_sats` / `payout_payment_hash` /
+  `last_invoice_request_at` are cleared, `payout_attempts` resets to 0,
+  and `slashed_at` is unchanged. On the next scheduler tick a fresh
+  `Action::AddBondInvoice` is enqueued to the winner and
   `invoice_request_attempts` increments.
+- **Indeterminate exhaustion keeps the invoice (double-payout guard).**
+  Same setup, but the failures are **indeterminate** (timeout / EOF /
+  send RPC error). After `payout_max_retries` the row stays
+  `PendingPayout` with `payout_invoice` **and** `payout_payment_hash`
+  intact (so reconciliation can poll LND), is **not** re-armed and
+  **not** `Failed`, and `payout_attempts` saturates at
+  `payout_max_retries`. Further indeterminate failures keep it pinned.
 - **Deadline does not move.** Across one or more re-request cycles, the
   `slashed_at` field and the `slashed_at` shipped in
   `Payload::BondPayoutRequest` are identical to the original slash

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -186,11 +186,12 @@ slash path.
 |------:|----------|------------|--------|
 | 0 | Foundation: config schema, `bonds` table, pure helpers, types | — | ✅ shipped (PR #712) |
 | 1 | Taker bond lifecycle: **lock + always release** (no slashing yet) | 0 | ✅ shipped (PR #719) |
-| 1.5 | Protocol cleanup: dedicated `Action::PayBondInvoice` + `Status::WaitingTakerBond` (retire the Phase 1 `PayInvoice` reuse) | 1 | pending |
-| 2 | Solver-directed dispute slash via `BondResolution` payload (taker bond) | 1.5 | pending |
-| 3 | Payout flow: `Action::AddBondInvoice` to winner, routing-fee estimation, retries | 2 | pending |
-| 3.5 | Payout confirmation to the winner: `BondInvoiceAccepted` (receipt) + `BondPayoutCompleted` (paid) + explicit "already paid" refusal | 3 | proposed |
-| 4 | Timeout slash for taker bond (`slash_on_waiting_timeout`) + `Action::BondSlashed` forfeiture notice | 3 | ✅ shipped (mostro-core 0.11.5) |
+| 1.5 | Protocol cleanup: dedicated `Action::PayBondInvoice` + `Status::WaitingTakerBond` (retire the Phase 1 `PayInvoice` reuse) | 1 | ✅ shipped (PR #736) |
+| 2 | Solver-directed dispute slash via `BondResolution` payload (taker bond) | 1.5 | ✅ shipped (PR #737) |
+| 3 | Payout flow: `Action::AddBondInvoice` to winner, routing-fee estimation, retries | 2 | ✅ shipped (PR #738) |
+| 3.5 | Payout confirmation to the winner: `BondInvoiceAccepted` (receipt) + `BondPayoutCompleted` (paid) + explicit "already paid" refusal | 3 | ✅ shipped (PR #743) |
+| 4 | Timeout slash for taker bond (`slash_on_waiting_timeout`) + `Action::BondSlashed` forfeiture notice | 3 | ✅ shipped (PR #744) |
+| 4.5 | Re-prompt the winner for a fresh payout invoice after `send_payment` retries exhaust, instead of stranding the bond in `Failed` ([issue #750](https://github.com/MostroP2P/mostro/issues/750)) | 3 | pending |
 | 5 | Maker bond (non-range): lock + dispute slash reusing Phase 2/3 | 3 | pending |
 | 6 | Maker bond for **range orders** with proportional slashes | 5 | pending |
 | 7 | Timeout slash for maker bond | 5 | pending |
@@ -199,7 +200,21 @@ slash path.
 Phases 4, 5, 6, 7 can partially overlap in time but must land in this
 order on `main` to keep review scope honest. Phase 3.5 depends only on
 Phase 3 and is orthogonal to the slash-path phases (4–7); it can land
-any time after Phase 3.
+any time after Phase 3. Phase 4.5 likewise depends only on Phase 3's
+payout flow (it hardens the `send_payment`-exhaustion path) and is
+orthogonal to the slash-direction phases — it can land any time after
+Phase 3, and is numbered 4.5 only because it was reported from field
+testing after Phase 4 shipped.
+
+**Status as of this revision.** Phases 0 through 4 are merged on
+`main` (PRs #712, #719, #736, #737, #738, #743, #744). The
+`mostro-core` pin in `Cargo.toml` is **0.11.5**, which carries every
+protocol variant those phases need (`Status::WaitingTakerBond`,
+`Action::PayBondInvoice`, `Payload::BondResolution`,
+`Action::AddBondInvoice`, `Payload::BondPayoutRequest`,
+`Action::BondInvoiceAccepted`, `Action::BondPayoutCompleted`,
+`Action::BondSlashed`). Phase 4.5 and Phases 5–8 are not yet
+implemented.
 
 ---
 
@@ -519,7 +534,7 @@ instead of memo parsing.
 
 ---
 
-## 6.5. Phase 1.5 — Dedicated `PayBondInvoice` + `WaitingTakerBond`
+## 6.5. Phase 1.5 — Dedicated `PayBondInvoice` + `WaitingTakerBond` ✅ Completed
 
 Small, protocol-only phase. Lands the dedicated `Action` and `Status`
 variants that Phase 1 deferred (§6 implementation note) so clients can
@@ -804,7 +819,7 @@ never has to lean on memo parsing in the wild.
 
 ---
 
-## 7. Phase 2 — Solver-directed dispute slash
+## 7. Phase 2 — Solver-directed dispute slash ✅ Completed
 
 Behaviour gate: `enabled && apply_to ∈ { take, both }` (Phase 5 extends to
 maker).
@@ -977,7 +992,7 @@ sats are already in Mostro's wallet.
 
 ---
 
-## 8. Phase 3 — Payout flow
+## 8. Phase 3 — Payout flow ✅ Completed
 
 Shared infrastructure used by every slash path afterwards. Non-blocking:
 trade finalization must never wait on the **counterparty** payout
@@ -1139,6 +1154,13 @@ must land hand-in-hand with the client adoption. See §14.3.
        to `PendingPayout`, overwrites `payout_invoice`, and resets
        `payout_attempts` to 0 (see `add_bond_invoice_action` below).
        Past the claim window, `Failed` requires operator attention.
+       **Superseded by Phase 4.5 (§9.5):** as shipped in Phase 3 this
+       recovery only fires if the winner *spontaneously* resubmits —
+       Mostro never re-prompts — which makes the in-window recovery
+       unreachable in practice ([issue #750](https://github.com/MostroP2P/mostro/issues/750)).
+       Phase 4.5 changes the in-window exhaustion transition to discard
+       the stale invoice and re-prompt the winner via the scheduler
+       instead of going straight to `Failed`.
 
   When `slash_node_share_pct = 1.0` the counterparty leg is skipped
   entirely (no `AddBondInvoice` message, no `send_payment`, no forfeit
@@ -1230,7 +1252,13 @@ must land hand-in-hand with the client adoption. See §14.3.
 - **User-side recovery from `Failed`.** `Failed` is *not* a hard
   terminal state from the recipient's perspective. A fresh
   `AddBondInvoice` from the same recipient resurrects the bond via a
-  guarded CAS:
+  guarded CAS. **(Phase 4.5 §9.5 makes this Mostro-driven.** In Phase 3
+  this resurrection depends on the winner spontaneously resubmitting;
+  Phase 4.5 has the daemon re-prompt the winner on in-window
+  retry-exhaustion so the recovery no longer hinges on a client guess —
+  see [issue #750](https://github.com/MostroP2P/mostro/issues/750). The
+  CAS below is retained as belt-and-braces for rows that still reach
+  `Failed`.)
   `UPDATE bonds SET state='pending-payout', payout_invoice=?,
    payout_attempts=0, invoice_request_attempts=0
    WHERE id=? AND state='failed'`, gated in Rust by `now -
@@ -1355,7 +1383,7 @@ must land hand-in-hand with the client adoption. See §14.3.
 
 ---
 
-## 8.5. Phase 3.5 — Payout confirmation to the winning counterparty
+## 8.5. Phase 3.5 — Payout confirmation to the winning counterparty ✅ Completed
 
 Small, protocol-only follow-up to Phase 3. Phase 3 drives the payout but
 tells the winner **nothing** once they have submitted their bolt11: the
@@ -1472,7 +1500,7 @@ the client to stop prompting.
 
 ---
 
-## 9. Phase 4 — Timeout slash (taker bond)
+## 9. Phase 4 — Timeout slash (taker bond) ✅ Completed
 
 Gate: `enabled && slash_on_waiting_timeout && apply_to ∈ { take, both }`.
 
@@ -1571,6 +1599,179 @@ slash notice uses `Action::BondSlashed` (mostro-core **0.11.5**).
 - Attack-invariant test passes: counterparty cancelling before timeout
   never causes a slash.
 - Timeout slashes feed Phase 3 payout flow.
+
+---
+
+## 9.5. Phase 4.5 — Re-prompt the winner after payout-payment failure
+
+Small, daemon-only follow-up to Phase 3. No `mostro-core` change, no
+schema change, no new slashing — it closes a hole in the Phase 3 payout
+state machine that makes a slashed bond's counterparty share
+unrecoverable in practice. Reported as
+[issue #750](https://github.com/MostroP2P/mostro/issues/750) from field
+testing of the bond rollout.
+
+Depends only on Phase 3 (it reuses `Action::AddBondInvoice` from Phase 3
+and `Action::BondInvoiceAccepted` from Phase 3.5); orthogonal to the
+slash-direction phases (4–7).
+
+### 9.5.1 The problem
+
+Once a bond is slashed and the winning counterparty has submitted a
+payout bolt11, Phase 3's scheduler (`run_bond_payout_cycle` →
+`process_one_bond` → `pay_counterparty`) tries `send_payment` against
+that invoice and, on failure, bumps `payout_attempts`
+(`on_send_payment_failure` in `src/app/bond/payout.rs`). When
+`payout_attempts >= payout_max_retries` (default 5) the bond transitions
+to `Failed` and **only an ERROR is logged — no message is sent to the
+winner**.
+
+From that point the counterparty share is stranded:
+
+1. The scheduler enumerates **only `PendingPayout` bonds**. A `Failed`
+   bond is invisible to it, so `Action::AddBondInvoice` is never
+   re-sent.
+2. Throughout the retry phase the row keeps its original
+   `payout_invoice` set, so `process_one_bond` always routes to
+   `pay_counterparty`. All `payout_max_retries` attempts hit the **same**
+   bolt11 — Mostro never asks the winner for a fresh one (e.g. routed via
+   a different path or a node with inbound liquidity).
+
+Phase 3 documented a recovery path (the "`Failed` resurrection" branch in
+`apply_payout_invoice`, §8.2): a fresh `AddBondInvoice` from the winner,
+inside the claim window, flips `Failed → PendingPayout`, overwrites
+`payout_invoice`, and resets `payout_attempts`. But that branch only
+fires if the **client spontaneously resubmits**. Mostro never prompts the
+winner and never tells them the payment failed, so the winner has no
+signal to act on — the resurrection path is, in practice, unreachable.
+Net effect: a payout that can't be routed on the first invoice silently
+stalls forever and requires manual operator intervention, contradicting
+the §8 "non-blocking, self-healing payout" intent.
+
+### 9.5.2 Expected behaviour (from the issue)
+
+After the final `send_payment` attempt against a given invoice fails,
+and **while the claim window is still open**, Mostro should:
+
+- **Re-request an invoice from the winner** — re-send
+  `Action::AddBondInvoice` — instead of going silent.
+- **Not reset the claim-window deadline.** The forfeit deadline stays
+  anchored on `slashed_at` (§8.1 / §15.4); re-prompting must never push
+  it forward, or a winner whose node is briefly unroutable could be kept
+  on the hook indefinitely.
+- **Stop prompting once a valid invoice is submitted** and routed
+  successfully (the bond reaches `Slashed`).
+
+### 9.5.3 Scope
+
+All changes are in `src/app/bond/payout.rs` and the scheduler cadence;
+no `mostro-core` variant, no migration.
+
+- **Stale invoice on retry exhaustion is discarded, not terminal.**
+  Change `on_send_payment_failure` so that when
+  `payout_attempts >= payout_max_retries`:
+  - **If `now - slashed_at < payout_claim_window_days * 86_400`** (claim
+    window still open): instead of transitioning to `Failed`, CAS the row
+    *back into the invoice-request phase* — clear `payout_invoice`,
+    `payout_routing_fee_sats`, and `payout_payment_hash` to `NULL`, reset
+    `payout_attempts = 0`, and **leave `state = PendingPayout`** and
+    `slashed_at` untouched. The guard is `WHERE id = ? AND state =
+    'pending-payout'` so a row that raced to another state in the
+    meantime is left alone.
+  - **Else** (claim window already elapsed): transition to `Failed` as
+    today. Past the deadline there is no point re-prompting; `Failed`
+    remains the terminal "we held a valid invoice but could not route it,
+    and the window is closed — operator review required" state. It stays
+    distinct from `Forfeited` ("the winner never submitted an invoice at
+    all").
+- **The scheduler re-prompts on the next tick automatically.** With
+  `payout_invoice` now `NULL`, §8.1 step 1 fires on the next
+  `run_bond_payout_cycle` pass: subject to the existing
+  `payout_invoice_window_seconds` cadence guard, it enqueues a fresh
+  `Action::AddBondInvoice` (carrying the **unchanged** `slashed_at` in
+  `Payload::BondPayoutRequest`, so the client renders the *same* forfeit
+  deadline as before — §8.1), bumps `invoice_request_attempts`, and sets
+  `last_invoice_request_at = now`. No new code path is needed for the
+  re-prompt itself — clearing the invoice is what re-arms step 1. The
+  persist-first ordering invariant from §8.1 step 1 still holds.
+- **Bounding the loop.** Re-prompting is bounded by the **forfeit
+  window**, not by `payout_max_retries`: the top-of-cycle forfeit check
+  (§8.1) keeps running, and once `now - slashed_at >= claim window` with
+  `payout_invoice IS NULL` the row CAS-transitions to `Forfeited` and the
+  node retains the full `amount_sats`. So the re-prompt/retry cycle
+  cannot run forever; it has exactly the same long-stop as the
+  never-claimed case. `invoice_request_attempts` continues to count
+  across re-prompts (it is bounded by the forfeit window, per §8.1, not
+  by the retry budget).
+- **`payout_max_retries` keeps its meaning *per invoice*.** It still
+  caps `send_payment` attempts against a single submitted bolt11. The
+  change is only what happens *after* the cap is hit inside the window:
+  discard that bolt11 and ask for another, rather than giving up
+  silently.
+- **Winner-facing signalling reuses Phase 3.5.** When the winner
+  responds to a re-prompt with a fresh bolt11, the existing
+  `add_bond_invoice_action` path persists it and enqueues
+  `Action::BondInvoiceAccepted` (Phase 3.5 §8.5) exactly as for the first
+  invoice — so the client sees "invoice received, payout in progress"
+  again and stops prompting locally until the next failure-driven
+  re-request, if any. On eventual success the winner still receives
+  `Action::BondPayoutCompleted`. No new action variant is required.
+
+### 9.5.4 Interaction with the §8.2 `Failed` resurrection path
+
+Phase 4.5 makes the in-window resurrection path the **common** path
+(now Mostro-driven) rather than relying on a spontaneous client resend.
+The §8.2 resurrection CAS (`Failed → PendingPayout` on a fresh
+`AddBondInvoice` within the window) is **retained** as a belt-and-braces
+recovery for any row that still reaches `Failed` — e.g. a row that was
+already `Failed` before this phase shipped, or one that exhausted retries
+exactly as the window closed. After Phase 4.5, the expected steady-state
+is that an in-window payout never silently terminates; `Failed` is only
+ever observed after the claim window has elapsed.
+
+### 9.5.5 Tests
+
+- **Re-request after exhaustion, in window.** Bond in `PendingPayout`
+  with a submitted-but-unroutable `payout_invoice`, day 2 of a 15-day
+  window. Drive `send_payment` failures up to `payout_max_retries`. The
+  row stays `PendingPayout`, `payout_invoice` / `payout_routing_fee_sats`
+  / `payout_payment_hash` are cleared, `payout_attempts` resets to 0, and
+  `slashed_at` is unchanged. On the next scheduler tick (cadence window
+  elapsed) a fresh `Action::AddBondInvoice` is enqueued to the winner and
+  `invoice_request_attempts` increments.
+- **Deadline does not move.** Across one or more re-request cycles, the
+  `slashed_at` field and the `slashed_at` shipped in
+  `Payload::BondPayoutRequest` are identical to the original slash
+  anchor; the forfeit deadline the client would compute is unchanged.
+- **Successful re-payment closes the claim.** After a re-prompt the
+  winner submits a routable bolt11 → `BondInvoiceAccepted` is enqueued,
+  the next tick's `send_payment` succeeds, the row reaches `Slashed`, and
+  `BondPayoutCompleted` is enqueued. No further `AddBondInvoice` is sent.
+- **Re-request loop is forfeit-bounded.** A winner whose every submitted
+  invoice keeps failing is re-prompted across the window; once
+  `now - slashed_at >= claim window` with `payout_invoice IS NULL`, the
+  row CAS-transitions to `Forfeited` (not an infinite loop), node retains
+  `amount_sats` in full.
+- **Past-window exhaustion still yields `Failed`.** A late invoice that
+  arrives near the deadline and exhausts `payout_max_retries` *after*
+  `now - slashed_at >= claim window` transitions to `Failed`, not back to
+  the invoice-request phase — preserving the operator-review terminal.
+- **`slash_node_share_pct = 1.0`.** No counterparty leg exists, so no
+  invoice is ever requested and this path is never reached (regression
+  guard).
+- **`enabled = false`.** No bond payouts run; no behaviour change.
+
+### 9.5.6 Acceptance
+
+- The issue #750 failure mode is gone: a payout whose first invoice
+  cannot be routed no longer strands silently in `Failed`. Mostro
+  re-prompts the winner for a fresh invoice within the claim window.
+- The forfeit deadline stays anchored on `slashed_at` across every
+  re-request; re-prompting cannot extend a winner's exposure.
+- `Failed` becomes an out-of-window-only terminal; the in-window payout
+  is self-healing without operator intervention.
+- Phase 3's split math and accounting are untouched — this phase only
+  changes the retry-exhaustion transition and reuses existing messages.
 
 ---
 
@@ -1820,12 +2021,16 @@ Tests mirror Phase 4 from the maker side; the "no slash" rows in the
   is.
 - New `Status` / `Action` / `Payload` variants in `mostro-core` must
   ship in that crate first and be pinned to a version in this repo's
-  `Cargo.toml`. As of `mostro-core` **0.11.0**, the variants for
-  Phases 1.5 and 2 (`Status::WaitingTakerBond`,
-  `Action::PayBondInvoice`, `Payload::BondResolution`) are released
-  and ready to pin. Phase 5's `Status::WaitingMakerBond` is still
-  pending in `mostro-core`. Clients must handle unknown statuses
-  gracefully — this is already the case.
+  `Cargo.toml`. As of `mostro-core` **0.11.5** (the current pin on
+  `main`), every variant for Phases 1.5 through 4 is released and
+  pinned: `Status::WaitingTakerBond`, `Action::PayBondInvoice`,
+  `Payload::BondResolution` (0.11.0), `Action::AddBondInvoice`
+  (0.11.2), `Payload::BondPayoutRequest` (0.11.3),
+  `Action::BondInvoiceAccepted` / `Action::BondPayoutCompleted`
+  (0.11.4), and `Action::BondSlashed` (0.11.5). Phase 4.5 needs no new
+  variant. Phase 5's `Status::WaitingMakerBond` is still pending in
+  `mostro-core`. Clients must handle unknown statuses gracefully — this
+  is already the case.
 - An admin/solver client that does not yet know about `BondResolution`
   sends `payload: null`, which the daemon interprets as
   "release-by-default". No silent slashes.
@@ -1846,7 +2051,8 @@ these requires a compatibility statement:
   the buyer-invoice `Action::AddInvoice` so the daemon can route on
   action type alone.
 - `Payload::BondPayoutRequest` variant in mostro-core (Phase 3).
-  **Targets `mostro-core` 0.11.3** (not yet released). Carries
+  **Released in `mostro-core` 0.11.3** (pinned via the 0.11.5 bump on
+  `main`). Carries
   `{ order: SmallOrder, slashed_at: i64 }` on `Action::AddBondInvoice`
   so the client can compute the forfeit deadline from the slash
   anchor instead of from message receipt time. Without this anchor a
@@ -1880,6 +2086,11 @@ these requires a compatibility statement:
   risk. `MessageKind::verify` accepts it like the other Mostro → user
   notifications (id required; `BondResolution` / `BondPayoutRequest`
   payloads rejected). No new `CantDoReason` is needed.
+- Phase 4.5 (§9.5). **No upstream dependency — daemon-side only.**
+  Reuses `Action::AddBondInvoice` (Phase 3) and
+  `Action::BondInvoiceAccepted` (Phase 3.5); it only changes the
+  `send_payment`-exhaustion transition in `src/app/bond/payout.rs`. No
+  new variant, no `mostro-core` bump, no migration.
 - `Status::WaitingMakerBond` (Phase 5). Not yet shipped upstream;
   needs a follow-up `mostro-core` minor release before Phase 5 can
   land here.

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -137,11 +137,21 @@ pub async fn run_bond_payout_cycle(pool: &Pool<Sqlite>, ln_client: &mut LndConne
 ///                          │                                                      │
 ///                          └──── send_payment success ─► Slashed                  │
 ///                                                                                 │
-///                                    send_payment failure ─► retry (or Failed) ◄──┘
+///                  retries left ─► retry next tick ◄── send_payment failure ◄─────┤
+///                                                                                 │
+///   re-arm (clear invoice, re-prompt) ◄── retries exhausted, in claim window ◄────┤
+///                                                                                 │
+///                              Failed ◄── retries exhausted, past claim window ◄───┘
 /// ```
 ///
 /// Each call advances by at most one of these arms; the scheduler
 /// reruns the row on the next tick until a terminal state is reached.
+/// The re-arm arm (Phase 4.5, [issue #750]) discards an unroutable
+/// invoice and loops the row back to the invoice-request sub-phase so
+/// the winner is re-prompted; it is bounded by the same forfeit window
+/// as the never-claimed case.
+///
+/// [issue #750]: https://github.com/MostroP2P/mostro/issues/750
 async fn process_one_bond(
     pool: &Pool<Sqlite>,
     ln_client: &mut LndConnector,
@@ -190,7 +200,17 @@ async fn process_one_bond(
 
     match bond.payout_invoice.as_deref() {
         None => request_payout_invoice(pool, bond, invoice_window_seconds).await,
-        Some(invoice) => pay_counterparty(pool, ln_client, bond, invoice, max_retries).await,
+        Some(invoice) => {
+            pay_counterparty(
+                pool,
+                ln_client,
+                bond,
+                invoice,
+                max_retries,
+                claim_window_seconds,
+            )
+            .await
+        }
     }
 }
 
@@ -476,6 +496,7 @@ async fn pay_counterparty(
     bond: &Bond,
     invoice: &str,
     max_retries: i64,
+    claim_window_seconds: i64,
 ) -> Result<(), MostroError> {
     let counterparty_share = counterparty_share_sats(bond)?;
 
@@ -490,6 +511,7 @@ async fn pay_counterparty(
                 pool,
                 bond,
                 max_retries,
+                claim_window_seconds,
                 &format!("payout invoice decode failed: {e}"),
             )
             .await;
@@ -522,6 +544,7 @@ async fn pay_counterparty(
                         pool,
                         bond,
                         max_retries,
+                        claim_window_seconds,
                         "tracked payment reported Failed on reconciliation",
                     )
                     .await;
@@ -595,7 +618,14 @@ async fn pay_counterparty(
         .send_payment(invoice, counterparty_share, tx)
         .await;
     if let Err(e) = send_outcome {
-        return on_send_payment_failure(pool, bond, max_retries, &format!("{e}")).await;
+        return on_send_payment_failure(
+            pool,
+            bond,
+            max_retries,
+            claim_window_seconds,
+            &format!("{e}"),
+        )
+        .await;
     }
 
     // Collect the first terminal status from the stream. Mirrors
@@ -643,7 +673,7 @@ async fn pay_counterparty(
     }
 
     let msg = failure.unwrap_or_else(|| "payment stream ended without terminal status".to_string());
-    on_send_payment_failure(pool, bond, max_retries, &msg).await
+    on_send_payment_failure(pool, bond, max_retries, claim_window_seconds, &msg).await
 }
 
 /// Flip a `PendingPayout` row to `Slashed` after a confirmed payment.
@@ -717,13 +747,41 @@ async fn slash_after_success(
     Err(MostroInternalErr(ServiceError::DbAccessError(cause)))
 }
 
-/// Bump `payout_attempts`; on `payout_max_retries` reached, transition
-/// the bond to `Failed`. This counter only increments on real
-/// `send_payment` failures, not on invoice-request messages.
+/// Bump `payout_attempts` after a failed `send_payment`. This counter
+/// only increments on real `send_payment` failures, not on
+/// invoice-request messages.
+///
+/// On reaching `payout_max_retries` against a single submitted invoice,
+/// the *current* bolt11 is unroutable. What happens next depends on the
+/// forfeit window (Phase 4.5, [issue #750]):
+///
+/// - **Inside the claim window** (`now - slashed_at < claim_window`):
+///   the stale invoice is discarded and the row is re-armed back into
+///   the invoice-request sub-phase (`payout_invoice`,
+///   `payout_routing_fee_sats`, `payout_payment_hash`, and
+///   `last_invoice_request_at` cleared; `payout_attempts` reset to 0;
+///   `state` stays `PendingPayout`). The next scheduler tick sees
+///   `payout_invoice IS NULL` and re-prompts the winner via
+///   `request_payout_invoice` for a fresh bolt11. The `slashed_at`
+///   anchor is **never touched**, so re-prompting cannot extend the
+///   winner's exposure — the forfeit deadline stays fixed and the
+///   re-prompt/retry cycle is bounded by `payout_claim_window_days`
+///   (after which `process_one_bond` forfeits the row). This makes the
+///   previously-unreachable §8.2 recovery Mostro-driven instead of
+///   relying on the winner spontaneously resubmitting.
+/// - **Outside the claim window**: there is no point re-prompting past
+///   the deadline, so the row transitions to `Failed` — the terminal
+///   "we held a valid invoice but could not route it and the window is
+///   closed" state, distinct from `Forfeited` (the winner never
+///   submitted an invoice at all). `Failed` requires operator
+///   attention.
+///
+/// [issue #750]: https://github.com/MostroP2P/mostro/issues/750
 async fn on_send_payment_failure(
     pool: &Pool<Sqlite>,
     bond: &Bond,
     max_retries: i64,
+    claim_window_seconds: i64,
     cause: &str,
 ) -> Result<(), MostroError> {
     let new_attempts = bond.payout_attempts + 1;
@@ -735,21 +793,7 @@ async fn on_send_payment_failure(
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
-    if new_attempts >= max_retries {
-        sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
-            .bind(BondState::Failed.to_string())
-            .bind(bond.id)
-            .bind(BondState::PendingPayout.to_string())
-            .execute(pool)
-            .await
-            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-        error!(
-            bond_id = %bond.id,
-            order_id = %bond.order_id,
-            attempts = new_attempts,
-            "bond payout: send_payment exhausted retries — transitioning to Failed; node share retained, counterparty share stranded (operator review required). last error: {cause}"
-        );
-    } else {
+    if new_attempts < max_retries {
         warn!(
             bond_id = %bond.id,
             order_id = %bond.order_id,
@@ -757,7 +801,85 @@ async fn on_send_payment_failure(
             max_retries,
             "bond payout: send_payment failure ({cause}); will retry on next tick"
         );
+        return Ok(());
     }
+
+    // Retry budget for the *current* invoice is exhausted. Decide
+    // between re-prompting the winner (in-window) and giving up
+    // (out-of-window) based on the forfeit deadline anchored on
+    // `slashed_at`. A missing `slashed_at` is an invariant violation
+    // (Phase 2's slash CAS writes it atomically with the transition to
+    // `PendingPayout`); treat it conservatively as out-of-window so a
+    // corrupted row terminates in `Failed` for operator review rather
+    // than looping forever.
+    let now = Utc::now().timestamp();
+    let within_window = bond
+        .slashed_at
+        .is_some_and(|slashed_at| now - slashed_at < claim_window_seconds);
+
+    if within_window {
+        // Phase 4.5: discard the unroutable invoice and re-arm the
+        // invoice-request sub-phase. `request_payout_invoice` gates on
+        // `payout_invoice IS NULL`, so clearing it is what re-prompts
+        // the winner on the next tick. `last_invoice_request_at` is
+        // cleared so the re-prompt fires immediately (the winner has
+        // already waited through a full retry budget). `payout_attempts`
+        // resets to 0 so the next invoice gets a fresh budget;
+        // `payout_routing_fee_sats` / `payout_payment_hash` are cleared
+        // because they describe the discarded attempt. `slashed_at` and
+        // `invoice_request_attempts` are intentionally left untouched —
+        // the deadline must not move, and the nudge counter is bounded
+        // by the forfeit window (not the retry budget) so it keeps
+        // accumulating across re-prompts for operator visibility.
+        let result = sqlx::query(
+            "UPDATE bonds \
+               SET payout_invoice = NULL, \
+                   payout_routing_fee_sats = NULL, \
+                   payout_payment_hash = NULL, \
+                   payout_attempts = 0, \
+                   last_invoice_request_at = NULL \
+             WHERE id = ? AND state = ?",
+        )
+        .bind(bond.id)
+        .bind(BondState::PendingPayout.to_string())
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+        if result.rows_affected() == 1 {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                attempts = new_attempts,
+                "bond payout: send_payment exhausted retries for this invoice ({cause}); re-requesting a fresh invoice from the winner (still inside claim window, deadline unchanged)"
+            );
+        } else {
+            // The row moved off `PendingPayout` between the attempts
+            // bump and this re-arm CAS (e.g. a concurrent forfeit at
+            // the window edge). Nothing to do — the winning transition
+            // already decided this row's fate.
+            info!(
+                bond_id = %bond.id,
+                order_id = %bond.order_id,
+                "bond payout: re-arm CAS missed (concurrent transition); leaving row as-is"
+            );
+        }
+        return Ok(());
+    }
+
+    sqlx::query("UPDATE bonds SET state = ? WHERE id = ? AND state = ?")
+        .bind(BondState::Failed.to_string())
+        .bind(bond.id)
+        .bind(BondState::PendingPayout.to_string())
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    error!(
+        bond_id = %bond.id,
+        order_id = %bond.order_id,
+        attempts = new_attempts,
+        "bond payout: send_payment exhausted retries past the claim window — transitioning to Failed; node share retained, counterparty share stranded (operator review required). last error: {cause}"
+    );
     Ok(())
 }
 
@@ -1599,26 +1721,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_payment_failure_increments_attempts_and_flips_to_failed() {
-        // After `max_retries` consecutive `send_payment` failures the
-        // row must transition `PendingPayout -> Failed`. Exercises
-        // `on_send_payment_failure` with a tight retry budget.
+    async fn send_payment_failure_past_window_flips_to_failed() {
+        // After `max_retries` consecutive `send_payment` failures, a bond
+        // whose claim window has already elapsed must transition
+        // `PendingPayout -> Failed` (Phase 4.5: re-prompting is pointless
+        // past the deadline). Exercises `on_send_payment_failure` with a
+        // tight retry budget and an out-of-window `slashed_at`.
         let pool = setup_pool().await;
         let order_id = Uuid::new_v4();
         insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        // slashed_at older than the claim window → out of window.
+        let slashed_at = Utc::now().timestamp() - (CLAIM_WINDOW_SECONDS + 86_400);
         let bond = pending_payout_bond(
             order_id,
             taker_pk(),
             10_000,
             5_000,
-            Utc::now().timestamp(),
+            slashed_at,
             Some("lnbc1pSOMETHING"),
             None,
         );
         let bond = create_bond(&pool, bond).await.unwrap();
 
         // First failure: attempts 0 -> 1, still PendingPayout.
-        on_send_payment_failure(&pool, &bond, 3, "transient")
+        on_send_payment_failure(&pool, &bond, 3, CLAIM_WINDOW_SECONDS, "transient")
             .await
             .unwrap();
         let bond_after_1: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
@@ -1631,7 +1757,7 @@ mod tests {
 
         // Second + third failures use the *fresh* row each time so the
         // counter math is exercised end-to-end. Third must flip Failed.
-        on_send_payment_failure(&pool, &bond_after_1, 3, "transient")
+        on_send_payment_failure(&pool, &bond_after_1, 3, CLAIM_WINDOW_SECONDS, "transient")
             .await
             .unwrap();
         let bond_after_2: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
@@ -1641,7 +1767,7 @@ mod tests {
             .unwrap();
         assert_eq!(bond_after_2.payout_attempts, 2);
 
-        on_send_payment_failure(&pool, &bond_after_2, 3, "transient")
+        on_send_payment_failure(&pool, &bond_after_2, 3, CLAIM_WINDOW_SECONDS, "transient")
             .await
             .unwrap();
         let bond_after_3: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
@@ -1651,6 +1777,84 @@ mod tests {
             .unwrap();
         assert_eq!(bond_after_3.payout_attempts, 3);
         assert_eq!(bond_after_3.state, BondState::Failed.to_string());
+    }
+
+    #[tokio::test]
+    async fn send_payment_failure_within_window_reprompts_winner() {
+        // Phase 4.5 / issue #750: after `max_retries` send_payment
+        // failures against a submitted invoice, a bond still inside its
+        // claim window must NOT terminate in `Failed`. Instead it
+        // re-arms the invoice-request sub-phase: `payout_invoice` and
+        // the per-attempt columns are cleared, `payout_attempts` resets
+        // to 0, the row stays `PendingPayout`, and `slashed_at` (the
+        // forfeit anchor) is left untouched so the deadline never moves.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let slashed_at = Utc::now().timestamp();
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            slashed_at,
+            Some("lnbc1pSTALE"),
+            Some(slashed_at), // last_invoice_request_at set
+        );
+        // Simulate the per-attempt state accumulated during the failed
+        // send: a routing-fee cap and a payment hash from the stale
+        // invoice, plus one prior nudge to the winner.
+        bond.payout_routing_fee_sats = Some(50);
+        bond.payout_payment_hash = Some("deadbeef".to_string());
+        bond.invoice_request_attempts = 1;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        // First two failures: budget not exhausted, row stays put with
+        // its invoice and counters intact.
+        on_send_payment_failure(&pool, &bond, 3, CLAIM_WINDOW_SECONDS, "transient")
+            .await
+            .unwrap();
+        let after_1: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after_1.payout_attempts, 1);
+        assert_eq!(after_1.state, BondState::PendingPayout.to_string());
+        assert_eq!(after_1.payout_invoice.as_deref(), Some("lnbc1pSTALE"));
+
+        on_send_payment_failure(&pool, &after_1, 3, CLAIM_WINDOW_SECONDS, "transient")
+            .await
+            .unwrap();
+        let after_2: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after_2.payout_attempts, 2);
+
+        // Third failure hits `max_retries` (3) inside the window → re-arm.
+        on_send_payment_failure(&pool, &after_2, 3, CLAIM_WINDOW_SECONDS, "transient")
+            .await
+            .unwrap();
+        let after_3: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        // Re-armed back into the invoice-request sub-phase, NOT Failed.
+        assert_eq!(after_3.state, BondState::PendingPayout.to_string());
+        assert!(after_3.payout_invoice.is_none());
+        assert!(after_3.payout_routing_fee_sats.is_none());
+        assert!(after_3.payout_payment_hash.is_none());
+        assert!(after_3.last_invoice_request_at.is_none());
+        assert_eq!(after_3.payout_attempts, 0);
+        // Forfeit anchor untouched: the deadline must not move.
+        assert_eq!(after_3.slashed_at, Some(slashed_at));
+        // Nudge counter is bounded by the forfeit window, not the retry
+        // budget, so it is preserved across the re-prompt.
+        assert_eq!(after_3.invoice_request_attempts, 1);
     }
 
     #[tokio::test]
@@ -1981,9 +2185,13 @@ mod tests {
         // Drive back to Failed via three consecutive send_payment
         // failures with retry budget = 3. Each call re-reads the row
         // so the counter math is exercised against fresh state.
+        // `claim_window_seconds = 0` forces the out-of-window branch so
+        // exhaustion terminates in `Failed` (Phase 4.5: an in-window
+        // exhaustion would re-arm instead) — here we want a `Failed` row
+        // to feed the second resurrection.
         let mut current = bond_after_b;
         for _ in 0..3 {
-            on_send_payment_failure(&pool, &current, 3, "transient")
+            on_send_payment_failure(&pool, &current, 3, 0, "transient")
                 .await
                 .unwrap();
             current = sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE id = ?")

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -139,9 +139,11 @@ pub async fn run_bond_payout_cycle(pool: &Pool<Sqlite>, ln_client: &mut LndConne
 ///                                                                                 │
 ///                  retries left ─► retry next tick ◄── send_payment failure ◄─────┤
 ///                                                                                 │
-///   re-arm (clear invoice, re-prompt) ◄── retries exhausted, in claim window ◄────┤
+///       keep invoice (reconcile) ◄── retries exhausted, indeterminate failure ◄───┤
 ///                                                                                 │
-///                              Failed ◄── retries exhausted, past claim window ◄───┘
+///   re-arm (clear invoice, re-prompt) ◄── exhausted, terminal, in claim window ◄──┤
+///                                                                                 │
+///                              Failed ◄── exhausted, terminal, past claim window ◄─┘
 /// ```
 ///
 /// Each call advances by at most one of these arms; the scheduler
@@ -149,7 +151,9 @@ pub async fn run_bond_payout_cycle(pool: &Pool<Sqlite>, ln_client: &mut LndConne
 /// The re-arm arm (Phase 4.5, [issue #750]) discards an unroutable
 /// invoice and loops the row back to the invoice-request sub-phase so
 /// the winner is re-prompted; it is bounded by the same forfeit window
-/// as the never-claimed case.
+/// as the never-claimed case. An *indeterminate* failure (timeout / EOF
+/// / send RPC error) never abandons the invoice — see
+/// [`PaymentFailureKind`].
 ///
 /// [issue #750]: https://github.com/MostroP2P/mostro/issues/750
 async fn process_one_bond(
@@ -507,11 +511,15 @@ async fn pay_counterparty(
     let decoded = match decode_invoice(invoice) {
         Ok(d) => d,
         Err(e) => {
+            // Structurally unusable invoice — no payment is or will be in
+            // flight for it, so this is a terminal failure (safe to
+            // abandon and re-prompt for a usable one).
             return on_send_payment_failure(
                 pool,
                 bond,
                 max_retries,
                 claim_window_seconds,
+                PaymentFailureKind::Terminal,
                 &format!("payout invoice decode failed: {e}"),
             )
             .await;
@@ -540,11 +548,14 @@ async fn pay_counterparty(
                     return slash_after_success(pool, bond, counterparty_share).await;
                 }
                 Ok(Some(PaymentStatus::Failed)) => {
+                    // LND confirms the prior payment for this invoice
+                    // failed — terminal, safe to abandon the invoice.
                     return on_send_payment_failure(
                         pool,
                         bond,
                         max_retries,
                         claim_window_seconds,
+                        PaymentFailureKind::Terminal,
                         "tracked payment reported Failed on reconciliation",
                     )
                     .await;
@@ -618,11 +629,16 @@ async fn pay_counterparty(
         .send_payment(invoice, counterparty_share, tx)
         .await;
     if let Err(e) = send_outcome {
+        // The RPC call itself errored. We cannot be sure the payment did
+        // not partially enter LND, so treat it as indeterminate: keep
+        // the invoice + hash for reconciliation rather than risk a
+        // double payout by re-prompting.
         return on_send_payment_failure(
             pool,
             bond,
             max_retries,
             claim_window_seconds,
+            PaymentFailureKind::Indeterminate,
             &format!("{e}"),
         )
         .await;
@@ -632,17 +648,22 @@ async fn pay_counterparty(
     // dev_fee::send_dev_fee_payment, but each recv is bounded by
     // `PAYMENT_STATUS_RECV_TIMEOUT` so a wedged LND stream (no terminal
     // update, no EOF, no InFlight churn) does not pin the scheduler
-    // task forever. A timeout and a clean EOF are both routed through
-    // `on_send_payment_failure` so the retry budget governs the
-    // recovery path uniformly.
+    // task forever. We track *why* the stream ended: only an explicit
+    // `PaymentStatus::Failed` is terminal. A timeout or clean EOF leaves
+    // the payment outcome unknown (it may still be in flight), so it is
+    // routed as `Indeterminate` — `on_send_payment_failure` then keeps
+    // the invoice + hash for reconciliation instead of re-prompting.
     let mut succeeded = false;
-    let mut failure: Option<String> = None;
+    let mut failure: Option<(PaymentFailureKind, String)> = None;
     loop {
         match timeout(PAYMENT_STATUS_RECV_TIMEOUT, rx.recv()).await {
             Err(_) => {
-                failure = Some(format!(
-                    "payment status stream timed out after {}s without a terminal update",
-                    PAYMENT_STATUS_RECV_TIMEOUT.as_secs()
+                failure = Some((
+                    PaymentFailureKind::Indeterminate,
+                    format!(
+                        "payment status stream timed out after {}s without a terminal update",
+                        PAYMENT_STATUS_RECV_TIMEOUT.as_secs()
+                    ),
                 ));
                 break;
             }
@@ -655,9 +676,9 @@ async fn pay_counterparty(
                             break;
                         }
                         PaymentStatus::Failed => {
-                            failure = Some(format!(
-                                "payment failed: reason {}",
-                                msg.payment.failure_reason
+                            failure = Some((
+                                PaymentFailureKind::Terminal,
+                                format!("payment failed: reason {}", msg.payment.failure_reason),
                             ));
                             break;
                         }
@@ -672,8 +693,13 @@ async fn pay_counterparty(
         return slash_after_success(pool, bond, counterparty_share).await;
     }
 
-    let msg = failure.unwrap_or_else(|| "payment stream ended without terminal status".to_string());
-    on_send_payment_failure(pool, bond, max_retries, claim_window_seconds, &msg).await
+    // EOF with no terminal status (the `Ok(None)` break above) is also
+    // indeterminate: the stream closed without telling us the outcome.
+    let (kind, msg) = failure.unwrap_or((
+        PaymentFailureKind::Indeterminate,
+        "payment stream ended without terminal status".to_string(),
+    ));
+    on_send_payment_failure(pool, bond, max_retries, claim_window_seconds, kind, &msg).await
 }
 
 /// Flip a `PendingPayout` row to `Slashed` after a confirmed payment.
@@ -747,33 +773,67 @@ async fn slash_after_success(
     Err(MostroInternalErr(ServiceError::DbAccessError(cause)))
 }
 
+/// Whether a `send_payment` attempt failed in a way LND has confirmed
+/// is terminal (the payment will not settle) or in a way that leaves the
+/// outcome unknown (the payment may still be in flight).
+///
+/// This distinction is load-bearing for the Phase 4.5 re-prompt path
+/// ([issue #750] review). Abandoning the current invoice — either by
+/// re-arming for a fresh one or by giving up to `Failed` — clears
+/// `payout_payment_hash`, which disables [`pay_counterparty`]'s
+/// reconciliation branch. Doing that while a payment is still in flight
+/// would let a freshly-prompted invoice be paid while the original later
+/// settles: a **double payout**. So an invoice may only be abandoned on
+/// a `Terminal` failure. An `Indeterminate` one keeps the invoice and
+/// its hash so reconciliation can poll LND to a definitive answer on a
+/// later tick.
+///
+/// [issue #750]: https://github.com/MostroP2P/mostro/issues/750
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum PaymentFailureKind {
+    /// LND reported the payment as `Failed` (via the status stream or
+    /// reconciliation), or the invoice is structurally unusable — no
+    /// payment is or will be in flight for it.
+    Terminal,
+    /// Outcome unknown: status-stream timeout, stream EOF, or a
+    /// `send_payment` RPC error. The payment may still be in flight.
+    Indeterminate,
+}
+
 /// Bump `payout_attempts` after a failed `send_payment`. This counter
 /// only increments on real `send_payment` failures, not on
 /// invoice-request messages.
 ///
-/// On reaching `payout_max_retries` against a single submitted invoice,
-/// the *current* bolt11 is unroutable. What happens next depends on the
-/// forfeit window (Phase 4.5, [issue #750]):
+/// What happens once `payout_max_retries` is reached against a single
+/// invoice depends on **both** the failure kind and the forfeit window
+/// (Phase 4.5, [issue #750]):
 ///
-/// - **Inside the claim window** (`now - slashed_at < claim_window`):
-///   the stale invoice is discarded and the row is re-armed back into
-///   the invoice-request sub-phase (`payout_invoice`,
-///   `payout_routing_fee_sats`, `payout_payment_hash`, and
-///   `last_invoice_request_at` cleared; `payout_attempts` reset to 0;
-///   `state` stays `PendingPayout`). The next scheduler tick sees
-///   `payout_invoice IS NULL` and re-prompts the winner via
-///   `request_payout_invoice` for a fresh bolt11. The `slashed_at`
-///   anchor is **never touched**, so re-prompting cannot extend the
-///   winner's exposure — the forfeit deadline stays fixed and the
+/// - **Indeterminate failure** (timeout / stream EOF / send RPC error):
+///   the payment may still be in flight, so the invoice is **never
+///   abandoned** here. The row keeps its `payout_invoice` +
+///   `payout_payment_hash` and `pay_counterparty`'s reconciliation
+///   branch drives it to a definitive Succeeded / Failed on a later
+///   tick. This is the guard against the double-payout the review
+///   flagged.
+/// - **Terminal failure, inside the claim window**
+///   (`now - slashed_at < claim_window`): the unroutable invoice is
+///   discarded and the row is re-armed back into the invoice-request
+///   sub-phase (`payout_invoice`, `payout_routing_fee_sats`,
+///   `payout_payment_hash`, and `last_invoice_request_at` cleared;
+///   `payout_attempts` reset to 0; `state` stays `PendingPayout`). The
+///   next scheduler tick sees `payout_invoice IS NULL` and re-prompts
+///   the winner via `request_payout_invoice`. The `slashed_at` anchor is
+///   **never touched**, so re-prompting cannot extend the winner's
+///   exposure — the forfeit deadline stays fixed and the
 ///   re-prompt/retry cycle is bounded by `payout_claim_window_days`
 ///   (after which `process_one_bond` forfeits the row). This makes the
 ///   previously-unreachable §8.2 recovery Mostro-driven instead of
 ///   relying on the winner spontaneously resubmitting.
-/// - **Outside the claim window**: there is no point re-prompting past
-///   the deadline, so the row transitions to `Failed` — the terminal
-///   "we held a valid invoice but could not route it and the window is
-///   closed" state, distinct from `Forfeited` (the winner never
-///   submitted an invoice at all). `Failed` requires operator
+/// - **Terminal failure, outside the claim window**: there is no point
+///   re-prompting past the deadline, so the row transitions to `Failed`
+///   — the terminal "we held a valid invoice but could not route it and
+///   the window is closed" state, distinct from `Forfeited` (the winner
+///   never submitted an invoice at all). `Failed` requires operator
 ///   attention.
 ///
 /// [issue #750]: https://github.com/MostroP2P/mostro/issues/750
@@ -782,9 +842,13 @@ async fn on_send_payment_failure(
     bond: &Bond,
     max_retries: i64,
     claim_window_seconds: i64,
+    kind: PaymentFailureKind,
     cause: &str,
 ) -> Result<(), MostroError> {
-    let new_attempts = bond.payout_attempts + 1;
+    // Saturate at `max_retries`: an indeterminate failure never abandons
+    // the invoice (see below), so without a cap a long LND outage could
+    // grow the counter without bound.
+    let new_attempts = std::cmp::min(bond.payout_attempts + 1, max_retries);
     sqlx::query("UPDATE bonds SET payout_attempts = ? WHERE id = ? AND state = ?")
         .bind(new_attempts)
         .bind(bond.id)
@@ -804,14 +868,32 @@ async fn on_send_payment_failure(
         return Ok(());
     }
 
-    // Retry budget for the *current* invoice is exhausted. Decide
-    // between re-prompting the winner (in-window) and giving up
-    // (out-of-window) based on the forfeit deadline anchored on
-    // `slashed_at`. A missing `slashed_at` is an invariant violation
-    // (Phase 2's slash CAS writes it atomically with the transition to
-    // `PendingPayout`); treat it conservatively as out-of-window so a
-    // corrupted row terminates in `Failed` for operator review rather
-    // than looping forever.
+    // Budget exhausted for the current invoice. An *indeterminate*
+    // failure means the payment may still be in flight, so we must NOT
+    // abandon the invoice: clearing `payout_invoice` /
+    // `payout_payment_hash` would let a freshly-prompted invoice be paid
+    // while the original later settles (double payout). Keep the invoice
+    // + hash so `pay_counterparty`'s reconciliation branch resolves the
+    // payment to a definitive Succeeded / Failed on a later tick; only a
+    // Terminal failure (handled below) ever abandons the invoice.
+    if kind == PaymentFailureKind::Indeterminate {
+        warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            attempts = new_attempts,
+            "bond payout: retry budget exhausted on an indeterminate failure ({cause}); keeping the current invoice for LND reconciliation — not re-prompting (payment may still be in flight)"
+        );
+        return Ok(());
+    }
+
+    // Terminal failure: no payment is in flight for this invoice, so it
+    // is safe to abandon it. Decide between re-prompting the winner
+    // (in-window) and giving up (out-of-window) based on the forfeit
+    // deadline anchored on `slashed_at`. A missing `slashed_at` is an
+    // invariant violation (Phase 2's slash CAS writes it atomically with
+    // the transition to `PendingPayout`); treat it conservatively as
+    // out-of-window so a corrupted row terminates in `Failed` for
+    // operator review rather than looping forever.
     let now = Utc::now().timestamp();
     let within_window = bond
         .slashed_at
@@ -1744,9 +1826,16 @@ mod tests {
         let bond = create_bond(&pool, bond).await.unwrap();
 
         // First failure: attempts 0 -> 1, still PendingPayout.
-        on_send_payment_failure(&pool, &bond, 3, CLAIM_WINDOW_SECONDS, "transient")
-            .await
-            .unwrap();
+        on_send_payment_failure(
+            &pool,
+            &bond,
+            3,
+            CLAIM_WINDOW_SECONDS,
+            PaymentFailureKind::Terminal,
+            "transient",
+        )
+        .await
+        .unwrap();
         let bond_after_1: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
             .bind(bond.id)
             .fetch_one(&pool)
@@ -1757,9 +1846,16 @@ mod tests {
 
         // Second + third failures use the *fresh* row each time so the
         // counter math is exercised end-to-end. Third must flip Failed.
-        on_send_payment_failure(&pool, &bond_after_1, 3, CLAIM_WINDOW_SECONDS, "transient")
-            .await
-            .unwrap();
+        on_send_payment_failure(
+            &pool,
+            &bond_after_1,
+            3,
+            CLAIM_WINDOW_SECONDS,
+            PaymentFailureKind::Terminal,
+            "transient",
+        )
+        .await
+        .unwrap();
         let bond_after_2: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
             .bind(bond.id)
             .fetch_one(&pool)
@@ -1767,9 +1863,16 @@ mod tests {
             .unwrap();
         assert_eq!(bond_after_2.payout_attempts, 2);
 
-        on_send_payment_failure(&pool, &bond_after_2, 3, CLAIM_WINDOW_SECONDS, "transient")
-            .await
-            .unwrap();
+        on_send_payment_failure(
+            &pool,
+            &bond_after_2,
+            3,
+            CLAIM_WINDOW_SECONDS,
+            PaymentFailureKind::Terminal,
+            "transient",
+        )
+        .await
+        .unwrap();
         let bond_after_3: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
             .bind(bond.id)
             .fetch_one(&pool)
@@ -1811,9 +1914,16 @@ mod tests {
 
         // First two failures: budget not exhausted, row stays put with
         // its invoice and counters intact.
-        on_send_payment_failure(&pool, &bond, 3, CLAIM_WINDOW_SECONDS, "transient")
-            .await
-            .unwrap();
+        on_send_payment_failure(
+            &pool,
+            &bond,
+            3,
+            CLAIM_WINDOW_SECONDS,
+            PaymentFailureKind::Terminal,
+            "transient",
+        )
+        .await
+        .unwrap();
         let after_1: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
             .bind(bond.id)
             .fetch_one(&pool)
@@ -1823,9 +1933,16 @@ mod tests {
         assert_eq!(after_1.state, BondState::PendingPayout.to_string());
         assert_eq!(after_1.payout_invoice.as_deref(), Some("lnbc1pSTALE"));
 
-        on_send_payment_failure(&pool, &after_1, 3, CLAIM_WINDOW_SECONDS, "transient")
-            .await
-            .unwrap();
+        on_send_payment_failure(
+            &pool,
+            &after_1,
+            3,
+            CLAIM_WINDOW_SECONDS,
+            PaymentFailureKind::Terminal,
+            "transient",
+        )
+        .await
+        .unwrap();
         let after_2: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
             .bind(bond.id)
             .fetch_one(&pool)
@@ -1834,9 +1951,16 @@ mod tests {
         assert_eq!(after_2.payout_attempts, 2);
 
         // Third failure hits `max_retries` (3) inside the window → re-arm.
-        on_send_payment_failure(&pool, &after_2, 3, CLAIM_WINDOW_SECONDS, "transient")
-            .await
-            .unwrap();
+        on_send_payment_failure(
+            &pool,
+            &after_2,
+            3,
+            CLAIM_WINDOW_SECONDS,
+            PaymentFailureKind::Terminal,
+            "transient",
+        )
+        .await
+        .unwrap();
         let after_3: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
             .bind(bond.id)
             .fetch_one(&pool)
@@ -1855,6 +1979,82 @@ mod tests {
         // Nudge counter is bounded by the forfeit window, not the retry
         // budget, so it is preserved across the re-prompt.
         assert_eq!(after_3.invoice_request_attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn send_payment_indeterminate_failure_keeps_invoice() {
+        // Double-payout guard (issue #750 review): when the retry budget
+        // is exhausted by *indeterminate* failures (status-stream
+        // timeout / EOF / send RPC error), the payment for the current
+        // invoice may still be in flight. The row must keep its invoice
+        // AND `payout_payment_hash` so `pay_counterparty`'s
+        // reconciliation branch can poll LND before any new invoice is
+        // paid — it must NOT re-arm (clear) or flip to `Failed`, even
+        // well inside the claim window.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let slashed_at = Utc::now().timestamp();
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            slashed_at,
+            Some("lnbc1pINFLIGHT"),
+            Some(slashed_at),
+        );
+        bond.payout_routing_fee_sats = Some(50);
+        bond.payout_payment_hash = Some("cafebabe".to_string());
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        // Exhaust the budget with indeterminate failures.
+        let mut current = bond;
+        for _ in 0..3 {
+            on_send_payment_failure(
+                &pool,
+                &current,
+                3,
+                CLAIM_WINDOW_SECONDS,
+                PaymentFailureKind::Indeterminate,
+                "stream timed out",
+            )
+            .await
+            .unwrap();
+            current = sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE id = ?")
+                .bind(current.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        }
+
+        // Still PendingPayout, invoice + hash intact for reconciliation.
+        assert_eq!(current.state, BondState::PendingPayout.to_string());
+        assert_eq!(current.payout_invoice.as_deref(), Some("lnbc1pINFLIGHT"));
+        assert_eq!(current.payout_payment_hash.as_deref(), Some("cafebabe"));
+        // Counter saturates at max_retries rather than growing unbounded.
+        assert_eq!(current.payout_attempts, 3);
+
+        // A further indeterminate failure keeps it pinned, never Failed.
+        on_send_payment_failure(
+            &pool,
+            &current,
+            3,
+            CLAIM_WINDOW_SECONDS,
+            PaymentFailureKind::Indeterminate,
+            "stream eof",
+        )
+        .await
+        .unwrap();
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(current.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.state, BondState::PendingPayout.to_string());
+        assert_eq!(after.payout_attempts, 3);
+        assert_eq!(after.payout_invoice.as_deref(), Some("lnbc1pINFLIGHT"));
+        assert_eq!(after.payout_payment_hash.as_deref(), Some("cafebabe"));
     }
 
     #[tokio::test]
@@ -2191,9 +2391,16 @@ mod tests {
         // to feed the second resurrection.
         let mut current = bond_after_b;
         for _ in 0..3 {
-            on_send_payment_failure(&pool, &current, 3, 0, "transient")
-                .await
-                .unwrap();
+            on_send_payment_failure(
+                &pool,
+                &current,
+                3,
+                0,
+                PaymentFailureKind::Terminal,
+                "transient",
+            )
+            .await
+            .unwrap();
             current = sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE id = ?")
                 .bind(bond.id)
                 .fetch_one(&pool)


### PR DESCRIPTION
## Summary

Implements **Phase 4.5** of the anti-abuse bond rollout (spec `docs/ANTI_ABUSE_BOND.md` §9.5), fixing the payout failure mode reported in #750.

When a slashed bond's counterparty payout exhausted `payout_max_retries` against a submitted invoice, `on_send_payment_failure` transitioned the bond straight to `Failed` and **the winner was never asked for a new invoice again**:

1. The scheduler (`run_bond_payout_cycle`) only enumerates `PendingPayout` bonds — a `Failed` bond is invisible to it, so `Action::AddBondInvoice` is never re-sent.
2. During the retry phase the row keeps its original `payout_invoice`, so all retries hit the **same** unroutable bolt11 — Mostro never asks for a fresh one.

A recovery path existed (the "`Failed` resurrection" branch in `apply_payout_invoice`), but it only fires if the client *spontaneously* resends. Mostro never prompts, so in practice the counterparty share stranded and required manual operator intervention.

## What changed

`src/app/bond/payout.rs` — `on_send_payment_failure` now decides what to do after the retry budget for a given invoice is exhausted, based on the forfeit window anchored on `slashed_at`:

- **Inside the claim window** → discard the unroutable invoice and re-arm the invoice-request sub-phase: clear `payout_invoice`, `payout_routing_fee_sats`, `payout_payment_hash`, `last_invoice_request_at`; reset `payout_attempts = 0`; keep `state = PendingPayout`. The next scheduler tick sees `payout_invoice IS NULL` and re-prompts the winner via `request_payout_invoice`. **`slashed_at` is never touched**, so the forfeit deadline does not move and the re-prompt/retry cycle is bounded by `payout_claim_window_days` (→ `Forfeited`). `invoice_request_attempts` is preserved (it's bounded by the forfeit window, not the retry budget).
- **Past the claim window** → transition to `Failed` as before (terminal technical failure, operator review). No point re-prompting past the deadline.

`claim_window_seconds` is threaded from `process_one_bond` through `pay_counterparty` into `on_send_payment_failure` (consistent with how `max_retries` is already passed), keeping the function unit-testable.

This is **daemon-only**: it reuses `Action::AddBondInvoice` (Phase 3) and `Action::BondInvoiceAccepted` (Phase 3.5). **No `mostro-core` bump, no schema migration.**

The spec was also updated: §9.5 added, the phase-overview table now marks Phases 0–4 as merged on `main` (PRs #712, #719, #736, #737, #738, #743, #744), and §8.1/§8.2/§14.2/§14.3 carry forward-references and corrected release status.

## How to test

### Automated

```bash
cargo test payout      # 30 tests, incl. the two new ones below
cargo test bond        # full bond suite (115 tests)
cargo clippy --all-targets --all-features
```

New/updated unit tests in `src/app/bond/payout.rs`:

- `send_payment_failure_within_window_reprompts_winner` — after `max_retries` failures with an in-window `slashed_at`, the row re-arms: `state` stays `PendingPayout`, `payout_invoice`/`payout_routing_fee_sats`/`payout_payment_hash`/`last_invoice_request_at` cleared, `payout_attempts = 0`, `slashed_at` unchanged, `invoice_request_attempts` preserved.
- `send_payment_failure_past_window_flips_to_failed` — same exhaustion but with an out-of-window `slashed_at` still terminates in `Failed`.
- `apply_payout_invoice_resurrects_after_re_failure` — updated to force the out-of-window branch where it needs a `Failed` row.

### Manual (regtest / Polar)

1. Enable bonds with `slash_node_share_pct` between 0 and 1 and a short `payout_invoice_window_seconds` so re-prompts are quick to observe.
2. Run a trade, open a dispute, and have the solver slash a bond (`BondResolution`) so a bond enters `PendingPayout`.
3. When Mostro sends `Action::AddBondInvoice`, reply from the winner with a bolt11 that **cannot be routed** (e.g. an invoice from a node with no path / no inbound liquidity).
4. Watch the scheduler logs: `send_payment` fails up to `payout_max_retries`, then logs `re-requesting a fresh invoice from the winner (still inside claim window, deadline unchanged)` and the bond stays `PendingPayout` with its invoice cleared.
5. On the next tick a fresh `Action::AddBondInvoice` is delivered to the winner. Reply with a **routable** invoice → the payout succeeds, the bond reaches `Slashed`, and the winner gets `Action::BondInvoiceAccepted` then `Action::BondPayoutCompleted`.
6. Confirm the forfeit deadline (`slashed_at + payout_claim_window_days`) the client renders does **not** shift across re-prompts.
7. Optional: keep submitting unroutable invoices past `payout_claim_window_days` and confirm the bond eventually `Forfeited` (no invoice in flight) — i.e. the loop is bounded.

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phase 4.5: improved in-window payout recovery — on terminal retry exhaustion the system clears stale invoice info and re-prompts winners for a fresh invoice; out-of-window failures still move to operator review. Indeterminate failures retain in-flight invoice for reconciliation.

* **Documentation**
  * Expanded anti-abuse bond rollout doc with Phase 1.5–4.5 headings, Phase 4.5 specification, compatibility notes, and core pinned to 0.11.5.

* **Tests**
  * Added coverage for in-window re-arming and indeterminate-failure reconciliation; adjusted end-to-end test paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->