### PR TITLE
feat(transport): log active transport at mostrod startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,9 +77,16 @@ async fn main() -> Result<()> {
 
     // Subscribe only to the configured transport's kind: 1059 (protocol v1
     // gift wrap) or 14 (protocol v2 NIP-44 direct). See docs/TRANSPORT_V2_SPEC.md.
+    let transport = Settings::get_mostro().transport;
+    tracing::info!(
+        "Transport: {} (protocol v{}, event kind {})",
+        transport,
+        transport.protocol_version(),
+        transport.event_kind().as_u16()
+    );
     let subscription = Filter::new()
         .pubkey(mostro_keys.public_key())
-        .kind(Settings::get_mostro().transport.event_kind())
+        .kind(transport.event_kind())
         .limit(0);
 
     let client = match get_nostr_client() {


### PR DESCRIPTION
## What

Emit an info-level log line on `mostrod` boot showing the configured transport, so operators can confirm at a glance which wire protocol the node speaks.

The line prints the transport name, protocol version, and Nostr event kind:

- `Transport: gift-wrap (protocol v1, event kind 1059)`
- `Transport: nip44 (protocol v2, event kind 14)`

## Why

With protocol v2 (NIP-44 direct) now wired in, a node speaks exactly one transport. Until now there was no startup signal telling an operator which one is active — only the NIP-33 info event advertised it to clients. This surfaces it directly in the daemon logs.

## Notes

Reuses the already-computed `transport` value for the subscription filter, so no extra `get_mostro()` call. `Transport` already implements `Display` plus `protocol_version()` / `event_kind()` in `mostro-core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Nostr relay subscription setup to improve transport configuration handling and logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->