### PR TITLE
fix(price): repair test-only price seeding broken by #753/#770 merge skew

### DIFF
--- a/src/bitcoin_price.rs
+++ b/src/bitcoin_price.rs
@@ -21,16 +21,17 @@ impl BitcoinPriceManager {
         crate::price::get_bitcoin_price(currency)
     }
 
-    /// Test-only: seed the in-memory price cache so unit tests in other
-    /// modules can exercise price-dependent paths (e.g. range-order bond
-    /// sizing) deterministically without hitting the network. Use a unique
-    /// `currency` per test to avoid cross-test interference on the shared
-    /// static.
+    /// Test-only: seed the price-override map consulted by
+    /// [`crate::price::get_bitcoin_price`] so unit tests in other modules
+    /// can exercise price-dependent paths (e.g. range-order bond sizing)
+    /// deterministically without hitting the network or installing the
+    /// global `PriceManager`. Use a unique `currency` per test to avoid
+    /// cross-test interference on the shared map.
     #[cfg(test)]
     pub(crate) fn set_price_for_test(currency: &str, price: f64) {
-        BITCOIN_PRICES
+        crate::price::test_price_overrides()
             .write()
-            .expect("price cache write lock")
+            .expect("price override write lock")
             .insert(currency.to_string(), price);
     }
 }

--- a/src/price/mod.rs
+++ b/src/price/mod.rs
@@ -27,6 +27,22 @@ pub use store::{AggregatedPrice, PriceError, PriceStore};
 
 use mostro_core::error::{MostroError, ServiceError};
 
+/// Test-only per-currency price overrides consulted by
+/// [`get_bitcoin_price`] before the global manager. Unit tests in other
+/// modules (e.g. range-order bond sizing in `util.rs`) seed this via
+/// `BitcoinPriceManager::set_price_for_test` instead of installing the
+/// global [`PriceManager`] — its `OnceLock` would leak one test's
+/// configuration into every other test in the binary. Tests use a unique
+/// currency code each to avoid cross-test interference on the shared map.
+#[cfg(test)]
+pub(crate) fn test_price_overrides(
+) -> &'static std::sync::RwLock<std::collections::HashMap<String, f64>> {
+    static OVERRIDES: std::sync::OnceLock<
+        std::sync::RwLock<std::collections::HashMap<String, f64>>,
+    > = std::sync::OnceLock::new();
+    OVERRIDES.get_or_init(|| std::sync::RwLock::new(std::collections::HashMap::new()))
+}
+
 /// Read a currency's per-BTC price from the global [`PriceManager`].
 ///
 /// This is the Phase 1 entry point for consumers (`util::get_bitcoin_price`
@@ -36,6 +52,14 @@ use mostro_core::error::{MostroError, ServiceError};
 /// legacy code returned when `BITCOIN_PRICES` was empty, so callers behave
 /// identically.
 pub fn get_bitcoin_price(currency: &str) -> Result<f64, MostroError> {
+    #[cfg(test)]
+    if let Some(price) = test_price_overrides()
+        .read()
+        .expect("price override read lock")
+        .get(currency)
+    {
+        return Ok(*price);
+    }
     match PriceManager::global() {
         Some(m) => m.get_price(currency),
         None => Err(MostroError::MostroInternalErr(ServiceError::NoAPIResponse)),

--- a/src/util.rs
+++ b/src/util.rs
@@ -1598,6 +1598,7 @@ pub async fn notify_taker_reputation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bitcoin_price::BitcoinPriceManager;
     use mostro_core::message::{Message, MessageKind};
     use mostro_core::order::Order;
     use sqlx::sqlite::SqlitePoolOptions;


### PR DESCRIPTION
## Problem

`main` does not compile under `cargo test` (`cargo check --all-targets` / `cargo clippy --all-targets`) since the last two merges crossed:

- #753 removed the `BITCOIN_PRICES` static when it migrated price reads to the new `PriceManager`.
- #770 (developed in parallel, merged after) added `BitcoinPriceManager::set_price_for_test`, which writes to that now-removed static, plus a `util.rs` test that calls it.

```
error[E0425]: cannot find value `BITCOIN_PRICES` in this scope --> src/bitcoin_price.rs:31:9
error[E0433]: failed to resolve: use of undeclared type `BitcoinPriceManager` --> src/util.rs:1936:9
```

## Fix

Re-point the test seam at a small `#[cfg(test)]` override map (`price::test_price_overrides`) consulted by `price::get_bitcoin_price` **before** the global manager:

- Unit tests keep seeding deterministic prices per unique currency code, exactly as the #770 test intended.
- No global `PriceManager` install in tests — its `OnceLock` would leak one test's configuration into every other test in the binary.
- Zero impact on non-test builds: the map and the lookup are both `cfg(test)`.

## Checks

- `cargo test`: 426 passed
- `cargo clippy --all-targets --all-features`: clean
- `cargo fmt`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal test price override handling for improved test isolation and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->