### PR TITLE
feat(bond): Phase 5 — maker bond (non-range) + dispute slash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1769,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.11.5"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964e2810ab700532c3e6677615123372bf9a0ef3fbba4e36b9d65e98f3734ef0"
+checksum = "f92c273ca52a38a27cdd74f3635055e092c0253d7fade399d64a1d5be63f8563"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.11.5", features = ["sqlx"] }
+mostro-core = { version = "0.12.1", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 async-trait = "0.1.83"

--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -1830,6 +1830,14 @@ buyer/seller resolution operates over:
 - Order completed (release path) → maker bond released.
 - Order cancelled before take, or expires `Pending` → maker bond
   released.
+- **Take attempt times out and the order is republished** (the taker is
+  the responsible party — `(WaitingBuyerInvoice, sell)` /
+  `(WaitingPayment, buy)`) → the maker bond **stays `Locked`**. The order
+  returns to the book with the maker still committed; only the abandoning
+  taker bond is resolved (slashed under §9.2, else released). The maker
+  bond is released only when the order itself terminates. Handled in
+  `slash_or_release_on_timeout` via the republish-aware release routing
+  (`release_taker_bonds_for_order_or_warn`).
 - Solver dispute resolution: `BondResolution { slash_seller, slash_buyer }`
   resolves to the maker bond when the maker is on the named side per
   §3.1 (sell-order → `slash_seller` targets maker; buy-order →

--- a/migrations/20260530120000_cashu_escrow_fields.sql
+++ b/migrations/20260530120000_cashu_escrow_fields.sql
@@ -1,4 +1,4 @@
--- mostro-core 0.12.0 adds three Cashu escrow fields to the `Order` model.
+-- mostro-core 0.12.1 adds three Cashu escrow fields to the `Order` model.
 -- These columns back the Cashu 2-of-3 multisig escrow mode (see the escrow
 -- architecture spec). They are `NULL` for Lightning orders.
 --

--- a/migrations/20260530120000_cashu_escrow_fields.sql
+++ b/migrations/20260530120000_cashu_escrow_fields.sql
@@ -1,0 +1,11 @@
+-- mostro-core 0.12.0 adds three Cashu escrow fields to the `Order` model.
+-- These columns back the Cashu 2-of-3 multisig escrow mode (see the escrow
+-- architecture spec). They are `NULL` for Lightning orders.
+--
+-- * cashu_mint_url         URL of the Cashu mint hosting the escrow.
+-- * cashu_escrow_token     Serialized Cashu 2-of-3 multisig token held as escrow.
+-- * cashu_escrow_locked_at Unix timestamp (seconds) when the escrow token was
+--                          validated and locked in.
+ALTER TABLE orders ADD COLUMN cashu_mint_url text;
+ALTER TABLE orders ADD COLUMN cashu_escrow_token text;
+ALTER TABLE orders ADD COLUMN cashu_escrow_locked_at integer;

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -1326,7 +1326,7 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_payout_payment_hash migration");
-        // cashu escrow columns (mostro-core 0.12.0) — `Order::by_id` SELECTs
+        // cashu escrow columns (mostro-core 0.12.1) — `Order::by_id` SELECTs
         // them. Apply each ALTER separately for the same reason as dev_fee.
         for stmt in include_str!("../../../migrations/20260530120000_cashu_escrow_fields.sql")
             .split(';')

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -593,8 +593,29 @@ pub async fn release_bonds_for_order(
     pool: &Pool<Sqlite>,
     order_id: Uuid,
 ) -> Result<(), MostroError> {
+    release_active_bonds(pool, order_id, false).await
+}
+
+/// Release every active bond on `order_id`, optionally **retaining** the
+/// maker's bond.
+///
+/// `retain_makers = true` is the waiting-timeout **republish** path: the
+/// order returns to the book, the maker is still committed to it, so its
+/// `Locked` bond must stay put and be resolved only when the order itself
+/// terminates (completed, cancelled, or expired `Pending`). Only the
+/// abandoning taker side is released. Every other path releases all bonds
+/// (`retain_makers = false`).
+async fn release_active_bonds(
+    pool: &Pool<Sqlite>,
+    order_id: Uuid,
+    retain_makers: bool,
+) -> Result<(), MostroError> {
     let bonds = find_active_bonds_for_order(pool, order_id).await?;
+    let maker = BondRole::Maker.to_string();
     for bond in bonds.iter() {
+        if retain_makers && bond.role == maker {
+            continue;
+        }
         if let Err(e) = release_bond(pool, bond).await {
             warn!("Failed to release bond {}: {}", bond.id, e);
         }
@@ -615,6 +636,21 @@ pub async fn release_bonds_for_order_or_warn(
     context: &'static str,
 ) {
     if let Err(e) = release_bonds_for_order(pool, order_id).await {
+        warn!("{context}: bond release failed for {}: {}", order_id, e);
+    }
+}
+
+/// Like [`release_bonds_for_order_or_warn`] but **retains the maker's
+/// bond** — the waiting-timeout republish path (see [`release_active_bonds`]).
+/// The maker's `Locked` bond stays put because the order returns to the
+/// book with the maker still committed; only the abandoning taker side is
+/// released.
+pub async fn release_taker_bonds_for_order_or_warn(
+    pool: &Pool<Sqlite>,
+    order_id: Uuid,
+    context: &'static str,
+) {
+    if let Err(e) = release_active_bonds(pool, order_id, true).await {
         warn!("{context}: bond release failed for {}: {}", order_id, e);
     }
 }

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -75,6 +75,36 @@ pub fn taker_bond_required() -> bool {
         .is_some_and(|cfg| cfg.apply_to.applies_to_taker())
 }
 
+/// True when the configuration requires the **maker** to post a bond.
+///
+/// Phase 5 gate, symmetric to [`taker_bond_required`]. `publish_order`
+/// asks this question before publishing a new order to Nostr: when it is
+/// true (and the order is non-range — Phase 6 handles range makers), the
+/// order is parked at [`Status::WaitingMakerBond`] and no NIP-33 event is
+/// emitted until the maker locks the bond.
+pub fn maker_bond_required() -> bool {
+    Settings::get_bond()
+        .filter(|cfg| cfg.enabled)
+        .is_some_and(|cfg| cfg.apply_to.applies_to_maker())
+}
+
+/// True when a `Locked` **taker** bond already exists among `bonds` — the
+/// signal that the order's trade is committed and no further take may
+/// begin (it must be rejected with `PendingOrderExists`).
+///
+/// The role scoping is load-bearing for Phase 5. Under `apply_to = both`
+/// the maker's own bond is `Locked` on *every* published order — that is
+/// the steady state, not a committed trade. Counting it here would reject
+/// every taker. Only a `Locked` *taker* bond marks the
+/// first-to-lock-wins race as decided (§6.5), so the take handlers
+/// (`take_buy_action` / `take_sell_action`) gate on this predicate
+/// instead of "any Locked bond".
+pub fn trade_committed_by_locked_taker_bond(bonds: &[Bond]) -> bool {
+    let locked = BondState::Locked.to_string();
+    let taker = BondRole::Taker.to_string();
+    bonds.iter().any(|b| b.state == locked && b.role == taker)
+}
+
 /// Per-take context that the take handler computed locally and now
 /// stashes on the bond row instead of mutating the order.
 ///
@@ -276,6 +306,119 @@ pub async fn request_taker_bond(
             }
         }
     }
+
+    Ok(bond)
+}
+
+/// Create a hold invoice for the **maker's** bond, persist a `Bond` row
+/// in `Requested`, ship the bolt11 to the maker, and arm the LND
+/// subscriber that flips the row to `Locked` once the maker pays.
+///
+/// Phase 5 counterpart of [`request_taker_bond`]. Unlike the taker side
+/// there is exactly one maker bond per order (no concurrent-bonds race),
+/// and the order has already been persisted at
+/// [`Status::WaitingMakerBond`] by `publish_order` with **no** NIP-33
+/// event emitted — the order stays invisible in the book until the bond
+/// locks. On `Accepted`, [`on_bond_invoice_accepted`] resumes the
+/// deferred publication (see `crate::util::resume_publish_after_maker_bond`).
+///
+/// `notional_sats` is the sats notional the bond is sized against: the
+/// fixed order amount for a fixed-price order, or the price-converted
+/// fiat amount for a market-priced single order. Range orders never
+/// reach this function in Phase 5 (deferred to Phase 6).
+///
+/// On any failure the bond row may exist in `Requested` with no LND
+/// counterpart; the order will be reaped (and the bond released) by the
+/// `WaitingMakerBond` expiry path, mirroring the taker "always release"
+/// contract.
+pub async fn request_maker_bond(
+    pool: &Pool<Sqlite>,
+    order: &Order,
+    maker_pubkey: PublicKey,
+    notional_sats: i64,
+    request_id: Option<u64>,
+    trade_index: Option<i64>,
+) -> Result<Bond, MostroError> {
+    let cfg = Settings::get_bond().ok_or_else(|| {
+        MostroInternalErr(ServiceError::UnexpectedError(
+            "anti_abuse_bond block is missing while maker bond was deemed required".into(),
+        ))
+    })?;
+
+    let amount = compute_bond_amount(notional_sats, cfg);
+    let memo = format!("mostro bond order_id={}", order.id);
+
+    let mut ln_client = LndConnector::new().await?;
+    let (invoice_resp, preimage, hash) = ln_client
+        .create_hold_invoice(&memo, amount)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::HoldInvoiceError(e.to_string())))?;
+
+    let mut bond = Bond::new_requested(order.id, maker_pubkey.to_string(), BondRole::Maker, amount);
+    bond.hash = Some(bytes_to_string(&hash));
+    bond.preimage = Some(bytes_to_string(&preimage));
+    bond.payment_request = Some(invoice_resp.payment_request.clone());
+    // No `taker_*` context on a maker bond: those columns describe the
+    // deferred take snapshot of a concurrent taker bond and stay NULL here.
+
+    let bond = create_bond(pool, bond).await?;
+
+    info!(
+        "Maker bond requested: bond_id={} order_id={} amount_sats={}",
+        bond.id, order.id, bond.amount_sats
+    );
+
+    // The bond bolt11 ships as a dedicated `Action::PayBondInvoice`, same
+    // as the taker side. The order is not on the wire yet (no NIP-33
+    // event), so the `SmallOrder` carries `Status::Pending` purely as a
+    // neutral placeholder for the client.
+    let order_kind = order.get_order_kind().map_err(MostroInternalErr)?;
+    let bond_small = SmallOrder::new(
+        Some(order.id),
+        Some(order_kind),
+        Some(Status::Pending),
+        amount,
+        order.fiat_code.clone(),
+        order.min_amount,
+        order.max_amount,
+        order.fiat_amount,
+        order.payment_method.clone(),
+        order.premium,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+
+    // Arm the subscriber BEFORE shipping the bolt11 (same ordering
+    // rationale as the taker side: a fast payer must not race ahead of
+    // the listener). On subscribe failure, release the row so we don't
+    // strand a `Requested` bond with no listener.
+    if let Err(e) = bond_invoice_subscribe(hash, request_id).await {
+        warn!(
+            bond_id = %bond.id,
+            order_id = %bond.order_id,
+            "request_maker_bond: subscribe failed ({}); rolling back bond row",
+            e
+        );
+        let _ = release_bond(pool, &bond).await;
+        return Err(e);
+    }
+
+    enqueue_order_msg(
+        request_id,
+        Some(order.id),
+        Action::PayBondInvoice,
+        Some(Payload::PaymentRequest(
+            Some(bond_small),
+            invoice_resp.payment_request,
+            None,
+        )),
+        maker_pubkey,
+        trade_index,
+    )
+    .await;
 
     Ok(bond)
 }
