### PR TITLE
feat(cashu): F5 DB helpers — CAS escrow lock + active-locked query

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -50,14 +50,14 @@
     },
     "query": "\n            UPDATE users SET last_trade_index = ?1 WHERE pubkey = ?2\n        "
   },
-  "c7aff45523b2133b9c78052a7ec84bc8b48f9ce847c2141b8ab720f6425ca8ec": {
+  "bf23fa0ce3f5267b35df93984179201bb89911e63eb9cfd2f1db1c4e4e3eece8": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
-        "Right": 4
+        "Right": 5
       }
     },
-    "query": "\n            UPDATE orders\n            SET\n            cashu_mint_url = ?1,\n            cashu_escrow_token = ?2,\n            cashu_escrow_locked_at = ?3\n            WHERE id = ?4 AND cashu_escrow_locked_at IS NULL\n        "
+    "query": "\n            UPDATE orders\n            SET\n            cashu_mint_url = ?1,\n            cashu_escrow_token = ?2,\n            cashu_escrow_locked_at = ?3\n            WHERE id = ?4 AND status = ?5 AND cashu_escrow_locked_at IS NULL\n        "
   }
 }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -49,5 +49,15 @@
       }
     },
     "query": "\n            UPDATE users SET last_trade_index = ?1 WHERE pubkey = ?2\n        "
+  },
+  "c7aff45523b2133b9c78052a7ec84bc8b48f9ce847c2141b8ab720f6425ca8ec": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Right": 4
+      }
+    },
+    "query": "\n            UPDATE orders\n            SET\n            cashu_mint_url = ?1,\n            cashu_escrow_token = ?2,\n            cashu_escrow_locked_at = ?3\n            WHERE id = ?4 AND cashu_escrow_locked_at IS NULL\n        "
   }
 }

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -50,14 +50,14 @@
     },
     "query": "\n            UPDATE users SET last_trade_index = ?1 WHERE pubkey = ?2\n        "
   },
-  "bf23fa0ce3f5267b35df93984179201bb89911e63eb9cfd2f1db1c4e4e3eece8": {
+  "73fe1627583bd68af9b3855446bb0cdd134121bbb04844daaf658f599014f03e": {
     "describe": {
       "columns": [],
       "nullable": [],
       "parameters": {
-        "Right": 5
+        "Right": 6
       }
     },
-    "query": "\n            UPDATE orders\n            SET\n            cashu_mint_url = ?1,\n            cashu_escrow_token = ?2,\n            cashu_escrow_locked_at = ?3\n            WHERE id = ?4 AND status = ?5 AND cashu_escrow_locked_at IS NULL\n        "
+    "query": "\n            UPDATE orders\n            SET\n            cashu_mint_url = ?1,\n            cashu_escrow_token = ?2,\n            cashu_escrow_locked_at = ?3,\n            status = ?4\n            WHERE id = ?5 AND status = ?6 AND cashu_escrow_locked_at IS NULL\n        "
   }
 }

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -678,6 +678,18 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_payout_payment_hash migration");
+        // cashu escrow columns (mostro-core 0.12.0) — `Order::by_id` SELECTs
+        // them. Apply each ALTER separately for the same reason as dev_fee.
+        for stmt in include_str!("../../../migrations/20260530120000_cashu_escrow_fields.sql")
+            .split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && !s.lines().all(|l| l.trim_start().starts_with("--")))
+        {
+            sqlx::query(stmt)
+                .execute(&pool)
+                .await
+                .expect("cashu escrow migration");
+        }
         pool
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -739,17 +739,23 @@ pub async fn update_order_invoice_held_at_time(
     Ok(rows_affected > 0)
 }
 
-/// Write the three Cashu escrow columns for an order once the submitted token
-/// has been verified and accepted. Called by Track A (`AddCashuEscrow` handler)
-/// immediately before advancing the order status.
+/// Atomically lock the Cashu escrow and advance the order's lifecycle status in
+/// a single write. Called by Track A (`AddCashuEscrow` handler) once the
+/// submitted token has been verified and accepted.
 ///
