### PR TITLE
Harden nsec storage with SecretString and one-time key init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,6 +2324,7 @@ dependencies = [
  "once_cell",
  "prost 0.14.4",
  "reqwest",
+ "secrecy",
  "serde",
  "serde_json",
  "sqlx",
@@ -2336,6 +2337,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -3353,6 +3355,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,8 @@ tonic = "0.14.2"
 prost = "0.14.1"
 tonic-prost = "0.14.1"
 cdk = { version = "0.17.2", default-features = false, features = ["wallet"] }
+secrecy = { version = "0.10", features = ["serde"] }
+zeroize = "1.8"
 
 [dev-dependencies]
 tokio = { version = "1.47.1", features = ["full", "test-util", "macros"] }

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -285,7 +285,7 @@ pub async fn request_taker_bond(
     };
     if claimed {
         let my_keys = get_keys()?;
-        match crate::util::update_order_event(&my_keys, Status::WaitingTakerBond, order).await {
+        match crate::util::update_order_event(my_keys, Status::WaitingTakerBond, order).await {
             Ok(updated) => {
                 if let Err(e) = sqlx::query("UPDATE orders SET event_id = ? WHERE id = ?")
                     .bind(&updated.event_id)
@@ -931,7 +931,7 @@ async fn on_bond_invoice_accepted(
     let order = promote_taker_context_to_order(pool, order, &current).await?;
 
     let my_keys = get_keys()?;
-    resume_take_after_bond(pool, order, &my_keys, request_id).await
+    resume_take_after_bond(pool, order, my_keys, request_id).await
 }
 
 /// Subscriber callback path for a **maker** bond reaching `Accepted`.
@@ -1015,7 +1015,7 @@ async fn on_maker_bond_accepted(
     }
 
     let my_keys = get_keys()?;
-    crate::util::resume_publish_after_maker_bond(pool, &my_keys, order, request_id).await
+    crate::util::resume_publish_after_maker_bond(pool, my_keys, order, request_id).await
 }
 
 /// Message the taker of a losing concurrent bond that their take was
@@ -1227,7 +1227,7 @@ pub(crate) async fn maybe_drop_waiting_taker_bond(
         None => return Ok(()),
     };
     let my_keys = get_keys()?;
-    match crate::util::update_order_event(&my_keys, Status::Pending, &fresh).await {
+    match crate::util::update_order_event(my_keys, Status::Pending, &fresh).await {
         Ok(updated) => {
             if let Err(e) = sqlx::query("UPDATE orders SET event_id = ? WHERE id = ?")
                 .bind(&updated.event_id)

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -2030,6 +2030,7 @@ mod tests {
     /// `anti_abuse_bond` block stays `None`, matching every other test
     /// init in the binary (the OnceCell is first-set-wins).
     fn init_test_settings() {
+        crate::config::init_test_nostr_keys();
         use crate::config::MOSTRO_CONFIG;
         let _ = MOSTRO_CONFIG.set(Settings {
             database: Default::default(),
@@ -2037,8 +2038,9 @@ mod tests {
                 // Valid canonical test nsec: whichever module wins the
                 // MOSTRO_CONFIG race must install a parseable key, or tests
                 // that reach get_keys() flake on init ordering.
-                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
-                    .to_string(),
+                nsec_privkey: secrecy::SecretString::from(
+                    "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd",
+                ),
                 relays: vec![],
             },
             mostro: Default::default(),

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -3041,8 +3041,9 @@ mod tests {
                 // Valid canonical test nsec: whichever module wins the
                 // MOSTRO_CONFIG race must install a parseable key, or tests
                 // that reach get_keys() flake on init ordering.
-                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
-                    .to_string(),
+                nsec_privkey: secrecy::SecretString::from(
+                    "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd",
+                ),
                 relays: vec![],
             },
             mostro: Default::default(),

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -99,6 +99,7 @@ pub mod test_utils {
         DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings, NostrSettings,
         RpcSettings,
     };
+    use secrecy::{ExposeSecret, SecretString};
 
     /// Test helper wrapper for inspecting the shared order-message queue.
     #[derive(Debug, Clone)]
@@ -230,7 +231,7 @@ pub mod test_utils {
 
             // Use provided keys or parse from settings
             let keys = self.keys.unwrap_or_else(|| {
-                Keys::parse(&settings.nostr.nsec_privkey)
+                Keys::parse(settings.nostr.nsec_privkey.expose_secret())
                     .expect("TestContextBuilder: invalid nsec_privkey in settings")
             });
 
@@ -259,8 +260,9 @@ pub mod test_utils {
             },
             nostr: NostrSettings {
                 // Valid test nsec from src/config/mod.rs tests
-                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
-                    .to_string(),
+                nsec_privkey: SecretString::from(
+                    "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd",
+                ),
                 relays: vec!["wss://relay.test".to_string()],
             },
             mostro: MostroSettings::default(),

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -95,11 +95,12 @@ impl AppContext {
 #[cfg(test)]
 pub mod test_utils {
     use super::*;
+    use crate::config::secret::take_nsec_for_init;
     use crate::config::types::{
         DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings, NostrSettings,
         RpcSettings,
     };
-    use secrecy::{ExposeSecret, SecretString};
+    use secrecy::SecretString;
 
     /// Test helper wrapper for inspecting the shared order-message queue.
     #[derive(Debug, Clone)]
@@ -229,11 +230,18 @@ pub mod test_utils {
                 .order_msg_queue
                 .unwrap_or_else(|| Arc::new(RwLock::new(Vec::new())));
 
-            // Use provided keys or parse from settings
-            let keys = self.keys.unwrap_or_else(|| {
-                Keys::parse(settings.nostr.nsec_privkey.expose_secret())
-                    .expect("TestContextBuilder: invalid nsec_privkey in settings")
-            });
+            let mut settings = Arc::try_unwrap(settings).unwrap_or_else(|arc| (*arc).clone());
+
+            let keys = match self.keys {
+                Some(keys) => {
+                    settings.nostr.nsec_privkey = SecretString::default();
+                    keys
+                }
+                None => take_nsec_for_init(&mut settings.nostr)
+                    .expect("TestContextBuilder: invalid nsec_privkey in settings"),
+            };
+
+            let settings = Arc::new(settings);
 
             AppContext::new(pool, nostr_client, settings, order_msg_queue, keys)
         }

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -1065,14 +1065,16 @@ mod tests {
     use std::collections::HashSet;
 
     fn init_test_settings() {
+        crate::config::init_test_nostr_keys();
         let _ = MOSTRO_CONFIG.set(Settings {
             database: Default::default(),
             nostr: crate::config::NostrSettings {
                 // Valid canonical test nsec: whichever module wins the
                 // MOSTRO_CONFIG race must install a parseable key, or tests
                 // that reach get_keys() flake on init ordering.
-                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
-                    .to_string(),
+                nsec_privkey: secrecy::SecretString::from(
+                    "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd",
+                ),
                 relays: vec![],
             },
             mostro: Default::default(),

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -232,14 +232,16 @@ mod tests {
     use uuid::Uuid;
 
     fn init_test_settings() {
+        crate::config::init_test_nostr_keys();
         let _ = MOSTRO_CONFIG.set(Settings {
             database: Default::default(),
             nostr: crate::config::NostrSettings {
                 // Valid canonical test nsec: whichever module wins the
                 // MOSTRO_CONFIG race must install a parseable key, or tests
                 // that reach get_keys() flake on init ordering.
-                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
-                    .to_string(),
+                nsec_privkey: secrecy::SecretString::from(
+                    "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd",
+                ),
                 relays: vec![],
             },
             mostro: Default::default(),

--- a/src/cashu/e2e_lock.rs
+++ b/src/cashu/e2e_lock.rs
@@ -335,7 +335,7 @@ async fn escrow_lock_end_to_end_against_a_live_mint() {
         mint_url: mint_url.clone(),
         escrow_locktime_days: days as u32,
     });
-    crate::config::settings::init_mostro_settings(settings);
+    let _ = crate::config::settings::init_mostro_settings(settings);
 
     let keys = EscrowKeys::generate();
     let keys_path = keys.persist();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,6 @@
 // Mostro module for configurataion settings
 pub mod constants;
+pub mod secret;
 pub mod settings;
 /// This module provides functionality to manage and initialize settings for the Mostro application.
 /// It includes structures for database, lightning, Nostr, and Mostro settings, as well as functions to initialize and access these settings.
@@ -19,7 +20,8 @@ use tokio::sync::RwLock;
 pub use constants::{DEV_FEE_LIGHTNING_ADDRESS, MAX_DEV_FEE_PERCENTAGE, MIN_DEV_FEE_PERCENTAGE};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
-pub use settings::{get_db_pool, init_mostro_settings, Settings};
+pub use secret::{parse_mostro_keys, read_nsec_env_var, take_nsec_for_init};
+pub use settings::{get_db_pool, get_mostro_keys, init_mostro_settings, Settings};
 pub use types::{
     AntiAbuseBondSettings, BondApplyTo, DatabaseSettings, ExpirationSettings, LightningSettings,
     MostroSettings, NostrSettings,
@@ -29,6 +31,7 @@ pub use types::{
 // almost all of them are initialized with OnceLock to ensure they are set only once
 // They are shared across the application using Arc and Mutex/RwLock for thread safety
 pub static MOSTRO_CONFIG: OnceLock<Settings> = OnceLock::new();
+pub static NOSTR_KEYS: OnceLock<Keys> = OnceLock::new();
 pub static NOSTR_CLIENT: OnceLock<Client> = OnceLock::new();
 pub static LN_STATUS: OnceLock<LnStatus> = OnceLock::new();
 pub static DB_POOL: OnceLock<Arc<sqlx::SqlitePool>> = OnceLock::new();
@@ -56,6 +59,7 @@ mod tests {
     use super::*;
     use crate::config::constants::DEV_FEE_AUDIT_EVENT_KIND;
     use mostro_core::prelude::{NOSTR_DISPUTE_EVENT_KIND, NOSTR_ORDER_EVENT_KIND};
+    use secrecy::ExposeSecret;
     use serde::Deserialize;
 
     // Fake settings for the test
@@ -195,7 +199,7 @@ mod tests {
         let nostr_settings: StubSettingsNostr =
             toml::from_str(NOSTR_SETTINGS).expect("Failed to deserialize");
         assert_eq!(
-            nostr_settings.nostr.nsec_privkey,
+            nostr_settings.nostr.nsec_privkey.expose_secret(),
             "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
         );
         assert_eq!(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,6 +44,17 @@ pub static PRICE_NOSTR_CLIENT: OnceLock<Client> = OnceLock::new();
 pub static LN_STATUS: OnceLock<LnStatus> = OnceLock::new();
 pub static DB_POOL: OnceLock<Arc<sqlx::SqlitePool>> = OnceLock::new();
 
+/// Install the canonical test keys into [`NOSTR_KEYS`] so code paths that
+/// call `get_keys()` work in unit tests. Idempotent: whichever test module
+/// wins the race installs the same key.
+#[cfg(test)]
+pub fn init_test_nostr_keys() {
+    let _ = NOSTR_KEYS.set(
+        Keys::parse("nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd")
+            .expect("valid canonical test nsec"),
+    );
+}
+
 /// Global message queues for Mostro
 /// This struct holds three queues:
 /// - `queue_order_msg`: Holds messages related to orders.

--- a/src/config/secret.rs
+++ b/src/config/secret.rs
@@ -1,0 +1,81 @@
+//! Helpers for loading and parsing the Mostro Nostr private key with
+//! zeroization of transient buffers.
+
+use crate::config::constants::NSEC_ENV_VAR;
+use crate::config::types::NostrSettings;
+use mostro_core::error::MostroError::{self, *};
+use mostro_core::error::ServiceError;
+use nostr_sdk::Keys;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Serializer;
+
+/// Serialize a [`SecretString`] for config files (wizard / TOML export only).
+pub fn serialize_nsec<S>(secret: &SecretString, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(secret.expose_secret())
+}
+
+/// Read `MOSTRO_NSEC_PRIVKEY` from the process environment, trim whitespace,
+/// and wrap in a [`SecretString`]. Returns `None` when unset or blank.
+pub fn read_nsec_env_var() -> Option<SecretString> {
+    let nsec_from_env = std::env::var(NSEC_ENV_VAR).ok()?;
+    let trimmed = nsec_from_env.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(SecretString::from(trimmed.to_owned()))
+}
+
+/// Parse a bech32 nsec into [`Keys`], exposing the secret only in this scope.
+pub fn parse_mostro_keys(secret: &SecretString) -> Result<Keys, MostroError> {
+    let nsec = secret.expose_secret();
+    if nsec.is_empty() {
+        return Err(MostroInternalErr(ServiceError::NostrError(
+            "Nostr private key is not configured".to_string(),
+        )));
+    }
+    Keys::parse(nsec).map_err(|e| {
+        tracing::error!("Failed to parse nostr private key: {}", e);
+        MostroInternalErr(ServiceError::NostrError(e.to_string()))
+    })
+}
+
+/// Take the nsec from nostr settings (env override must already be applied),
+/// parse it into [`Keys`], and clear the field so global settings no longer
+/// retain plaintext.
+pub fn take_nsec_for_init(nostr: &mut NostrSettings) -> Result<Keys, MostroError> {
+    let secret = std::mem::take(&mut nostr.nsec_privkey);
+    let keys = parse_mostro_keys(&secret)?;
+    nostr.nsec_privkey = SecretString::default();
+    Ok(keys)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::ExposeSecret;
+
+    #[test]
+    fn take_nsec_clears_settings_field() {
+        let mut nostr = NostrSettings {
+            nsec_privkey: SecretString::from(
+                "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd",
+            ),
+            relays: vec![],
+        };
+        let keys = take_nsec_for_init(&mut nostr).expect("valid test nsec");
+        assert!(nostr.nsec_privkey.expose_secret().is_empty());
+        assert!(!keys.public_key().to_hex().is_empty());
+    }
+
+    #[test]
+    fn parse_mostro_keys_rejects_empty() {
+        let err = parse_mostro_keys(&SecretString::default()).unwrap_err();
+        assert!(matches!(
+            err,
+            MostroInternalErr(ServiceError::NostrError(_))
+        ));
+    }
+}

--- a/src/config/secret.rs
+++ b/src/config/secret.rs
@@ -8,6 +8,7 @@ use mostro_core::error::ServiceError;
 use nostr_sdk::Keys;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Serializer;
+use zeroize::Zeroize;
 
 /// Serialize a [`SecretString`] for config files (wizard / TOML export only).
 pub fn serialize_nsec<S>(secret: &SecretString, serializer: S) -> Result<S::Ok, S::Error>
@@ -20,12 +21,15 @@ where
 /// Read `MOSTRO_NSEC_PRIVKEY` from the process environment, trim whitespace,
 /// and wrap in a [`SecretString`]. Returns `None` when unset or blank.
 pub fn read_nsec_env_var() -> Option<SecretString> {
-    let nsec_from_env = std::env::var(NSEC_ENV_VAR).ok()?;
+    let mut nsec_from_env = std::env::var(NSEC_ENV_VAR).ok()?;
     let trimmed = nsec_from_env.trim();
     if trimmed.is_empty() {
+        nsec_from_env.zeroize();
         return None;
     }
-    Some(SecretString::from(trimmed.to_owned()))
+    let secret = SecretString::from(trimmed.to_owned());
+    nsec_from_env.zeroize();
+    Some(secret)
 }
 
 /// Parse a bech32 nsec into [`Keys`], exposing the secret only in this scope.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -5,6 +5,8 @@ use crate::config::types::{
     LightningSettings, MostroSettings, NostrSettings, RpcSettings,
 };
 use crate::price::PriceSettings;
+use mostro_core::error::MostroError::{self, *};
+use mostro_core::error::ServiceError;
 use mostro_core::transport::Transport;
 use nostr_sdk::Keys;
 use serde::{Deserialize, Serialize};
@@ -41,14 +43,19 @@ pub struct Settings {
 }
 
 /// Initialize the global `MOSTRO_CONFIG` and `NOSTR_KEYS` structs.
-pub fn init_mostro_settings(mut s: Settings) {
-    let keys = take_nsec_for_init(&mut s.nostr).expect("Failed to parse nostr private key");
-    NOSTR_KEYS
-        .set(keys)
-        .expect("Failed to set Mostro nostr keys");
-    MOSTRO_CONFIG
-        .set(s)
-        .expect("Failed to set Mostro global settings");
+pub fn init_mostro_settings(mut s: Settings) -> Result<(), MostroError> {
+    let keys = take_nsec_for_init(&mut s.nostr)?;
+    NOSTR_KEYS.set(keys).map_err(|_| {
+        MostroInternalErr(ServiceError::IOError(
+            "Mostro nostr keys already initialized".to_string(),
+        ))
+    })?;
+    MOSTRO_CONFIG.set(s).map_err(|_| {
+        MostroInternalErr(ServiceError::IOError(
+            "Mostro settings already initialized".to_string(),
+        ))
+    })?;
+    Ok(())
 }
 
 /// Parsed Mostro Nostr signing keys, initialized once at startup.

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,10 +1,12 @@
-use super::{DB_POOL, MOSTRO_CONFIG};
+use super::{DB_POOL, MOSTRO_CONFIG, NOSTR_KEYS};
+use crate::config::secret::take_nsec_for_init;
 use crate::config::types::{
     AntiAbuseBondSettings, CashuSettings, DatabaseSettings, EscrowMode, ExpirationSettings,
     LightningSettings, MostroSettings, NostrSettings, RpcSettings,
 };
 use crate::price::PriceSettings;
 use mostro_core::transport::Transport;
+use nostr_sdk::Keys;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -38,11 +40,20 @@ pub struct Settings {
     pub price: Option<PriceSettings>,
 }
 
-/// Initialize the global MOSTRO_CONFIG struct
-pub fn init_mostro_settings(s: Settings) {
+/// Initialize the global `MOSTRO_CONFIG` and `NOSTR_KEYS` structs.
+pub fn init_mostro_settings(mut s: Settings) {
+    let keys = take_nsec_for_init(&mut s.nostr).expect("Failed to parse nostr private key");
+    NOSTR_KEYS
+        .set(keys)
+        .expect("Failed to set Mostro nostr keys");
     MOSTRO_CONFIG
         .set(s)
         .expect("Failed to set Mostro global settings");
+}
+
+/// Parsed Mostro Nostr signing keys, initialized once at startup.
+pub fn get_mostro_keys() -> Option<&'static Keys> {
+    NOSTR_KEYS.get()
 }
 
 /// Get database pool for Mostro db operations to share across the thread

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -408,8 +408,8 @@ pub struct LightningSettings {
 pub struct NostrSettings {
     /// Nostr private key. Optional when `MOSTRO_NSEC_PRIVKEY` is provided via
     /// environment variable or `<settings_dir>/.env`.
-    #[serde(default)]
-    pub nsec_privkey: String,
+    #[serde(default, serialize_with = "crate::config::secret::serialize_nsec")]
+    pub nsec_privkey: secrecy::SecretString,
     /// Nostr relays list
     pub relays: Vec<String>,
 }

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -174,7 +174,7 @@ pub fn init_configuration_file(config_path: Option<String>) -> Result<(), Mostro
 
         apply_nsec_env_override(&mut settings);
         validate_mostro_settings(&settings)?;
-        init_mostro_settings(settings);
+        init_mostro_settings(settings)?;
         tracing::info!("Settings correctly loaded!");
         return Ok(());
     }
@@ -201,7 +201,7 @@ pub fn init_configuration_file(config_path: Option<String>) -> Result<(), Mostro
     settings.database.url = format!("sqlite://{}", settings_dir.join(DB_FILENAME).display());
 
     // Initialize the global settings variable
-    init_mostro_settings(settings);
+    init_mostro_settings(settings)?;
 
     tracing::info!("Settings correctly loaded!");
 

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -2,9 +2,8 @@
 /// This module provides utility functions for the config module.
 /// It includes functions to initialize the default settings directory and create a settings file from the template if it doesn't exist.
 /// It also includes functions to add a trailing slash to a path if it doesn't already have one.
-use crate::config::constants::{
-    ENV_FILENAME, MAX_DEV_FEE_PERCENTAGE, MIN_DEV_FEE_PERCENTAGE, NSEC_ENV_VAR,
-};
+use crate::config::constants::{ENV_FILENAME, MAX_DEV_FEE_PERCENTAGE, MIN_DEV_FEE_PERCENTAGE};
+use crate::config::secret::read_nsec_env_var;
 use crate::config::wizard;
 use crate::config::{init_mostro_settings, Settings};
 use mostro_core::error::MostroError::{self, *};
@@ -12,6 +11,7 @@ use mostro_core::error::ServiceError;
 use std::fs;
 use std::io::IsTerminal;
 use std::path::PathBuf;
+use zeroize::Zeroizing;
 
 const DB_FILENAME: &str = "mostro.db";
 
@@ -41,11 +41,8 @@ fn load_env_file(settings_dir: &std::path::Path) {
 /// value, override the nsec loaded from `settings.toml`. Whitespace is
 /// trimmed; blank values are ignored so the TOML stays the fallback.
 fn apply_nsec_env_override(settings: &mut Settings) {
-    if let Ok(nsec_from_env) = std::env::var(NSEC_ENV_VAR) {
-        let trimmed = nsec_from_env.trim();
-        if !trimmed.is_empty() {
-            settings.nostr.nsec_privkey = trimmed.to_string();
-        }
+    if let Some(nsec) = read_nsec_env_var() {
+        settings.nostr.nsec_privkey = nsec;
     }
 }
 
@@ -182,9 +179,12 @@ pub fn init_configuration_file(config_path: Option<String>) -> Result<(), Mostro
         return Ok(());
     }
 
-    // Read the file content
-    let contents = fs::read_to_string(&config_file_path)
-        .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
+    // Read the file content into a zeroizing buffer so TOML plaintext is wiped
+    // after parsing.
+    let contents = Zeroizing::new(
+        fs::read_to_string(&config_file_path)
+            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?,
+    );
 
     // Parse TOML content
     let mut settings: Settings = toml::from_str(&contents)
@@ -211,9 +211,11 @@ pub fn init_configuration_file(config_path: Option<String>) -> Result<(), Mostro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::constants::NSEC_ENV_VAR;
     use crate::config::types::{
         DatabaseSettings, LightningSettings, MostroSettings, NostrSettings, RpcSettings,
     };
+    use secrecy::{ExposeSecret, SecretString};
     use std::sync::Mutex;
 
     // Tests that read/write MOSTRO_NSEC_PRIVKEY must run serially because the
@@ -253,7 +255,7 @@ mod tests {
             database: DatabaseSettings::default(),
             lightning: LightningSettings::default(),
             nostr: NostrSettings {
-                nsec_privkey: nsec.to_string(),
+                nsec_privkey: SecretString::from(nsec.to_owned()),
                 relays: vec!["wss://relay.test".to_string()],
             },
             mostro: MostroSettings::default(),
@@ -274,7 +276,7 @@ mod tests {
         let mut settings = make_settings("nsec_from_toml");
         apply_nsec_env_override(&mut settings);
 
-        assert_eq!(settings.nostr.nsec_privkey, "nsec_from_env");
+        assert_eq!(settings.nostr.nsec_privkey.expose_secret(), "nsec_from_env");
     }
 
     #[test]
@@ -286,7 +288,10 @@ mod tests {
         let mut settings = make_settings("nsec_from_toml");
         apply_nsec_env_override(&mut settings);
 
-        assert_eq!(settings.nostr.nsec_privkey, "nsec_from_toml");
+        assert_eq!(
+            settings.nostr.nsec_privkey.expose_secret(),
+            "nsec_from_toml"
+        );
     }
 
     #[test]
@@ -297,7 +302,10 @@ mod tests {
         let mut settings = make_settings("nsec_from_toml");
         apply_nsec_env_override(&mut settings);
 
-        assert_eq!(settings.nostr.nsec_privkey, "nsec_from_toml");
+        assert_eq!(
+            settings.nostr.nsec_privkey.expose_secret(),
+            "nsec_from_toml"
+        );
     }
 
     #[test]
@@ -309,7 +317,10 @@ mod tests {
         let mut settings = make_settings("nsec_from_toml");
         apply_nsec_env_override(&mut settings);
 
-        assert_eq!(settings.nostr.nsec_privkey, "nsec_from_toml");
+        assert_eq!(
+            settings.nostr.nsec_privkey.expose_secret(),
+            "nsec_from_toml"
+        );
     }
 
     #[test]
@@ -321,7 +332,7 @@ mod tests {
         let mut settings = make_settings("nsec_from_toml");
         apply_nsec_env_override(&mut settings);
 
-        assert_eq!(settings.nostr.nsec_privkey, "nsec_from_env");
+        assert_eq!(settings.nostr.nsec_privkey.expose_secret(), "nsec_from_env");
     }
 
     #[test]
@@ -331,7 +342,7 @@ mod tests {
         let toml_without_nsec = r#"relays = ["wss://relay.test"]"#;
         let nostr: NostrSettings =
             toml::from_str(toml_without_nsec).expect("nsec_privkey should be optional in TOML");
-        assert_eq!(nostr.nsec_privkey, "");
+        assert!(nostr.nsec_privkey.expose_secret().is_empty());
         assert_eq!(nostr.relays, vec!["wss://relay.test"]);
     }
 }

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -5,6 +5,8 @@ use dialoguer::{Confirm, Input, Select};
 use mostro_core::error::MostroError::{self, MostroInternalErr};
 use mostro_core::error::ServiceError;
 use nostr_sdk::prelude::*;
+use secrecy::{ExposeSecret, SecretString};
+use zeroize::Zeroizing;
 
 use super::constants::{ENV_FILENAME, NSEC_ENV_VAR};
 use super::settings::Settings;
@@ -154,11 +156,14 @@ fn prompt_nostr_settings(settings_dir: &Path) -> Result<NostrSettings, MostroErr
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
     let nsec = if has_nsec {
-        Input::new()
-            .with_prompt("Enter your nsec private key")
-            .validate_with(|input: &String| validate_nsec(input))
-            .interact_text()
-            .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?
+        let input = Zeroizing::new(
+            Input::new()
+                .with_prompt("Enter your nsec private key")
+                .validate_with(|input: &String| validate_nsec(input))
+                .interact_text()
+                .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?,
+        );
+        SecretString::from(input.to_string())
     } else {
         let keys = Keys::generate();
         let nsec = keys
@@ -174,7 +179,7 @@ fn prompt_nostr_settings(settings_dir: &Path) -> Result<NostrSettings, MostroErr
         println!("  nsec: {}", nsec);
         println!("  npub: {}", npub);
 
-        nsec
+        SecretString::from(nsec)
     };
 
     let nsec_privkey = prompt_nsec_storage(settings_dir, &nsec)?;
@@ -200,7 +205,10 @@ fn prompt_nostr_settings(settings_dir: &Path) -> Result<NostrSettings, MostroErr
 
 /// Ask the user where to persist the nsec and return the value that should be
 /// written into `settings.toml` (empty string when the key is stored elsewhere).
-fn prompt_nsec_storage(settings_dir: &Path, nsec: &str) -> Result<String, MostroError> {
+fn prompt_nsec_storage(
+    settings_dir: &Path,
+    nsec: &SecretString,
+) -> Result<SecretString, MostroError> {
     println!("\nMostro supports two storage locations for your nsec. Both are fully supported;");
     println!("pick the one that fits your threat model and deployment setup. You can also");
     println!("provide MOSTRO_NSEC_PRIVKEY via the real process environment (systemd, Docker,");
@@ -221,21 +229,21 @@ fn prompt_nsec_storage(settings_dir: &Path, nsec: &str) -> Result<String, Mostro
         .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
     let nsec_in_toml = if selection == 0 {
-        write_env_file(&env_file_path, nsec)?;
+        write_env_file(&env_file_path, nsec.expose_secret())?;
         // Export the key into the current process so the daemon can use it
         // immediately after the wizard finishes, without requiring a restart.
-        std::env::set_var(NSEC_ENV_VAR, nsec);
+        std::env::set_var(NSEC_ENV_VAR, nsec.expose_secret());
         println!(
             "\n  Private key saved to {} (permissions 600).",
             env_file_path.display()
         );
-        String::new()
+        SecretString::default()
     } else {
         println!(
             "\n  Private key will be written inside {}.",
             settings_dir.join("settings.toml").display()
         );
-        nsec.to_string()
+        nsec.clone()
     };
 
     println!(

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use dialoguer::{Confirm, Input, Select};
+use dialoguer::{Confirm, Input, Password, Select};
 use mostro_core::error::MostroError::{self, MostroInternalErr};
 use mostro_core::error::ServiceError;
 use nostr_sdk::prelude::*;
@@ -157,10 +157,10 @@ fn prompt_nostr_settings(settings_dir: &Path) -> Result<NostrSettings, MostroErr
 
     let nsec = if has_nsec {
         let input = Zeroizing::new(
-            Input::new()
+            Password::new()
                 .with_prompt("Enter your nsec private key")
                 .validate_with(|input: &String| validate_nsec(input))
-                .interact_text()
+                .interact()
                 .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?,
         );
         SecretString::from(input.to_string())
@@ -176,8 +176,8 @@ fn prompt_nostr_settings(settings_dir: &Path) -> Result<NostrSettings, MostroErr
             .map_err(|e| MostroInternalErr(ServiceError::IOError(e.to_string())))?;
 
         println!("\nGenerated new Nostr keypair:");
-        println!("  nsec: {}", nsec);
-        println!("  npub: {}", npub);
+        println!("  npub: {npub}");
+        println!("  You will be prompted to store the private key securely next.");
 
         SecretString::from(nsec)
     };

--- a/src/db.rs
+++ b/src/db.rs
@@ -3336,6 +3336,7 @@ mod migration_and_query_tests {
     use sqlx::sqlite::SqlitePoolOptions;
 
     fn init_test_settings() {
+        crate::config::init_test_nostr_keys();
         let _ = MOSTRO_CONFIG.set(test_settings());
     }
 

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -214,8 +214,9 @@ mod tests {
         // The template ships a placeholder nsec; install a parseable one so
         // whichever module wins the MOSTRO_CONFIG race leaves get_keys()
         // usable for every other test.
-        test_settings.nostr.nsec_privkey =
-            "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd".to_string();
+        test_settings.nostr.nsec_privkey = secrecy::SecretString::from(
+            "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd",
+        );
         MOSTRO_CONFIG.get_or_init(|| test_settings);
     }
 

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -464,12 +464,14 @@ mod tests {
     use mostro_core::prelude::*;
 
     fn init_test_settings() {
+        crate::config::init_test_nostr_keys();
         // Defaults set `max_routing_fee = 0.002`.
         let _ = MOSTRO_CONFIG.set(Settings {
             database: Default::default(),
             nostr: crate::config::NostrSettings {
-                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
-                    .to_string(),
+                nsec_privkey: secrecy::SecretString::from(
+                    "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd",
+                ),
                 relays: vec![],
             },
             mostro: Default::default(),
@@ -616,6 +618,7 @@ mod offline_connector_tests {
     use fedimint_tonic_lnd::lnrpc::GetInfoResponse;
 
     fn init_test_settings() {
+        crate::config::init_test_nostr_keys();
         let _ = MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ async fn main() -> Result<()> {
     }
 
     if has_metadata {
-        if let Ok(metadata_ev) = EventBuilder::metadata(&metadata).sign_with_keys(&mostro_keys) {
+        if let Ok(metadata_ev) = EventBuilder::metadata(&metadata).sign_with_keys(mostro_keys) {
             let _ = client.send_event(&metadata_ev).await;
             tracing::info!("Published NIP-01 kind 0 metadata event");
         }

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -727,6 +727,7 @@ mod tests {
     /// rest of the test infrastructure.
     /// Uses `let _ =` to silently ignore if the OnceLock is already set by another test.
     fn init_test_settings() {
+        crate::config::init_test_nostr_keys();
         let _ = MOSTRO_CONFIG.set(test_settings());
     }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -528,7 +528,7 @@ impl PriceManager {
             Tag::expiration(Timestamp::from(expiration as u64)),
         ]);
 
-        let event = match crate::nip33::new_exchange_rates_event(&keys, &content, tags) {
+        let event = match crate::nip33::new_exchange_rates_event(keys, &content, tags) {
             Ok(e) => e,
             Err(e) => {
                 error!("price: failed to build exchange-rates event: {e}");

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -892,6 +892,7 @@ mod tests {
     use uuid::Uuid;
 
     fn init_test_settings() {
+        crate::config::init_test_nostr_keys();
         let _ = MOSTRO_CONFIG.set(test_settings());
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -806,6 +806,17 @@ pub async fn publish_dev_fee_audit_event(
     Ok(())
 }
 
+/// Return Mostro's parsed Nostr signing keys.
+///
+/// Keys are initialized once at startup by [`crate::config::init_mostro_settings`],
+/// which parses the nsec and stores the result in the global `NOSTR_KEYS`
+/// slot. Callers must ensure that initialization has completed before invoking
+/// this function (normally guaranteed by `settings_init()` in `main`).
+///
+/// Returns a borrowed `Keys` on success. Returns
+/// [`MostroInternalErr`](mostro_core::error::MostroError::MostroInternalErr) with
+/// [`ServiceError::NostrError`] when `NOSTR_KEYS` has not been set — for example
+/// in unit tests that skip the full configuration bootstrap.
 pub fn get_keys() -> Result<&'static Keys, MostroError> {
     crate::config::get_mostro_keys().ok_or_else(|| {
         MostroInternalErr(ServiceError::NostrError(

--- a/src/util.rs
+++ b/src/util.rs
@@ -789,7 +789,7 @@ pub async fn publish_dev_fee_audit_event(
     // Create and sign event
     let event = EventBuilder::new(nostr_sdk::Kind::Custom(DEV_FEE_AUDIT_EVENT_KIND), "")
         .tags(tags)
-        .sign_with_keys(&keys)
+        .sign_with_keys(keys)
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
 
     // Publish event to relays
@@ -806,16 +806,12 @@ pub async fn publish_dev_fee_audit_event(
     Ok(())
 }
 
-pub fn get_keys() -> Result<Keys, MostroError> {
-    let nostr_settings = Settings::get_nostr();
-    // nostr private key
-    match Keys::parse(&nostr_settings.nsec_privkey) {
-        Ok(my_keys) => Ok(my_keys),
-        Err(e) => {
-            tracing::error!("Failed to parse nostr private key: {}", e);
-            Err(MostroInternalErr(ServiceError::NostrError(e.to_string())))
-        }
-    }
+pub fn get_keys() -> Result<&'static Keys, MostroError> {
+    crate::config::get_mostro_keys().ok_or_else(|| {
+        MostroInternalErr(ServiceError::NostrError(
+            "Nostr keys not initialized".to_string(),
+        ))
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1079,7 +1075,7 @@ pub async fn invoice_subscribe(hash: Vec<u8>, request_id: Option<u64>) -> Result
                             continue;
                         }
                     };
-                    if let Err(e) = flow::hold_invoice_paid(&hash, request_id, &pool, &keys).await {
+                    if let Err(e) = flow::hold_invoice_paid(&hash, request_id, &pool, keys).await {
                         info!("Invoice flow error {e}");
                     } else {
                         info!("Invoice with hash {hash} accepted!");


### PR DESCRIPTION
## Summary
- Wrap `nsec_privkey` in `secrecy::SecretString` with `zeroize` for transient buffers (TOML load, wizard input, env reads).
- Parse Mostro `Keys` once at startup into `NOSTR_KEYS`, then wipe the nsec from global `Settings` so `MOSTRO_CONFIG` / `Arc<Settings>` clones no longer retain a duplicate plaintext copy.
- Change `get_keys()` to return the cached `&'static Keys` instead of re-parsing on every call.

## Residual exposure (unchanged)
- Process environment (`MOSTRO_NSEC_PRIVKEY`) and on-disk `.env` / `settings.toml` remain plaintext by design.
- `nostr_sdk::Keys` internal representation is not zeroized (upstream).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Protected Nostr private keys with secure, automatically cleared storage.
  * Prevented private keys from appearing in generated console output.
  * Improved environment-variable and configuration-file handling for sensitive credentials.

* **Reliability**
  * Added clearer validation and error handling when Nostr credentials are missing or invalid.
  * Centralized Nostr key initialization for consistent signing across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->