@@ -600,6 +743,14 @@ async fn on_bond_invoice_accepted(
         }
     };
 
+    // Phase 5: a maker bond is a singleton (one per order, posted at
+    // order-creation time), so it never participates in the taker
+    // first-to-lock-wins race below. Route it to its own lock + resume
+    // path, which finishes the deferred order publication.
+    if bond.role == BondRole::Maker.to_string() {
+        return on_maker_bond_accepted(&bond, hash, pool, request_id).await;
+    }
+
     // Atomic Requested → Locked with concurrent-bonds guard. Exactly
     // one bond can win per order — if two `Accepted` events arrive in
     // the same window, the loser's UPDATE returns `rows_affected = 0`.
@@ -734,6 +885,90 @@ async fn on_bond_invoice_accepted(
 
     let my_keys = get_keys()?;
     resume_take_after_bond(pool, order, &my_keys, request_id).await
+}
+
+/// Subscriber callback path for a **maker** bond reaching `Accepted`.
+///
+/// The maker bond is a singleton, so there is no first-to-lock-wins race
+/// and no loser to cancel. We atomically flip `Requested → Locked`, then
+/// — if the order is still parked at `WaitingMakerBond` — resume the
+/// deferred order publication that `publish_order` skipped.
+///
+/// Idempotent across redeliveries and the restart resubscriber: a
+/// duplicate firing for an already-`Locked` bond re-reads `Locked` and
+/// falls through to the resume, which itself no-ops once the order has
+/// moved on to `Pending` (already published).
+async fn on_maker_bond_accepted(
+    bond: &Bond,
+    hash: &str,
+    pool: &Pool<Sqlite>,
+    request_id: Option<u64>,
+) -> Result<(), MostroError> {
+    let now = Utc::now().timestamp();
+    let result =
+        sqlx::query("UPDATE bonds SET state = ?, locked_at = ? WHERE id = ? AND state = ?")
+            .bind(BondState::Locked.to_string())
+            .bind(now)
+            .bind(bond.id)
+            .bind(BondState::Requested.to_string())
+            .execute(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    // Re-read so a concurrent release (e.g. the order expired and its
+    // bond was cancelled) is visible before we try to publish.
+    let current = match find_bond_by_hash(pool, hash).await? {
+        Some(b) => b,
+        None => return Ok(()),
+    };
+    let current_state = match BondState::from_str(&current.state) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!(
+                "Maker bond {} has unparseable state {:?}: {} — skipping publish",
+                current.id, current.state, e
+            );
+            return Ok(());
+        }
+    };
+    if current_state != BondState::Locked {
+        info!(
+            "Maker bond {} no longer Locked (state={}) — skipping publish",
+            current.id, current.state
+        );
+        return Ok(());
+    }
+    if result.rows_affected() == 1 {
+        info!(
+            "Maker bond {} locked for order {}",
+            current.id, current.order_id
+        );
+    }
+
+    let order = Order::by_id(pool, current.order_id)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?
+        .ok_or_else(|| {
+            MostroInternalErr(ServiceError::UnexpectedError(format!(
+                "Maker bond {} references missing order {}",
+                current.id, current.order_id
+            )))
+        })?;
+
+    // Only resume the deferred publication while the order is still
+    // parked at `WaitingMakerBond`. A previous firing (or the restart
+    // resubscriber) may already have published it (status `Pending`),
+    // in which case we must not re-publish or re-ack the maker.
+    if order.status != Status::WaitingMakerBond.to_string() {
+        info!(
+            "Maker bond {} accepted but order {} is in status {} — skipping publish",
+            current.id, order.id, order.status
+        );
+        return Ok(());
+    }
+
+    let my_keys = get_keys()?;
+    crate::util::resume_publish_after_maker_bond(pool, &my_keys, order, request_id).await
 }
 
 /// Message the taker of a losing concurrent bond that their take was
@@ -1058,6 +1293,18 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_payout_payment_hash migration");
+        // cashu escrow columns (mostro-core 0.12.0) — `Order::by_id` SELECTs
+        // them. Apply each ALTER separately for the same reason as dev_fee.
+        for stmt in include_str!("../../../migrations/20260530120000_cashu_escrow_fields.sql")
+            .split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && !s.lines().all(|l| l.trim_start().starts_with("--")))
+        {
+            sqlx::query(stmt)
+                .execute(&pool)
+                .await
+                .expect("cashu escrow migration");
+        }
         pool
     }
 
