### PR TITLE
feat(bond): Phase 7 — maker timeout slash

### DIFF
--- a/docs/ANTI_ABUSE_BOND.md
+++ b/docs/ANTI_ABUSE_BOND.md
@@ -191,10 +191,10 @@ slash path.
 | 3 | Payout flow: `Action::AddBondInvoice` to winner, routing-fee estimation, retries | 2 | ✅ shipped (PR #738) |
 | 3.5 | Payout confirmation to the winner: `BondInvoiceAccepted` (receipt) + `BondPayoutCompleted` (paid) + explicit "already paid" refusal | 3 | ✅ shipped (PR #743) |
 | 4 | Timeout slash for taker bond (`slash_on_waiting_timeout`) + `Action::BondSlashed` forfeiture notice | 3 | ✅ shipped (PR #744) |
-| 4.5 | Re-prompt the winner for a fresh payout invoice after `send_payment` retries exhaust, instead of stranding the bond in `Failed` ([issue #750](https://github.com/MostroP2P/mostro/issues/750)) | 3 | pending |
+| 4.5 | Re-prompt the winner for a fresh payout invoice after `send_payment` retries exhaust, instead of stranding the bond in `Failed` ([issue #750](https://github.com/MostroP2P/mostro/issues/750)) | 3 | ✅ shipped (PR #755) |
 | 5 | Maker bond (non-range): lock + dispute slash reusing Phase 2/3 | 3 | ✅ shipped (PR #767) |
 | 6 | Maker bond for **range orders** with proportional slashes | 5 | ✅ shipped (PR #770) |
-| 7 | Timeout slash for maker bond | 5 | pending |
+| 7 | Timeout slash for maker bond | 5 | ✅ shipped (PR #775) |
 | 8 | Public config exposure (Mostro info event) + operator docs polish | 7 | pending |
 
 Phases 4, 5, 6, 7 can partially overlap in time but must land in this
@@ -206,16 +206,17 @@ orthogonal to the slash-direction phases — it can land any time after
 Phase 3, and is numbered 4.5 only because it was reported from field
 testing after Phase 4 shipped.
 
-**Status as of this revision.** Phases 0 through 5 (including 4.5) are
+**Status as of this revision.** Phases 0 through 6 (including 4.5) are
 merged on `main` (PRs #712, #719, #736, #737, #738, #743, #744, #755,
-#767), and Phase 6 is implemented. The `mostro-core` pin in `Cargo.toml`
-is **0.12.1**, which carries every protocol variant those phases need
-(`Status::WaitingTakerBond`, `Status::WaitingMakerBond`,
-`Action::PayBondInvoice`, `Payload::BondResolution`,
-`Action::AddBondInvoice`, `Payload::BondPayoutRequest`,
-`Action::BondInvoiceAccepted`, `Action::BondPayoutCompleted`,
-`Action::BondSlashed`). Phase 6 is daemon-only (no protocol/schema
-change). Phases 7–8 are not yet implemented.
+#767, #770), and Phase 7 is implemented (PR #775). The `mostro-core` pin
+in `Cargo.toml` is **0.12.1**, which carries every protocol variant
+those phases need (`Status::WaitingTakerBond`,
+`Status::WaitingMakerBond`, `Action::PayBondInvoice`,
+`Payload::BondResolution`, `Action::AddBondInvoice`,
+`Payload::BondPayoutRequest`, `Action::BondInvoiceAccepted`,
+`Action::BondPayoutCompleted`, `Action::BondSlashed`). Phases 6 and 7
+are daemon-only (no protocol/schema change). Phase 8 is not yet
+implemented.
 
 ---
 
@@ -1914,8 +1915,9 @@ carries `parent_bond_id` / `child_order_id` / `slashed_share_sats`).
   `admin_cancel` (a dispute ends the range), the three `cancel.rs` order-
   termination paths, and the scheduler's `pending_expiry`. It is idempotent
   (a CAS `Locked → Slashed`) and a no-op for non-range / already-resolved
-  bonds. Maker-responsible **timeout** slashes for range bonds land in
-  Phase 7; until then a maker-timeout cancel releases (no slash).
+  bonds. Maker-responsible **timeout** slashes for range bonds shipped in
+  Phase 7 (a per-slice child slash via this same path; the scheduler's
+  terminal cancel branch then runs the close).
 - **"One slash row per slice" is enforced at the schema level.** Besides the
   atomic `INSERT ... WHERE NOT EXISTS` in `record_maker_slice_slash` (which
   already wins/loses the TOCTOU race correctly), a partial UNIQUE index on
@@ -2035,7 +2037,7 @@ the maker.
 
 ---
 
-## 12. Phase 7 — Maker timeout slash
+## 12. Phase 7 — Maker timeout slash ✅ Completed
 
 Gate: `enabled && slash_on_waiting_timeout && apply_to ∈ { make, both }`.
 
@@ -2051,6 +2053,49 @@ Phase 6 partial-slash path.
 
 Tests mirror Phase 4 from the maker side; the "no slash" rows in the
 §9.2 table become "slash maker bond".
+
+**Implementation notes (as shipped, PR #775).** Daemon-only — no
+`mostro-core` change, no migration (reuses `Action::BondSlashed` from
+Phase 4 and the Phase 6 child-slash schema).
+
+- **The gate is per responsible role.** `slash_or_release_on_timeout`
+  maps the §9.2 responsible side to maker/taker via the §3.1 order-kind
+  mapping and checks `apply_to` against *that* posting role
+  (`applies_to_maker()` / `applies_to_taker()`). A leftover `Locked`
+  maker bond under `apply_to = take` therefore still releases — the
+  gate is about who the node's policy covers, not "any side has a
+  bond".
+- **Range-aware bond resolution.** The responsible bond resolves
+  through the Phase 2/6 `resolve_slash_target` primitive: pubkey match
+  on the order's own bonds first, then the range-root walk for the
+  maker side (the maker bond of a range order lives on the root, not
+  the slice).
+- **Non-range maker slash** settles the HTLC inline via the Phase 2
+  `slash_one` primitive and confirms through the durable
+  `slashed_reason = Timeout` witness, exactly like the taker path.
+- **Range maker slash** records a proportional child row
+  (`record_maker_slice_slash`, `reason = Timeout`) and leaves the
+  parent HTLC `Locked` — settle-at-close, per Phase 6. The dispatch
+  reports the *child* row, so the `Action::BondSlashed` notice carries
+  the slice's slashed amount. `record_maker_slice_slash` now returns
+  whether it actually inserted; the notice fires only on a fresh
+  insert, so a scheduler retry (order persist failed, next tick
+  re-runs) never re-notifies — the range parent stays `Locked` by
+  design, so the Phase 4 "no `Locked` bond on re-entry" guarantee
+  cannot provide this and the insert flag does instead.
+- **Range close on the terminal cancel.** A maker-responsible timeout
+  cancels the order outright (no remainder is spawned on a cancel), so
+  the range terminates. The scheduler's cancel branch runs
+  `resolve_range_maker_bond_at_close_or_warn` right after the
+  `Canceled` status persists: the parent settles once and the
+  per-slice counterparty shares + maker refund distribute promptly via
+  Phase 3, instead of waiting for the 5-minute reconciliation sweep
+  (which remains the backstop on transient failure). The republish
+  branch never closes — the order returns to the book with the maker
+  still committed and its bond `Locked`.
+- **The timeout release loop retains a range maker parent** alongside
+  the existing retain-on-republish carve-out: the parent spans the
+  whole range and is only ever resolved at range close.
 
 ---
 

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -375,17 +375,25 @@ async fn order_has_range_maker_bond(
 /// Responsibility maps directly from the waiting state:
 /// `WaitingBuyerInvoice → buyer`, `WaitingPayment → seller`. The
 /// buyer/seller → bond-row resolution then reuses the §3.1 order-kind
-/// mapping baked into [`apply_bond_resolution`] (a slash flag is matched
-/// against `order.buyer_pubkey` / `order.seller_pubkey`, which equal the
-/// bonded taker's trade pubkey). So under `apply_to = "take"` only the
-/// taker side ever carries a bond, and the maker-responsible rows of the
-/// §9.2 table fall through to release.
+/// mapping (a slash side is matched against `order.buyer_pubkey` /
+/// `order.seller_pubkey`, with the Phase 6 range-root fallback for a
+/// maker bond living on the range root). Phase 4 armed the taker side of
+/// the §9.2 table; Phase 7 fills the maker-responsible rows — the gate
+/// checks `apply_to` against the *responsible* party's posting role.
 ///
 /// A slash happens **only** when all of the following hold:
 /// - the feature is enabled, `slash_on_waiting_timeout = true`, and
-///   `apply_to` covers the taker;
+///   `apply_to` covers the responsible party's posting role (taker since
+///   Phase 4, maker since Phase 7);
 /// - the order is in a waiting state;
 /// - the responsible party holds a `Locked` bond.
+///
+/// A maker-responsible slash on a **range** order goes through the Phase 6
+/// partial-slash path: a proportional child row is recorded and the parent
+/// HTLC stays `Locked` (the single settle happens at range close — the
+/// scheduler's cancel branch runs the close right after the order
+/// terminates, with the reconciliation sweep as backstop). The returned
+/// bond is then the *child* row, carrying the slice's slashed amount.
 ///
 /// Otherwise every active bond is released. This preserves today's
 /// behaviour when the feature is off, when the bond belongs to the
@@ -469,21 +477,35 @@ pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
     // republish-vs-cancel split (keep the two in sync).
     let republishes = order_republishes_on_timeout(order);
 
-    // Gate the slash. `apply_to` is a posting-timing switch; Phase 4 is
-    // taker-only, so we check `applies_to_taker` (Phase 7 widens this to
-    // the maker). When the gate is closed we still release — bonds left
+    // Gate the slash per responsible role. `apply_to` is a posting-timing
+    // switch: Phase 4 armed the taker side, Phase 7 widens to the maker —
+    // the slash only arms when `apply_to` covers the *responsible* party's
+    // posting role. When the gate is closed we still release — bonds left
     // over from a prior enabled period must drain regardless (but a
     // republish still retains the maker bond).
-    let slash_armed = bond_cfg
-        .is_some_and(|c| c.enabled && c.slash_on_waiting_timeout && c.apply_to.applies_to_taker());
+    let responsible_is_maker = side_is_maker(order, side)?;
+    let slash_armed = bond_cfg.is_some_and(|c| {
+        c.enabled
+            && c.slash_on_waiting_timeout
+            && if responsible_is_maker {
+                c.apply_to.applies_to_maker()
+            } else {
+                c.apply_to.applies_to_taker()
+            }
+    });
     if !slash_armed {
         release_on_timeout(pool, order.id, republishes).await;
         return Ok(None);
     }
 
-    // Does the responsible party hold a `Locked` bond?
+    // Does the responsible party hold a `Locked` bond? Phase 7: a range
+    // order's maker bond lives on the range *root*, so the resolver must be
+    // range-aware (`resolve_slash_target` falls back to the root walk for
+    // the maker side; the taker side resolves on this order's bonds alone,
+    // exactly as Phase 4 did).
     let bonds = find_active_bonds_for_order(pool, order.id).await?;
-    let Some(responsible) = resolve_locked_bond(order, &bonds, side).cloned() else {
+    let is_range = order_has_range_maker_bond(pool, order).await?;
+    let Some(responsible) = resolve_slash_target(pool, order, &bonds, side, is_range).await? else {
         // Responsible party has no bond (e.g. the maker under
         // `apply_to = take`), or the bond already moved out of `Locked`.
         // No slash; release whatever is still active on the order
@@ -492,29 +514,71 @@ pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
         return Ok(None);
     };
 
-    // Settle the responsible bond's HTLC + CAS → PendingPayout(Timeout)
-    // (the Phase 2 `slash_one` primitive), then resolve the remaining
-    // active bonds: release them — but on a republish retain the maker's
-    // still-`Locked` bond, which the abandoning taker's timeout must not
-    // disturb. (We intentionally do **not** route this through
-    // `apply_bond_resolution`, which always releases every non-slashed
-    // bond — that is correct for a terminal dispute resolution but would
-    // wrongly release the maker on a republish.)
+    // Slash the responsible bond, then resolve the remaining active bonds:
+    // release them — but on a republish retain the maker's still-`Locked`
+    // bond, which the abandoning taker's timeout must not disturb. (We
+    // intentionally do **not** route this through `apply_bond_resolution`,
+    // which always releases every non-slashed bond — that is correct for a
+    // terminal dispute resolution but would wrongly release the maker on a
+    // republish.)
+    //
+    // Two slash shapes (mirroring `apply_bond_resolution`):
+    // - **Range maker** (Phase 7 × Phase 6): record a proportional child
+    //   slash row and leave the parent HTLC `Locked` — the single settle
+    //   happens at range close (`resolve_range_maker_bond_at_close`, run
+    //   by the scheduler's cancel branch / reconciliation sweep once the
+    //   order terminates). The notice-worthy row is the *child* (it carries
+    //   the slice's slashed amount), and only when this call actually
+    //   inserted it — an idempotent re-run must not re-notify.
+    // - **Everything else** (taker, non-range maker): settle the HTLC
+    //   inline via the Phase 2 `slash_one` primitive and confirm through
+    //   the durable `slashed_reason = Timeout` witness.
     let node_share_pct = Settings::get_bond().map_or(0.0, |c| c.slash_node_share_pct);
-    slash_one(
-        pool,
-        ln_client,
-        &responsible,
-        BondSlashReason::Timeout,
-        node_share_pct,
-    )
-    .await;
+    let slashed_row: Option<Bond> = if responsible_is_maker && is_range {
+        let root = find_range_root_order(pool, order.clone()).await?;
+        let inserted = record_maker_slice_slash(
+            pool,
+            order,
+            &root,
+            &responsible,
+            BondSlashReason::Timeout,
+            node_share_pct,
+        )
+        .await?;
+        if inserted {
+            find_slice_slash_child(pool, responsible.id, order.id).await?
+        } else {
+            None
+        }
+    } else {
+        slash_one(
+            pool,
+            ln_client,
+            &responsible,
+            BondSlashReason::Timeout,
+            node_share_pct,
+        )
+        .await;
+        // Confirm the slash actually landed before claiming it: a transient
+        // settle failure leaves the bond `Locked` (`slash_one` is
+        // best-effort), and we must never tell a user their bond was
+        // forfeited while the HTLC is still theirs.
+        if timeout_slash_confirmed(pool, responsible.id).await? {
+            Some(responsible.clone())
+        } else {
+            None
+        }
+    };
+
     let maker = BondRole::Maker.to_string();
     for bond in bonds.iter() {
         if bond.id == responsible.id {
             continue;
         }
-        if republishes && bond.role == maker {
+        // Retain the maker bond when the order survives (republish) or when
+        // it is a range parent — the latter spans the whole range and is
+        // resolved only at range close, never inline here.
+        if bond.role == maker && (republishes || is_range) {
             continue;
         }
         if let Err(e) = release_bond(pool, bond).await {
@@ -526,26 +590,42 @@ pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
         }
     }
 
-    // Confirm the slash actually landed before claiming it: a transient
-    // settle failure leaves the bond `Locked` (`slash_one` is best-effort),
-    // and we must never tell a user their bond was forfeited while the HTLC
-    // is still theirs.
-    if timeout_slash_confirmed(pool, responsible.id).await? {
-        info!(
-            bond_id = %responsible.id,
-            order_id = %order.id,
-            role = %responsible.role,
-            "Bond slashed on waiting-state timeout"
-        );
-        Ok(Some(responsible))
-    } else {
-        warn!(
-            bond_id = %responsible.id,
-            order_id = %order.id,
-            "timeout slash did not land (bond still Locked); no forfeiture notice sent"
-        );
-        Ok(None)
+    match slashed_row {
+        Some(slashed) => {
+            info!(
+                bond_id = %slashed.id,
+                order_id = %order.id,
+                role = %slashed.role,
+                "Bond slashed on waiting-state timeout"
+            );
+            Ok(Some(slashed))
+        }
+        None => {
+            warn!(
+                bond_id = %responsible.id,
+                order_id = %order.id,
+                "timeout slash did not land (still Locked / already slashed); no forfeiture notice sent"
+            );
+            Ok(None)
+        }
     }
+}
+
+/// Fetch the Phase 6 child slash row recorded for `(parent_bond_id,
+/// slice_order_id)` — the row the Phase 7 range-maker timeout path returns
+/// to the caller for the `BondSlashed` notice (it carries the slice's
+/// proportional slashed amount, not the whole parent bond).
+async fn find_slice_slash_child(
+    pool: &Pool<Sqlite>,
+    parent_bond_id: Uuid,
+    slice_order_id: Uuid,
+) -> Result<Option<Bond>, MostroError> {
+    sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE parent_bond_id = ? AND child_order_id = ?")
+        .bind(parent_bond_id)
+        .bind(slice_order_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
 }
 
 /// Confirm a timeout slash actually landed on `bond_id`, regardless of
@@ -755,6 +835,12 @@ async fn slash_one<L: SettleLightning + Send>(
 /// publication and take), times the locked bond amount. The child row's
 /// `order_id` and maker-side `pubkey` are the slice's, so the Phase 3
 /// recipient resolver pays the slice's *other* side (the winner).
+///
+/// Returns `Ok(true)` when a child row was actually inserted by this call,
+/// `Ok(false)` on every idempotent skip (slice already slashed, parent no
+/// longer `Locked`, degenerate share). The Phase 7 timeout path keys the
+/// one-shot `BondSlashed` notice on this so a scheduler retry never
+/// re-notifies the maker for a slash that already landed.
 async fn record_maker_slice_slash(
     pool: &Pool<Sqlite>,
     slice: &Order,
@@ -762,7 +848,7 @@ async fn record_maker_slice_slash(
     parent_bond: &Bond,
     reason: BondSlashReason,
     node_share_pct: f64,
-) -> Result<(), MostroError> {
+) -> Result<bool, MostroError> {
     let kind = slice.get_order_kind().map_err(MostroInternalErr)?;
     let maker_slice_pubkey = match kind {
         Kind::Sell => slice.seller_pubkey.as_deref(),
@@ -774,7 +860,7 @@ async fn record_maker_slice_slash(
             slice_order_id = %slice.id,
             "record_maker_slice_slash: slice has no maker-side pubkey; skipping"
         );
-        return Ok(());
+        return Ok(false);
     };
     let Some(max_fiat) = root.max_amount.filter(|m| *m > 0) else {
         warn!(
@@ -782,7 +868,7 @@ async fn record_maker_slice_slash(
             root_order_id = %root.id,
             "record_maker_slice_slash: range root missing positive max_amount; skipping"
         );
-        return Ok(());
+        return Ok(false);
     };
 
     // Price-invariant proportional share, clamped so the cumulative slashed
@@ -798,7 +884,7 @@ async fn record_maker_slice_slash(
             raw, remaining,
             "record_maker_slice_slash: computed non-positive / over-allocated share; skipping"
         );
-        return Ok(());
+        return Ok(false);
     }
 
     let now = Utc::now().timestamp();
@@ -871,7 +957,7 @@ async fn record_maker_slice_slash(
                 slice_order_id = %slice.id,
                 "record_maker_slice_slash: slice already slashed (unique index); skipping duplicate"
             );
-            return Ok(());
+            return Ok(false);
         }
         Err(e) => {
             return Err(MostroInternalErr(ServiceError::DbAccessError(
@@ -888,7 +974,7 @@ async fn record_maker_slice_slash(
             slice_order_id = %slice.id,
             "record_maker_slice_slash: slice already slashed or parent no longer Locked; skipping"
         );
-        return Ok(());
+        return Ok(false);
     }
 
     // Recompute the parent's running total from the authoritative slice
@@ -916,7 +1002,7 @@ async fn record_maker_slice_slash(
         slash_amount,
         "Phase 6: recorded proportional maker slice slash (parent HTLC stays Locked)"
     );
-    Ok(())
+    Ok(true)
 }
 
 /// Phase 6 — resolve a maker bond when its order (range chain) terminates
@@ -2428,6 +2514,256 @@ mod tests {
         assert_eq!(
             read_bond_state(&pool, bond.id).await,
             BondState::Released.to_string()
+        );
+    }
+
+    // ── Phase 7 — maker timeout slash ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn timeout_maker_responsible_slashes_maker_bond_sell_order() {
+        // Phase 7: sell order, WaitingPayment — the seller is responsible
+        // and on a sell order the seller is the *maker*. With apply_to=make
+        // armed, the maker's bond is slashed with reason=Timeout (the §9.2
+        // "no slash" row filled in by Phase 7).
+        let pool = setup_pool().await;
+        let order = waiting_order(Kind::Sell, maker_pk(), taker_pk(), Status::WaitingPayment);
+        insert_order_row(&pool, &order).await;
+        let maker_bond = insert_bond_with_role(
+            &pool,
+            order.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Locked,
+        )
+        .await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Make);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result.map(|b| b.id),
+            Some(maker_bond.id),
+            "must report the slashed maker bond for notification"
+        );
+        assert_eq!(
+            ln.calls(),
+            vec![stub_preimage()],
+            "the non-range maker slash settles the HTLC inline"
+        );
+        let row: (String, Option<String>) =
+            sqlx::query_as("SELECT state, slashed_reason FROM bonds WHERE id = ?")
+                .bind(maker_bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, BondState::PendingPayout.to_string());
+        assert_eq!(row.1.as_deref(), Some("timeout"));
+    }
+
+    #[tokio::test]
+    async fn timeout_maker_responsible_buy_order_slashes_maker_and_releases_taker() {
+        // Phase 7 buy-order mirror: WaitingBuyerInvoice → buyer responsible,
+        // and on a buy order the buyer is the maker. Under apply_to=both the
+        // taker (seller) also holds a bond — it belongs to the
+        // non-responsible party, so it must be released, never slashed, and
+        // never retained (the timeout cancels the order outright).
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Buy,
+            taker_pk(),
+            maker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let maker_bond = insert_bond_with_role(
+            &pool,
+            order.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Locked,
+        )
+        .await;
+        let taker_bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Both);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert_eq!(result.map(|b| b.id), Some(maker_bond.id));
+        assert_eq!(
+            read_bond_state(&pool, maker_bond.id).await,
+            BondState::PendingPayout.to_string(),
+            "maker bond slashed on maker-responsible timeout"
+        );
+        assert_eq!(
+            read_bond_state(&pool, taker_bond.id).await,
+            BondState::Released.to_string(),
+            "the non-responsible taker's bond is released on the terminal cancel"
+        );
+        assert_eq!(
+            ln.calls(),
+            vec![stub_preimage()],
+            "only the slashed maker HTLC is settled"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_maker_slash_skipped_when_apply_to_take_only() {
+        // Per-role gate: a maker-responsible timeout with a leftover Locked
+        // maker bond (posted during a prior apply_to=make period) must NOT
+        // slash under apply_to=take — the gate checks the responsible
+        // party's posting role, not "any side is covered". The bond drains
+        // via release instead.
+        let pool = setup_pool().await;
+        let order = waiting_order(Kind::Sell, maker_pk(), taker_pk(), Status::WaitingPayment);
+        insert_order_row(&pool, &order).await;
+        let maker_bond = insert_bond_with_role(
+            &pool,
+            order.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Locked,
+        )
+        .await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Take);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(result.is_none());
+        assert!(ln.calls().is_empty());
+        assert_eq!(
+            read_bond_state(&pool, maker_bond.id).await,
+            BondState::Released.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_range_maker_slash_records_child_and_keeps_parent_locked() {
+        // Phase 7 × Phase 6: a maker-responsible timeout on a *range* order
+        // goes through the partial-slash path — a proportional child row is
+        // recorded (slice fiat 40 / max 100 × bond 1000 = 400, reason
+        // timeout) and the parent HTLC stays Locked; the single settle
+        // happens at range close, never here. The reported bond is the
+        // child (it carries the slice's slashed amount for the notice).
+        // The taker's own bond is released on the terminal cancel.
+        let pool = setup_pool().await;
+        let mut root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        root.status = Status::WaitingPayment.to_string();
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        let taker_bond = insert_bond(&pool, root.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Both);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &root, Some(&cfg))
+            .await
+            .unwrap();
+
+        let child = result.expect("range maker timeout must report the child slash row");
+        assert_eq!(child.parent_bond_id, Some(parent.id));
+        assert_eq!(child.child_order_id, Some(root.id));
+        assert_eq!(child.amount_sats, 400, "proportional slice share");
+        assert_eq!(child.state, BondState::PendingPayout.to_string());
+        assert_eq!(child.slashed_reason.as_deref(), Some("timeout"));
+        assert_eq!(child.pubkey, maker_pk(), "the maker is the slashed party");
+
+        assert!(
+            ln.calls().is_empty(),
+            "the parent HTLC must NOT be settled mid-range (settle-at-close)"
+        );
+        let parent_row = find_bond_by_id(&pool, parent.id).await.unwrap().unwrap();
+        assert_eq!(parent_row.state, BondState::Locked.to_string());
+        assert_eq!(parent_row.slashed_share_sats, 400);
+        assert_eq!(
+            read_bond_state(&pool, taker_bond.id).await,
+            BondState::Released.to_string(),
+            "taker bond released on the terminal cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_range_maker_slash_resolves_root_bond_from_descendant_slice() {
+        // The maker bond lives on the range *root*; a timeout on a
+        // descendant slice (range remainder spawned by an earlier release)
+        // must walk `range_parent_id` to find it and record the child slash
+        // against the slice's own order id.
+        let pool = setup_pool().await;
+        let root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 0, 10, 100);
+        insert_range_order_row(&pool, &root).await;
+        let mut slice = range_slice(Kind::Sell, maker_pk(), taker_pk(), 25, 10, 100);
+        slice.status = Status::WaitingPayment.to_string();
+        slice.range_parent_id = Some(root.id);
+        insert_range_order_row(&pool, &slice).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Make);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &slice, Some(&cfg))
+            .await
+            .unwrap();
+
+        let child = result.expect("slice timeout must resolve the root's maker bond");
+        assert_eq!(child.parent_bond_id, Some(parent.id));
+        assert_eq!(child.child_order_id, Some(slice.id));
+        assert_eq!(child.amount_sats, 250, "25/100 of the 1000-sat bond");
+        assert!(ln.calls().is_empty());
+        assert_eq!(
+            read_bond_state(&pool, parent.id).await,
+            BondState::Locked.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_range_maker_slash_is_idempotent_per_slice() {
+        // A slice whose share was already slashed (e.g. by a dispute, or by
+        // a prior tick whose order-persist failed) must not be slashed
+        // twice, and — crucially for the notice — the dispatch must report
+        // None so the maker is never re-notified for the same slash.
+        let pool = setup_pool().await;
+        let mut root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        root.status = Status::WaitingPayment.to_string();
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        // Pre-existing child slash for this same slice.
+        let inserted = record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.0,
+        )
+        .await
+        .unwrap();
+        assert!(inserted, "fixture insert must land");
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Make);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &root, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "an already-slashed slice must not re-notify"
+        );
+        assert!(ln.calls().is_empty());
+        let children = find_child_slashes_for_parent(&pool, parent.id)
+            .await
+            .unwrap();
+        assert_eq!(children.len(), 1, "no duplicate child row");
+        assert_eq!(
+            children[0].slashed_reason.as_deref(),
+            Some("lost-dispute"),
+            "the original slash row is untouched"
         );
     }
 

--- a/src/bitcoin_price.rs
+++ b/src/bitcoin_price.rs
@@ -21,16 +21,17 @@ impl BitcoinPriceManager {
         crate::price::get_bitcoin_price(currency)
     }
 
-    /// Test-only: seed the in-memory price cache so unit tests in other
-    /// modules can exercise price-dependent paths (e.g. range-order bond
-    /// sizing) deterministically without hitting the network. Use a unique
-    /// `currency` per test to avoid cross-test interference on the shared
-    /// static.
+    /// Test-only: seed the price-override map consulted by
+    /// [`crate::price::get_bitcoin_price`] so unit tests in other modules
+    /// can exercise price-dependent paths (e.g. range-order bond sizing)
+    /// deterministically without hitting the network or installing the
+    /// global `PriceManager`. Use a unique `currency` per test to avoid
+    /// cross-test interference on the shared map.
     #[cfg(test)]
     pub(crate) fn set_price_for_test(currency: &str, price: f64) {
-        BITCOIN_PRICES
+        crate::price::test_price_overrides()
             .write()
-            .expect("price cache write lock")
+            .expect("price override write lock")
             .insert(currency.to_string(), price);
     }
 }

--- a/src/price/mod.rs
+++ b/src/price/mod.rs
@@ -27,6 +27,22 @@ pub use store::{AggregatedPrice, PriceError, PriceStore};
 
 use mostro_core::error::{MostroError, ServiceError};
 
+/// Test-only per-currency price overrides consulted by
+/// [`get_bitcoin_price`] before the global manager. Unit tests in other
+/// modules (e.g. range-order bond sizing in `util.rs`) seed this via
+/// `BitcoinPriceManager::set_price_for_test` instead of installing the
+/// global [`PriceManager`] — its `OnceLock` would leak one test's
+/// configuration into every other test in the binary. Tests use a unique
+/// currency code each to avoid cross-test interference on the shared map.
+#[cfg(test)]
+pub(crate) fn test_price_overrides(
+) -> &'static std::sync::RwLock<std::collections::HashMap<String, f64>> {
+    static OVERRIDES: std::sync::OnceLock<
+        std::sync::RwLock<std::collections::HashMap<String, f64>>,
+    > = std::sync::OnceLock::new();
+    OVERRIDES.get_or_init(|| std::sync::RwLock::new(std::collections::HashMap::new()))
+}
+
 /// Read a currency's per-BTC price from the global [`PriceManager`].
 ///
 /// This is the Phase 1 entry point for consumers (`util::get_bitcoin_price`
@@ -36,6 +52,14 @@ use mostro_core::error::{MostroError, ServiceError};
 /// legacy code returned when `BITCOIN_PRICES` was empty, so callers behave
 /// identically.
 pub fn get_bitcoin_price(currency: &str) -> Result<f64, MostroError> {
+    #[cfg(test)]
+    if let Some(price) = test_price_overrides()
+        .read()
+        .expect("price override read lock")
+        .get(currency)
+    {
+        return Ok(*price);
+    }
     match PriceManager::global() {
         Some(m) => m.get_price(currency),
         None => Err(MostroError::MostroInternalErr(ServiceError::NoAPIResponse)),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -482,13 +482,39 @@ async fn job_cancel_orders(ctx: AppContext) {
                             // that strips eligibility) — on persist failure
                             // the next tick retries this branch only; the
                             // slash is durable in `bonds.slashed_reason` and
-                            // a re-entry sees no `Locked` bond, so it is a
+                            // a re-entry sees no `Locked` bond (or an
+                            // already-recorded slice child), so it is a
                             // no-op (no duplicate notify).
-                            if let Err(e) = order_updated.update(pool).await {
-                                tracing::warn!(
-                                    "scheduler_timeout: persist failed for order {} ({}); will retry next tick",
-                                    order_id, e
-                                );
+                            match order_updated.update(pool).await {
+                                Ok(_) => {
+                                    // Phase 7: a maker-responsible timeout
+                                    // cancels the order outright, terminating
+                                    // its range chain — resolve the range
+                                    // maker bond at close (settle + per-slice
+                                    // payouts + maker refund when a slice was
+                                    // slashed; plain release otherwise). The
+                                    // close helper is idempotent and a cheap
+                                    // no-op for non-range / already-resolved
+                                    // bonds; on transient failure the
+                                    // reconciliation sweep retries. The
+                                    // republish branch must NOT close: the
+                                    // order returns to the book with the
+                                    // maker still committed.
+                                    if matches!(new_status, Status::Canceled) {
+                                        bond::resolve_range_maker_bond_at_close_or_warn(
+                                            pool,
+                                            &order,
+                                            "scheduler_timeout",
+                                        )
+                                        .await;
+                                    }
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "scheduler_timeout: persist failed for order {} ({}); will retry next tick",
+                                        order_id, e
+                                    );
+                                }
                             }
                         }
                     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1598,6 +1598,7 @@ pub async fn notify_taker_reputation(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bitcoin_price::BitcoinPriceManager;
     use mostro_core::message::{Message, MessageKind};
     use mostro_core::order::Order;
     use sqlx::sqlite::SqlitePoolOptions;


### PR DESCRIPTION
## Anti-Abuse Bond — Phase 7: maker timeout slash

Implements [spec §12](../blob/bond-phase-7-maker-timeout-slash/docs/ANTI_ABUSE_BOND.md#12-phase-7--maker-timeout-slash--completed) (issue #711): timeout slash for the **maker** bond. Symmetric to Phase 4 — no new mechanism, the `job_cancel_orders` dispatch already exists; the `apply_to` gate widens to the maker side and the bond lookup becomes range-aware.

Gate: `enabled && slash_on_waiting_timeout && apply_to ∈ { make, both }` (checked against the **responsible** party's posting role, so a leftover maker bond under `apply_to = take` still releases, never slashes).

**Daemon-only**: no `mostro-core` change, no migration, no new protocol variant (reuses `Action::BondSlashed` from Phase 4 and the Phase 6 child-slash schema). `enabled = false` keeps today's behaviour bit-for-bit.

### What changed

**`src/app/bond/slash.rs` — `slash_or_release_on_timeout`**
- The slash gate is now per-role: the responsible side (from the §9.2 waiting-state table) maps to maker/taker via the §3.1 order-kind mapping, and `apply_to` must cover *that* role.
- The responsible bond resolves through `resolve_slash_target` (the Phase 2/6 resolver), which adds the range-root fallback: a range order's maker bond lives on the range **root**, found by walking `range_parent_id`.
- **Non-range maker** (and the existing taker path): HTLC settled inline via the Phase 2 `slash_one` primitive, confirmed through the durable `slashed_reason = Timeout` witness.
- **Range maker**: goes through the Phase 6 partial-slash path — `record_maker_slice_slash` inserts a proportional child row (`PendingPayout`, `reason = Timeout`) and the parent HTLC stays `Locked`; the single settle happens at range close. The reported bond is the *child* row, so the `BondSlashed` notice carries the slice's slashed amount, not the whole parent bond.
- `record_maker_slice_slash` now returns whether it actually inserted the child. The timeout path keys the one-shot `BondSlashed` notice on that, so a scheduler retry (order-persist failed, next tick re-runs) never re-notifies the maker — the same no-duplicate-notice guarantee Phase 4 gets from the `Locked` re-check, which a range parent (deliberately still `Locked`) can't provide.
- The post-slash release loop retains a range maker parent bond alongside the existing republish carve-out — it is resolved only at range close.

**`src/scheduler.rs` — `job_cancel_orders`**
- After the terminal `Canceled` status persists, the cancel branch now runs `resolve_range_maker_bond_at_close_or_warn`: a maker-responsible timeout terminates the range (no remainder is spawned on a cancel), so the parent settles and distributes (per-slice counterparty shares + maker refund) promptly instead of waiting for the 5-minute reconciliation sweep — which remains the backstop on transient failure. The close helper is idempotent and a cheap no-op for non-range / already-resolved bonds. The republish branch never closes: the order returns to the book with the maker still committed.

### Phase 4 invariants preserved

- Cancels before the timeout never slash (this dispatch only runs from the scheduler's waiting-state timeout).
- The notice is only sent when the slash durably landed (inline-settle confirmation for non-range; the atomically-guarded child insert for range).
- Gate-closed / no-config paths still drain leftover bonds via release, and a republish still retains the maker bond.

---

## How to test

### Automated

```bash
cargo test  --bin mostrod          # full suite (432 passing, incl. 6 new Phase 7 tests)
cargo test  --bin mostrod bond     # bond module only
cargo clippy --all-targets --all-features
cargo fmt --check
```

Key new unit tests (`src/app/bond/slash.rs`, mirroring Phase 4 from the maker side):

- `timeout_maker_responsible_slashes_maker_bond_sell_order` — sell / `WaitingPayment` (seller = maker silent): maker bond → `pending-payout`, `reason = timeout`, HTLC settled inline exactly once.
- `timeout_maker_responsible_buy_order_slashes_maker_and_releases_taker` — buy / `WaitingBuyerInvoice` mirror under `apply_to = both`: maker slashed, the non-responsible taker's bond **released**, only one settle call.
- `timeout_maker_slash_skipped_when_apply_to_take_only` — per-role gate: a leftover `Locked` maker bond under `apply_to = take` releases, never slashes.
- `timeout_range_maker_slash_records_child_and_keeps_parent_locked` — range: proportional child recorded (40/100 × 1000 = 400, `reason = timeout`), parent stays `Locked` with `slashed_share_sats = 400`, **no settle call**, taker bond released.
- `timeout_range_maker_slash_resolves_root_bond_from_descendant_slice` — the `range_parent_id` walk finds the root's maker bond from a remainder slice; child recorded against the slice's own order id.
- `timeout_range_maker_slash_is_idempotent_per_slice` — an already-slashed slice reports `None`: no duplicate child row, no re-notification.

### Manual (regtest / Polar)

Enable the feature in `settings.toml` — the **maker** side must be bonded and the timeout slash armed:

```toml
[anti_abuse_bond]
enabled = true
apply_to = "make"               # or "both" to also bond takers
amount_pct = 0.01
base_amount_sats = 1000
slash_on_waiting_timeout = true # ← the Phase 7 gate
slash_node_share_pct = 0.5
payout_claim_window_days = 15
```

> Tip: lower `[mostro] expiration_seconds` (the waiting-state window the scheduler enforces) so you don't wait long for the timeout to elapse. The cancel job ticks every 60 s.

Handy inspection queries:

```sql
SELECT id, status, kind, range_parent_id, fiat_amount, max_amount FROM orders;
SELECT id, role, state, amount_sats, parent_bond_id, child_order_id,
       slashed_share_sats, node_share_sats, slashed_reason
  FROM bonds ORDER BY created_at;
```

1. **Non-range maker timeout slash (sell order).** Maker creates a fixed-amount *sell* order and pays the bond (`Action::PayBondInvoice` → order publishes). A taker takes it; the order enters `waiting-payment` and the maker (seller) **never pays the trade hold invoice**. When `expiration_seconds` elapses: the order is **cancelled outright** (not republished), the maker bond flips to `state = pending-payout, slashed_reason = timeout` (HTLC settled — check Mostro's wallet), the maker receives `Action::BondSlashed` (amount = the bond) plus the order's `Action::Canceled`, and the taker (winner) receives `Action::AddBondInvoice` for the counterparty share. Reply with a bolt11 → `BondInvoiceAccepted` then `BondPayoutCompleted`.
2. **Buy-order mirror.** Maker creates a *buy* order, bond locked, taker takes and pays the trade hold invoice; the order enters `waiting-buyer-invoice` and the maker (buyer) **never adds the invoice**. Same outcome as step 1: cancel + maker bond slashed with `timeout`.
3. **Taker-responsible timeout does NOT touch the maker bond.** On a *sell* order with `apply_to = "make"`, the taker (buyer) goes silent in `waiting-buyer-invoice`. The order is **republished** to the book and the maker bond **stays `locked`** (it follows the order, not the failed take). Nothing is slashed — under `apply_to = make` the taker posted no bond. With `apply_to = "both"` the same scenario slashes the *taker's* bond (Phase 4) and still retains the maker's.
4. **Cancel before timeout always releases (invariant).** Repeat step 1 but have either party cancel (cooperative/unilateral) *before* `expiration_seconds` elapses → the maker bond is **released**, never slashed.
5. **Range maker timeout → proportional child, parent stays `Locked`, close settles once.** Maker creates a *range* sell order (e.g. min 10 / max 50 USD), bond locked (sized against `max_amount`). A taker takes a slice (e.g. 20 USD) and the maker goes silent in `waiting-payment`. On timeout, in one tick:
   - a **child** bonds row appears: `parent_bond_id` set, `child_order_id` = the slice, `amount_sats = round(bond × slice_fiat / max_fiat)`, `state = pending-payout`, `slashed_reason = timeout`;
   - the maker receives `Action::BondSlashed` with the **child's** (proportional) amount, not the whole bond;
   - the order is cancelled, terminating the range, and the close runs immediately (no 5-minute wait): parent `state = slashed` (HTLC settled **once**), a **refund** row appears (`child_order_id` NULL, recipient = the maker);
   - the slice winner (taker) gets `Action::AddBondInvoice` for their counterparty share and the maker gets a *separate* `Action::AddBondInvoice` for the unslashed remainder.
6. **Wallet accounting for step 5.** With bond 1000, slice 20/50 → child 400 (node 200 / winner 200), maker refund 600. Mostro's wallet nets exactly the node share: `settle(1000) − winner 200 − refund 600 = 200`. Child + refund rows sum to the parent `amount_sats`.
7. **No duplicate notice on retry.** While reproducing step 5, restart the daemon (or watch a tick where the order persist races): the child row is recorded at most once (`UNIQUE (parent_bond_id, child_order_id)`) and `Action::BondSlashed` is sent exactly once.
8. **Per-role gate.** Set `apply_to = "take"` and repeat step 1 (the maker now posts no bond): the timeout cancels the order with nothing slashed — old behaviour. Conversely `slash_on_waiting_timeout = false` releases every bond on timeout even with `apply_to = "make"`.
9. **Disabled unchanged.** `enabled = false` → no bond messages, timeouts cancel/republish exactly as before this PR.

---

> **Note:** based on #774 (fix for the `cargo test` compile breakage on `main` from the #753/#770 merge skew). Merge that first; this PR's first commit is that fix and the diff will collapse to the Phase 7 change after a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