-/// The `WHERE` clause makes this an atomic compare-and-set on two conditions:
-/// - `status = ?5` — the order must still be in the lifecycle status the caller
-///   expects (e.g. `waiting-payment`). If a concurrent cancel/expire moved the
-///   order to a terminal status first, the write matches zero rows instead of
-///   stamping escrow data onto a dead order. The caller passes the expected
-///   status rather than F5 hard-coding it, so this primitive stays decoupled
-///   from Track A's lifecycle transitions.
+/// Locking the escrow and the status transition (`new_status`, e.g.
+/// `waiting-payment` → `active`) happen in **one** `UPDATE`, so there is no
+/// window in which the token is persisted but the order has not yet advanced. A
+/// crash right after this write leaves the order already `active` with the token
+/// recorded, so `find_locked_cashu_orders` (and thus the monitor / restore path)
+/// always sees a locked escrow — funds can never be locked-but-invisible.
+///
+/// The `WHERE` clause is a compare-and-set on two conditions:
+/// - `status = ?6` — the order must still be in the lifecycle status the caller
+///   expects. If a concurrent cancel/expire moved it to a terminal status first,
+///   the write matches zero rows instead of stamping escrow onto a dead order.
+///   The caller passes both the expected and the target status, so this
+///   primitive stays decoupled from Track A's lifecycle definitions.
 /// - `cashu_escrow_locked_at IS NULL` — the escrow is not yet locked, so a
 ///   replayed `AddCashuEscrow` (or a race between two takers) cannot overwrite
 ///   an already-locked token.