@@ -1151,6 +1398,131 @@ mod tests {
         // Guarantees that all bond touchpoints are inert in the absence
         // of an `[anti_abuse_bond]` block.
         assert!(!taker_bond_required());
+    }
+
+    #[test]
+    fn maker_bond_required_is_false_without_config() {
+        // Phase 5: same inertness guarantee for the maker gate. With no
+        // `[anti_abuse_bond]` block, `publish_order` must never park an
+        // order at `WaitingMakerBond` or request a maker bond.
+        assert!(!maker_bond_required());
+    }
+
+    #[test]
+    fn locked_maker_bond_does_not_commit_the_trade() {
+        // Phase 5 (load-bearing): under `apply_to = both` every published
+        // order already carries a `Locked` maker bond. The take handlers'
+        // committed-trade gate must NOT count it — otherwise the first
+        // taker is wrongly rejected with `PendingOrderExists` on every
+        // bond-enabled order. Only a `Locked` *taker* bond commits the
+        // trade (first-to-lock-wins, §6.5).
+        let order_id = Uuid::new_v4();
+        let mut maker = Bond::new_requested(order_id, "a".repeat(64), BondRole::Maker, 1_000);
+        maker.state = BondState::Locked.to_string();
+        // A still-racing taker bond (Requested) must also not commit.
+        let taker_requested = Bond::new_requested(order_id, "b".repeat(64), BondRole::Taker, 1_000);
+
+        assert!(
+            !trade_committed_by_locked_taker_bond(&[maker.clone(), taker_requested.clone()]),
+            "a Locked maker bond + a Requested taker bond must not commit the trade"
+        );
+
+        // Once a taker bond reaches Locked, the trade IS committed.
+        let mut taker_locked = taker_requested;
+        taker_locked.state = BondState::Locked.to_string();
+        assert!(
+            trade_committed_by_locked_taker_bond(&[maker, taker_locked]),
+            "a Locked taker bond commits the trade"
+        );
+    }
+
+    #[test]
+    fn empty_bond_set_does_not_commit_the_trade() {
+        // Defensive: the no-bonds case (feature just enabled, or all
+        // bonds released) must read as "not committed" so takes proceed.
+        assert!(!trade_committed_by_locked_taker_bond(&[]));
+    }
+
+    #[tokio::test]
+    async fn maker_bond_lock_is_singleton_and_idempotent() {
+        // Phase 5: the maker bond is a singleton, so `on_maker_bond_accepted`
+        // uses a plain `Requested → Locked` CAS (no concurrent-bonds
+        // `NOT EXISTS` guard). The first firing locks it; a duplicate
+        // firing (LND redelivery / restart resubscriber) affects zero
+        // rows because the row is no longer `Requested`, and the bond
+        // stays `Locked` exactly once.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut bond = Bond::new_requested(order_id, "d".repeat(64), BondRole::Maker, 1_000);
+        bond.hash = Some("e".repeat(64));
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        async fn try_lock(pool: &Pool<Sqlite>, bond: &Bond) -> u64 {
+            sqlx::query("UPDATE bonds SET state = ?, locked_at = ? WHERE id = ? AND state = ?")
+                .bind(BondState::Locked.to_string())
+                .bind(Utc::now().timestamp())
+                .bind(bond.id)
+                .bind(BondState::Requested.to_string())
+                .execute(pool)
+                .await
+                .unwrap()
+                .rows_affected()
+        }
+
+        assert_eq!(try_lock(&pool, &bond).await, 1, "first lock wins");
+        assert_eq!(
+            try_lock(&pool, &bond).await,
+            0,
+            "duplicate firing is a no-op"
+        );
+
+        let after = find_bond_by_hash(&pool, &"e".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.state, BondState::Locked.to_string());
+        assert_eq!(after.role, BondRole::Maker.to_string());
+    }
+
+    #[tokio::test]
+    async fn maker_bond_lock_does_not_touch_other_bonds() {
+        // The maker lock CAS is keyed by `id`, so it must flip only the
+        // maker row even when an unrelated bond row exists on the same
+        // order. Guards against a future refactor accidentally widening
+        // the predicate.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut maker = Bond::new_requested(order_id, "d".repeat(64), BondRole::Maker, 1_000);
+        maker.hash = Some("e".repeat(64));
+        let maker = create_bond(&pool, maker).await.unwrap();
+
+        let mut other = Bond::new_requested(order_id, "f".repeat(64), BondRole::Taker, 1_000);
+        other.hash = Some("0".repeat(64));
+        let other = create_bond(&pool, other).await.unwrap();
+
+        sqlx::query("UPDATE bonds SET state = ?, locked_at = ? WHERE id = ? AND state = ?")
+            .bind(BondState::Locked.to_string())
+            .bind(Utc::now().timestamp())
+            .bind(maker.id)
+            .bind(BondState::Requested.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let other_after = find_bond_by_hash(&pool, &"0".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            other_after.state,
+            BondState::Requested.to_string(),
+            "unrelated bond must stay Requested"
+        );
+        assert_eq!(other_after.id, other.id);
     }
 
     #[tokio::test]

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -754,13 +754,22 @@ async fn on_bond_invoice_accepted(
     // Atomic Requested → Locked with concurrent-bonds guard. Exactly
     // one bond can win per order — if two `Accepted` events arrive in
     // the same window, the loser's UPDATE returns `rows_affected = 0`.
+    //
+    // Phase 5: the guard counts only OTHER `Locked` *taker* bonds. The
+    // first-to-lock-wins race is purely a taker concern; under
+    // `apply_to = both` the maker's own bond is already `Locked` on every
+    // published order (that is the steady state, not a competitor). Without
+    // the `role = 'taker'` filter the `NOT EXISTS` subquery would see the
+    // maker bond, this UPDATE would affect zero rows, and the first taker
+    // to pay would be wrongly treated as a race loser — rejecting every
+    // taker on a maker-bonded order.
     let now = Utc::now().timestamp();
     let result = sqlx::query(
         "UPDATE bonds SET state = ?, locked_at = ? \
          WHERE id = ? AND state = ? \
            AND NOT EXISTS ( \
              SELECT 1 FROM bonds b2 \
-             WHERE b2.order_id = ? AND b2.state = ? AND b2.id != ? \
+             WHERE b2.order_id = ? AND b2.state = ? AND b2.role = ? AND b2.id != ? \
            )",
     )
     .bind(BondState::Locked.to_string())
@@ -769,6 +778,7 @@ async fn on_bond_invoice_accepted(
     .bind(BondState::Requested.to_string())
     .bind(bond.order_id)
     .bind(BondState::Locked.to_string())
+    .bind(BondRole::Taker.to_string())
     .bind(bond.id)
     .execute(pool)
     .await
@@ -1113,15 +1123,22 @@ pub(crate) async fn maybe_drop_waiting_taker_bond(
     pool: &Pool<Sqlite>,
     order_id: Uuid,
 ) -> Result<(), MostroError> {
-    // Atomic compare-and-swap on (status, no active bonds). A single
+    // Atomic compare-and-swap on (status, no active taker bonds). A single
     // statement so SQLite snapshots both predicates at the same point
     // in time.
+    //
+    // Phase 5: the active-bond check is scoped to `role = 'taker'`. Under
+    // `apply_to = both` the order carries a `Locked` *maker* bond for the
+    // whole trade; counting it here would make `NOT EXISTS` permanently
+    // false, so a `WaitingTakerBond` order whose last taker bond was just
+    // cancelled would never drop back to `Pending`. The drop-to-Pending
+    // decision depends solely on whether any *taker* is still racing.
     let cas = sqlx::query(
         "UPDATE orders SET status = ? \
          WHERE id = ? AND status = ? \
            AND NOT EXISTS ( \
              SELECT 1 FROM bonds \
-             WHERE order_id = ? AND state IN (?, ?) \
+             WHERE order_id = ? AND state IN (?, ?) AND role = ? \
            )",
     )
     .bind(Status::Pending.to_string())
@@ -1130,6 +1147,7 @@ pub(crate) async fn maybe_drop_waiting_taker_bond(
     .bind(order_id)
     .bind(BondState::Requested.to_string())
     .bind(BondState::Locked.to_string())
+    .bind(BondRole::Taker.to_string())
     .execute(pool)
     .await
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
@@ -1327,6 +1345,33 @@ mod tests {
         b.state = state.to_string();
         b.hash = Some("c".repeat(64));
         b
+    }
+
+    /// Mirror of the production taker first-to-lock-wins CAS in
+    /// `on_bond_invoice_accepted` (including the `role = 'taker'` filter on
+    /// the `NOT EXISTS` guard). Returns `rows_affected`. Kept in lockstep
+    /// with the real query so the race tests verify the actual semantics.
+    async fn try_lock(pool: &Pool<Sqlite>, bond: &Bond) -> u64 {
+        sqlx::query(
+            "UPDATE bonds SET state = ?, locked_at = ? \
+             WHERE id = ? AND state = ? \
+               AND NOT EXISTS ( \
+                 SELECT 1 FROM bonds b2 \
+                 WHERE b2.order_id = ? AND b2.state = ? AND b2.role = ? AND b2.id != ? \
+               )",
+        )
+        .bind(BondState::Locked.to_string())
+        .bind(Utc::now().timestamp())
+        .bind(bond.id)
+        .bind(BondState::Requested.to_string())
+        .bind(bond.order_id)
+        .bind(BondState::Locked.to_string())
+        .bind(BondRole::Taker.to_string())
+        .bind(bond.id)
+        .execute(pool)
+        .await
+        .unwrap()
+        .rows_affected()
     }
 
     #[tokio::test]
@@ -1547,29 +1592,6 @@ mod tests {
         b.pubkey = "b".repeat(64);
         let bond_b = create_bond(&pool, b).await.unwrap();
 
-        // Helper that runs the same SQL as `on_bond_invoice_accepted`.
-        async fn try_lock(pool: &Pool<Sqlite>, bond: &Bond) -> u64 {
-            sqlx::query(
-                "UPDATE bonds SET state = ?, locked_at = ? \
-                 WHERE id = ? AND state = ? \
-                   AND NOT EXISTS ( \
-                     SELECT 1 FROM bonds b2 \
-                     WHERE b2.order_id = ? AND b2.state = ? AND b2.id != ? \
-                   )",
-            )
-            .bind(BondState::Locked.to_string())
-            .bind(Utc::now().timestamp())
-            .bind(bond.id)
-            .bind(BondState::Requested.to_string())
-            .bind(bond.order_id)
-            .bind(BondState::Locked.to_string())
-            .bind(bond.id)
-            .execute(pool)
-            .await
-            .unwrap()
-            .rows_affected()
-        }
-
         // A goes first and wins.
         assert_eq!(try_lock(&pool, &bond_a).await, 1);
         // B's UPDATE sees A already Locked → guarded out.
@@ -1583,6 +1605,114 @@ mod tests {
         assert!(states
             .iter()
             .any(|(id, s)| *id == bond_b.id && s == &BondState::Requested.to_string()));
+    }
+
+    #[tokio::test]
+    async fn locked_maker_bond_does_not_block_taker_lock_race() {
+        // Phase 5 regression (apply_to = both): a `Locked` maker bond is
+        // present on every published order. The taker first-to-lock-wins
+        // CAS must IGNORE it (its `NOT EXISTS` guard is scoped to
+        // `role = 'taker'`), so the first taker to pay still wins. Without
+        // the role filter the maker bond would satisfy the guard, the
+        // taker's UPDATE would affect zero rows, and every taker would be
+        // wrongly rejected as a race loser.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        // Maker bond already Locked (the steady state after publication).
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.state = BondState::Locked.to_string();
+        maker.hash = Some("d".repeat(64));
+        let maker = create_bond(&pool, maker).await.unwrap();
+
+        // A taker now pays their bond.
+        let mut taker = make_bond(order_id, BondState::Requested);
+        taker.pubkey = "t".repeat(64);
+        taker.hash = Some("e".repeat(64));
+        let taker = create_bond(&pool, taker).await.unwrap();
+
+        assert_eq!(
+            try_lock(&pool, &taker).await,
+            1,
+            "taker must win the lock race despite the Locked maker bond"
+        );
+
+        // Maker bond untouched; taker bond now Locked.
+        let maker_after = find_bond_by_hash(&pool, &"d".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(maker_after.id, maker.id);
+        assert_eq!(maker_after.state, BondState::Locked.to_string());
+        let taker_after = find_bond_by_hash(&pool, &"e".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(taker_after.id, taker.id);
+        assert_eq!(taker_after.state, BondState::Locked.to_string());
+    }
+
+    #[tokio::test]
+    async fn maybe_drop_waiting_taker_bond_ignores_locked_maker_bond() {
+        // Phase 5 regression (apply_to = both): when the last taker bond is
+        // cancelled, the order must drop from `WaitingTakerBond` back to
+        // `Pending` even though the maker's `Locked` bond is still on the
+        // order. The CAS's active-bond check is scoped to `role = 'taker'`,
+        // so the lingering maker bond does not pin the order in
+        // `WaitingTakerBond`. (No Nostr globals needed: with the order at
+        // `Pending` after the CAS, the republish path is exercised by the
+        // dedicated Phase 1.5 tests; here we assert the DB transition via a
+        // direct status read after forcing the helper's CAS.)
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = ? WHERE id = ?")
+            .bind(Status::WaitingTakerBond.to_string())
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Only a Locked maker bond remains (the taker bond was already
+        // released by the caller before maybe_drop runs).
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.state = BondState::Locked.to_string();
+        maker.hash = Some("d".repeat(64));
+        create_bond(&pool, maker).await.unwrap();
+
+        // Run the same CAS the helper uses (isolated from the Nostr
+        // republish that follows it, which needs process-wide keys).
+        let cas = sqlx::query(
+            "UPDATE orders SET status = ? \
+             WHERE id = ? AND status = ? \
+               AND NOT EXISTS ( \
+                 SELECT 1 FROM bonds \
+                 WHERE order_id = ? AND state IN (?, ?) AND role = ? \
+               )",
+        )
+        .bind(Status::Pending.to_string())
+        .bind(order_id)
+        .bind(Status::WaitingTakerBond.to_string())
+        .bind(order_id)
+        .bind(BondState::Requested.to_string())
+        .bind(BondState::Locked.to_string())
+        .bind(BondRole::Taker.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            cas.rows_affected(),
+            1,
+            "order must drop to Pending: the Locked maker bond must not count as an active taker bond"
+        );
+
+        let status: String = sqlx::query_scalar("SELECT status FROM orders WHERE id = ?")
+            .bind(order_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, Status::Pending.to_string());
     }
 
     #[tokio::test]

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -1100,15 +1100,15 @@ async fn on_bond_invoice_canceled(hash: &str, pool: &Pool<Sqlite>) -> Result<(),
     Ok(())
 }
 
-/// If `order_id` is currently in `Status::WaitingTakerBond` and has no
-/// remaining active bond rows, transition it back to `Status::Pending`
-/// and republish the NIP-33 event. No-op otherwise.
+/// Atomically transition `order_id` from `WaitingTakerBond` back to
+/// `Pending` **iff** no active taker bond remains on it. Returns `true`
+/// when the transition was applied, `false` when it was a no-op.
 ///
-/// Used by `on_bond_invoice_canceled` (when LND cancels the only
-/// outstanding bond's hold invoice) and by the taker self-cancel path
-/// in `cancel.rs` (when the sender was the last bonded taker). Both
-/// call sites need the same "drop back to Pending if empty" logic;
-/// extracting it keeps them consistent.
+/// This is the load-bearing, side-effect-free core of
+/// [`maybe_drop_waiting_taker_bond`] (the latter adds the NIP-33
+/// republish, which needs process-wide keys). Splitting it out lets the
+/// CAS semantics be unit-tested directly instead of via an inlined SQL
+/// copy that could drift from production.
 ///
 /// Race-free: the status check, active-bond check, and status update
 /// run in a single conditional `UPDATE … WHERE … AND NOT EXISTS (…)`
@@ -1119,20 +1119,17 @@ async fn on_bond_invoice_canceled(hash: &str, pool: &Pool<Sqlite>) -> Result<(),
 /// `WaitingTakerBond` (winner promotes to `WaitingPayment`, maker
 /// cancels, etc.) is caught by the `status = 'waiting-taker-bond'`
 /// predicate.
-pub(crate) async fn maybe_drop_waiting_taker_bond(
+///
+/// Phase 5: the active-bond check is scoped to `role = 'taker'`. Under
+/// `apply_to = both` the order carries a `Locked` *maker* bond for the
+/// whole trade; counting it here would make `NOT EXISTS` permanently
+/// false, so a `WaitingTakerBond` order whose last taker bond was just
+/// cancelled would never drop back to `Pending`. The drop-to-Pending
+/// decision depends solely on whether any *taker* is still racing.
+pub(crate) async fn drop_waiting_taker_bond_to_pending(
     pool: &Pool<Sqlite>,
     order_id: Uuid,
-) -> Result<(), MostroError> {
-    // Atomic compare-and-swap on (status, no active taker bonds). A single
-    // statement so SQLite snapshots both predicates at the same point
-    // in time.
-    //
-    // Phase 5: the active-bond check is scoped to `role = 'taker'`. Under
-    // `apply_to = both` the order carries a `Locked` *maker* bond for the
-    // whole trade; counting it here would make `NOT EXISTS` permanently
-    // false, so a `WaitingTakerBond` order whose last taker bond was just
-    // cancelled would never drop back to `Pending`. The drop-to-Pending
-    // decision depends solely on whether any *taker* is still racing.
+) -> Result<bool, MostroError> {
     let cas = sqlx::query(
         "UPDATE orders SET status = ? \
          WHERE id = ? AND status = ? \
@@ -1152,10 +1149,28 @@ pub(crate) async fn maybe_drop_waiting_taker_bond(
     .await
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
-    if cas.rows_affected() == 0 {
+    Ok(cas.rows_affected() == 1)
+}
+
+/// If `order_id` is currently in `Status::WaitingTakerBond` and has no
+/// remaining active taker bond, transition it back to `Status::Pending`
+/// and republish the NIP-33 event. No-op otherwise.
+///
+/// Used by `on_bond_invoice_canceled` (when LND cancels the only
+/// outstanding bond's hold invoice) and by the taker self-cancel path
+/// in `cancel.rs` (when the sender was the last bonded taker). Both
+/// call sites need the same "drop back to Pending if empty" logic;
+/// extracting it keeps them consistent. The CAS itself lives in
+/// [`drop_waiting_taker_bond_to_pending`]; this wrapper adds the
+/// NIP-33 republish.
+pub(crate) async fn maybe_drop_waiting_taker_bond(
+    pool: &Pool<Sqlite>,
+    order_id: Uuid,
+) -> Result<(), MostroError> {
+    if !drop_waiting_taker_bond_to_pending(pool, order_id).await? {
         // Either the order is no longer in `WaitingTakerBond`
         // (winner / maker-cancel / admin already moved it on), or a
-        // concurrent bond is still racing. Either way we have no
+        // concurrent taker bond is still racing. Either way we have no
         // status transition to publish.
         return Ok(());
     }
@@ -1660,10 +1675,9 @@ mod tests {
         // `Pending` even though the maker's `Locked` bond is still on the
         // order. The CAS's active-bond check is scoped to `role = 'taker'`,
         // so the lingering maker bond does not pin the order in
-        // `WaitingTakerBond`. (No Nostr globals needed: with the order at
-        // `Pending` after the CAS, the republish path is exercised by the
-        // dedicated Phase 1.5 tests; here we assert the DB transition via a
-        // direct status read after forcing the helper's CAS.)
+        // `WaitingTakerBond`. Exercises the real CAS helper
+        // (`drop_waiting_taker_bond_to_pending`) — not an inlined SQL copy
+        // — so the test tracks production semantics.
         let pool = setup_pool().await;
         let order_id = Uuid::new_v4();
         insert_order(&pool, order_id).await;
@@ -1681,29 +1695,11 @@ mod tests {
         maker.hash = Some("d".repeat(64));
         create_bond(&pool, maker).await.unwrap();
 
-        // Run the same CAS the helper uses (isolated from the Nostr
-        // republish that follows it, which needs process-wide keys).
-        let cas = sqlx::query(
-            "UPDATE orders SET status = ? \
-             WHERE id = ? AND status = ? \
-               AND NOT EXISTS ( \
-                 SELECT 1 FROM bonds \
-                 WHERE order_id = ? AND state IN (?, ?) AND role = ? \
-               )",
-        )
-        .bind(Status::Pending.to_string())
-        .bind(order_id)
-        .bind(Status::WaitingTakerBond.to_string())
-        .bind(order_id)
-        .bind(BondState::Requested.to_string())
-        .bind(BondState::Locked.to_string())
-        .bind(BondRole::Taker.to_string())
-        .execute(&pool)
-        .await
-        .unwrap();
-        assert_eq!(
-            cas.rows_affected(),
-            1,
+        let dropped = drop_waiting_taker_bond_to_pending(&pool, order_id)
+            .await
+            .unwrap();
+        assert!(
+            dropped,
             "order must drop to Pending: the Locked maker bond must not count as an active taker bond"
         );
 
@@ -1713,6 +1709,40 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(status, Status::Pending.to_string());
+    }
+
+    #[tokio::test]
+    async fn drop_waiting_taker_bond_held_by_active_taker_bond() {
+        // Counterpart to the maker-bond test: a still-active *taker* bond
+        // (Requested) MUST pin the order in `WaitingTakerBond` — the CAS
+        // returns false and the status is unchanged. Confirms the role
+        // filter does not over-drop while another taker is still racing.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = ? WHERE id = ?")
+            .bind(Status::WaitingTakerBond.to_string())
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut taker = make_bond(order_id, BondState::Requested);
+        taker.pubkey = "t".repeat(64);
+        taker.hash = Some("e".repeat(64));
+        create_bond(&pool, taker).await.unwrap();
+
+        let dropped = drop_waiting_taker_bond_to_pending(&pool, order_id)
+            .await
+            .unwrap();
+        assert!(!dropped, "an active taker bond must keep the order parked");
+
+        let status: String = sqlx::query_scalar("SELECT status FROM orders WHERE id = ?")
+            .bind(order_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, Status::WaitingTakerBond.to_string());
     }
 
     #[tokio::test]

--- a/src/app/bond/mod.rs
+++ b/src/app/bond/mod.rs
@@ -19,8 +19,9 @@ pub mod types;
 
 pub use flow::{
     maker_bond_required, release_bond, release_bonds_for_order, release_bonds_for_order_or_warn,
-    request_maker_bond, request_taker_bond, resubscribe_active_bonds, taker_bond_required,
-    trade_committed_by_locked_taker_bond, TakerContext,
+    release_taker_bonds_for_order_or_warn, request_maker_bond, request_taker_bond,
+    resubscribe_active_bonds, taker_bond_required, trade_committed_by_locked_taker_bond,
+    TakerContext,
 };
 pub use math::{compute_bond_amount, compute_node_share};
 pub use model::Bond;

--- a/src/app/bond/mod.rs
+++ b/src/app/bond/mod.rs
@@ -18,8 +18,9 @@ pub mod slash;
 pub mod types;
 
 pub use flow::{
-    release_bond, release_bonds_for_order, release_bonds_for_order_or_warn, request_taker_bond,
-    resubscribe_active_bonds, taker_bond_required, TakerContext,
+    maker_bond_required, release_bond, release_bonds_for_order, release_bonds_for_order_or_warn,
+    request_maker_bond, request_taker_bond, resubscribe_active_bonds, taker_bond_required,
+    trade_committed_by_locked_taker_bond, TakerContext,
 };
 pub use math::{compute_bond_amount, compute_node_share};
 pub use model::Bond;

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -1524,6 +1524,18 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_payout_payment_hash migration");
+        // cashu escrow columns (mostro-core 0.12.0) — `Order::by_id` SELECTs
+        // them. Apply each ALTER separately for the same reason as dev_fee.
+        for stmt in include_str!("../../../migrations/20260530120000_cashu_escrow_fields.sql")
+            .split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && !s.lines().all(|l| l.trim_start().starts_with("--")))
+        {
+            sqlx::query(stmt)
+                .execute(&pool)
+                .await
+                .expect("cashu escrow migration");
+        }
         pool
     }
 

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -1524,7 +1524,7 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_payout_payment_hash migration");
-        // cashu escrow columns (mostro-core 0.12.0) — `Order::by_id` SELECTs
+        // cashu escrow columns (mostro-core 0.12.1) — `Order::by_id` SELECTs
         // them. Apply each ALTER separately for the same reason as dev_fee.
         for stmt in include_str!("../../../migrations/20260530120000_cashu_escrow_fields.sql")
             .split(';')

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -737,7 +737,21 @@ mod tests {
         pubkey: &str,
         state: BondState,
     ) -> Bond {
-        let mut b = Bond::new_requested(order_id, pubkey.to_string(), BondRole::Taker, 10_000);
+        insert_bond_with_role(pool, order_id, pubkey, BondRole::Taker, state).await
+    }
+
+    /// Phase 5: same fixture as [`insert_bond`] but parameterised on the
+    /// posting role, so maker-bond dispute-slash tests can assert the
+    /// buyer/seller → bond-row resolution resolves to the maker row when
+    /// the maker is on the named side (§3.1).
+    async fn insert_bond_with_role(
+        pool: &Pool<Sqlite>,
+        order_id: Uuid,
+        pubkey: &str,
+        role: BondRole,
+        state: BondState,
+    ) -> Bond {
+        let mut b = Bond::new_requested(order_id, pubkey.to_string(), role, 10_000);
         b.state = state.to_string();
         b.preimage = Some(stub_preimage());
         // No hash → release_bond skips the LND cancel branch entirely
@@ -943,6 +957,120 @@ mod tests {
         // snapshot is *persisted* on the row; the specific value is a
         // function of config and is exercised by math.rs tests.
         assert_eq!(row.3, Some(0));
+    }
+
+    #[tokio::test]
+    async fn apply_slash_seller_on_sell_order_transitions_maker_bond() {
+        // Phase 5 (§10.2 / §10.4 acceptance bullet 3): on a sell-order
+        // the maker IS the seller, so `slash_seller=true` must resolve to
+        // the maker's bond row via the §3.1 pubkey mapping — even though
+        // the resolver is role-agnostic and matches on
+        // `order.seller_pubkey`. With both a maker bond (seller) and a
+        // taker bond (buyer) posted, slashing only the seller transitions
+        // the maker bond to PendingPayout and releases the taker bond,
+        // proving the two sides resolve orthogonally.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let maker_bond = insert_bond_with_role(
+            &pool,
+            order.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Locked,
+        )
+        .await;
+        let taker_bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let res = BondResolution {
+            slash_seller: true,
+            slash_buyer: false,
+        };
+
+        // Pre-flight validation must accept the directive: the seller
+        // (maker) holds a Locked bond.
+        validate_bond_resolution(&pool, &order, &res).await.unwrap();
+
+        apply_bond_resolution(
+            &pool,
+            &mut StubSettle::new(),
+            &order,
+            &res,
+            BondSlashReason::LostDispute,
+        )
+        .await
+        .unwrap();
+
+        let maker_row: (String, Option<String>) =
+            sqlx::query_as("SELECT state, slashed_reason FROM bonds WHERE id = ?")
+                .bind(maker_bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            maker_row.0,
+            BondState::PendingPayout.to_string(),
+            "maker bond must be slashed on slash_seller for a sell order"
+        );
+        assert_eq!(maker_row.1.as_deref(), Some("lost-dispute"));
+
+        let taker_state: String = sqlx::query_scalar("SELECT state FROM bonds WHERE id = ?")
+            .bind(taker_bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            taker_state,
+            BondState::Released.to_string(),
+            "the non-slashed taker bond must be released, not settled"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_slash_buyer_on_buy_order_transitions_maker_bond() {
+        // Phase 5 (§3.1 mirror): on a buy-order the maker IS the buyer,
+        // so `slash_buyer=true` resolves to the maker's bond row. This is
+        // the buy-order counterpart of the sell-order test above and
+        // completes the §10.4 acceptance bullet 3 matrix.
+        let pool = setup_pool().await;
+        // Buy order: maker is the buyer, taker is the seller.
+        let order = fixture_order(Kind::Buy, taker_pk(), maker_pk());
+        insert_order_row(&pool, &order).await;
+        let maker_bond = insert_bond_with_role(
+            &pool,
+            order.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Locked,
+        )
+        .await;
+        let res = BondResolution {
+            slash_seller: false,
+            slash_buyer: true,
+        };
+
+        validate_bond_resolution(&pool, &order, &res).await.unwrap();
+        apply_bond_resolution(
+            &pool,
+            &mut StubSettle::new(),
+            &order,
+            &res,
+            BondSlashReason::LostDispute,
+        )
+        .await
+        .unwrap();
+
+        let row: (String, Option<String>) =
+            sqlx::query_as("SELECT state, slashed_reason FROM bonds WHERE id = ?")
+                .bind(maker_bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            row.0,
+            BondState::PendingPayout.to_string(),
+            "maker bond must be slashed on slash_buyer for a buy order"
+        );
+        assert_eq!(row.1.as_deref(), Some("lost-dispute"));
     }
 
     #[tokio::test]

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -48,17 +48,19 @@ use mostro_core::error::{
     ServiceError,
 };
 use mostro_core::message::{Action, BondResolution, Message, Payload};
-use mostro_core::order::{Order, SmallOrder, Status};
+use mostro_core::order::{Kind, Order, SmallOrder, Status};
 use nostr_sdk::prelude::PublicKey;
 use sqlx::{Pool, Sqlite};
 use tracing::{info, warn};
 use uuid::Uuid;
 
 use super::db::find_active_bonds_for_order;
-use super::flow::{release_bond, release_bonds_for_order_or_warn};
+use super::flow::{
+    release_bond, release_bonds_for_order_or_warn, release_taker_bonds_for_order_or_warn,
+};
 use super::math::compute_node_share;
 use super::model::Bond;
-use super::types::{BondSlashReason, BondState};
+use super::types::{BondRole, BondSlashReason, BondState};
 use crate::config::settings::Settings;
 use crate::config::types::AntiAbuseBondSettings;
 use crate::lightning::LndConnector;
@@ -293,6 +295,36 @@ pub async fn apply_bond_resolution<L: SettleLightning + Send>(
 /// config (the scheduler passes `Settings::get_bond()`); it is taken as a
 /// parameter rather than read from the global so the gate is unit-testable
 /// without mutating process-wide state.
+/// Does a waiting-state timeout on this order **republish** it (return it
+/// to the book in `Pending`) rather than cancel it outright?
+///
+/// Mirrors the republish branch of `scheduler::job_cancel_orders`:
+/// `(WaitingBuyerInvoice, Sell)` and `(WaitingPayment, Buy)` republish —
+/// in both the responsible party is the *taker*, so the maker stays
+/// committed and the order goes back to the book. The complementary
+/// `(WaitingBuyerInvoice, Buy)` / `(WaitingPayment, Sell)` cases cancel the
+/// order (the responsible party is the *maker*). Keep this in sync with the
+/// scheduler's match.
+fn order_republishes_on_timeout(order: &Order) -> bool {
+    matches!(
+        (order.get_order_status(), order.get_order_kind()),
+        (Ok(Status::WaitingBuyerInvoice), Ok(Kind::Sell))
+            | (Ok(Status::WaitingPayment), Ok(Kind::Buy))
+    )
+}
+
+/// Release the still-active bonds on a timed-out order, honouring the
+/// republish-vs-cancel distinction: on a republish the maker's `Locked`
+/// bond is retained (it follows the order's lifecycle), otherwise every
+/// bond is released.
+async fn release_on_timeout(pool: &Pool<Sqlite>, order_id: Uuid, republishes: bool) {
+    if republishes {
+        release_taker_bonds_for_order_or_warn(pool, order_id, "scheduler_timeout").await;
+    } else {
+        release_bonds_for_order_or_warn(pool, order_id, "scheduler_timeout").await;
+    }
+}
+
 pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
     pool: &Pool<Sqlite>,
     ln_client: &mut L,
@@ -311,14 +343,26 @@ pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
         }
     };
 
+    // Will this timeout **republish** the order (return it to the book) or
+    // **terminate** it? When the taker is the responsible party the order
+    // goes back to `Pending` and is republished, so the maker's commitment
+    // survives — its bond stays `Locked` and is resolved only when the
+    // order itself terminates (completed / cancelled / `Pending` expiry).
+    // Only the abandoning taker side is settled here. When the maker is
+    // responsible the order is cancelled outright, so every bond is
+    // released. This mirrors `scheduler::job_cancel_orders`' own
+    // republish-vs-cancel split (keep the two in sync).
+    let republishes = order_republishes_on_timeout(order);
+
     // Gate the slash. `apply_to` is a posting-timing switch; Phase 4 is
     // taker-only, so we check `applies_to_taker` (Phase 7 widens this to
     // the maker). When the gate is closed we still release — bonds left
-    // over from a prior enabled period must drain regardless.
+    // over from a prior enabled period must drain regardless (but a
+    // republish still retains the maker bond).
     let slash_armed = bond_cfg
         .is_some_and(|c| c.enabled && c.slash_on_waiting_timeout && c.apply_to.applies_to_taker());
     if !slash_armed {
-        release_bonds_for_order_or_warn(pool, order.id, "scheduler_timeout").await;
+        release_on_timeout(pool, order.id, republishes).await;
         return Ok(None);
     }
 
@@ -327,38 +371,50 @@ pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
     let Some(responsible) = resolve_locked_bond(order, &bonds, side).cloned() else {
         // Responsible party has no bond (e.g. the maker under
         // `apply_to = take`), or the bond already moved out of `Locked`.
-        // No slash; release whatever is still active on the order.
-        release_bonds_for_order_or_warn(pool, order.id, "scheduler_timeout").await;
+        // No slash; release whatever is still active on the order
+        // (retaining the maker bond on a republish).
+        release_on_timeout(pool, order.id, republishes).await;
         return Ok(None);
     };
 
-    // Reuse the Phase 2 primitive. The `BondResolution` names the
-    // responsible side; `apply_bond_resolution` settles that bond's HTLC
-    // + CAS → PendingPayout(Timeout) and releases every other active bond
-    // on the order (the Phase 1 cancel path).
-    let resolution = match side {
-        Side::Buyer => BondResolution {
-            slash_seller: false,
-            slash_buyer: true,
-        },
-        Side::Seller => BondResolution {
-            slash_seller: true,
-            slash_buyer: false,
-        },
-    };
-    apply_bond_resolution(
+    // Settle the responsible bond's HTLC + CAS → PendingPayout(Timeout)
+    // (the Phase 2 `slash_one` primitive), then resolve the remaining
+    // active bonds: release them — but on a republish retain the maker's
+    // still-`Locked` bond, which the abandoning taker's timeout must not
+    // disturb. (We intentionally do **not** route this through
+    // `apply_bond_resolution`, which always releases every non-slashed
+    // bond — that is correct for a terminal dispute resolution but would
+    // wrongly release the maker on a republish.)
+    let node_share_pct = Settings::get_bond().map_or(0.0, |c| c.slash_node_share_pct);
+    slash_one(
         pool,
         ln_client,
-        order,
-        &resolution,
+        &responsible,
         BondSlashReason::Timeout,
+        node_share_pct,
     )
-    .await?;
+    .await;
+    let maker = BondRole::Maker.to_string();
+    for bond in bonds.iter() {
+        if bond.id == responsible.id {
+            continue;
+        }
+        if republishes && bond.role == maker {
+            continue;
+        }
+        if let Err(e) = release_bond(pool, bond).await {
+            warn!(
+                bond_id = %bond.id,
+                order_id = %order.id,
+                "scheduler_timeout: release_bond failed: {}", e
+            );
+        }
+    }
 
     // Confirm the slash actually landed before claiming it: a transient
-    // settle failure leaves the bond `Locked` (apply_bond_resolution is
-    // best-effort), and we must never tell a user their bond was forfeited
-    // while the HTLC is still theirs.
+    // settle failure leaves the bond `Locked` (`slash_one` is best-effort),
+    // and we must never tell a user their bond was forfeited while the HTLC
+    // is still theirs.
     if timeout_slash_confirmed(pool, responsible.id).await? {
         info!(
             bond_id = %responsible.id,
@@ -1449,6 +1505,148 @@ mod tests {
         assert_eq!(row.0, BondState::PendingPayout.to_string());
         assert_eq!(row.1.as_deref(), Some("timeout"));
         assert!(row.2.unwrap() > 0, "slashed_at must be set");
+    }
+
+    #[tokio::test]
+    async fn timeout_republish_retains_maker_bond_sell_order() {
+        // Regression (PR #767 review): sell order, WaitingBuyerInvoice. The
+        // buyer (taker) times out, so the order is **republished** to the
+        // book — the maker (seller) is still committed to it. The taker
+        // bond must be slashed, but the maker bond must stay `Locked`:
+        // releasing it would put a takeable order back in the book with no
+        // maker bond backing it. It is only released when the order itself
+        // terminates.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let maker_bond = insert_bond_with_role(
+            &pool,
+            order.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Locked,
+        )
+        .await;
+        let taker_bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        // apply_to=both so a maker bond is in play alongside the taker bond.
+        let cfg = timeout_cfg(true, true, BondApplyTo::Both);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.map(|b| b.id),
+            Some(taker_bond.id),
+            "the abandoning taker's bond is the one slashed"
+        );
+        assert_eq!(
+            read_bond_state(&pool, taker_bond.id).await,
+            BondState::PendingPayout.to_string(),
+            "taker bond is slashed on the republish path"
+        );
+        assert_eq!(
+            read_bond_state(&pool, maker_bond.id).await,
+            BondState::Locked.to_string(),
+            "maker bond must stay Locked when the order is republished"
+        );
+        assert_eq!(
+            ln.calls(),
+            vec![stub_preimage()],
+            "only the slashed taker HTLC is settled; the maker HTLC is untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_republish_with_no_slash_still_retains_maker_bond() {
+        // Same republish scenario but with the slash gate closed
+        // (slash_on_waiting_timeout = false). The taker bond drains via the
+        // Phase 1 release, but the maker bond must still be retained — the
+        // order goes back to the book with the maker committed.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let maker_bond = insert_bond_with_role(
+            &pool,
+            order.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Locked,
+        )
+        .await;
+        let taker_bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, false, BondApplyTo::Both);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(result.is_none(), "gate closed → no slash reported");
+        assert!(ln.calls().is_empty(), "release path never settles an HTLC");
+        assert_eq!(
+            read_bond_state(&pool, taker_bond.id).await,
+            BondState::Released.to_string(),
+            "taker bond is released when the slash gate is closed"
+        );
+        assert_eq!(
+            read_bond_state(&pool, maker_bond.id).await,
+            BondState::Locked.to_string(),
+            "maker bond is retained on republish even when no slash happens"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_cancel_releases_maker_bond_sell_order() {
+        // Counterpart to the republish case: sell order, WaitingPayment.
+        // The seller (maker) is responsible, so the order is **cancelled**
+        // outright (not republished). Because the order terminates, the
+        // maker bond must be released — the retain-on-republish carve-out
+        // must NOT leak into the terminal cancel path. Gate closed
+        // (slash_on_waiting_timeout = false) keeps this purely about the
+        // release routing, mirroring the republish/no-slash test above.
+        let pool = setup_pool().await;
+        let order = waiting_order(Kind::Sell, maker_pk(), taker_pk(), Status::WaitingPayment);
+        insert_order_row(&pool, &order).await;
+        let maker_bond = insert_bond_with_role(
+            &pool,
+            order.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Locked,
+        )
+        .await;
+        let taker_bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, false, BondApplyTo::Both);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+        assert!(ln.calls().is_empty());
+        assert_eq!(
+            read_bond_state(&pool, maker_bond.id).await,
+            BondState::Released.to_string(),
+            "maker bond is released when the order is cancelled (terminal)"
+        );
+        assert_eq!(
+            read_bond_state(&pool, taker_bond.id).await,
+            BondState::Released.to_string(),
+            "taker bond is released too on a terminal cancel"
+        );
     }
 
     #[tokio::test]

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -235,8 +235,16 @@ async fn cancel_order_by_taker<L: CancelLightning + Send>(
     // Look at what's left on the order. If other concurrent takers
     // still have active bonds, do NOT reset the order — they are
     // still racing. Just message the sender that their take is cancelled.
+    //
+    // Phase 5: scope this to *taker* bonds. Under `apply_to = both` the
+    // order also carries a `Locked` maker bond (pubkey != the cancelling
+    // taker), which must not count as "another taker still racing" — that
+    // would wrongly keep the order in `WaitingTakerBond` and prevent it
+    // from dropping back to `Pending` when the last taker backs out.
     let remaining = crate::app::bond::db::find_active_bonds_for_order(pool, order_id).await?;
-    let others_remain = remaining.iter().any(|b| b.pubkey != sender_str);
+    let others_remain = remaining
+        .iter()
+        .any(|b| b.pubkey != sender_str && b.role == crate::app::bond::BondRole::Taker.to_string());
     if others_remain {
         enqueue_order_msg(
             request_id,

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -1070,6 +1070,12 @@ mod tests {
             .execute(&pool)
             .await
             .expect("Failed to apply dev_fee migration");
+        sqlx::query(include_str!(
+            "../../migrations/20260530120000_cashu_escrow_fields.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("Failed to apply cashu escrow migration");
 
         pool
     }

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -53,8 +53,8 @@ pub async fn take_buy_action(
     // handler doesn't release prior bonds at retake-time anymore —
     // multiple `Requested` taker bonds coexist on the order and the
     // first to reach `Locked` wins. We still need three guards here:
-    //   1. A `Locked` bond already on the order means the trade is
-    //      committed; reject with `PendingOrderExists`.
+    //   1. A `Locked` *taker* bond already on the order means the
+    //      trade is committed; reject with `PendingOrderExists`.
     //   2. The sender's own pubkey already has a `Requested` bond on
     //      this order → idempotent retry: re-send the same
     //      `PayInvoice` message and return.
@@ -63,13 +63,16 @@ pub async fn take_buy_action(
     // path; that context lives on the bond row's `taker_*` columns
     // until the winning bond locks and
     // `on_bond_invoice_accepted` promotes it onto the order.
+    //
+    // Phase 5: with `apply_to = both` the maker's own bond is already
+    // `Locked` on every published order — that is the normal state, not
+    // a committed trade. The committed-trade gate must therefore only
+    // count `Locked` *taker* bonds; otherwise a locked maker bond would
+    // wrongly block every taker with `PendingOrderExists`.
     let bond_required = bond::taker_bond_required();
     if bond_required {
         let active = crate::app::bond::db::find_active_bonds_for_order(pool, order.id).await?;
-        if active
-            .iter()
-            .any(|b| b.state == crate::app::bond::BondState::Locked.to_string())
-        {
+        if bond::trade_committed_by_locked_taker_bond(&active) {
             return Err(MostroCantDo(CantDoReason::PendingOrderExists));
         }
         let sender_str = event.sender.to_string();

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -77,8 +77,8 @@ pub async fn take_sell_action(
     // multiple `Requested` taker bonds coexist on the order and the
     // first to reach `Locked` wins. Three guards before this take
     // proceeds:
-    //   1. A `Locked` bond already on the order means the trade is
-    //      committed; reject with `PendingOrderExists`.
+    //   1. A `Locked` *taker* bond already on the order means the
+    //      trade is committed; reject with `PendingOrderExists`.
     //   2. The sender's own pubkey already has a `Requested` bond on
     //      this order → idempotent retry: re-send the same
     //      `PayInvoice` message and return.
@@ -87,13 +87,16 @@ pub async fn take_sell_action(
     // The order's taker fields are not mutated under the bond path —
     // they're stashed on the bond row's `taker_*` columns until the
     // winning bond locks.
+    //
+    // Phase 5: with `apply_to = both` the maker's own bond is already
+    // `Locked` on every published order — that is the normal state, not
+    // a committed trade. The committed-trade gate must therefore only
+    // count `Locked` *taker* bonds; otherwise a locked maker bond would
+    // wrongly block every taker with `PendingOrderExists`.
     let bond_required = bond::taker_bond_required();
     if bond_required {
         let active = crate::app::bond::db::find_active_bonds_for_order(pool, order.id).await?;
-        if active
-            .iter()
-            .any(|b| b.state == crate::app::bond::BondState::Locked.to_string())
-        {
+        if bond::trade_committed_by_locked_taker_bond(&active) {
             return Err(MostroCantDo(CantDoReason::PendingOrderExists));
         }
         let sender_str = event.sender.to_string();

--- a/src/db.rs
+++ b/src/db.rs
@@ -593,12 +593,19 @@ pub async fn find_order_by_date(pool: &SqlitePool) -> Result<Vec<Order>, MostroE
     // `waiting-taker-bond` here, an order parked at that status past its
     // `expires_at` would never expire and the bond HTLCs would tie up
     // taker funds in LND until CLTV expiry.
+    //
+    // Phase 5: `waiting-maker-bond` is the maker-side analogue — an order
+    // whose maker never paid the bond, so it was never published to
+    // Nostr at all. It must also expire here, otherwise the abandoned
+    // order row and its bond HTLC linger until CLTV. Unlike the other two
+    // buckets this status has no NIP-33 event, so the expiry job skips the
+    // Nostr republish for it (see `job_expire_pending_older_orders`).
     let order = sqlx::query_as::<_, Order>(
         r#"
           SELECT *
           FROM orders
           WHERE expires_at < ?1
-            AND status IN ('pending', 'waiting-taker-bond')
+            AND status IN ('pending', 'waiting-taker-bond', 'waiting-maker-bond')
         "#,
     )
     .bind(expire_time.as_secs() as i64)
@@ -1356,7 +1363,10 @@ mod tests {
                 next_trade_index integer default 0,
                 dev_fee integer default 0,
                 dev_fee_paid integer not null default 0,
-                dev_fee_payment_hash char(64)
+                dev_fee_payment_hash char(64),
+                cashu_mint_url text,
+                cashu_escrow_token text,
+                cashu_escrow_locked_at integer
             )
             "#,
         )
@@ -1764,8 +1774,10 @@ mod tests {
 
         let pending_expired = uuid::Uuid::new_v4();
         let waiting_taker_bond_expired = uuid::Uuid::new_v4();
+        let waiting_maker_bond_expired = uuid::Uuid::new_v4();
         let pending_fresh = uuid::Uuid::new_v4();
         let waiting_taker_bond_fresh = uuid::Uuid::new_v4();
+        let waiting_maker_bond_fresh = uuid::Uuid::new_v4();
         let active_expired = uuid::Uuid::new_v4(); // out-of-bucket; must not match
 
         insert(&pool, pending_expired, "pending", past).await;
@@ -1776,11 +1788,25 @@ mod tests {
             past,
         )
         .await;
+        insert(
+            &pool,
+            waiting_maker_bond_expired,
+            "waiting-maker-bond",
+            past,
+        )
+        .await;
         insert(&pool, pending_fresh, "pending", future).await;
         insert(
             &pool,
             waiting_taker_bond_fresh,
             "waiting-taker-bond",
+            future,
+        )
+        .await;
+        insert(
+            &pool,
+            waiting_maker_bond_fresh,
+            "waiting-maker-bond",
             future,
         )
         .await;
@@ -1798,12 +1824,20 @@ mod tests {
             "expired WaitingTakerBond must be returned (Phase 1.5)"
         );
         assert!(
+            ids.contains(&waiting_maker_bond_expired),
+            "expired WaitingMakerBond must be returned (Phase 5)"
+        );
+        assert!(
             !ids.contains(&pending_fresh),
             "non-expired Pending must NOT be returned"
         );
         assert!(
             !ids.contains(&waiting_taker_bond_fresh),
             "non-expired WaitingTakerBond must NOT be returned"
+        );
+        assert!(
+            !ids.contains(&waiting_maker_bond_fresh),
+            "non-expired WaitingMakerBond must NOT be returned"
         );
         assert!(
             !ids.contains(&active_expired),

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1074,6 +1074,26 @@ mod tests {
         );
     }
 
+    /// Phase 5 (`docs/ANTI_ABUSE_BOND.md` §10.1 / §10.4): an order whose
+    /// daemon-internal status is `WaitingMakerBond` has **not** been
+    /// published to Nostr yet — the maker's bond is still outstanding.
+    /// `create_status_tags` must therefore signal "do not emit an event"
+    /// (`create_event == false`), so the order never appears in the book
+    /// until the bond locks and the order transitions to `Pending`. This
+    /// is the opposite of `WaitingTakerBond`, which is already advertised
+    /// and must keep emitting.
+    #[test]
+    fn waiting_maker_bond_is_not_published_on_wire() {
+        let mut order = make_pending_order();
+        order.status = Status::WaitingMakerBond.to_string();
+
+        let (emit, _mapped) = create_status_tags(&order).expect("status tags");
+        assert!(
+            !emit,
+            "WaitingMakerBond must NOT emit an order event — the order is invisible until the bond locks"
+        );
+    }
+
     /// Sanity: the existing `Pending` mapping behaves identically. If
     /// somebody refactors `create_status_tags` the bucket-equivalence
     /// between `Pending` and `WaitingTakerBond` must not drift.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -521,6 +521,38 @@ async fn job_expire_pending_older_orders(ctx: AppContext) {
                         order.id,
                         order.created_at
                     );
+
+                    // Phase 5: a `WaitingMakerBond` order was never
+                    // published to Nostr (the maker abandoned the bond
+                    // invoice), so there is no NIP-33 event to replace.
+                    // Going through `update_order_event` would publish a
+                    // brand-new Expired/Canceled event for an order that
+                    // never appeared in the book — a ghost entry the
+                    // §10.4 acceptance forbids. Mark it Expired directly
+                    // in the DB and release any bond row instead.
+                    if order.status == Status::WaitingMakerBond.to_string() {
+                        let order_id = order.id;
+                        let mut expired = order.clone();
+                        expired.status = Status::Expired.to_string();
+                        match expired.update(pool).await {
+                            Ok(_) => {
+                                bond::release_bonds_for_order_or_warn(
+                                    pool,
+                                    order_id,
+                                    "maker_bond_expiry",
+                                )
+                                .await;
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "maker_bond_expiry: persist failed for order {} ({}); skipping bond release — will retry next tick",
+                                    order_id, e
+                                );
+                            }
+                        }
+                        continue;
+                    }
+
                     // We update the order id with the new event_id
                     if let Ok(order_updated) =
                         crate::util::update_order_event(&keys, Status::Expired, order).await

--- a/src/util.rs
+++ b/src/util.rs
@@ -363,7 +363,7 @@ pub async fn publish_order(
     trade_index: Option<i64>,
 ) -> Result<(), MostroError> {
     // Prepare a new default order
-    let new_order_db = match prepare_new_order(
+    let mut new_order_db = match prepare_new_order(
         new_order,
         initiator_pubkey,
         trade_index,
@@ -378,19 +378,98 @@ pub async fn publish_order(
         }
     };
 
+    // Phase 5: when the maker side is bonded, the order must NOT hit the
+    // order book until the maker locks an anti-abuse bond. Park it at
+    // `WaitingMakerBond` (no NIP-33 event emitted), request the bond, and
+    // defer the publication to `resume_publish_after_maker_bond`, which
+    // the bond subscriber calls on `Accepted`. Range makers are deferred
+    // to Phase 6 (parent/child proportional slashes), so they keep
+    // publishing immediately for now.
+    if crate::app::bond::maker_bond_required() && !new_order_db.is_range_order() {
+        let notional = maker_bond_notional_sats(&new_order_db)?;
+        new_order_db.status = Status::WaitingMakerBond.to_string();
+        let order = new_order_db
+            .create(pool)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+        info!("New order saved (awaiting maker bond) Id: {}", order.id);
+        crate::app::bond::request_maker_bond(
+            pool,
+            &order,
+            trade_pubkey,
+            notional,
+            request_id,
+            trade_index,
+        )
+        .await?;
+        return Ok(());
+    }
+
     // CRUD order creation
-    let mut order = new_order_db
-        .clone()
+    let order = new_order_db
         .create(pool)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    info!("New order saved Id: {}", order.id);
+
+    finalize_order_publication(
+        pool,
+        keys,
+        order,
+        identity_pubkey,
+        trade_pubkey,
+        request_id,
+        trade_index,
+    )
+    .await
+}
+
+/// Sats notional a maker bond is sized against (Phase 5, non-range only).
+///
+/// Fixed-price orders carry their sats `amount` directly. Market-priced
+/// single orders have `amount == 0` at creation, so we convert the fiat
+/// amount at the current cached price — the same quote
+/// `calculate_and_check_quote` validates against at order time. The bond
+/// is a one-time snapshot and is not repriced if the market moves before
+/// the order is taken (spec §10.3). Range orders never reach this path in
+/// Phase 5; their `max_amount`-based sizing lands in Phase 6.
+fn maker_bond_notional_sats(order: &Order) -> Result<i64, MostroError> {
+    if order.amount > 0 {
+        return Ok(order.amount);
+    }
+    let price = get_bitcoin_price(&order.fiat_code)?;
+    if price <= 0.0 {
+        return Err(MostroInternalErr(ServiceError::NoAPIResponse));
+    }
+    let sats = (order.fiat_amount as f64 / price) * 1E8;
+    Ok(sats as i64)
+}
+
+/// Publish the NIP-33 event for a freshly-persisted order, persist its
+/// `event_id`, ack the maker with [`Action::NewOrder`], and broadcast.
+///
+/// Shared by the inline `publish_order` path (no maker bond) and the
+/// deferred [`resume_publish_after_maker_bond`] path (maker bond locked).
+/// The order row must already exist in the DB; on success it is in
+/// `Status::Pending` with its `event_id` set.
+async fn finalize_order_publication(
+    pool: &SqlitePool,
+    keys: &Keys,
+    mut order: Order,
+    identity_pubkey: PublicKey,
+    trade_pubkey: PublicKey,
+    request_id: Option<u64>,
+    trade_index: Option<i64>,
+) -> Result<(), MostroError> {
     let order_id = order.id;
-    info!("New order saved Id: {}", order_id);
+    // The maker-bond path parked the order at `WaitingMakerBond`; the
+    // no-bond path created it at `Pending`. Either way it goes live now.
+    order.status = Status::Pending.to_string();
 
     // Get tags for new order in case of full privacy or normal order
     // nip33 kind with order fields as tags and order id as identifier (kind 38383 for orders)
     let event = if let Some(tags) =
-        get_tags_for_new_order(&new_order_db, pool, &identity_pubkey, &trade_pubkey, keys).await?
+        get_tags_for_new_order(&order, pool, &identity_pubkey, &trade_pubkey, keys).await?
     {
         new_order_event(keys, "", order_id.to_string(), tags)
             .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?
@@ -401,21 +480,22 @@ pub async fn publish_order(
     info!("Order event to be published: {event:#?}");
     let event_id = event.id.to_string();
     info!("Publishing Event Id: {event_id} for Order Id: {order_id}");
-    // We update the order with the new event_id
+    // We update the order with the new event_id (and Pending status)
     order.event_id = event_id;
+    // Build the ack payload before `update` consumes the order row.
+    let mut small = order.as_new_order();
+    small.id = Some(order_id);
     order
         .update(pool)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-    let mut order = new_order_db.as_new_order();
-    order.id = Some(order_id);
 
     // Send message as ack with small order
     enqueue_order_msg(
         request_id,
         Some(order_id),
         Action::NewOrder,
-        Some(Payload::Order(order)),
+        Some(Payload::Order(small)),
         trade_pubkey,
         trade_index,
     )
@@ -428,6 +508,47 @@ pub async fn publish_order(
         .await
         .map(|_s| ())
         .map_err(|err| MostroInternalErr(ServiceError::NostrError(err.to_string())))
+}
+
+/// Finish publishing an order whose maker bond has just locked.
+///
+/// Called from the bond subscriber (`bond::flow::on_maker_bond_accepted`).
+/// Derives the maker's identity and trade pubkeys from the order row —
+/// the maker is the seller on a sell order, the buyer on a buy order
+/// (§3.1) — and hands off to [`finalize_order_publication`]. Idempotency
+/// across redeliveries is enforced by the caller, which only invokes this
+/// while the order is still in `WaitingMakerBond`.
+pub async fn resume_publish_after_maker_bond(
+    pool: &SqlitePool,
+    keys: &Keys,
+    order: Order,
+    request_id: Option<u64>,
+) -> Result<(), MostroError> {
+    let kind = order.get_order_kind().map_err(MostroInternalErr)?;
+    let (trade_pubkey, identity_pubkey, trade_index) = match kind {
+        OrderKind::Sell => (
+            order.get_seller_pubkey().map_err(MostroInternalErr)?,
+            order
+                .get_master_seller_pubkey()
+                .map_err(MostroInternalErr)?,
+            order.trade_index_seller,
+        ),
+        OrderKind::Buy => (
+            order.get_buyer_pubkey().map_err(MostroInternalErr)?,
+            order.get_master_buyer_pubkey().map_err(MostroInternalErr)?,
+            order.trade_index_buyer,
+        ),
+    };
+    finalize_order_publication(
+        pool,
+        keys,
+        order,
+        identity_pubkey,
+        trade_pubkey,
+        request_id,
+        trade_index,
+    )
+    .await
 }
 
 async fn prepare_new_order(
@@ -1382,6 +1503,12 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+        sqlx::query(include_str!(
+            "../migrations/20260530120000_cashu_escrow_fields.sql"
+        ))
+        .execute(&pool)
+        .await
+        .unwrap();
 
         pool
     }
@@ -1610,5 +1737,19 @@ mod tests {
         // With 30%, 1 * 0.30 = 0.3 -> 0
         let fee = calculate_dev_fee(1, 0.30);
         assert_eq!(fee, 0);
+    }
+
+    #[test]
+    fn maker_bond_notional_uses_fixed_amount_directly() {
+        // Phase 5: a fixed-price order carries its sats `amount`, so the
+        // maker-bond notional is exactly that — no price lookup, no API
+        // dependency in this path.
+        let order = Order {
+            amount: 50_000,
+            fiat_code: "USD".to_string(),
+            fiat_amount: 25,
+            ..Default::default()
+        };
+        assert_eq!(maker_bond_notional_sats(&order).unwrap(), 50_000);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -385,7 +385,21 @@ pub async fn publish_order(
     // the bond subscriber calls on `Accepted`. Range makers are deferred
     // to Phase 6 (parent/child proportional slashes), so they keep
     // publishing immediately for now.
-    if crate::app::bond::maker_bond_required() && !new_order_db.is_range_order() {
+    let maker_bond_required = crate::app::bond::maker_bond_required();
+    if maker_bond_required && new_order_db.is_range_order() {
+        // Visibility for operators: with `apply_to ∈ { make, both }` a
+        // range order is published WITHOUT a maker bond because
+        // proportional range-bond sizing/slashing is Phase 6. Without
+        // this log the operator could wrongly assume every order on a
+        // bond-enabled node is bonded.
+        tracing::warn!(
+            order_kind = %new_order_db.kind,
+            "publish_order: maker bond is enabled but order {} is a range order — \
+             publishing WITHOUT a maker bond (range maker bonds land in Phase 6)",
+            new_order_db.id
+        );
+    }
+    if maker_bond_required && !new_order_db.is_range_order() {
         let notional = maker_bond_notional_sats(&new_order_db)?;
         new_order_db.status = Status::WaitingMakerBond.to_string();
         let order = new_order_db

--- a/src/util.rs
+++ b/src/util.rs
@@ -407,7 +407,7 @@ pub async fn publish_order(
             .await
             .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
         info!("New order saved (awaiting maker bond) Id: {}", order.id);
-        crate::app::bond::request_maker_bond(
+        if let Err(e) = crate::app::bond::request_maker_bond(
             pool,
             &order,
             trade_pubkey,
@@ -415,7 +415,33 @@ pub async fn publish_order(
             request_id,
             trade_index,
         )
-        .await?;
+        .await
+        {
+            // The order was parked at `WaitingMakerBond` but never emitted
+            // a NIP-33 event, and `request_maker_bond` already released any
+            // bond row it managed to create. Without cleanup the row would
+            // sit hidden in `WaitingMakerBond` until the order-expiry job
+            // reaps it hours later. Delete the stranded row now (scoped to
+            // the parked status so we never touch one that has since
+            // advanced) and surface the error to the maker.
+            tracing::warn!(
+                order_id = %order.id,
+                "publish_order: request_maker_bond failed ({}); deleting stranded WaitingMakerBond order",
+                e
+            );
+            if let Err(del) = sqlx::query("DELETE FROM orders WHERE id = ? AND status = ?")
+                .bind(order.id)
+                .bind(Status::WaitingMakerBond.to_string())
+                .execute(pool)
+                .await
+            {
+                tracing::warn!(
+                    order_id = %order.id,
+                    "publish_order: failed to delete stranded order: {}", del
+                );
+            }
+            return Err(e);
+        }
         return Ok(());
     }
 
@@ -538,6 +564,29 @@ pub async fn resume_publish_after_maker_bond(
     order: Order,
     request_id: Option<u64>,
 ) -> Result<(), MostroError> {
+    // Atomically claim the deferred `WaitingMakerBond → Pending`
+    // transition. The bond subscriber already re-read the row and saw
+    // `WaitingMakerBond`, but that check is not atomic with the publish
+    // below: the order-expiry job (`job_expire_pending_older_orders`) can
+    // flip the row `WaitingMakerBond → Expired` (and cancel the just-locked
+    // bond) in between. Without a CAS the full-row write inside
+    // `finalize_order_publication` would blindly resurrect the dead order
+    // back to `Pending` and emit a NIP-33 event for it. If the CAS affects
+    // 0 rows another path already owns the status, so we skip cleanly.
+    let cas = sqlx::query("UPDATE orders SET status = ? WHERE id = ? AND status = ?")
+        .bind(Status::Pending.to_string())
+        .bind(order.id)
+        .bind(Status::WaitingMakerBond.to_string())
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    if cas.rows_affected() != 1 {
+        info!(
+            "resume_publish_after_maker_bond: order {} no longer WaitingMakerBond — skipping deferred publish",
+            order.id
+        );
+        return Ok(());
+    }
     let kind = order.get_order_kind().map_err(MostroInternalErr)?;
     let (trade_pubkey, identity_pubkey, trade_index) = match kind {
         OrderKind::Sell => (


### PR DESCRIPTION
## Phase 5 — Maker bond (non-range) + dispute slash

Implements Phase 5 of the anti-abuse bond (`docs/ANTI_ABUSE_BOND.md` §10). The maker posts a bond **before** the order is published to Nostr, gated by `enabled && apply_to ∈ { make, both }`. Off by default — nodes that don't flip `enabled = true` see zero behavior change.

### Lifecycle (maker-specific)
- `publish_order` parks a non-range order at `Status::WaitingMakerBond` with **no** NIP-33 event, requests the maker bond, and defers the publication. `finalize_order_publication` is factored out and shared by the no-bond inline path and the deferred resume path.
- `request_maker_bond` mints the hold invoice, persists a **singleton** `Bond` row, arms the subscriber, and ships the bolt11 as `Action::PayBondInvoice`. Notional is the fixed sats `amount`, or the price-converted fiat amount for a market-priced single order (one-time snapshot, not repriced — §10.3). Range makers are deferred to Phase 6.
- `on_maker_bond_accepted` does a plain `Requested → Locked` CAS (no first-to-lock race — the maker bond is a singleton), idempotent across LND redelivery and the restart resubscriber, then resumes the deferred publication via `resume_publish_after_maker_bond` only while the order is still `WaitingMakerBond`.

### Slash + release hooks (reused unchanged from Phase 2/4)
- **Dispute slash** resolves to the maker bond by pubkey (sell-order → `slash_seller` targets maker; buy-order → `slash_buyer`), orthogonally to settle/cancel.
- **Release** on every existing exit is role-agnostic, so the maker bond is released on completion, cancel, and expiry.
- **Expiry**: `WaitingMakerBond` orders expire via the scheduler, marked `Expired` directly in the DB without a NIP-33 republish (the order never appeared in the book — no ghost entry, §10.4), with any bond row released.
- `nip33::create_status_tags` emits no event for `WaitingMakerBond`.
- Take handlers gate on the new `trade_committed_by_locked_taker_bond` helper (extracted from the duplicated inline check) so a `Locked` maker bond — the steady state under `apply_to = both` — does not block takers with `PendingOrderExists`.

### `apply_to = both` correctness (review fix)
Under `apply_to = both` a `Locked` maker bond is present on **every** published order. Three taker-flow checks were scoped to `role = 'taker'` so the always-present maker bond is never mistaken for a competing taker bond:
- the first-to-lock-wins CAS in `on_bond_invoice_accepted` (otherwise the first taker to pay is wrongly treated as a race loser → every taker rejected),
- the drop-to-Pending CAS (`drop_waiting_taker_bond_to_pending`, extracted as a testable helper),
- the `others_remain` check in `cancel_order_by_taker`.

### Out of scope (deferred per §4)
Range maker orders (Phase 6) and maker timeout slash (Phase 7); the timeout gate stays `applies_to_taker()`. A `warn!` is logged when a range order is published under `apply_to ∈ { make, both }` without a maker bond, for operator visibility.

### Dependency
Bumps `mostro-core` to **0.12.1** (ships `Status::WaitingMakerBond`). That release line also carries the Cashu F1 escrow fields on the `Order` model, so `migrations/20260530120000_cashu_escrow_fields.sql` is included to keep `Order::by_id` SELECT consistent with the new columns.

## How to test

### Automated

```bash
cargo test --bin mostrod bond     # full bond suite (maker-bond + role-scoping tests)
cargo test --bin mostrod          # full suite (387 passing)
cargo clippy --all-targets --all-features
cargo fmt --check
```

Key new unit tests:

- `src/app/bond/flow.rs`
  - `maker_bond_lock_is_singleton_and_idempotent` — singleton `Requested → Locked` CAS; duplicate firing (LND redelivery / restart resubscriber) is a no-op.
  - `maker_bond_lock_does_not_touch_other_bonds` — the maker lock CAS is keyed by `id` and never touches unrelated bonds.
  - `locked_maker_bond_does_not_commit_the_trade` / `empty_bond_set_does_not_commit_the_trade` — the committed-trade gate counts only `Locked` *taker* bonds.
  - `locked_maker_bond_does_not_block_taker_lock_race` — a taker still wins the first-to-lock race with a `Locked` maker bond present.
  - `maybe_drop_waiting_taker_bond_ignores_locked_maker_bond` / `drop_waiting_taker_bond_held_by_active_taker_bond` — `WaitingTakerBond → Pending` drop ignores the maker bond but is still pinned by an active taker bond (exercises the real `drop_waiting_taker_bond_to_pending` helper).
- `src/app/bond/slash.rs`
  - `apply_slash_seller_on_sell_order_transitions_maker_bond` / `apply_slash_buyer_on_buy_order_transitions_maker_bond` — dispute slash resolves to the maker bond on both order kinds (§10.4 acceptance), releasing the non-slashed taker bond.
- `src/nip33.rs` — `waiting_maker_bond_is_not_published_on_wire` (no NIP-33 event for `WaitingMakerBond`).
- `src/db.rs` — `find_order_by_date` includes `waiting-maker-bond` for expiry.
- `src/util.rs` — `maker_bond_notional_uses_fixed_amount_directly`.

### Manual (regtest / Polar)

Enable the feature in `settings.toml`:

```toml
[anti_abuse_bond]
enabled = true
apply_to = "make"          # or "both" to exercise the role-scoping fixes
amount_pct = 0.01
base_amount_sats = 1000
slash_node_share_pct = 0.5
```

1. **Publish gating.** Create a non-range order. Confirm the maker receives `Action::PayBondInvoice`, the order does **not** appear in the order book (no NIP-33 event), and the DB row is `status = waiting-maker-bond`.
2. **Lock → publish.** Pay the bond hold invoice. The order is then published (NIP-33 event appears, maker gets `Action::NewOrder`) and the DB row flips to `pending`.
3. **Abandonment / no ghost entry.** Create another order but never pay the bond. After `expires_at`, the scheduler marks it `Expired` and releases the bond — confirm **no** order event ever hit the relays (no ghost book entry).
4. **Dispute slash.** Take the published order, open a dispute, and have the solver send `admin-settle` / `admin-cancel` with `BondResolution` targeting the maker (`slash_seller` on a sell order, `slash_buyer` on a buy order). The maker bond enters `PendingPayout` and the Phase 3 payout flow runs.
5. **`apply_to = both`.** With both sides bonded, confirm a taker can still take a maker-bonded order (the `Locked` maker bond must not block with `PendingOrderExists`), and that a lone taker's self-cancel returns the order to `pending`.
6. **Range order under `apply_to = make`.** Create a range order. Confirm it publishes immediately **without** a maker bond and the daemon logs the range-skip `warn!` (range-maker bonds land in Phase 6).
7. **Disabled.** Set `enabled = false` and confirm order creation behaves exactly as before (no `WaitingMakerBond`, no bond invoice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cashu escrow fields added to orders (mint URL, escrow token, escrow lock timestamp)
  * Maker-bond flow: certain orders defer publication until maker bond is secured; publication resumes after acceptance

* **Bug Fixes**
  * Trade-commitment and anti-abuse checks now consider only locked taker bonds
  * Expiry/cancel/publish flows correctly handle waiting-maker-bond state

* **Tests**
  * Expanded coverage for maker/taker bond scenarios and migration-aware test setup

* **Documentation**
  * Clarified Phase 5 maker-bond behavior in anti-abuse docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->