### PR TITLE
ci(mutation): run as scheduled audit + opt-in instead of on every push to main

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,8 +1,11 @@
 name: Mutation Testing
 
 on:
-  push:
-    branches: [main]
+  # NOTE: intentionally NOT run on push to main. Full mutation testing is
+  # slow (one test-suite run per mutant) and `continue-on-error` here, so it
+  # gates nothing — running it on every merge only burns CI minutes. It runs
+  # as a weekly audit (schedule) and on demand (workflow_dispatch), plus an
+  # opt-in per-PR job (the `run-mutation` label).
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
@@ -38,7 +41,9 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
 
       - name: Run mutation testing on changed files
         # Only test mutants in files changed in this PR
@@ -185,7 +190,9 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-mutants
-        run: cargo install cargo-mutants
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
 
       - name: Run full mutation testing
         run: cargo mutants

--- a/docs/MUTATION_TESTING.md
+++ b/docs/MUTATION_TESTING.md
@@ -110,11 +110,21 @@ test_tool_options = ["--", "--test-threads=1"]
 
 ## CI/CD Integration
 
-Mutation testing runs in CI on every PR and on main branch:
+Mutation testing is **not** run on every push to `main`: a full run is slow
+(one test-suite run per mutant) and the job is `continue-on-error`, so running
+it on every merge would only burn CI minutes without gating anything. Instead
+it runs as a periodic audit plus an opt-in per-PR job:
 
-1. **PR workflow**: Runs mutation testing on changed files only (faster feedback)
-2. **Main branch**: Runs full mutation testing weekly (baseline tracking)
-3. **Release gate**: Mutation score must not decrease from previous release
+1. **PR workflow (opt-in)**: Add the `run-mutation` label to a PR to test
+   mutants in the files it changed only (faster feedback).
+2. **Weekly baseline** (`schedule`): Full mutation testing every Sunday for
+   baseline tracking, with the HTML report published to GitHub Pages.
+3. **On demand** (`workflow_dispatch`): Trigger a full run manually from the
+   Actions tab whenever needed.
+
+For pre-push feedback, run it locally instead (see [Running Locally](#running-locally))
+— `cargo mutants --in-diff` against `main` is the closest equivalent to the
+opt-in PR job.
 
 ### Initial Setup (Non-blocking)
 
@@ -224,6 +234,9 @@ fn test_order_validation_rejects_invalid() {
 
 # Or run cargo-mutants directly:
 cargo mutants --file src/flow.rs --output mutants.out
+
+# Pre-push: only mutants in your diff vs main (mirrors the opt-in PR job)
+cargo mutants --in-diff <(git diff origin/main...HEAD)
 ```
 
 ## Performance Considerations


### PR DESCRIPTION
## What

Stop running full mutation testing on every push to `main`. Keep it as a periodic + on-demand audit and an opt-in per-PR job, and speed up the tool install.

## Why

The `mutation-baseline` job ran a **full `cargo mutants` over the whole codebase on every push to `main`** (the run that prompted this: it sat in progress for 20+ min). Two problems:

- It is `continue-on-error: true`, so it **gates nothing** — it only produces a report.
- Mutation testing is inherently slow (one full test-suite run per mutant), so a per-merge full run burns a lot of CI minutes for no enforcement value, especially when a **weekly scheduled run already exists**.

Moving it fully local was considered and rejected: a non-gating, informational job that depends on each dev remembering to run a slow command locally would simply rot, and we'd lose the published HTML report and historical artifacts. The right fix is changing *when* CI runs it, not removing it.

## Changes

- **Drop the `push: [main]` trigger.** The baseline now runs via:
  - `schedule` — weekly full run (unchanged), HTML report to GitHub Pages
  - `workflow_dispatch` — manual on-demand full run
  - opt-in per-PR job via the existing `run-mutation` label (unchanged)
- **Swap `cargo install cargo-mutants` → `taiki-e/install-action`** (prebuilt binaries) in both jobs, saving the from-source compile each run.
- **Docs** (`docs/MUTATION_TESTING.md`): describe the new triggers and point to `cargo mutants --in-diff` for pre-push local feedback.

## Notes

- No behavior change for the actual mutation analysis — only its triggers and install method.
- YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated mutation testing documentation with new workflow descriptions and local pre-push testing command example.

* **Chores**
  * Modified mutation testing workflow to require opt-in via label for pull requests, while maintaining weekly scheduled and manual on-demand runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->