@@ -763,6 +769,7 @@ pub async fn update_order_cashu_escrow(
     token: &str,
     locked_at: i64,
     expected_status: &str,
+    new_status: &str,
 ) -> Result<bool, MostroError> {
     let result = sqlx::query!(
         r#"
@@ -770,12 +777,14 @@ pub async fn update_order_cashu_escrow(
             SET
             cashu_mint_url = ?1,
             cashu_escrow_token = ?2,
-            cashu_escrow_locked_at = ?3
-            WHERE id = ?4 AND status = ?5 AND cashu_escrow_locked_at IS NULL
+            cashu_escrow_locked_at = ?3,
+            status = ?4
+            WHERE id = ?5 AND status = ?6 AND cashu_escrow_locked_at IS NULL
         "#,
         mint_url,
         token,
         locked_at,
+        new_status,
         order_id,
         expected_status,
     )
@@ -1718,10 +1727,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn update_order_cashu_escrow_locks_when_status_matches() {
+    async fn update_order_cashu_escrow_locks_and_advances_atomically() {
         let pool = setup_orders_db().await.unwrap();
         let id = uuid::Uuid::new_v4();
-        // Lock happens while the order awaits payment (spec: WaitingPayment → Active).
+        // Lock happens while the order awaits payment (spec: WaitingPayment -> Active).
         insert_order_with_status(&pool, id, "waiting-payment").await;
 
         let locked = super::update_order_cashu_escrow(
@@ -1731,12 +1740,26 @@ mod tests {
             "cashuABC",
             1700001000,
             "waiting-payment",
+            "active",
         )
         .await
         .unwrap();
         assert!(locked, "First lock should affect the row");
 
-        // Re-locking is now refused even with the same expected status.
+        // Crash-window regression: the single write left the order BOTH `active`
+        // and locked, so the monitor/restore path sees it. There is no state in
+        // which the token is persisted but the order is not yet active.
+        let monitored = super::find_locked_cashu_orders(&pool).await.unwrap();
+        assert_eq!(
+            monitored.len(),
+            1,
+            "Locked order must be visible to monitor"
+        );
+        assert_eq!(monitored[0].cashu_escrow_token.as_deref(), Some("cashuABC"));
+        assert_eq!(monitored[0].status, "active");
+
+        // Re-locking is refused: the status already advanced past the expected
+        // one and the escrow is already locked.
         let again = super::update_order_cashu_escrow(
             &pool,
             id,
@@ -1744,6 +1767,7 @@ mod tests {
             "cashuABC",
             1700001000,
             "waiting-payment",
+            "active",
         )
         .await
         .unwrap();
@@ -1765,6 +1789,7 @@ mod tests {
             "cashuABC",
             1700001000,
             "waiting-payment",
+            "active",
         )
         .await
         .unwrap();
@@ -1786,15 +1811,16 @@ mod tests {
     async fn update_order_cashu_escrow_is_compare_and_set() {
         let pool = setup_orders_db().await.unwrap();
         let id = uuid::Uuid::new_v4();
-        insert_order_with_status(&pool, id, "active").await;
+        insert_order_with_status(&pool, id, "waiting-payment").await;
 
-        // First lock wins.
+        // First lock wins and advances the order to `active`.
         assert!(super::update_order_cashu_escrow(
             &pool,
             id,
             "https://mint.a",
             "tokenA",
             1700001000,
+            "waiting-payment",
             "active",
         )
         .await
@@ -1807,6 +1833,7 @@ mod tests {
             "https://mint.evil",
             "tokenEVIL",
             1700009999,
+            "waiting-payment",
             "active",
         )
         .await

--- a/src/db.rs
+++ b/src/db.rs
@@ -743,17 +743,26 @@ pub async fn update_order_invoice_held_at_time(
 /// has been verified and accepted. Called by Track A (`AddCashuEscrow` handler)
 /// immediately before advancing the order status.
 ///
-/// The `WHERE cashu_escrow_locked_at IS NULL` guard makes this a compare-and-set:
-/// it only locks an escrow that is not yet locked. A replayed `AddCashuEscrow`
-/// message (or a race between two takers) therefore cannot silently overwrite an
-/// already-locked token — the second write matches zero rows and returns
-/// `Ok(false)`, so the caller can reject it instead of advancing the order again.
+/// The `WHERE` clause makes this an atomic compare-and-set on two conditions:
+/// - `status = ?5` — the order must still be in the lifecycle status the caller
+///   expects (e.g. `waiting-payment`). If a concurrent cancel/expire moved the
+///   order to a terminal status first, the write matches zero rows instead of
+///   stamping escrow data onto a dead order. The caller passes the expected
+///   status rather than F5 hard-coding it, so this primitive stays decoupled
+///   from Track A's lifecycle transitions.
+/// - `cashu_escrow_locked_at IS NULL` — the escrow is not yet locked, so a
+///   replayed `AddCashuEscrow` (or a race between two takers) cannot overwrite
+///   an already-locked token.
+///
+/// On either miss the function returns `Ok(false)` and the caller rejects the
+/// request instead of advancing the order.
 pub async fn update_order_cashu_escrow(
     pool: &SqlitePool,
     order_id: Uuid,
     mint_url: &str,
     token: &str,
     locked_at: i64,
+    expected_status: &str,
 ) -> Result<bool, MostroError> {
     let result = sqlx::query!(
         r#"
@@ -762,12 +771,13 @@ pub async fn update_order_cashu_escrow(
             cashu_mint_url = ?1,
             cashu_escrow_token = ?2,
             cashu_escrow_locked_at = ?3
-            WHERE id = ?4 AND cashu_escrow_locked_at IS NULL
+            WHERE id = ?4 AND status = ?5 AND cashu_escrow_locked_at IS NULL
         "#,
         mint_url,
         token,
         locked_at,
         order_id,
+        expected_status,
     )
     .execute(pool)
     .await
@@ -1359,9 +1369,9 @@ mod tests {
         Ok(pool)
     }
 
-    /// Create the orders table matching the production schema (base + dev_fee
-    /// + cashu escrow columns). Keep this DDL in sync with the migration files
-    /// whenever a new `orders` column is added.
+    /// Create the orders table matching the production schema (base plus the
+    /// dev_fee and cashu escrow columns). Keep this DDL in sync with the
+    /// migration files whenever a new `orders` column is added.
     async fn setup_orders_db() -> Result<SqlitePool, Error> {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
@@ -1690,27 +1700,29 @@ mod tests {
 
     // -- Tests for update_order_cashu_escrow / find_locked_cashu_orders --
 
-    /// Insert an `active` order with no Cashu escrow locked yet.
-    async fn insert_active_order(pool: &SqlitePool, id: uuid::Uuid) {
+    /// Insert an order in the given status with no Cashu escrow locked yet.
+    async fn insert_order_with_status(pool: &SqlitePool, id: uuid::Uuid, status: &str) {
         sqlx::query(
             r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
                     amount, fiat_code, fiat_amount, created_at, expires_at,
                     failed_payment, payment_attempts, dev_fee, dev_fee_paid)
-            VALUES (?1, 'buy', 'ev1', 'active', 0, 'lightning',
+            VALUES (?1, 'buy', 'ev1', ?2, 0, 'lightning',
                     100000, 'USD', 100, 1700000000, 1700086400,
                     0, 0, 0, 0)"#,
         )
         .bind(id)
+        .bind(status)
         .execute(pool)
         .await
         .unwrap();
     }
 
     #[tokio::test]
-    async fn update_order_cashu_escrow_locks_an_unlocked_order() {
+    async fn update_order_cashu_escrow_locks_when_status_matches() {
         let pool = setup_orders_db().await.unwrap();
         let id = uuid::Uuid::new_v4();
-        insert_active_order(&pool, id).await;
+        // Lock happens while the order awaits payment (spec: WaitingPayment → Active).
+        insert_order_with_status(&pool, id, "waiting-payment").await;
 
         let locked = super::update_order_cashu_escrow(
             &pool,
@@ -1718,22 +1730,63 @@ mod tests {
             "https://mint.example",
             "cashuABC",
             1700001000,
+            "waiting-payment",
         )
         .await
         .unwrap();
         assert!(locked, "First lock should affect the row");
 
-        // The order is now visible to the escrow monitor.
-        let monitored = super::find_locked_cashu_orders(&pool).await.unwrap();
-        assert_eq!(monitored.len(), 1, "Locked active order should be returned");
-        assert_eq!(monitored[0].cashu_escrow_token.as_deref(), Some("cashuABC"));
+        // Re-locking is now refused even with the same expected status.
+        let again = super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://mint.example",
+            "cashuABC",
+            1700001000,
+            "waiting-payment",
+        )
+        .await
+        .unwrap();
+        assert!(!again, "An already-locked escrow must not be re-locked");
+    }
+
+    #[tokio::test]
+    async fn update_order_cashu_escrow_rejects_status_mismatch() {
+        let pool = setup_orders_db().await.unwrap();
+        let id = uuid::Uuid::new_v4();
+        insert_order_with_status(&pool, id, "active").await;
+
+        // A concurrent cancel/expire moved the order off the expected status:
+        // the CAS must reject and leave no escrow data stamped on the order.
+        let locked = super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://mint.example",
+            "cashuABC",
+            1700001000,
+            "waiting-payment",
+        )
+        .await
+        .unwrap();
+        assert!(!locked, "Status mismatch must match zero rows");
+
+        let token: Option<String> =
+            sqlx::query_scalar("SELECT cashu_escrow_token FROM orders WHERE id = ?1")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(
+            token.is_none(),
+            "No escrow should be stamped on a mismatched order"
+        );
     }
 
     #[tokio::test]
     async fn update_order_cashu_escrow_is_compare_and_set() {
         let pool = setup_orders_db().await.unwrap();
         let id = uuid::Uuid::new_v4();
-        insert_active_order(&pool, id).await;
+        insert_order_with_status(&pool, id, "active").await;
 
         // First lock wins.
         assert!(super::update_order_cashu_escrow(
@@ -1741,7 +1794,8 @@ mod tests {
             id,
             "https://mint.a",
             "tokenA",
-            1700001000
+            1700001000,
+            "active",
         )
         .await
         .unwrap());
@@ -1753,6 +1807,7 @@ mod tests {
             "https://mint.evil",
             "tokenEVIL",
             1700009999,
+            "active",
         )
         .await
         .unwrap();
@@ -1773,7 +1828,7 @@ mod tests {
         let pool = setup_orders_db().await.unwrap();
 
         // Active but no escrow locked → excluded (cashu_escrow_locked_at IS NULL).
-        insert_active_order(&pool, uuid::Uuid::new_v4()).await;
+        insert_order_with_status(&pool, uuid::Uuid::new_v4(), "active").await;
 
         // Locked escrow but non-active status → excluded.
         let cancelled = uuid::Uuid::new_v4();

--- a/src/db.rs
+++ b/src/db.rs
@@ -739,6 +739,62 @@ pub async fn update_order_invoice_held_at_time(
     Ok(rows_affected > 0)
 }
 
+/// Write the three Cashu escrow columns for an order once the submitted token
+/// has been verified and accepted. Called by Track A (`AddCashuEscrow` handler)
+/// immediately before advancing the order status.
+///
+/// The `WHERE cashu_escrow_locked_at IS NULL` guard makes this a compare-and-set:
+/// it only locks an escrow that is not yet locked. A replayed `AddCashuEscrow`
+/// message (or a race between two takers) therefore cannot silently overwrite an
+/// already-locked token — the second write matches zero rows and returns
+/// `Ok(false)`, so the caller can reject it instead of advancing the order again.
+pub async fn update_order_cashu_escrow(
+    pool: &SqlitePool,
+    order_id: Uuid,
+    mint_url: &str,
+    token: &str,
+    locked_at: i64,
+) -> Result<bool, MostroError> {
+    let result = sqlx::query!(
+        r#"
+            UPDATE orders
+            SET
+            cashu_mint_url = ?1,
+            cashu_escrow_token = ?2,
+            cashu_escrow_locked_at = ?3
+            WHERE id = ?4 AND cashu_escrow_locked_at IS NULL
+        "#,
+        mint_url,
+        token,
+        locked_at,
+        order_id,
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Return all orders that have a locked Cashu escrow token and are still
+/// active. Used by background monitors and `restore_session` to re-check
+/// in-flight Cashu escrows after a daemon restart.
+pub async fn find_locked_cashu_orders(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
+    let orders = sqlx::query_as::<_, Order>(
+        r#"
+          SELECT *
+          FROM orders
+          WHERE cashu_escrow_locked_at IS NOT NULL
+            AND status = 'active'
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(orders)
+}
+
 pub async fn find_held_invoices(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
     let order = sqlx::query_as::<_, Order>(
         r#"
@@ -1303,7 +1359,9 @@ mod tests {
         Ok(pool)
     }
 
-    /// Create the orders table matching the production schema (base + dev_fee migration)
+    /// Create the orders table matching the production schema (base + dev_fee
+    /// + cashu escrow columns). Keep this DDL in sync with the migration files
+    /// whenever a new `orders` column is added.
     async fn setup_orders_db() -> Result<SqlitePool, Error> {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
@@ -1628,6 +1686,116 @@ mod tests {
 
         let result = super::find_held_invoices(&pool).await.unwrap();
         assert!(result.is_empty(), "Should not find orders with held_at = 0");
+    }
+
+    // -- Tests for update_order_cashu_escrow / find_locked_cashu_orders --
+
+    /// Insert an `active` order with no Cashu escrow locked yet.
+    async fn insert_active_order(pool: &SqlitePool, id: uuid::Uuid) {
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid)
+            VALUES (?1, 'buy', 'ev1', 'active', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0)"#,
+        )
+        .bind(id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn update_order_cashu_escrow_locks_an_unlocked_order() {
+        let pool = setup_orders_db().await.unwrap();
+        let id = uuid::Uuid::new_v4();
+        insert_active_order(&pool, id).await;
+
+        let locked = super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://mint.example",
+            "cashuABC",
+            1700001000,
+        )
+        .await
+        .unwrap();
+        assert!(locked, "First lock should affect the row");
+
+        // The order is now visible to the escrow monitor.
+        let monitored = super::find_locked_cashu_orders(&pool).await.unwrap();
+        assert_eq!(monitored.len(), 1, "Locked active order should be returned");
+        assert_eq!(monitored[0].cashu_escrow_token.as_deref(), Some("cashuABC"));
+    }
+
+    #[tokio::test]
+    async fn update_order_cashu_escrow_is_compare_and_set() {
+        let pool = setup_orders_db().await.unwrap();
+        let id = uuid::Uuid::new_v4();
+        insert_active_order(&pool, id).await;
+
+        // First lock wins.
+        assert!(super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://mint.a",
+            "tokenA",
+            1700001000
+        )
+        .await
+        .unwrap());
+
+        // A replayed/racing AddCashuEscrow must NOT overwrite the locked token.
+        let second = super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://mint.evil",
+            "tokenEVIL",
+            1700009999,
+        )
+        .await
+        .unwrap();
+        assert!(!second, "Second lock must match zero rows");
+
+        // The original token is intact.
+        let monitored = super::find_locked_cashu_orders(&pool).await.unwrap();
+        assert_eq!(monitored.len(), 1);
+        assert_eq!(monitored[0].cashu_escrow_token.as_deref(), Some("tokenA"));
+        assert_eq!(
+            monitored[0].cashu_mint_url.as_deref(),
+            Some("https://mint.a")
+        );
+    }
+
+    #[tokio::test]
+    async fn find_locked_cashu_orders_ignores_unlocked_and_non_active() {
+        let pool = setup_orders_db().await.unwrap();
+
+        // Active but no escrow locked → excluded (cashu_escrow_locked_at IS NULL).
+        insert_active_order(&pool, uuid::Uuid::new_v4()).await;
+
+        // Locked escrow but non-active status → excluded.
+        let cancelled = uuid::Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    cashu_mint_url, cashu_escrow_token, cashu_escrow_locked_at)
+            VALUES (?1, 'buy', 'ev1', 'canceled', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0, 'https://mint.x', 'tokenX', 1700001000)"#,
+        )
+        .bind(cancelled)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = super::find_locked_cashu_orders(&pool).await.unwrap();
+        assert!(
+            result.is_empty(),
+            "Neither unlocked nor non-active escrows should be returned"
+        );
     }
 
     // -- Tests for find_failed_payment --


### PR DESCRIPTION
Foundation milestone **F5** from the [Cashu 2-of-3 escrow architecture](docs/CASHU_ESCROW_ARCHITECTURE.md): the DB layer for Cashu escrow. Opt-in, zero behavior change when the feature is off.

## Changes
- **Migration** `20260530120000_cashu_escrow_fields.sql` adds `cashu_mint_url`, `cashu_escrow_token`, `cashu_escrow_locked_at` to `orders` (NULL for Lightning orders). Frozen after this PR.
- **`mostro-core` 0.12.0** bump — the `Order` model now carries the three fields.
- **`db::update_order_cashu_escrow`** — compare-and-set write guarded by `WHERE cashu_escrow_locked_at IS NULL`, so a replayed `AddCashuEscrow` or a taker race returns `Ok(false)` instead of overwriting a locked token.
- **`db::find_locked_cashu_orders`** — returns `active` orders with a locked escrow, for the background monitor / `restore_session`.
- Test `setup_*` helpers across all order-touching modules apply the new migration (incl. `bond/slash.rs`, which would otherwise hit `no such column` on full `Order` reads).

## Tests
- New unit tests: lock, CAS rejection, monitor filter.
- Full suite green (376 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cashu escrow support for orders with an atomic lock-and-stamp flow that only applies when the order is in the expected state, preventing overwrite.

* **Tests**
  * Added tests validating escrow locking, conditional stamping, prevention of double-locking, and queries for locked orders in the active state.

* **Chores**
  * Updated database schema and test migrations to include Cashu escrow fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MostroP2P/mostro/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->