### PR TITLE
feat(transport): Phase 2 — anti-spam gates for protocol v2

### DIFF
--- a/docs/TRANSPORT_V2_SPEC.md
+++ b/docs/TRANSPORT_V2_SPEC.md
@@ -1,6 +1,6 @@
 # Transport v2 — NIP-44 Direct Messaging (Protocol v2)
 
-**Status:** Phase 1 implemented (this spec ships with it) · Phases 2–4 pending
+**Status:** Phases 1–2 implemented · Phases 3–4 pending
 **Issue:** [#626 — Messaging Transport Abstraction Layer](https://github.com/MostroP2P/mostro/issues/626)
 **Full proposal:** [issue comment](https://github.com/MostroP2P/mostro/issues/626#issuecomment-4694164653)
 **Core implementation:** [mostro-core#152](https://github.com/MostroP2P/mostro-core/pull/152), released in mostro-core **0.13.0** (`transport` module)
@@ -193,19 +193,42 @@ Minimal daemon integration; **zero handler changes** by design:
   when the caller didn't pass one.
 - `src/nip33.rs` — `protocol_versions` tag in the kind-38385 info event.
 
-### Phase 2 — anti-spam gates (PENDING — daemon-only, the payoff)
+### Phase 2 — anti-spam gates (DONE — this change; daemon-only, the payoff)
 
-The reason v2 exists: reject junk *before* paying decrypt/parse costs.
+The reason v2 exists: reject junk *before* paying decrypt/parse costs. All of
+the following are **v2-only** — the gate is skipped on the `gift-wrap`
+transport, whose outer key is a throwaway with no pre-validatable signal.
 
-- Cache of active trade pubkeys (open orders/disputes), refreshed on state
-  changes.
-- Cheap pre-validation in the event loop for kind 14: check `event.pubkey`
-  against the cache **before** decrypting.
-- Two lanes — this is the necessary nuance to "only accept known keys":
-  brand-new orders and takes arrive from keys Mostro has never seen, so
-  there is a *known-keys lane* (pre-validated, cheap) and a *first-contact
-  lane* (where spam lives; PoW + relay rate-limiting apply there).
-- TTL / stale-event rejection and dedup as defense in depth.
+- **Active-trade-pubkey cache** (`src/spam_gate.rs`, `SpamGate`): the trade
+  keys that may legitimately message Mostro now — buyer/seller/creator of
+  every non-terminal order, plus the solver of every active dispute. Built by
+  `db::find_active_trade_pubkeys` (terminal set = the restore-session
+  `EXCLUDED_ORDER_STATUSES` **minus `'dispute'`**, so disputed orders stay
+  active). Warmed at startup in `main.rs` and rebuilt every
+  `active_pubkeys_refresh_interval` seconds (default 60) by
+  `scheduler::job_refresh_active_pubkeys` — a periodic full reload, chosen
+  because status mutations are scattered across handlers with no single
+  choke-point. Global-singleton (`OnceLock`), mirroring `PriceManager`.
+- **Cheap pre-validation in the event loop** (`src/app.rs`), for kind 14,
+  **before** `unwrap_incoming` decrypts: check `event.pubkey` against the
+  cache.
+- **Two lanes** — the necessary nuance to "only accept known keys": brand-new
+  orders and takes arrive from keys Mostro has never seen.
+  - *Known-keys lane:* sender in the cache → fast-path; only the base `pow`
+    (already checked at the top of the loop) applies.
+  - *First-contact lane:* sender unseen → must clear `pow_first_contact`
+    (`[mostro]`, defaults to `pow` so existing configs are unchanged) before
+    the daemon decrypts. This is where spam concentrates; PoW here plus
+    relay-side rate limiting are the toll.
+- **Dedup as defense in depth:** a `REPLAY_WINDOW_SECS` (60 s) guard drops a
+  re-sent identical event id before decryption. The existing 10-second
+  freshness window (post-decrypt, on the inner `created_at`) still applies as
+  the precise stale-event check.
+
+New config (`[mostro]`): `pow_first_contact` (`Option<u8>`, default = `pow`)
+and `active_pubkeys_refresh_interval` (default 60). Both `#[serde(default)]`,
+so pre-Phase-2 `settings.toml` files are wire-identical. Zero handler changes;
+the gate sits entirely in the event-loop preamble.
 
 ### Phase 3 — protocol docs + client migration (PENDING)
 

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -60,6 +60,19 @@ pow = 0
 #                 your community uses support protocol v2.
 # See docs/TRANSPORT_V2_SPEC.md
 transport = "gift-wrap"
+# Anti-spam gate for the "nip44" transport (docs/TRANSPORT_V2_SPEC.md §6
+# Phase 2). Proof-of-work (leading-zero bits) demanded of a *first-contact*
+# event — one whose visible sender (trade key) is not part of an active
+# order/dispute — checked BEFORE decryption. Ongoing trades (known keys) need
+# only `pow`; brand-new orders/takes from unseen keys must clear this stiffer
+# toll. Omit (or leave commented) to fall back to `pow`. No effect on
+# "gift-wrap". Example: keep pow = 0 for cheap ongoing trades but require work
+# from first-contact senders.
+# pow_first_contact = 16
+# How often (seconds) to rebuild the active-trade-pubkey cache the gate
+# consults. Lower = a just-taken order's keys fast-path sooner; higher = less
+# DB load. Default 60.
+# active_pubkeys_refresh_interval = 60
 # Publish mostro info interval
 publish_mostro_info_interval = 300
 # Bitcoin price API base URL.

--- a/src/app.rs
+++ b/src/app.rs
@@ -305,6 +305,13 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
     // NIP-44 direct); events of any other kind are dropped before any
     // decryption work. See docs/TRANSPORT_V2_SPEC.md.
     let accepted_kind = ctx.settings().mostro.transport.event_kind();
+    // Phase 2 anti-spam gate (docs/TRANSPORT_V2_SPEC.md §6): on the v2 (kind
+    // 14) transport the visible author is the trade key, so the daemon can
+    // pre-validate before decrypting. Unknown (first-contact) senders must
+    // clear `pow_first_contact`; known active-trade keys need only `pow`. The
+    // gate is meaningless for v1 (gift wraps are signed by throwaway keys).
+    let pow_first_contact = ctx.settings().mostro.effective_pow_first_contact();
+    let is_v2 = accepted_kind.as_u16() == crate::config::constants::DM_EVENT_KIND;
 
     loop {
         let mut notifications = client.notifications();
@@ -318,6 +325,38 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
                     continue;
                 }
                 if event.kind == accepted_kind {
+                    // Phase 2 anti-spam gate (protocol v2 / kind 14 only):
+                    // cheap pre-validation BEFORE paying the NIP-44 decrypt
+                    // cost. v1 gift wraps skip this — their outer key is a
+                    // throwaway with no pre-validatable signal.
+                    if is_v2 {
+                        if let Some(gate) = crate::spam_gate::SpamGate::global() {
+                            let now = chrono::Utc::now().timestamp();
+                            // Dedup: drop a re-sent identical event (defense in
+                            // depth against replay floods).
+                            if gate.is_replay(event.id, now) {
+                                tracing::debug!("Dropping replayed event {}", event.id);
+                                continue;
+                            }
+                            // Two lanes: a sender already in an active trade is
+                            // fast-pathed (only the base `pow` already checked
+                            // above applies); an unseen first-contact sender
+                            // must clear the stiffer `pow_first_contact` before
+                            // we decrypt. New orders/takes legitimately arrive
+                            // here — so does spam, hence the PoW toll.
+                            if !gate.is_known(&event.pubkey.to_string())
+                                && !event.check_pow(pow_first_contact)
+                            {
+                                tracing::info!(
+                                    "Dropping first-contact kind-14 event from unknown key {} below pow_first_contact ({} bits)",
+                                    event.pubkey,
+                                    pow_first_contact
+                                );
+                                continue;
+                            }
+                        }
+                    }
+
                     // Validate event signature
                     if event.verify().is_err() {
                         tracing::warn!("Error in event verification")

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -240,6 +240,62 @@ mod tests {
     }
 
     #[test]
+    fn pow_first_contact_defaults_to_base_pow() {
+        // Unset ⇒ first-contact gate uses the base `pow`, so a config that
+        // predates Phase 2 behaves exactly as before (spec §6 Phase 2).
+        let s = MostroSettings {
+            pow: 8,
+            ..MostroSettings::default()
+        };
+        assert_eq!(s.pow_first_contact, None);
+        assert_eq!(s.effective_pow_first_contact(), 8);
+    }
+
+    #[test]
+    fn pow_first_contact_override_takes_precedence() {
+        let s = MostroSettings {
+            pow: 4,
+            pow_first_contact: Some(20),
+            ..MostroSettings::default()
+        };
+        assert_eq!(s.effective_pow_first_contact(), 20);
+    }
+
+    #[test]
+    fn active_pubkeys_refresh_interval_defaults_to_60() {
+        assert_eq!(
+            MostroSettings::default().active_pubkeys_refresh_interval,
+            60
+        );
+    }
+
+    #[test]
+    fn mostro_settings_omitting_phase2_keys_parses() {
+        // An existing settings.toml without the Phase 2 keys must still
+        // deserialize (both fields are `#[serde(default)]`).
+        let toml_str = r#"
+fee = 0
+max_routing_fee = 0.002
+max_order_amount = 1000000
+min_payment_amount = 100
+expiration_hours = 24
+expiration_seconds = 900
+user_rates_sent_interval_seconds = 3600
+max_expiration_days = 15
+publish_relays_interval = 60
+pow = 0
+publish_mostro_info_interval = 300
+fiat_currencies_accepted = ["USD"]
+max_orders_per_response = 10
+dev_fee_percentage = 0.30
+"#;
+        let s: MostroSettings = toml::from_str(toml_str).expect("legacy config parses");
+        assert_eq!(s.pow_first_contact, None);
+        assert_eq!(s.active_pubkeys_refresh_interval, 60);
+        assert_eq!(s.effective_pow_first_contact(), 0);
+    }
+
+    #[test]
     fn dispute_kind_falls_back_to_90_when_unconfigured() {
         let settings = ExpirationSettings::default();
         assert_eq!(
@@ -397,6 +453,33 @@ pub struct MostroSettings {
     /// A node speaks exactly one. See docs/TRANSPORT_V2_SPEC.md.
     #[serde(default)]
     pub transport: Transport,
+    /// Proof-of-work difficulty (leading-zero bits) demanded of a
+    /// *first-contact* event on the protocol-v2 (`nip44`) transport — one
+    /// whose visible sender (trade key) is **not** in the active-trade
+    /// cache — checked BEFORE the daemon pays the NIP-44 decrypt cost. This
+    /// is the Phase 2 anti-spam lane: ongoing trades (known keys) need only
+    /// `pow`, while brand-new orders/takes from unseen keys must grind this
+    /// harder toll (see docs/TRANSPORT_V2_SPEC.md §6 Phase 2).
+    ///
+    /// `None` ⇒ falls back to `pow`, so existing configs and the v1
+    /// transport are wire-identical to before. Has no effect on `gift-wrap`
+    /// (v1 senders are throwaway keys that can't be pre-validated).
+    #[serde(default)]
+    pub pow_first_contact: Option<u8>,
+    /// How often (seconds) to rebuild the active-trade-pubkey cache that the
+    /// Phase 2 anti-spam gate consults. Lower = fresher known-keys set (a
+    /// just-taken order's keys fast-path sooner); higher = less DB load.
+    #[serde(default = "default_active_pubkeys_refresh_interval")]
+    pub active_pubkeys_refresh_interval: u64,
+}
+
+impl MostroSettings {
+    /// Effective first-contact PoW difficulty: the explicit
+    /// `pow_first_contact` when set, otherwise the base `pow`. Centralised so
+    /// the event loop and tests agree on the fallback (spec §6 Phase 2).
+    pub fn effective_pow_first_contact(&self) -> u8 {
+        self.pow_first_contact.unwrap_or(self.pow)
+    }
 }
 
 fn default_bitcoin_price_api_url() -> String {
@@ -411,6 +494,10 @@ fn default_publish_exchange_rates() -> bool {
 
 fn default_exchange_rates_update_interval() -> u64 {
     300 // 5 minutes
+}
+
+fn default_active_pubkeys_refresh_interval() -> u64 {
+    60 // 1 minute — keeps a just-taken order's keys fast-pathing promptly
 }
 
 impl Default for MostroSettings {
@@ -443,6 +530,8 @@ impl Default for MostroSettings {
             publish_exchange_rates_to_nostr: default_publish_exchange_rates(),
             exchange_rates_update_interval_seconds: default_exchange_rates_update_interval(),
             transport: Transport::default(),
+            pow_first_contact: None,
+            active_pubkeys_refresh_interval: default_active_pubkeys_refresh_interval(),
         }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,6 +5,7 @@ use nostr_sdk::prelude::*;
 use sqlx::pool::Pool;
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Row, Sqlite, SqlitePool};
+use std::collections::HashSet;
 use std::fs::{set_permissions, Permissions};
 use std::path::Path;
 use std::sync::Arc;
@@ -14,8 +15,68 @@ use uuid::Uuid;
 const EXCLUDED_ORDER_STATUSES: &str = "'expired','success','canceled','dispute','canceledbyadmin','completedbyadmin','settledbyadmin','cooperativelycanceled'";
 const ACTIVE_DISPUTE_STATUSES: &str = "'initiated','in-progress'";
 
+/// Terminal order statuses for the Phase 2 active-trade-pubkey cache: an
+/// order in any of these will never legitimately originate further trade-key
+/// messages, so its participants drop out of the "known keys" set.
+///
+/// This is deliberately [`EXCLUDED_ORDER_STATUSES`] **minus `'dispute'`** — a
+/// disputed order is still active (buyer, seller and the assigned solver keep
+/// messaging), so its trade keys must stay fast-pathed. See
+/// `find_active_trade_pubkeys` and docs/TRANSPORT_V2_SPEC.md §6 Phase 2.
+const TERMINAL_ORDER_STATUSES: &str = "'expired','success','canceled','canceledbyadmin','completedbyadmin','settledbyadmin','cooperativelycanceled'";
+
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+
+/// Collect the "known keys" the Phase 2 anti-spam gate fast-paths: the trade
+/// pubkeys (buyer / seller / creator) of every **non-terminal** order, plus
+/// the solver pubkey of every **active** dispute (spec §6 Phase 2).
+///
+/// Status lists are compile-time constants ([`TERMINAL_ORDER_STATUSES`],
+/// [`ACTIVE_DISPUTE_STATUSES`]), never user input, so the inline
+/// interpolation carries no injection risk — same pattern the restore-session
+/// queries already use. The result is deduplicated.
+pub async fn find_active_trade_pubkeys(pool: &SqlitePool) -> Result<Vec<String>, MostroError> {
+    let mut keys: HashSet<String> = HashSet::new();
+
+    // Order participants of every still-active order (disputed orders
+    // included — `TERMINAL_ORDER_STATUSES` excludes `'dispute'`).
+    let order_query = format!(
+        "SELECT buyer_pubkey, seller_pubkey, creator_pubkey FROM orders WHERE status NOT IN ({TERMINAL_ORDER_STATUSES})"
+    );
+    let order_rows = sqlx::query(&order_query)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    for row in order_rows {
+        for col in ["buyer_pubkey", "seller_pubkey", "creator_pubkey"] {
+            if let Ok(Some(pk)) = row.try_get::<Option<String>, _>(col) {
+                if !pk.is_empty() {
+                    keys.insert(pk);
+                }
+            }
+        }
+    }
+
+    // Assigned solvers of active disputes (so admin-settle/cancel/take from
+    // the solver's key fast-paths instead of hitting the first-contact lane).
+    let dispute_query = format!(
+        "SELECT solver_pubkey FROM disputes WHERE status IN ({ACTIVE_DISPUTE_STATUSES}) AND solver_pubkey IS NOT NULL"
+    );
+    let dispute_rows = sqlx::query(&dispute_query)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    for row in dispute_rows {
+        if let Ok(Some(pk)) = row.try_get::<Option<String>, _>("solver_pubkey") {
+            if !pk.is_empty() {
+                keys.insert(pk);
+            }
+        }
+    }
+
+    Ok(keys.into_iter().collect())
+}
 
 /// Helper function to rebuild disputes table without token columns when DROP COLUMN is unsupported.
 async fn rebuild_disputes_table_without_tokens(pool: &SqlitePool) -> Result<(), MostroError> {
@@ -1405,6 +1466,156 @@ mod tests {
         .execute(pool)
         .await
         .unwrap();
+    }
+
+    /// Insert an order carrying explicit trade pubkeys, for the Phase 2
+    /// active-trade-pubkey cache query.
+    async fn insert_order_with_pubkeys(
+        pool: &SqlitePool,
+        id: uuid::Uuid,
+        status: &str,
+        creator: Option<&str>,
+        buyer: Option<&str>,
+        seller: Option<&str>,
+    ) {
+        sqlx::query(
+            r#"
+            INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                                amount, fiat_code, fiat_amount, created_at, expires_at,
+                                creator_pubkey, buyer_pubkey, seller_pubkey)
+            VALUES (?1, 'buy', 'event123', ?2, 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400, ?3, ?4, ?5)
+            "#,
+        )
+        .bind(id)
+        .bind(status)
+        .bind(creator)
+        .bind(buyer)
+        .bind(seller)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn setup_disputes_table(pool: &SqlitePool) {
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS disputes (
+                id char(36) primary key not null,
+                order_id char(36) unique not null,
+                status varchar(10) not null,
+                order_previous_status varchar(10) not null,
+                solver_pubkey char(64),
+                created_at integer not null,
+                taken_at integer default 0
+            )
+            "#,
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Phase 2 (docs/TRANSPORT_V2_SPEC.md §6): the active-trade-pubkey cache
+    /// must include participants of every non-terminal order — **including
+    /// disputed ones** — and the solvers of active disputes, while excluding
+    /// terminal orders and resolved disputes.
+    #[tokio::test]
+    async fn find_active_trade_pubkeys_covers_active_and_disputed_excludes_terminal() {
+        let pool = setup_orders_db().await.unwrap();
+        setup_disputes_table(&pool).await;
+
+        // Active order — all three keys are "known".
+        insert_order_with_pubkeys(
+            &pool,
+            uuid::Uuid::new_v4(),
+            "waiting-payment",
+            Some("creator_active"),
+            Some("buyer_active"),
+            Some("seller_active"),
+        )
+        .await;
+        // Disputed order — still active (the load-bearing nuance: 'dispute' is
+        // NOT in TERMINAL_ORDER_STATUSES), so its keys must be included.
+        insert_order_with_pubkeys(
+            &pool,
+            uuid::Uuid::new_v4(),
+            "dispute",
+            Some("creator_disp"),
+            Some("buyer_disp"),
+            Some("seller_disp"),
+        )
+        .await;
+        // Terminal orders — excluded.
+        insert_order_with_pubkeys(
+            &pool,
+            uuid::Uuid::new_v4(),
+            "success",
+            Some("creator_succ"),
+            Some("buyer_succ"),
+            Some("seller_succ"),
+        )
+        .await;
+        insert_order_with_pubkeys(
+            &pool,
+            uuid::Uuid::new_v4(),
+            "canceled",
+            Some("creator_canc"),
+            None,
+            None,
+        )
+        .await;
+
+        // Active dispute with an assigned solver → solver key included.
+        sqlx::query(
+            "INSERT INTO disputes (id, order_id, status, order_previous_status, solver_pubkey, created_at) \
+             VALUES (?1, ?2, 'in-progress', 'fiat-sent', 'solver_active', 1700000000)",
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(uuid::Uuid::new_v4())
+        .execute(&pool)
+        .await
+        .unwrap();
+        // Resolved dispute → its solver is NOT included.
+        sqlx::query(
+            "INSERT INTO disputes (id, order_id, status, order_previous_status, solver_pubkey, created_at) \
+             VALUES (?1, ?2, 'settled', 'fiat-sent', 'solver_settled', 1700000000)",
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(uuid::Uuid::new_v4())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let keys: HashSet<String> = super::find_active_trade_pubkeys(&pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+
+        for k in [
+            "creator_active",
+            "buyer_active",
+            "seller_active",
+            "creator_disp",
+            "buyer_disp",
+            "seller_disp",
+            "solver_active",
+        ] {
+            assert!(keys.contains(k), "{k} should be a known active key");
+        }
+        for k in [
+            "creator_succ",
+            "buyer_succ",
+            "seller_succ",
+            "creator_canc",
+            "solver_settled",
+        ] {
+            assert!(
+                !keys.contains(k),
+                "{k} must NOT be known (terminal/resolved)"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ pub mod nip33;
 pub mod price;
 pub mod rpc;
 pub mod scheduler;
+pub mod spam_gate;
 pub mod util;
 
 use crate::app::context::AppContext;
@@ -169,6 +170,29 @@ async fn main() -> Result<()> {
                 Err(e) => tracing::error!("RPC server failed to start: {}", e),
             }
         });
+    }
+
+    // Install the protocol-v2 anti-spam gate and warm its active-trade-pubkey
+    // cache before the event loop starts, so the very first kind-14 events are
+    // already pre-filtered against known keys (spec §6 Phase 2). The cache is
+    // kept fresh afterwards by `job_refresh_active_pubkeys`. Inert on the v1
+    // (gift-wrap) transport, which never consults the gate.
+    {
+        use crate::spam_gate::{SpamGate, REPLAY_WINDOW_SECS};
+        let gate = SpamGate::new(REPLAY_WINDOW_SECS);
+        match db::find_active_trade_pubkeys(get_db_pool().as_ref()).await {
+            Ok(keys) => {
+                tracing::info!(
+                    "SpamGate: warming active-trade-pubkey cache ({} keys)",
+                    keys.len()
+                );
+                gate.set_known(keys);
+            }
+            Err(e) => tracing::warn!("SpamGate: initial cache warm failed: {e}"),
+        }
+        if gate.install_global().is_err() {
+            tracing::warn!("SpamGate already installed");
+        }
     }
 
     // Build AppContext explicitly with all dependencies

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -36,8 +36,38 @@ pub async fn start_scheduler(ctx: AppContext) {
     job_relay_list(ctx.clone()).await;
     job_update_bitcoin_prices().await;
     job_flush_messages_queue(ctx.clone()).await;
+    job_refresh_active_pubkeys(ctx.clone()).await;
 
     info!("Scheduler Started");
+}
+
+/// Periodically rebuild the protocol-v2 anti-spam gate's active-trade-pubkey
+/// cache from the DB (spec §6 Phase 2). Status mutations are scattered across
+/// many handlers with no single choke-point, so a periodic full reload is the
+/// robust, low-coupling refresh strategy: a just-taken order's keys begin
+/// fast-pathing within one `active_pubkeys_refresh_interval`. Inert on the v1
+/// transport (the event loop only consults the gate for kind-14 events).
+async fn job_refresh_active_pubkeys(ctx: AppContext) {
+    let interval = ctx.settings().mostro.active_pubkeys_refresh_interval.max(1);
+    tokio::spawn(async move {
+        loop {
+            match find_active_trade_pubkeys(ctx.pool()).await {
+                Ok(keys) => {
+                    if let Some(gate) = crate::spam_gate::SpamGate::global() {
+                        let n = keys.len();
+                        gate.set_known(keys);
+                        tracing::debug!(
+                            "spam_gate: refreshed active-trade-pubkey cache ({n} keys)"
+                        );
+                    }
+                }
+                Err(e) => {
+                    warn!("spam_gate: failed to refresh active-trade-pubkey cache: {e}")
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
+        }
+    });
 }
 
 async fn job_flush_messages_queue(ctx: AppContext) {

--- a/src/spam_gate.rs
+++ b/src/spam_gate.rs
@@ -1,0 +1,234 @@
+//! Protocol-v2 anti-spam gate (spec §6 Phase 2, docs/TRANSPORT_V2_SPEC.md).
+//!
+//! The whole point of the kind-14 transport is that the visible sender is the
+//! authoring **trade key**, so the daemon can pre-validate cheaply *before*
+//! paying the NIP-44 decrypt cost. This module holds the two in-memory pieces
+//! that make that work:
+//!
+//! 1. **Active-trade-pubkey cache** — the set of trade keys that legitimately
+//!    message Mostro right now (participants of non-terminal orders + active
+//!    dispute solvers). Rebuilt periodically from the DB by a scheduler job
+//!    (`job_refresh_active_pubkeys`) and warmed once at startup.
+//! 2. **Replay guard** — a short-window dedup of seen event ids, so a flood of
+//!    re-sent identical events is dropped before decryption (defense in depth).
+//!
+//! The gate has **two lanes**: a *known-keys lane* (sender in the cache →
+//! fast-path, only the base `pow` applies) and a *first-contact lane* (sender
+//! unseen → must clear the stiffer `pow_first_contact` before the daemon
+//! decrypts). Brand-new orders and takes legitimately arrive on the
+//! first-contact lane; that is also where spam concentrates, so PoW (plus
+//! relay-side rate limiting) is the toll there.
+//!
+//! Only the v2 (`nip44`) transport uses this gate — v1 gift wraps are authored
+//! by throwaway keys that carry no pre-validatable signal.
+//!
+//! Follows the established global-singleton pattern (`OnceLock`, like
+//! `PRICE_MANAGER` / `MOSTRO_CONFIG`); the cache is an inner `RwLock` and the
+//! replay guard a `Mutex`, matching the daemon's single-consumer event loop.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Mutex, OnceLock, RwLock};
+
+use nostr_sdk::EventId;
+
+/// How long (seconds) a seen event id is remembered for replay dedup. Must be
+/// ≥ the event loop's 10-second freshness window so a duplicate can never slip
+/// past the guard while the original is still acceptable; 60s adds margin for
+/// clock skew without unbounded memory (entries are pruned past this age).
+pub const REPLAY_WINDOW_SECS: i64 = 60;
+
+/// Process-wide gate. `None` until [`SpamGate::install_global`] runs in `main`;
+/// the event loop treats an absent gate as fail-open (no pre-filtering), so
+/// unit tests that never install it are unaffected.
+static SPAM_GATE: OnceLock<SpamGate> = OnceLock::new();
+
+/// Why [`SpamGate::install_global`] refused. A zero-size enum (not the bulky
+/// `SpamGate`) so the `Result` stays small; mirrors `price::InstallError`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallError {
+    /// A gate is already installed.
+    AlreadyInstalled,
+}
+
+/// Short-window dedup of event ids (defense in depth, §6 Phase 2).
+struct ReplayGuard {
+    seen: HashMap<EventId, i64>,
+    window_secs: i64,
+}
+
+impl ReplayGuard {
+    fn new(window_secs: i64) -> Self {
+        Self {
+            seen: HashMap::new(),
+            window_secs,
+        }
+    }
+
+    /// Record `id` as seen at `now` and report whether it was **already**
+    /// present within the window (i.e. a replay the caller should drop).
+    /// Expired entries are pruned on the way through so the map stays bounded
+    /// by the in-window event rate.
+    fn check_and_record(&mut self, id: EventId, now: i64) -> bool {
+        let cutoff = now - self.window_secs;
+        self.seen.retain(|_, &mut seen_at| seen_at >= cutoff);
+        // `insert` returns the previous value if the key was present — a
+        // non-expired prior sighting means this is a replay.
+        self.seen.insert(id, now).is_some()
+    }
+}
+
+/// The anti-spam gate: known-keys cache + replay guard.
+pub struct SpamGate {
+    known: RwLock<HashSet<String>>,
+    replay: Mutex<ReplayGuard>,
+}
+
+impl SpamGate {
+    /// Build an empty gate with the given replay window.
+    pub fn new(replay_window_secs: i64) -> Self {
+        Self {
+            known: RwLock::new(HashSet::new()),
+            replay: Mutex::new(ReplayGuard::new(replay_window_secs)),
+        }
+    }
+
+    /// Install as the process-wide gate. Mirrors `PriceManager::install_global`:
+    /// a second call returns `Err(AlreadyInstalled)` rather than panicking.
+    /// (The large `SpamGate` is dropped on the error path rather than returned,
+    /// keeping the `Result` small — clippy `result_large_err`.)
+    pub fn install_global(self) -> Result<(), InstallError> {
+        SPAM_GATE
+            .set(self)
+            .map_err(|_| InstallError::AlreadyInstalled)
+    }
+
+    /// Borrow the installed gate, if any. `None` ⇒ not installed (fail-open).
+    pub fn global() -> Option<&'static SpamGate> {
+        SPAM_GATE.get()
+    }
+
+    /// Replace the known-keys set wholesale with the latest snapshot from the
+    /// DB. A poisoned lock is logged and skipped — a stale cache only costs a
+    /// few legitimate keys a trip through the first-contact lane, never a
+    /// crash.
+    pub fn set_known<I: IntoIterator<Item = String>>(&self, keys: I) {
+        match self.known.write() {
+            Ok(mut set) => {
+                *set = keys.into_iter().collect();
+            }
+            Err(_) => tracing::error!("spam_gate: known-keys lock poisoned; skipping refresh"),
+        }
+    }
+
+    /// Is `pubkey` (hex trade key) a currently-active participant? A poisoned
+    /// lock degrades to `false` (treat as first-contact) — the safe direction:
+    /// the sender just pays the PoW toll instead of being waved through.
+    pub fn is_known(&self, pubkey: &str) -> bool {
+        self.known
+            .read()
+            .map(|set| set.contains(pubkey))
+            .unwrap_or(false)
+    }
+
+    /// Number of cached active keys (diagnostics / tests).
+    pub fn known_count(&self) -> usize {
+        self.known.read().map(|set| set.len()).unwrap_or(0)
+    }
+
+    /// Record `id` and report whether it is a replay to drop. A poisoned lock
+    /// degrades to `false` (never drop a real message because dedup state was
+    /// lost).
+    pub fn is_replay(&self, id: EventId, now: i64) -> bool {
+        match self.replay.lock() {
+            Ok(mut guard) => guard.check_and_record(id, now),
+            Err(_) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nostr_sdk::{EventBuilder, Keys};
+
+    fn an_event_id(note: &str) -> EventId {
+        EventBuilder::text_note(note)
+            .sign_with_keys(&Keys::generate())
+            .expect("sign test event")
+            .id
+    }
+
+    #[test]
+    fn known_set_membership_and_replace() {
+        let gate = SpamGate::new(REPLAY_WINDOW_SECS);
+        assert!(!gate.is_known("a"));
+        gate.set_known(["a".to_string(), "b".to_string()]);
+        assert!(gate.is_known("a"));
+        assert!(gate.is_known("b"));
+        assert!(!gate.is_known("c"));
+        assert_eq!(gate.known_count(), 2);
+
+        // set_known replaces wholesale (a refreshed DB snapshot, not a merge):
+        // a key no longer active drops out.
+        gate.set_known(["c".to_string()]);
+        assert!(gate.is_known("c"));
+        assert!(!gate.is_known("a"));
+        assert_eq!(gate.known_count(), 1);
+    }
+
+    #[test]
+    fn replay_first_seen_then_duplicate() {
+        let gate = SpamGate::new(REPLAY_WINDOW_SECS);
+        let id = an_event_id("dup");
+        let now = 1_000_000;
+        assert!(!gate.is_replay(id, now), "first sighting is not a replay");
+        assert!(
+            gate.is_replay(id, now + 1),
+            "second sighting within window is a replay"
+        );
+        assert!(
+            gate.is_replay(id, now + 30),
+            "still a replay later in the window"
+        );
+    }
+
+    #[test]
+    fn distinct_ids_are_independent() {
+        let gate = SpamGate::new(REPLAY_WINDOW_SECS);
+        let a = an_event_id("a");
+        let b = an_event_id("b");
+        let now = 500;
+        assert!(!gate.is_replay(a, now));
+        assert!(!gate.is_replay(b, now), "a different id is not a replay");
+        assert!(gate.is_replay(a, now), "but re-seeing a is");
+    }
+
+    #[test]
+    fn entry_expires_after_window() {
+        let mut guard = ReplayGuard::new(60);
+        let id = an_event_id("expire");
+        assert!(!guard.check_and_record(id, 1_000));
+        // Past the window the prior sighting is pruned, so it reads as fresh.
+        assert!(!guard.check_and_record(id, 1_000 + 61));
+        // ...and is tracked again from the new timestamp.
+        assert!(guard.check_and_record(id, 1_000 + 61));
+    }
+
+    #[test]
+    fn prune_keeps_map_bounded_to_window() {
+        let mut guard = ReplayGuard::new(60);
+        for i in 0..100 {
+            // Each a distinct id at a distinct, steadily-advancing time.
+            guard.check_and_record(an_event_id(&format!("e{i}")), 10_000 + i);
+        }
+        // Advancing well past the window and touching the guard prunes every
+        // stale entry, leaving only the one just recorded.
+        let fresh = an_event_id("fresh");
+        guard.check_and_record(fresh, 10_000 + 100 + 61);
+        assert_eq!(
+            guard.seen.len(),
+            1,
+            "stale entries must be pruned, leaving only the fresh sighting"
+        );
+    }
+}


### PR DESCRIPTION
## Phase 2 of `docs/TRANSPORT_V2_SPEC.md` — anti-spam gates (the payoff)

Phase (spec §6): **2** — depends on Phase 1 (#776, merged). This is *why* the kind-14 transport exists: because the visible author of a v2 event is the **trade key**, the daemon can pre-validate cheaply **before** paying the NIP-44 decrypt cost.

**v2-only.** The `gift-wrap` (v1) path is completely untouched — its outer key is a throwaway with no pre-validatable signal, so the gate is skipped. **Zero handler changes**: the gate lives entirely in the event-loop preamble.

### Design (confirmed with the maintainer before coding)

Two genuine forks the spec left open were settled via direct question:

1. **First-contact gate = dedicated `pow_first_contact` knob.** Known active-trade keys need only the base `[mostro].pow`; unseen (first-contact) senders must clear `pow_first_contact` *before* the daemon decrypts. It **defaults to `pow`**, so existing `settings.toml` files and the v1 transport are wire-identical until an operator raises it. This is the real "reject before decrypt" lever: keep `pow = 0` for cheap ongoing trades, set `pow_first_contact` high to make spam from fresh keys grind.
2. **Cache refresh = periodic scheduler reload.** Order status mutations are scattered across 13+ handlers with no choke-point, so a periodic full reload (+ startup warm) is the robust, low-coupling strategy over fragile per-handler hooks.

### The two lanes (event loop, kind 14 only)

For each incoming v2 event, before `unwrap_incoming` decrypts:
- **Dedup** — a 60 s replay guard drops a re-sent identical event id (defense in depth). The existing 10 s post-decrypt freshness check still applies as the precise stale-event guard.
- **Known-keys lane** — `event.pubkey` is in the active-trade cache → fast-path (only the base `pow`, already checked, applies).
- **First-contact lane** — `event.pubkey` unseen → must clear `pow_first_contact` or it's dropped pre-decrypt. New orders/takes legitimately arrive here; so does spam, hence the PoW toll (plus relay-side rate limiting).

### What the cache contains

`db::find_active_trade_pubkeys`: buyer/seller/creator trade keys of every **non-terminal** order, plus the solver of every **active** dispute. The terminal set is the restore-session `EXCLUDED_ORDER_STATUSES` **minus `'dispute'`** — a disputed order is still active (parties + solver keep messaging), so its keys must stay fast-pathed. Warmed at startup (`main.rs`) and rebuilt every `active_pubkeys_refresh_interval` seconds (default 60) by `scheduler::job_refresh_active_pubkeys`. Global singleton (`OnceLock`), mirroring `PriceManager`.

### Files

- **`src/spam_gate.rs`** (new) — `SpamGate`: known-keys cache (`RwLock<HashSet>`) + replay guard (`Mutex`), global via `OnceLock`. `InstallError` mirrors `price::InstallError`.
- **`src/db.rs`** — `find_active_trade_pubkeys` + `TERMINAL_ORDER_STATUSES`.
- **`src/app.rs`** — the gate in the event loop (v2 only).
- **`src/config/types.rs`** — `pow_first_contact: Option<u8>` + `active_pubkeys_refresh_interval: u64` (both `#[serde(default)]`), `effective_pow_first_contact()`.
- **`src/scheduler.rs`** — `job_refresh_active_pubkeys`.
- **`src/main.rs`** — install + warm before the event loop.
- **`settings.tpl.toml`**, **`docs/TRANSPORT_V2_SPEC.md`** — document the knobs; Phase 2 marked done.

### Test evidence

- `spam_gate`: membership/wholesale-replace, replay first-seen-then-duplicate, distinct ids independent, window expiry, prune bound.
- `db`: `find_active_trade_pubkeys` covers active + disputed (included) vs terminal + resolved-dispute (excluded), incl. the active-dispute solver.
- `config`: `pow_first_contact` defaults to `pow` / override wins; refresh interval default; a legacy config omitting both Phase 2 keys still parses.
- Full suite: **482 passed, 0 failed**; `cargo clippy --all-targets --all-features -D warnings` clean; `cargo fmt` clean. No `sqlx::query!` macros added → no `sqlx-data` regeneration.

---

## 🧪 Manual testing — step by step

Prereqs: a `mostrod` dev setup. The gate only engages on the **v2** transport, so set `[mostro] transport = "nip44"`. Steps 1–2 need no special client (they read daemon logs + DB); steps exercising real takes need a v2-capable client (mostro-core 0.13). Run with `RUST_LOG=mostro=debug` to see the gate's debug lines.

### 1. Regression — gift-wrap is untouched

1. Keep the default `transport = "gift-wrap"` (or omit it). Start `mostrod`.
2. Expected: behaves exactly as before this PR. The gate is never consulted (it's v2-only); no `pow_first_contact` effect. Existing clients trade normally. ✔️

### 2. Cache warms at startup and refreshes periodically

1. Seed the DB with at least one active order (any non-terminal status) — e.g. create + take an order on a dev node, or insert a row directly.
2. Set:
   ```toml
   [mostro]
   transport = "nip44"
   active_pubkeys_refresh_interval = 10   # fast feedback for testing
   ```
3. Start `mostrod`. Expected at startup:
   ```
   SpamGate: warming active-trade-pubkey cache (N keys)
   ```
   where N = distinct trade keys across non-terminal orders + active-dispute solvers. Then every ~10 s (at debug level):
   ```
   spam_gate: refreshed active-trade-pubkey cache (N keys)
   ```
4. Move an order to a terminal state (e.g. cancel/settle) and watch N drop on the next refresh; create a new order and watch it rise. ✔️

### 3. First-contact PoW gate (the core)

1. Configure a base `pow = 0` (cheap ongoing trades) but a stiff first-contact toll:
   ```toml
   [mostro]
   transport = "nip44"
   pow = 0
   pow_first_contact = 16
   ```
2. From a v2 client using a **brand-new** trade key (one not in any active order), send any message (e.g. a `new-order`) **without** mining 16 bits of PoW on the kind-14 event. Expected — dropped *before decryption*:
   ```
   Dropping first-contact kind-14 event from unknown key <pubkey> below pow_first_contact (16 bits)
   ```
3. Send the same with ≥16 bits of PoW on the event → it passes the gate and is processed normally (the order is created). ✔️
4. **Known-key fast-path:** once that order exists (its trade key is now cached — wait one refresh interval), send a follow-up from that same trade key with **no** PoW. Expected: it is **not** dropped (known keys need only the base `pow = 0`), and is processed. This is the lane split working: ongoing trades are never burdened, only first contact pays. ✔️

### 4. Default `pow_first_contact` = `pow` (backward compatible)

1. Set `transport = "nip44"`, `pow = 0`, and **omit** `pow_first_contact`.
2. Expected: first-contact events with no PoW are accepted (the gate falls back to `pow = 0`) — i.e. flipping a node to v2 alone changes nothing about who can trade; the anti-spam lever is opt-in via `pow_first_contact`. ✔️

### 5. Replay dedup (defense in depth)

1. With `transport = "nip44"`, capture one valid kind-14 event your client sent (e.g. via `nak`) and re-publish the exact same event again within 60 s.
2. Expected (debug): the duplicate is dropped before decryption:
   ```
   Dropping replayed event <event-id>
   ```
   The first copy is processed; the replay is not. ✔️

### 6. Disputed orders stay fast-pathed

1. Open a dispute on an active order (status → `dispute`) and let a solver take it.
2. After the next refresh, confirm (debug log count, or by sending a follow-up from a party's trade key) that the disputed order's buyer/seller/creator **and** the assigned solver are still in the cache — a dispute must not push its participants onto the first-contact lane. ✔️

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Protocol v2 events now undergo replay detection and configurable proof-of-work validation for first-contact participants.
  * Active trade pubkeys are automatically tracked and periodically refreshed from the database.
  * New configuration options: `pow_first_contact` and `active_pubkeys_refresh_interval`.

* **Documentation**
  * Transport v2 specification updated to document Phase 2 implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->