### PR TITLE
feat(cashu): F2 — config, escrow mode, and conditional boot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,10 +158,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -310,6 +346,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
 dependencies = [
  "bitcoin_hashes 0.13.0",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -321,6 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
+ "base64 0.21.7",
  "bech32",
  "bitcoin-internals 0.3.0",
  "bitcoin-io",
@@ -352,6 +391,17 @@ name = "bitcoin-io"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin-payment-instructions"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c300c948b2ff78c965ea3a613372352125448a22f1acf49e95e3878149824091"
+dependencies = [
+ "bitcoin",
+ "lightning",
+ "lightning-invoice 0.34.0",
+]
 
 [[package]]
 name = "bitcoin-units"
@@ -392,9 +442,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -436,6 +486,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +546,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cashu"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b4ad04070fb67914feb2641e7b54001000f1f7f67a7c39a08f32edf01fd3ae"
+dependencies = [
+ "bitcoin",
+ "cbor-diag",
+ "ciborium",
+ "lightning",
+ "lightning-invoice 0.34.0",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.17",
+ "tracing",
+ "unicode-normalization",
+ "url",
+ "uuid",
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,13 +581,147 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cdk"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6536eb1df7a497cb334edf6bb9eea1fa8e4a9b08c79fe45c40d43413ecb88c8"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "bitcoin",
+ "bitcoin-payment-instructions",
+ "cbor-diag",
+ "cdk-common",
+ "cdk-signatory",
+ "ciborium",
+ "getrandom 0.2.16",
+ "gloo-timers",
+ "jsonwebtoken",
+ "lightning",
+ "lightning-invoice 0.34.0",
+ "regex",
+ "ring 0.17.14",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "cdk-common"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a371d218ffe83dcabd202278251af53744b8fa3e846124ddcd34247c4e38bdc3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitcoin",
+ "cashu",
+ "cbor-diag",
+ "cdk-http-client",
+ "ciborium",
+ "futures",
+ "getrandom 0.2.16",
+ "jsonwebtoken",
+ "lightning",
+ "lightning-invoice 0.34.0",
+ "parking_lot 0.12.5",
+ "paste",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.17",
+ "tokio",
+ "tonic 0.14.2",
+ "tracing",
+ "url",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "cdk-http-client"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf194792d45975b360911417d3713e4d3f0142e18b082e2a8c2c88a91630b43d"
+dependencies = [
+ "futures",
+ "futures-channel",
+ "js-sys",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "cdk-signatory"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f40745c9402049bbba47ae52e1fc7552d4af8e99572fd73697448f51bbb3a02"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bip39",
+ "bitcoin",
+ "cdk-common",
+ "clap",
+ "getrandom 0.2.16",
+ "home",
+ "rustls 0.23.35",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -529,8 +769,36 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -604,6 +872,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +902,16 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -692,6 +990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,10 +1007,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
+]
 
 [[package]]
 name = "dialoguer"
@@ -774,10 +1122,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dnssec-prover"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "easy-hasher"
@@ -1106,10 +1469,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -1185,6 +1565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1266,6 +1655,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls 0.23.35",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -1416,6 +1806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1840,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1454,6 +1851,8 @@ checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1516,6 +1915,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,6 +1932,21 @@ checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring 0.17.14",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1547,12 +1971,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -1568,6 +1998,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c90397b635e3ece6b9a723fb470a46cb9b3592f217d72e40540a5fada00289d"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "dnssec-prover",
+ "hashbrown 0.13.2",
+ "libm",
+ "lightning-invoice 0.34.0",
+ "lightning-macros",
+ "lightning-types 0.3.1",
+ "possiblyrandom",
+]
+
+[[package]]
 name = "lightning-invoice"
 version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,7 +2022,30 @@ checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
 dependencies = [
  "bech32",
  "bitcoin",
- "lightning-types",
+ "lightning-types 0.2.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85e5e14bcdb30d746e9785b04f27938292e8944f78f26517e01e91691f6b3f2"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "lightning-types 0.3.1",
+ "serde",
+]
+
+[[package]]
+name = "lightning-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1583,6 +2053,15 @@ name = "lightning-types"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
+dependencies = [
+ "bitcoin",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb1aac93f22f2c2eac8a0ee83bb1a1ea58673caa2c82847302710b83364d04e6"
 dependencies = [
  "bitcoin",
 ]
@@ -1736,6 +2215,7 @@ dependencies = [
  "axum",
  "bech32",
  "bitcoin",
+ "cdk",
  "chrono",
  "clap",
  "clearscreen",
@@ -1744,7 +2224,7 @@ dependencies = [
  "dotenvy",
  "easy-hasher",
  "fedimint-tonic-lnd",
- "lightning-invoice",
+ "lightning-invoice 0.33.2",
  "lnurl-rs",
  "mostro-core",
  "mutants",
@@ -1808,7 +2288,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1911,6 +2391,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,6 +2458,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2022,6 +2544,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -2128,6 +2660,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "possiblyrandom"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b122a615d72104fb3d8b26523fdf9232cd8ee06949fb37e4ce3ff964d15dffd"
+dependencies = [
+ "getrandom 0.2.16",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,6 +2676,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2276,7 +2823,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "memchr",
  "unicase",
 ]
@@ -2434,7 +2981,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2446,6 +2993,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.17",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2483,9 +3050,11 @@ version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2498,6 +3067,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.35",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2505,6 +3075,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
@@ -2556,7 +3127,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2588,6 +3159,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2642,6 +3225,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +3305,35 @@ checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
@@ -2763,6 +3408,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.12.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2862,6 +3539,18 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.17",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -3066,6 +3755,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3188,6 +3895,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3293,6 +4031,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls 0.23.35",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -3488,7 +4227,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -4290,4 +5029,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ pre-release-hook = [
 
 
 [dependencies]
+cdk = { version = "0.16", default-features = false }
 mutants = "0.0.3" # For #[mutants::skip] annotations
 chrono = "0.4.35"
 easy-hasher = "2.2.1"

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -111,3 +111,12 @@ port = 50051
 # # Days the winner has to claim their share by submitting a bolt11; after
 # # this the bond closes as `forfeited` and the node retains everything.
 # payout_claim_window_days = 15
+
+# Cashu 2-of-3 multisig escrow (alternative to Lightning hold invoices).
+# Opt-in, disabled by default. Mutually exclusive with [anti_abuse_bond].
+# When enabled, the node operates in Cashu mode and does not require LND.
+# See docs/CASHU_ESCROW_ARCHITECTURE.md for the full phased rollout.
+#
+# [cashu]
+# enabled = false
+# mint_url = "https://mint.example.com"

--- a/src/app.rs
+++ b/src/app.rs
@@ -457,7 +457,12 @@ pub async fn run_cashu(ctx: AppContext) -> Result<()> {
                             // Cashu mode (F4). Return CantDo so the peer gets
                             // a clear error instead of a cryptic LND failure.
                             let result = match action {
-                                Action::TakeSell
+                                // No escrow backend wired in F2: reject all
+                                // trade actions so peers get a clear error
+                                // rather than orders that can never be filled
+                                // or cancelled.
+                                Action::NewOrder
+                                | Action::TakeSell
                                 | Action::TakeBuy
                                 | Action::AddInvoice
                                 | Action::Release

--- a/src/app.rs
+++ b/src/app.rs
@@ -453,15 +453,26 @@ pub async fn run_cashu(ctx: AppContext) -> Result<()> {
 
                     if inner_message.verify() {
                         if let Some(action) = message.inner_action() {
-                            if let Err(e) = handle_message_action_no_ln(
-                                &action,
-                                message.clone(),
-                                &unwrapped,
-                                my_keys,
-                                &ctx,
-                            )
-                            .await
-                            {
+                            // Escrow-dependent actions are not yet wired for
+                            // Cashu mode (F4). Return CantDo so the peer gets
+                            // a clear error instead of a cryptic LND failure.
+                            let result = match action {
+                                Action::TakeSell | Action::TakeBuy | Action::AddInvoice => {
+                                    Err(MostroError::MostroCantDo(CantDoReason::InvalidAction)
+                                        .into())
+                                }
+                                _ => {
+                                    handle_message_action_no_ln(
+                                        &action,
+                                        message.clone(),
+                                        &unwrapped,
+                                        my_keys,
+                                        &ctx,
+                                    )
+                                    .await
+                                }
+                            };
+                            if let Err(e) = result {
                                 match e.downcast::<MostroError>() {
                                     Ok(err) => {
                                         manage_errors(*err, message, unwrapped, &action).await;

--- a/src/app.rs
+++ b/src/app.rs
@@ -453,9 +453,14 @@ pub async fn run_cashu(ctx: AppContext) -> Result<()> {
 
                     if inner_message.verify() {
                         if let Some(action) = message.inner_action() {
-                            if let Err(e) =
-                                handle_message_action_no_ln(&action, message.clone(), &unwrapped, my_keys, &ctx)
-                                    .await
+                            if let Err(e) = handle_message_action_no_ln(
+                                &action,
+                                message.clone(),
+                                &unwrapped,
+                                my_keys,
+                                &ctx,
+                            )
+                            .await
                             {
                                 match e.downcast::<MostroError>() {
                                     Ok(err) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -457,7 +457,13 @@ pub async fn run_cashu(ctx: AppContext) -> Result<()> {
                             // Cashu mode (F4). Return CantDo so the peer gets
                             // a clear error instead of a cryptic LND failure.
                             let result = match action {
-                                Action::TakeSell | Action::TakeBuy | Action::AddInvoice => {
+                                Action::TakeSell
+                                | Action::TakeBuy
+                                | Action::AddInvoice
+                                | Action::Release
+                                | Action::Cancel
+                                | Action::AdminCancel
+                                | Action::AdminSettle => {
                                     Err(MostroError::MostroCantDo(CantDoReason::InvalidAction)
                                         .into())
                                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -395,6 +395,89 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
     }
 }
 
+/// Cashu-mode event loop. Mirrors `run()` but without an LND client — all
+/// actions are routed through `handle_message_action_no_ln`. Actions that
+/// require LND (Release, Cancel, AdminCancel, AdminSettle) fall through to
+/// its `_` arm and are logged/ignored until the EscrowBackend abstraction
+/// lands in F3 and wires up proper Cashu dispatch.
+pub async fn run_cashu(ctx: AppContext) -> Result<()> {
+    let my_keys = ctx.keys();
+    let client = ctx.nostr_client();
+    let pow = ctx.settings().mostro.pow;
+
+    loop {
+        let mut notifications = client.notifications();
+
+        while let Ok(notification) = notifications.recv().await {
+            if let RelayPoolNotification::Event { event, .. } = notification {
+                if !event.check_pow(pow) {
+                    tracing::info!("Not POW verified event!");
+                    continue;
+                }
+                if let Kind::GiftWrap = event.kind {
+                    if event.verify().is_err() {
+                        tracing::warn!("Error in event verification")
+                    };
+
+                    let unwrapped = match unwrap_message(&event, my_keys).await {
+                        Ok(Some(u)) => u,
+                        Ok(None) => continue,
+                        Err(e) => {
+                            tracing::warn!("Error unwrapping NIP-59 message: {}", e);
+                            continue;
+                        }
+                    };
+                    let since_time = chrono::Utc::now()
+                        .checked_sub_signed(chrono::Duration::seconds(10))
+                        .unwrap()
+                        .timestamp() as u64;
+                    if unwrapped.created_at.as_secs() < since_time {
+                        continue;
+                    }
+                    let message = unwrapped.message.clone();
+
+                    if unwrapped.identity != unwrapped.sender && unwrapped.signature.is_none() {
+                        tracing::warn!(
+                            "Missing inner signature: identity {} differs from trade key {}",
+                            unwrapped.identity,
+                            unwrapped.sender
+                        );
+                        continue;
+                    }
+
+                    let inner_message = message.get_inner_message_kind();
+                    if let Err(e) = check_trade_index(&ctx, &unwrapped, &message).await {
+                        tracing::warn!("Error checking trade index: {}", e);
+                        continue;
+                    }
+
+                    if inner_message.verify() {
+                        if let Some(action) = message.inner_action() {
+                            if let Err(e) =
+                                handle_message_action_no_ln(&action, message.clone(), &unwrapped, my_keys, &ctx)
+                                    .await
+                            {
+                                match e.downcast::<MostroError>() {
+                                    Ok(err) => {
+                                        manage_errors(*err, message, unwrapped, &action).await;
+                                    }
+                                    Err(e) => {
+                                        tracing::error!("Unexpected error type: {}", e);
+                                        warning_msg(
+                                            &action,
+                                            ServiceError::UnexpectedError(e.to_string()),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -269,6 +269,7 @@ pub mod test_utils {
             expiration: Some(ExpirationSettings::default()),
             anti_abuse_bond: None,
             price: None,
+            cashu: None,
         }
     }
 }

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -1051,6 +1051,7 @@ mod tests {
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
             price: None,
+            cashu: None,
         });
     }
 

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -241,6 +241,7 @@ mod tests {
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
             price: None,
+            cashu: None,
         });
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,8 +21,8 @@ use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 pub use settings::{get_db_pool, init_mostro_settings, Settings};
 pub use types::{
-    AntiAbuseBondSettings, BondApplyTo, DatabaseSettings, ExpirationSettings, LightningSettings,
-    MostroSettings, NostrSettings,
+    AntiAbuseBondSettings, BondApplyTo, CashuSettings, DatabaseSettings, EscrowMode,
+    ExpirationSettings, LightningSettings, MostroSettings, NostrSettings,
 };
 
 // Global variables for Mostro configuration, Nostr client, Lightning status, and database pool

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,7 +1,7 @@
 use super::{DB_POOL, MOSTRO_CONFIG};
 use crate::config::types::{
-    AntiAbuseBondSettings, DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings,
-    NostrSettings, RpcSettings,
+    AntiAbuseBondSettings, CashuSettings, DatabaseSettings, EscrowMode, ExpirationSettings,
+    LightningSettings, MostroSettings, NostrSettings, RpcSettings,
 };
 use crate::price::PriceSettings;
 use serde::{Deserialize, Serialize};
@@ -30,6 +30,11 @@ pub struct Settings {
     /// Phase 1's migration).
     #[serde(default)]
     pub price: Option<PriceSettings>,
+    /// Cashu 2-of-3 multisig escrow (see `docs/CASHU_ESCROW_ARCHITECTURE.md`).
+    /// Absent section ≡ Lightning mode. Mutually exclusive with
+    /// `anti_abuse_bond`.
+    #[serde(default)]
+    pub cashu: Option<CashuSettings>,
 }
 
 /// Initialize the global MOSTRO_CONFIG struct
@@ -115,5 +120,31 @@ impl Settings {
     /// `false` when settings haven't been initialized.
     pub fn is_bond_enabled() -> bool {
         Self::get_bond().is_some_and(|cfg| cfg.enabled)
+    }
+
+    /// Retrieve the Cashu escrow configuration from the global
+    /// `MOSTRO_CONFIG`. Returns `None` when the `[cashu]` block is absent
+    /// (treated as Lightning mode) and also when the global settings haven't
+    /// been initialized yet — never panics.
+    pub fn get_cashu() -> Option<&'static CashuSettings> {
+        MOSTRO_CONFIG.get()?.cashu.as_ref()
+    }
+
+    /// True when the `[cashu]` block is present AND `enabled = true`. This
+    /// is the single gate for Cashu-mode code paths. Returns `false` when
+    /// settings haven't been initialized.
+    pub fn is_cashu_enabled() -> bool {
+        Self::get_cashu().is_some_and(|cfg| cfg.enabled)
+    }
+
+    /// Resolves the active escrow mode from configuration. Returns
+    /// `EscrowMode::Cashu` only when Cashu is explicitly enabled; defaults
+    /// to `EscrowMode::Lightning` in every other case.
+    pub fn escrow_mode() -> EscrowMode {
+        if Self::is_cashu_enabled() {
+            EscrowMode::Cashu
+        } else {
+            EscrowMode::Lightning
+        }
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -173,22 +173,13 @@ pub enum EscrowMode {
 /// feature remains inert — existing orders behave exactly as before. Mutually
 /// exclusive with `[anti_abuse_bond]`; the daemon refuses to start if both are
 /// enabled. See `docs/CASHU_ESCROW_ARCHITECTURE.md` for the full spec.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct CashuSettings {
     /// Master switch. When false, Lightning escrow is used.
     #[serde(default)]
     pub enabled: bool,
     /// URL of the Cashu mint all trades on this node will use.
     pub mint_url: String,
-}
-
-impl Default for CashuSettings {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            mint_url: String::new(),
-        }
-    }
 }
 
 /// Event expiration configuration settings
@@ -634,10 +625,9 @@ mod cashu_settings_tests {
 
     #[test]
     fn toml_cashu_minimal_block_enabled() {
-        let parsed: Stub = toml::from_str(
-            "[cashu]\nenabled = true\nmint_url = \"https://mint.example.com\"",
-        )
-        .expect("minimal enabled block parses");
+        let parsed: Stub =
+            toml::from_str("[cashu]\nenabled = true\nmint_url = \"https://mint.example.com\"")
+                .expect("minimal enabled block parses");
         let cashu = parsed.cashu.expect("cashu block present");
         assert!(cashu.enabled);
         assert_eq!(cashu.mint_url, "https://mint.example.com");

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -179,6 +179,7 @@ pub struct CashuSettings {
     #[serde(default)]
     pub enabled: bool,
     /// URL of the Cashu mint all trades on this node will use.
+    #[serde(default)]
     pub mint_url: String,
 }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -158,6 +158,39 @@ impl Default for AntiAbuseBondSettings {
     }
 }
 
+/// Selects the escrow backend for this node. Resolved from `[cashu].enabled`
+/// at startup; defaults to `Lightning` when the `[cashu]` block is absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EscrowMode {
+    #[default]
+    Lightning,
+    Cashu,
+}
+
+/// Cashu 2-of-3 multisig escrow configuration.
+///
+/// Opt-in. When `enabled = false` (the default) every code path added by this
+/// feature remains inert — existing orders behave exactly as before. Mutually
+/// exclusive with `[anti_abuse_bond]`; the daemon refuses to start if both are
+/// enabled. See `docs/CASHU_ESCROW_ARCHITECTURE.md` for the full spec.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CashuSettings {
+    /// Master switch. When false, Lightning escrow is used.
+    #[serde(default)]
+    pub enabled: bool,
+    /// URL of the Cashu mint all trades on this node will use.
+    pub mint_url: String,
+}
+
+impl Default for CashuSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mint_url: String::new(),
+        }
+    }
+}
+
 /// Event expiration configuration settings
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct ExpirationSettings {
@@ -572,5 +605,41 @@ payout_claim_window_days = 30"#,
         // Other fields on the same block must still deserialize correctly.
         assert_eq!(parsed.anti_abuse_bond.slash_node_share_pct, 0.25);
         assert_eq!(parsed.anti_abuse_bond.payout_claim_window_days, 30);
+    }
+}
+
+#[cfg(test)]
+mod cashu_settings_tests {
+    use super::*;
+
+    #[derive(serde::Deserialize)]
+    struct Stub {
+        cashu: Option<CashuSettings>,
+    }
+
+    #[test]
+    fn toml_cashu_absent_defaults_to_none() {
+        let parsed: Stub = toml::from_str("").expect("empty toml is valid");
+        assert!(parsed.cashu.is_none());
+    }
+
+    #[test]
+    fn toml_cashu_disabled_by_default() {
+        let parsed: Stub = toml::from_str("[cashu]\nmint_url = \"https://mint.example.com\"")
+            .expect("minimal block parses");
+        let cashu = parsed.cashu.expect("cashu block present");
+        assert!(!cashu.enabled);
+        assert_eq!(cashu.mint_url, "https://mint.example.com");
+    }
+
+    #[test]
+    fn toml_cashu_minimal_block_enabled() {
+        let parsed: Stub = toml::from_str(
+            "[cashu]\nenabled = true\nmint_url = \"https://mint.example.com\"",
+        )
+        .expect("minimal enabled block parses");
+        let cashu = parsed.cashu.expect("cashu block present");
+        assert!(cashu.enabled);
+        assert_eq!(cashu.mint_url, "https://mint.example.com");
     }
 }

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -68,6 +68,38 @@ fn validate_mostro_settings(settings: &Settings) -> Result<(), MostroError> {
         ))));
     }
 
+    // Cashu + anti_abuse_bond are mutually exclusive (design decision #5).
+    let cashu_on = settings.cashu.as_ref().is_some_and(|c| c.enabled);
+    let bond_on = settings
+        .anti_abuse_bond
+        .as_ref()
+        .is_some_and(|b| b.enabled);
+    if cashu_on && bond_on {
+        return Err(MostroInternalErr(ServiceError::IOError(
+            "cashu and anti_abuse_bond cannot both be enabled".to_string(),
+        )));
+    }
+
+    if let Some(cashu) = settings.cashu.as_ref().filter(|c| c.enabled) {
+        if cashu.mint_url.is_empty() {
+            return Err(MostroInternalErr(ServiceError::IOError(
+                "cashu.mint_url must not be empty when cashu is enabled".to_string(),
+            )));
+        }
+        let parsed = nostr_sdk::Url::parse(&cashu.mint_url).map_err(|_| {
+            MostroInternalErr(ServiceError::IOError(format!(
+                "cashu.mint_url is not a valid URL: {}",
+                cashu.mint_url
+            )))
+        })?;
+        if parsed.scheme() != "http" && parsed.scheme() != "https" {
+            return Err(MostroInternalErr(ServiceError::IOError(format!(
+                "cashu.mint_url must use http or https, got: {}",
+                parsed.scheme()
+            ))));
+        }
+    }
+
     Ok(())
 }
 
@@ -200,6 +232,7 @@ mod tests {
             expiration: None,
             anti_abuse_bond: None,
             price: None,
+            cashu: None,
         }
     }
 
@@ -271,5 +304,88 @@ mod tests {
             toml::from_str(toml_without_nsec).expect("nsec_privkey should be optional in TOML");
         assert_eq!(nostr.nsec_privkey, "");
         assert_eq!(nostr.relays, vec!["wss://relay.test"]);
+    }
+}
+
+#[cfg(test)]
+mod cashu_validation_tests {
+    use super::*;
+    use crate::config::types::{
+        AntiAbuseBondSettings, CashuSettings, DatabaseSettings, LightningSettings, MostroSettings,
+        NostrSettings, RpcSettings,
+    };
+
+    fn base_settings() -> Settings {
+        Settings {
+            database: DatabaseSettings::default(),
+            lightning: LightningSettings::default(),
+            nostr: NostrSettings {
+                nsec_privkey: String::new(),
+                relays: vec!["wss://relay.test".to_string()],
+            },
+            mostro: MostroSettings::default(),
+            rpc: RpcSettings::default(),
+            expiration: None,
+            anti_abuse_bond: None,
+            price: None,
+            cashu: None,
+        }
+    }
+
+    #[test]
+    fn cashu_valid_config_passes() {
+        let mut s = base_settings();
+        s.cashu = Some(CashuSettings {
+            enabled: true,
+            mint_url: "https://mint.example.com".to_string(),
+        });
+        assert!(validate_mostro_settings(&s).is_ok());
+    }
+
+    #[test]
+    fn cashu_and_bond_both_enabled_rejected() {
+        let mut s = base_settings();
+        s.cashu = Some(CashuSettings {
+            enabled: true,
+            mint_url: "https://mint.example.com".to_string(),
+        });
+        s.anti_abuse_bond = Some(AntiAbuseBondSettings {
+            enabled: true,
+            ..AntiAbuseBondSettings::default()
+        });
+        let err = validate_mostro_settings(&s).expect_err("must be rejected");
+        assert!(err.to_string().contains("cashu and anti_abuse_bond"));
+    }
+
+    #[test]
+    fn cashu_empty_mint_url_rejected() {
+        let mut s = base_settings();
+        s.cashu = Some(CashuSettings {
+            enabled: true,
+            mint_url: String::new(),
+        });
+        let err = validate_mostro_settings(&s).expect_err("empty URL must be rejected");
+        assert!(err.to_string().contains("mint_url must not be empty"));
+    }
+
+    #[test]
+    fn cashu_invalid_url_scheme_rejected() {
+        let mut s = base_settings();
+        s.cashu = Some(CashuSettings {
+            enabled: true,
+            mint_url: "ftp://mint.example.com".to_string(),
+        });
+        let err = validate_mostro_settings(&s).expect_err("non-http URL must be rejected");
+        assert!(err.to_string().contains("http or https"));
+    }
+
+    #[test]
+    fn cashu_disabled_skips_url_validation() {
+        let mut s = base_settings();
+        s.cashu = Some(CashuSettings {
+            enabled: false,
+            mint_url: String::new(),
+        });
+        assert!(validate_mostro_settings(&s).is_ok());
     }
 }

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -70,10 +70,7 @@ fn validate_mostro_settings(settings: &Settings) -> Result<(), MostroError> {
 
     // Cashu + anti_abuse_bond are mutually exclusive (design decision #5).
     let cashu_on = settings.cashu.as_ref().is_some_and(|c| c.enabled);
-    let bond_on = settings
-        .anti_abuse_bond
-        .as_ref()
-        .is_some_and(|b| b.enabled);
+    let bond_on = settings.anti_abuse_bond.as_ref().is_some_and(|b| b.enabled);
     if cashu_on && bond_on {
         return Err(MostroInternalErr(ServiceError::IOError(
             "cashu and anti_abuse_bond cannot both be enabled".to_string(),

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -376,8 +376,8 @@ pub fn validate_nsec(input: &str) -> Result<(), String> {
 }
 
 pub fn validate_mint_url(input: &str) -> Result<(), String> {
-    let parsed = nostr_sdk::Url::parse(input.trim())
-        .map_err(|_| format!("Invalid URL: {}", input))?;
+    let parsed =
+        nostr_sdk::Url::parse(input.trim()).map_err(|_| format!("Invalid URL: {}", input))?;
     if parsed.scheme() != "http" && parsed.scheme() != "https" {
         return Err(format!(
             "Mint URL must use http or https, got: {}",

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -9,7 +9,7 @@ use nostr_sdk::prelude::*;
 use super::constants::{ENV_FILENAME, NSEC_ENV_VAR};
 use super::settings::Settings;
 use super::types::{
-    DatabaseSettings, LightningSettings, MostroSettings, NostrSettings, RpcSettings,
+    CashuSettings, DatabaseSettings, LightningSettings, MostroSettings, NostrSettings, RpcSettings,
 };
 
 const TEMPLATE_BYTES: &[u8] = include_bytes!("../../settings.tpl.toml");
@@ -53,9 +53,27 @@ pub fn run_setup_menu(
 }
 
 fn run_setup_wizard(settings_dir: &Path, config_file_path: &Path) -> Result<Settings, MostroError> {
-    println!("\n--- Lightning (LND) Configuration ---\n");
+    println!("\n--- Escrow Mode ---\n");
 
-    let lightning = prompt_lightning_settings()?;
+    let mode_choices = &[
+        "Lightning (LND hold invoices — default)",
+        "Cashu (ecash 2-of-3, no LND required)",
+    ];
+    let mode_selection = Select::new()
+        .with_prompt("Escrow mode")
+        .items(mode_choices)
+        .default(0)
+        .interact()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    let (lightning, cashu) = if mode_selection == 0 {
+        println!("\n--- Lightning (LND) Configuration ---\n");
+        (prompt_lightning_settings()?, None)
+    } else {
+        println!("\n--- Cashu Mint Configuration ---\n");
+        let cashu = prompt_cashu_settings()?;
+        (LightningSettings::default(), Some(cashu))
+    };
 
     println!("\n--- Nostr Configuration ---\n");
 
@@ -74,6 +92,7 @@ fn run_setup_wizard(settings_dir: &Path, config_file_path: &Path) -> Result<Sett
         expiration: None,
         anti_abuse_bond: None,
         price: None,
+        cashu,
     };
 
     let toml_content = toml::to_string_pretty(&settings)
@@ -314,6 +333,19 @@ fn prompt_mostro_settings() -> Result<MostroSettings, MostroError> {
     })
 }
 
+fn prompt_cashu_settings() -> Result<CashuSettings, MostroError> {
+    let mint_url: String = Input::new()
+        .with_prompt("Cashu mint URL (http or https)")
+        .validate_with(|input: &String| validate_mint_url(input))
+        .interact_text()
+        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+
+    Ok(CashuSettings {
+        enabled: true,
+        mint_url,
+    })
+}
+
 // --- Validation helpers ---
 
 pub fn validate_file_exists(path: &str) -> Result<(), String> {
@@ -341,6 +373,18 @@ pub fn validate_nsec(input: &str) -> Result<(), String> {
     Keys::parse(input.trim())
         .map(|_| ())
         .map_err(|e| format!("Invalid nsec key: {}", e))
+}
+
+pub fn validate_mint_url(input: &str) -> Result<(), String> {
+    let parsed = nostr_sdk::Url::parse(input.trim())
+        .map_err(|_| format!("Invalid URL: {}", input))?;
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return Err(format!(
+            "Mint URL must use http or https, got: {}",
+            parsed.scheme()
+        ));
+    }
+    Ok(())
 }
 
 pub fn validate_relays(input: &str) -> Result<(), String> {

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -438,6 +438,7 @@ mod tests {
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
             price: None,
+            cashu: None,
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ pub mod scheduler;
 pub mod util;
 
 use crate::app::context::AppContext;
-use crate::app::run;
+use crate::app::{run, run_cashu};
 use crate::cli::settings_init;
 use crate::config::{
     get_db_pool, Settings, DB_POOL, LN_STATUS, MESSAGE_QUEUES, MOSTRO_CONFIG, NOSTR_CLIENT,
@@ -123,6 +123,30 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Build AppContext and start the scheduler before mode-specific init so
+    // both Lightning and Cashu paths share the same context.
+    let settings = Arc::new(
+        MOSTRO_CONFIG
+            .get()
+            .expect("MOSTRO_CONFIG not initialized")
+            .clone(),
+    );
+    let ctx = AppContext::new(
+        get_db_pool(),
+        client.clone(),
+        settings,
+        MESSAGE_QUEUES.queue_order_msg.clone(),
+        mostro_keys.clone(),
+    );
+
+    start_scheduler(ctx.clone()).await;
+
+    if Settings::is_cashu_enabled() {
+        tracing::info!("Starting in Cashu escrow mode (LND not required)");
+        return run_cashu(ctx).await;
+    }
+
+    // Lightning mode: initialize LND connector and run the Lightning event loop.
     let mut ln_client = LndConnector::new().await?;
     let ln_status = ln_client.get_node_info().await?;
     let ln_status = LnStatus::from_get_info_response(ln_status);
@@ -164,25 +188,6 @@ async fn main() -> Result<()> {
         });
     }
 
-    // Build AppContext explicitly with all dependencies
-    let settings = Arc::new(
-        MOSTRO_CONFIG
-            .get()
-            .expect("MOSTRO_CONFIG not initialized")
-            .clone(),
-    );
-    let ctx = AppContext::new(
-        get_db_pool(),
-        client.clone(),
-        settings,
-        MESSAGE_QUEUES.queue_order_msg.clone(),
-        mostro_keys.clone(),
-    );
-
-    // Start scheduler for tasks
-    start_scheduler(ctx.clone()).await;
-
-    // Run the Mostro and be happy!!
     run(ctx, &mut ln_client).await
 }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -614,6 +614,9 @@ async fn job_update_bitcoin_prices() {
 /// All state-machine logic lives in [`crate::app::dev_fee`].
 #[mutants::skip]
 async fn job_process_dev_fee_payment(ctx: AppContext) {
+    if Settings::is_cashu_enabled() {
+        return;
+    }
     let interval = 60u64;
 
     let mut ln_client = if let Ok(client) = LndConnector::new().await {
@@ -647,6 +650,9 @@ async fn job_process_dev_fee_payment(ctx: AppContext) {
 /// negligible.
 #[mutants::skip]
 async fn job_process_bond_payouts(ctx: AppContext) {
+    if Settings::is_cashu_enabled() {
+        return;
+    }
     let interval = 60u64;
 
     tokio::spawn(async move {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -138,20 +138,22 @@ async fn job_info_event_send(ctx: AppContext) {
     let mostro_keys = ctx.keys().clone();
     let client = ctx.nostr_client().clone();
     let interval = ctx.settings().mostro.publish_mostro_info_interval as u64;
-    let ln_status = LN_STATUS.get().unwrap();
     tokio::spawn(async move {
         loop {
-            info!("Sending info about mostro");
+            // LN_STATUS is absent in Cashu mode; skip the info event.
+            if let Some(ln_status) = LN_STATUS.get() {
+                info!("Sending info about mostro");
 
-            let tags = crate::nip33::info_to_tags(ln_status);
-            let id = mostro_keys.public_key().to_string();
+                let tags = crate::nip33::info_to_tags(ln_status);
+                let id = mostro_keys.public_key().to_string();
 
-            let info_ev = match crate::nip33::new_info_event(&mostro_keys, "", id, tags) {
-                Ok(info) => info,
-                Err(e) => return error!("{e}"),
-            };
+                let info_ev = match crate::nip33::new_info_event(&mostro_keys, "", id, tags) {
+                    Ok(info) => info,
+                    Err(e) => return error!("{e}"),
+                };
 
-            let _ = client.send_event(&info_ev).await;
+                let _ = client.send_event(&info_ev).await;
+            }
 
             tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
         }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -161,6 +161,9 @@ async fn job_info_event_send(ctx: AppContext) {
 }
 
 async fn job_retry_failed_payments(ctx: AppContext) {
+    if Settings::is_cashu_enabled() {
+        return;
+    }
     let ln_settings = &ctx.settings().lightning;
     let retries_number = ln_settings.payment_attempts as i64;
     let interval = ln_settings.payment_retries_interval as u64;
@@ -293,6 +296,9 @@ async fn notify_users_canceled_order(
 }
 
 async fn job_cancel_orders(ctx: AppContext) {
+    if Settings::is_cashu_enabled() {
+        return;
+    }
     info!("Create a pool to connect to db");
 
     let keys = ctx.keys().clone();


### PR DESCRIPTION
Adds the CashuSettings config struct and EscrowMode enum, wires them into startup validation (Cashu and anti-abuse bonds are mutually exclusive; mint_url must be a valid HTTP/HTTPS URL), and branches the daemon boot path: when [cashu] enabled = true the node starts without LND and routes all actions through a no-LN event loop stub. Lightning behavior is entirely unchanged when the [cashu] block is absent. Includes wizard support for escrow mode selection and a commented [cashu] block in the settings template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Cashu 2-of-3 multisig escrow mode as an alternative to Lightning hold invoices (disabled by default)
  * Added interactive setup wizard support for Cashu mint configuration
  * Application now supports runtime selection between escrow modes

* **Chores**
  * Updated configuration validation to enforce mutual exclusivity of Cashu and anti-abuse bond modes
  * Added Cashu dependency support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->