### PR TITLE
docs(cashu): phased implementation spec series for Cashu escrow

### DIFF
--- a/docs/CASHU_ESCROW_ARCHITECTURE.md
+++ b/docs/CASHU_ESCROW_ARCHITECTURE.md
@@ -97,7 +97,7 @@ The introduction of Cashu Escrow modifies the responsibility of core action hand
 ## CDK Implementation Details
 
 ### Generating Spending Conditions
-Sellers construct the 2-of-3 spending condition using `cdk::nuts::nut10`. We recommend the `SIG_INPUTS` flag. This allows the seller to sign the authorization once and pass it to the buyer, allowing the buyer to specify their own target outputs independently.
+Sellers construct the 2-of-3 spending condition using `cdk::nuts::nut10`. We recommend the `SIG_INPUTS` flag. This allows the seller to sign the authorization once and pass it to the buyer, allowing the buyer to specify their own target outputs independently. The same condition also carries a **seller-recovery `locktime` + `refund = [P_S]`** (see the note after the snippet, and Track A §4B for the exact rules).
 
 ```rust
 use cdk::nuts::nut10::{Conditions, SpendingConditions, SigFlag};
@@ -123,6 +123,18 @@ let conditions = Conditions::new(
 let secret = SpendingConditions::new_p2pk(p_s, Some(conditions));
 ```
 
+> **Note — the snippet omits the seller-recovery locktime for brevity.** The
+> production condition MUST also set a NUT-11 `locktime = now +
+> cashu.escrow_locktime_days` (default **15 days**) and `refund = [P_S]` with
+> `n_sigs_refund = 1`. Before the locktime it is the plain 2-of-3; after it, the
+> seller (`P_S`) can reclaim **alone**, so funds are never permanently stuck if
+> Mostro vanishes and the buyer won't cooperate. The daemon enforces a floor on
+> the locktime and that `refund` is exactly `[P_S]`. Exact construction and the
+> security rationale (the "short-locktime theft" vector) are in
+> [`cashu/02-track-a-lock.md`](./cashu/02-track-a-lock.md) §4B. (The exact
+> `Conditions::new` argument order is whatever the pinned `cdk` version uses —
+> confirm against it; the snippet above is illustrative.)
+
 ### Signature Flags: `SIG_INPUTS` vs `SIG_ALL`
 *   **`SIG_INPUTS`:** The easiest UX. The Seller only signs the intent to release. The Buyer receives the signature via Nostr DM, crafts their own unblinded outputs, signs the request, and asks the Mint to swap.
 *   **`SIG_ALL`:** The safest UX against malicious Mints. The Buyer must pre-construct their outputs, send the hash to the Seller, and the Seller signs the entire bundle. 
@@ -131,7 +143,7 @@ let secret = SpendingConditions::new_p2pk(p_s, Some(conditions));
 ## Advantages over Lightning Hold Invoices
 
 1. **Non-Custodial:** Mostro drops all legal and technical burdens of custody. A compromised Mostro server only leaks 1 of 3 keys, meaning attacker cannot steal active escrows.
-2. **Offline Resilience:** If Mostro's daemon crashes or vanishes permanently, the Buyer and Seller can still cooperate out-of-band to settle the trade (Seller + Buyer = 2 keys).
+2. **Offline Resilience:** If Mostro's daemon crashes or vanishes permanently, the Buyer and Seller can still cooperate out-of-band to settle the trade (Seller + Buyer = 2 keys). And if the buyer *also* goes silent, the NUT-11 `locktime` lets the **seller reclaim alone** once it expires (`cashu.escrow_locktime_days`, default 15 — see Track A §4B), so the funds are never permanently stuck.
 3. **No Routing Failures:** Bypasses Lightning Network topology, channel liquidity constraints, and unpredictable routing fees.
 4. **Zero Capital Lockup:** Mostro does not require inbound/outbound channel liquidity to facilitate trades.
 

--- a/docs/cashu/01-fundamentals.md
+++ b/docs/cashu/01-fundamentals.md
@@ -82,15 +82,29 @@ need a foundation PR.** Treat them as the frozen contract the tracks build on.
 | Item | Location | Notes |
 |------|----------|-------|
 | Migration `cashu_escrow_fields` | `migrations/20260530120000_cashu_escrow_fields.sql` | adds the 3 `cashu_*` columns; **schema is frozen — no track adds a migration for escrow fields** |
-| `EscrowBackend` trait | `src/escrow.rs` | `create_hold_invoice` / `settle_hold_invoice` / `cancel_hold_invoice` |
-| `impl EscrowBackend for LndConnector` | `src/escrow.rs` | behaviour-preserving Lightning pass-through |
-| `CashuBackend` stub | `src/escrow.rs` | methods return a typed "not implemented" error (no `panic!`) |
-| `release_action` routed through `&mut dyn EscrowBackend` | `src/app/release.rs` | the seam already exists for release |
 
-> **Design consequence:** because the protocol, schema, and the escrow seam are
-> already on `main`, the foundation is **much smaller** than the original F1–F6
-> plan. We do **not** re-open `mostro-core`, we do **not** add a migration, and we
-> do **not** do a large handler refactor. The risk surface shrinks accordingly.
+### Escrow seam — NOT yet on `main` (owned by CF-0)
+
+The narrow `EscrowBackend` seam is **not** in the tree yet: `rg 'trait
+EscrowBackend' src` is empty, there is no `src/escrow.rs`, and `release_action`
+still takes `&mut LndConnector` directly. It is therefore **not** a baseline
+assumption — it is the first foundation PR, **CF-0**, a behaviour-preserving
+refactor that must merge before CF-5 (which wires `Arc<dyn EscrowBackend>` into
+`AppContext`):
+
+| Item | Location | Notes |
+|------|----------|-------|
+| `EscrowBackend` trait | `src/escrow.rs` (new) | `create_hold_invoice` / `settle_hold_invoice` / `cancel_hold_invoice` |
+| `impl EscrowBackend for LndConnector` | `src/escrow.rs` (new) | behaviour-preserving Lightning pass-through |
+| `CashuBackend` stub | `src/escrow.rs` (new) | methods return a typed "not implemented" error (no `panic!`) |
+| `release_action` routed through `&mut dyn EscrowBackend` | `src/app/release.rs` | replaces the direct `&mut LndConnector` parameter; Lightning behaviour unchanged |
+
+> **Design consequence:** because the protocol and schema are already on `main`,
+> the foundation is **much smaller** than the original F1–F6 plan. We do **not**
+> re-open `mostro-core` and we do **not** add a migration. The one refactor we do
+> need — establishing the `EscrowBackend` seam — is isolated into **CF-0** so no
+> later track has to touch `release.rs` or invent an unplanned shared-file
+> refactor mid-flight. The risk surface shrinks accordingly.
 
 ---
 
@@ -112,12 +126,13 @@ Carried from the architecture doc, restated as constraints:
    cashu.enabled` is a hard config error at startup.
 6. **`mostro-core 0.13.0` protocol is frozen** for the whole foundation +
    tracks effort (see §3).
-7. **Keep the existing narrow `EscrowBackend` seam; branch handlers on
+7. **Establish a narrow `EscrowBackend` seam (CF-0); branch handlers on
    `escrow_mode`.** We do **not** redesign `EscrowBackend` into a high-level
-   `lock`/`release`/`cancel`/`dispute` trait during foundation. The trait stays
-   the LN hold-invoice shape already on `main`; Cashu behaviour is added by
-   branching the relevant handlers on `Settings::escrow_mode()` /
-   `is_cashu_enabled()` (the pattern the existing `release_action` already uses).
+   `lock`/`release`/`cancel`/`dispute` trait during foundation. The trait keeps
+   the LN hold-invoice shape (`create`/`settle`/`cancel_hold_invoice`); Cashu
+   behaviour is added by branching the relevant handlers on
+   `Settings::escrow_mode()` / `is_cashu_enabled()` (the same pattern `release_action`
+   adopts once CF-0 routes it through `&mut dyn EscrowBackend`).
    Rationale: the high-traffic handler files (`take_*`, `cancel`, `admin_*`,
    `release`) stay behaviourally untouched on the Lightning path, which is the
    whole point of keeping `mostrod` stable. A higher-level escrow trait is
@@ -127,15 +142,18 @@ Carried from the architecture doc, restated as constraints:
 
 ## 5. Foundation milestone — overview
 
-Five PRs. Four are independent and parallelisable; one is the integration PR that
-must merge last.
+Six PRs. One precursor (CF-0) establishes the escrow seam and merges first; four
+are independent and parallelisable; one is the integration PR that merges last.
 
 ```mermaid
 flowchart TD
   subgraph BASE["Already on main (no PR)"]
     P["Protocol surface (mostro-core 0.13.0)"]
     M["cashu_* columns migration"]
-    E["EscrowBackend trait + Lightning impl + Cashu stub"]
+  end
+
+  subgraph WAVE0["Wave 0 — precursor (merges first)"]
+    CF0["CF-0 · EscrowBackend seam<br/>(trait + Lightning impl + Cashu stub,<br/>route release through it)"]
   end
 
   subgraph WAVE1["Wave 1 — fully parallel (4 devs)"]
@@ -150,6 +168,7 @@ flowchart TD
   end
 
   P --> CF2
+  CF0 --> CF5
   CF1 --> CF5
   CF2 --> CF5
   CF4 -. used by .-> CF5
@@ -158,10 +177,13 @@ flowchart TD
   CF5 --> END
 ```
 
-**Reading the graph:** `CF-1`, `CF-2`, `CF-3`, `CF-4` have no dependencies on
-each other and can be opened simultaneously. `CF-5` is the only sequential gate —
-it needs `CF-1` (to read the mode) and `CF-2` (to connect the mint) merged first,
-and soft-uses `CF-4`'s helpers for in-flight discovery.
+**Reading the graph:** `CF-0` is the behaviour-preserving precursor that lands the
+`EscrowBackend` seam (and routes `release` through it) before anything builds on
+it. `CF-1`, `CF-2`, `CF-3`, `CF-4` have no dependencies on each other and can be
+opened simultaneously once CF-0 is in. `CF-5` is the only sequential gate — it
+needs `CF-0` (the seam it wires into `AppContext`), `CF-1` (to read the mode) and
+`CF-2` (to connect the mint) merged first, and soft-uses `CF-4`'s helpers for
+in-flight discovery.
 
 ---
 
@@ -298,8 +320,11 @@ schema-adjacent code is frozen and reviewed once.
     cashu_escrow_locked_at IS NULL`, returning whether a row matched. No
     lock-without-advance window; replay-safe.
   - `async fn find_locked_cashu_orders(pool) -> Result<Vec<Order>, MostroError>`
-    — `WHERE cashu_escrow_locked_at IS NOT NULL AND status = <Active>` (bind the
-    `Status` enum, not a literal).
+    — `WHERE cashu_escrow_locked_at IS NOT NULL`. Do **not** add a `status`
+    predicate: `update_order_cashu_escrow` advances the status in the same write
+    as the lock, so filtering on `Active` would skip legitimately locked rows
+    that have already moved on. Only re-add a status predicate if a separate
+    invariant guarantees locked rows never leave `Active`.
 
 **Must NOT.** Add or alter any migration. Be called from a hot path yet.
 
@@ -356,8 +381,9 @@ unmodified.
 Cashu mode yields `CantDo(InvalidAction)`; scheduler skips LN jobs in Cashu mode.
 The "Lightning mode unchanged" guarantee is covered by the existing suite.
 
-**Dependencies.** **CF-1** (mode + `is_cashu_enabled`) and **CF-2** (mint
-connect) are hard prerequisites; **CF-4** is a soft prerequisite (used for
+**Dependencies.** **CF-0** (the `EscrowBackend` seam wired into `AppContext`),
+**CF-1** (mode + `is_cashu_enabled`) and **CF-2** (mint connect) are hard
+prerequisites; **CF-4** is a soft prerequisite (used for
 in-flight Cashu discovery / restore if included). **Conflict surface.** `main.rs`,
 `app.rs`, `app/context.rs`, `scheduler.rs` — the high-traffic shared files. This
 is why it merges **last and alone** in the milestone. **Parallel with.** Nothing
@@ -469,9 +495,9 @@ change.
 wrapper) and `cashu_client: Option<Arc<CashuClient>>`, with `escrow()` /
 `cashu_client()` accessors. Lightning constructs `LndConnector`-backed escrow and
 `cashu_client = None`; Cashu constructs the `CashuBackend` (still stubbed) and
-`cashu_client = Some(connected)`. The narrow `EscrowBackend` trait is unchanged
-(see §4.7) — handlers reach Cashu behaviour by branching on
-`Settings::escrow_mode()`, not through new trait methods.
+`cashu_client = Some(connected)`. The narrow `EscrowBackend` trait (established by
+CF-0, see §4.7) is consumed here unchanged — handlers reach Cashu behaviour by
+branching on `Settings::escrow_mode()`, not through new trait methods.
 
 ---
 
@@ -483,19 +509,21 @@ wrapper) and `cashu_client: Option<Arc<CashuClient>>`, with `escrow()` /
 
 | ID | Title | Wave | Depends on | Can run in parallel with | Conflict-prone files | Risk |
 |----|-------|------|-----------|--------------------------|----------------------|------|
+| **CF-0** | `EscrowBackend` seam (trait + `LndConnector` impl + `CashuBackend` stub; route `release_action` through `&mut dyn EscrowBackend`) | 0 | — | — (precursor, merges first) | new `src/escrow.rs`, `src/app/release.rs` | Low (behaviour-preserving) |
 | **CF-1** | Config + escrow mode (`CashuSettings`, `EscrowMode`, validation, wizard/template) | 1 | — | CF-2, CF-3, CF-4 | `config/*`, `settings.tpl.toml` | Low |
 | **CF-2** | `CashuClient` library (`cdk` wrapper, token/condition/DLEQ verification) | 1 | — (`cdk` only) | CF-1, CF-3, CF-4 | new `src/cashu/mod.rs`, `Cargo.toml` | Medium (crypto) |
 | **CF-3** | Cashu test harness (mint container + opt-in CI + integration skeleton) | 1 | — | CF-1, CF-2, CF-4 | `.github/workflows/ci.yml`, new test files | Low |
 | **CF-4** | DB escrow helpers (`update_order_cashu_escrow` CAS, `find_locked_cashu_orders`) | 1 | — (schema on `main`) | CF-1, CF-2, CF-3 | `src/db.rs` (additive) | Low |
-| **CF-5** | Cashu boot + `run_cashu` + `AppContext` wiring + scheduler gating | 2 | **CF-1, CF-2** (hard), CF-4 (soft) | — (integration join) | `main.rs`, `app.rs`, `app/context.rs`, `scheduler.rs` | Medium-High |
+| **CF-5** | Cashu boot + `run_cashu` + `AppContext` wiring + scheduler gating | 2 | **CF-0, CF-1, CF-2** (hard), CF-4 (soft) | — (integration join) | `main.rs`, `app.rs`, `app/context.rs`, `scheduler.rs` | Medium-High |
 
 ### Critical path
-`CF-1` + `CF-2` → `CF-5`. Everything else (`CF-3`, `CF-4`) hangs off the side and
-never blocks the critical path. With four developers, Wave 1 collapses to the
-duration of the slowest of `CF-1`/`CF-2`, then `CF-5`.
+`CF-0` → (`CF-1` + `CF-2`) → `CF-5`. Everything else (`CF-3`, `CF-4`) hangs off
+the side and never blocks the critical path. With four developers, CF-0 lands
+first (small, behaviour-preserving), then Wave 1 collapses to the duration of the
+slowest of `CF-1`/`CF-2`, then `CF-5`.
 
 ### Suggested assignment (4 devs)
-- Dev A → **CF-1** (config), then pairs on **CF-5**.
+- Dev A → **CF-0** (escrow seam, merges first), then **CF-1** (config), then pairs on **CF-5**.
 - Dev B → **CF-2** (mint client) — the longest pole; start first.
 - Dev C → **CF-3** (harness), then unblocks CF-2's mint-backed tests.
 - Dev D → **CF-4** (db helpers), then reviews **CF-5**.
@@ -506,7 +534,7 @@ duration of the slowest of `CF-1`/`CF-2`, then `CF-5`.
 
 The foundation is complete when **all** hold:
 
-1. `CF-1`…`CF-5` are merged to `main`, each as its own PR.
+1. `CF-0`…`CF-5` are merged to `main`, each as its own PR.
 2. A node with `[cashu] enabled = true` and a reachable `mint_url` **boots**,
    logs that it is in Cashu mode, connects to the mint, and runs `run_cashu`
    **without an LND node present**.

--- a/docs/cashu/01-fundamentals.md
+++ b/docs/cashu/01-fundamentals.md
@@ -200,8 +200,10 @@ validation — but wire it to **nothing** at runtime yet (only config validation
 reads it).
 
 **Files.**
-- `src/config/types.rs` — `struct CashuSettings { enabled: bool, mint_url: String }`
-  (both `#[serde(default)]`); `enum EscrowMode { Lightning, Cashu }`.
+- `src/config/types.rs` — `struct CashuSettings { enabled: bool, mint_url: String,
+  escrow_locktime_days: u32 }` (all `#[serde(default)]`; `escrow_locktime_days`
+  defaults to **15** and must be `>= 1` — it is the seller-recovery locktime floor,
+  see Track A §4B); `enum EscrowMode { Lightning, Cashu }`.
 - `src/config/settings.rs` — `pub cashu: Option<CashuSettings>` on `Settings`
   (`#[serde(default)]`, mirroring `anti_abuse_bond`); `Settings::get_cashu()`,
   `Settings::is_cashu_enabled()`, `Settings::escrow_mode()`.
@@ -240,12 +242,17 @@ parse/validate tokens and talk to a mint. **Not wired into the daemon.**
     is reachable and supports the required NUTs (07 state, 11 P2PK, 12 DLEQ).
   - `async fn check_state(&self, ys) -> Result<CheckStateResponse, Error>` — NUT-07.
   - `fn verify_2of3_condition(token, p_b, p_s, p_m) -> Result<Token, Error>` —
-    parses, asserts exactly 2 required sigs, no locktime, no refund keys, and the
-    three expected pubkeys present (NUT-10/11).
+    parses, asserts exactly 2 required sigs (`n_sigs = 2`) over the three expected
+    pubkeys, **a `locktime` tag present**, and **`refund = [P_S]` with
+    `n_sigs_refund = 1`** and no other refund key (the seller-recovery path, Track A
+    §4B) (NUT-10/11). The locktime *value* (floor check) is verified by
+    `verify_escrow_token`, which holds the config.
   - `async fn verify_token_dleq(&self, token) -> Result<(), Error>` — NUT-12.
-  - `async fn verify_escrow_token(&self, token, p_b, p_s, p_m, expected_amount)` —
+  - `async fn verify_escrow_token(&self, token, p_b, p_s, p_m, expected_amount, min_locktime)` —
     composes the above into one acceptance check (condition + mint binding +
-    amount + DLEQ + unspent).
+    amount + DLEQ + unspent + **`token.locktime >= min_locktime`**, where the
+    caller passes `min_locktime = now + cashu.escrow_locktime_days`; the seller may
+    set a longer locktime for marketplace trades, never a shorter one — Track A §4B).
   - `fn cashu_pubkey_from_xonly_hex(hex) -> Result<PublicKey, Error>` — maps a
     Nostr x-only trade pubkey to a Cashu `PublicKey`.
 - `src/main.rs` — register `pub mod cashu;` **only** (a `mod` declaration is not
@@ -257,8 +264,9 @@ global state beyond what the unit tests need.
 **Backwards-compat guarantee.** Adding a dependency and an unreferenced module
 changes no runtime behaviour. The Lightning path never constructs a `CashuClient`.
 
-**Tests.** Unit tests for `verify_2of3_condition` (accept valid 2-of-3; reject
-wrong sig count, locktime present, refund keys present, missing/extra pubkey) and
+**Tests.** Unit tests for `verify_2of3_condition` (accept a valid 2-of-3 carrying a
+`locktime` + `refund = [P_S]`; reject wrong sig count, missing locktime, missing/
+wrong/extra refund key, missing/extra pubkey) and
 `cashu_pubkey_from_xonly_hex`. Mint-backed tests (`connect`, `check_state`,
 `verify_token_dleq`) run against the CF-3 container and are `#[ignore]`d /
 env-gated when the mint is absent, so they don't break offline CI.

--- a/docs/cashu/01-fundamentals.md
+++ b/docs/cashu/01-fundamentals.md
@@ -1,0 +1,568 @@
+# Cashu Escrow — Fundamentals (Foundation Milestone)
+
+**Status:** Draft for review · **Target:** `main` (`mostro-core 0.13.0`) ·
+**Feature flag:** `[cashu].enabled`, defaults to `false`
+
+This document is the engineering plan for the **foundation** of Cashu escrow in
+`mostrod`. It does not implement any trade flow — its single goal is to put every
+shared scaffold in place, on `main`, **without changing how the daemon behaves
+today**, so that the four feature tracks (lock / release / cooperative-cancel /
+dispute) can afterwards be built in parallel on disjoint files.
+
+Read [`../CASHU_ESCROW_ARCHITECTURE.md`](../CASHU_ESCROW_ARCHITECTURE.md) first
+for the crypto model and motivation. This document assumes it.
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+- Land all **shared, conflict-prone scaffolding** for Cashu on `main` in small
+  PRs, each independently reviewable and shippable.
+- After the milestone: a node configured with `[cashu] enabled = true` **boots**,
+  connects to its mint, and runs — but every trade action is safely rejected
+  with a clear "not implemented yet" error. No trade can be completed yet.
+- Keep `mostrod` byte-for-byte behaviourally identical when Cashu is **off**.
+- Maximise parallelism for the feature tracks that follow.
+
+### Non-goals (explicitly out of scope here)
+- Any actual Cashu trade flow: lock, release, cancel, dispute. Those are the
+  feature tracks (docs 02–05).
+- Any change to the Lightning hold-invoice flow beyond *additive* seams.
+- `mostro-core` protocol changes — the 0.13.0 surface is treated as **frozen**
+  (see §3). If a track later needs a new variant, that is a separate
+  `mostro-core` release, not foundation work.
+- Per-order mint negotiation, multi-mint allow-lists, Cashu-native bonds, Cashu
+  fee collection — all future work.
+
+---
+
+## 2. Non-negotiable principles (merge gates)
+
+Every PR in this milestone is reviewed against these. A PR that cannot satisfy
+all four is mis-scoped and must be split.
+
+1. **Off-by-default, behaviour-preserving.** With `[cashu]` absent or
+   `enabled = false`, the daemon must behave exactly as it does on `main` today.
+   This is verified by the existing test suite staying green *unmodified* (tests
+   may be *added*, not *changed to accommodate new behaviour*).
+2. **Atomic and shippable.** Each PR is self-contained and leaves `main`
+   releasable. No PR depends on a *future* PR to compile or pass CI.
+3. **Additive only.** New modules, new config keys, new DB helper functions, new
+   trait methods. No existing public signature changes in a way that breaks the
+   Lightning path. Schema changes are forbidden here — the columns already exist
+   on `main` (see §3).
+4. **Inert until wired.** New code paths added before the integration PR
+   (`CF-5`) must be unreachable at runtime (dead-but-tested library code). The
+   single PR that makes Cashu code reachable is `CF-5`, and even then only the
+   *boot path* — all *handlers* still return "not implemented".
+
+---
+
+## 3. Baseline — what is ALREADY on `main` (do not re-implement)
+
+Confirmed present on `origin/main` with `mostro-core 0.13.0`. **None of these
+need a foundation PR.** Treat them as the frozen contract the tracks build on.
+
+### Protocol surface (in `mostro-core 0.13.0`, frozen)
+
+| Item | Location | Notes |
+|------|----------|-------|
+| `Action::AddCashuEscrow` | `message.rs` | seller → Mostro, carries `CashuLockProof` |
+| `Action::CashuEscrowLocked` | `message.rs` | Mostro → parties, informational |
+| `Action::CashuPmSignature` | `message.rs` | Mostro → winner, carries `CashuSignatures` |
+| `Payload::CashuLockProof(CashuLockProof)` | `message.rs` | `{ token, mint_url, buyer_pubkey, seller_pubkey, mostro_pubkey }` (all hex/strings) |
+| `Payload::CashuSignatures(Vec<CashuProofSignature>)` | `message.rs` | `CashuProofSignature { secret, signature }` |
+| `CantDoReason::{InvalidCashuToken, CashuMintUnavailable, InvalidMintUrl, CashuEscrowNotLocked, CashuSignatureMissing}` | `error.rs` | |
+| `Order.{cashu_mint_url, cashu_escrow_token, cashu_escrow_locked_at}` | `order.rs` | all `Option`, `SmallOrder` unaffected |
+| `MessageKind::verify()` arms for `AddCashuEscrow` / `CashuPmSignature` | `message.rs` | payload-shape checks |
+
+### Daemon scaffolding already merged to `main`
+
+| Item | Location | Notes |
+|------|----------|-------|
+| Migration `cashu_escrow_fields` | `migrations/20260530120000_cashu_escrow_fields.sql` | adds the 3 `cashu_*` columns; **schema is frozen — no track adds a migration for escrow fields** |
+| `EscrowBackend` trait | `src/escrow.rs` | `create_hold_invoice` / `settle_hold_invoice` / `cancel_hold_invoice` |
+| `impl EscrowBackend for LndConnector` | `src/escrow.rs` | behaviour-preserving Lightning pass-through |
+| `CashuBackend` stub | `src/escrow.rs` | methods return a typed "not implemented" error (no `panic!`) |
+| `release_action` routed through `&mut dyn EscrowBackend` | `src/app/release.rs` | the seam already exists for release |
+
+> **Design consequence:** because the protocol, schema, and the escrow seam are
+> already on `main`, the foundation is **much smaller** than the original F1–F6
+> plan. We do **not** re-open `mostro-core`, we do **not** add a migration, and we
+> do **not** do a large handler refactor. The risk surface shrinks accordingly.
+
+---
+
+## 4. Locked design decisions (do not re-litigate per PR)
+
+Carried from the architecture doc, restated as constraints:
+
+1. **Global mode switch, not per-order.** A node runs in exactly one escrow mode:
+   `lightning` (default) **or** `cashu`, fixed in `settings.toml`. In `cashu`
+   mode the LND connector is **not initialised** at boot.
+2. **Node-configured, fixed mint.** One `mint_url` per node; all Cashu trades use
+   it. No per-order mint.
+3. **Coordinator, not wallet.** The daemon validates tokens, holds `P_M`, and
+   signs only during dispute resolution. All wallet operations live in clients.
+4. **Trade keys for `P_B` / `P_S`.** The 2-of-3 condition embeds the per-order
+   **trade** pubkeys, never identity/master keys. `P_M` is Mostro's arbitrator
+   key.
+5. **Bonds ⊕ Cashu are mutually exclusive.** `anti_abuse_bond.enabled &&
+   cashu.enabled` is a hard config error at startup.
+6. **`mostro-core 0.13.0` protocol is frozen** for the whole foundation +
+   tracks effort (see §3).
+7. **Keep the existing narrow `EscrowBackend` seam; branch handlers on
+   `escrow_mode`.** We do **not** redesign `EscrowBackend` into a high-level
+   `lock`/`release`/`cancel`/`dispute` trait during foundation. The trait stays
+   the LN hold-invoice shape already on `main`; Cashu behaviour is added by
+   branching the relevant handlers on `Settings::escrow_mode()` /
+   `is_cashu_enabled()` (the pattern the existing `release_action` already uses).
+   Rationale: the high-traffic handler files (`take_*`, `cancel`, `admin_*`,
+   `release`) stay behaviourally untouched on the Lightning path, which is the
+   whole point of keeping `mostrod` stable. A higher-level escrow trait is
+   possible *future* refactor work, never a prerequisite for shipping Cashu.
+
+---
+
+## 5. Foundation milestone — overview
+
+Five PRs. Four are independent and parallelisable; one is the integration PR that
+must merge last.
+
+```mermaid
+flowchart TD
+  subgraph BASE["Already on main (no PR)"]
+    P["Protocol surface (mostro-core 0.13.0)"]
+    M["cashu_* columns migration"]
+    E["EscrowBackend trait + Lightning impl + Cashu stub"]
+  end
+
+  subgraph WAVE1["Wave 1 — fully parallel (4 devs)"]
+    CF1["CF-1 · Config + escrow mode<br/>(no boot wiring)"]
+    CF2["CF-2 · CashuClient library<br/>(cdk wrapper, unit-tested)"]
+    CF3["CF-3 · Cashu test harness<br/>(mint container + CI)"]
+    CF4["CF-4 · DB escrow helpers"]
+  end
+
+  subgraph WAVE2["Wave 2 — integration (merges last)"]
+    CF5["CF-5 · Cashu boot + run_cashu + AppContext wiring"]
+  end
+
+  P --> CF2
+  CF1 --> CF5
+  CF2 --> CF5
+  CF4 -. used by .-> CF5
+  CF3 -. validates .-> CF2
+  CF1 --> END["Foundation done:<br/>node boots in cashu mode,<br/>all handlers stubbed/blocked"]
+  CF5 --> END
+```
+
+**Reading the graph:** `CF-1`, `CF-2`, `CF-3`, `CF-4` have no dependencies on
+each other and can be opened simultaneously. `CF-5` is the only sequential gate —
+it needs `CF-1` (to read the mode) and `CF-2` (to connect the mint) merged first,
+and soft-uses `CF-4`'s helpers for in-flight discovery.
+
+---
+
+## 6. PR specifications
+
+Each PR below lists: **scope**, **files**, **what it must NOT do**,
+**backwards-compat guarantee**, **tests**, **dependencies**, and **conflict
+surface**.
+
+### CF-1 · Config + escrow mode (no boot change)
+
+**Scope.** Introduce Cashu configuration and the escrow-mode resolution, with
+validation — but wire it to **nothing** at runtime yet (only config validation
+reads it).
+
+**Files.**
+- `src/config/types.rs` — `struct CashuSettings { enabled: bool, mint_url: String }`
+  (both `#[serde(default)]`); `enum EscrowMode { Lightning, Cashu }`.
+- `src/config/settings.rs` — `pub cashu: Option<CashuSettings>` on `Settings`
+  (`#[serde(default)]`, mirroring `anti_abuse_bond`); `Settings::get_cashu()`,
+  `Settings::is_cashu_enabled()`, `Settings::escrow_mode()`.
+- `src/config/util.rs` — validation in `validate_mostro_settings`: (a) reject
+  `cashu.enabled && anti_abuse_bond.enabled`; (b) when enabled, require non-empty
+  `mint_url` that parses as `http`/`https`.
+- `src/config/wizard.rs` + `settings.tpl.toml` — a commented `[cashu]` block and
+  an optional interactive prompt.
+
+**Must NOT.** Touch `main.rs` boot, the scheduler, `AppContext`, or any handler.
+`escrow_mode()` may exist but nothing calls it on a hot path yet.
+
+**Backwards-compat guarantee.** `[cashu]` absent ⇒ `get_cashu() == None` ⇒
+`is_cashu_enabled() == false` ⇒ `escrow_mode() == Lightning`. A config that does
+not mention Cashu validates and boots exactly as before.
+
+**Tests.** Unit tests for serde defaults (absent block, disabled block, enabled
+block), mutual-exclusion rejection, and `mint_url` scheme validation. (These
+mirror the `anti_abuse_bond` config tests already in the tree.)
+
+**Dependencies.** None. **Conflict surface.** `config/*`, `settings.tpl.toml` —
+small, additive. **Parallel with.** CF-2, CF-3, CF-4.
+
+---
+
+### CF-2 · CashuClient library
+
+**Scope.** A self-contained `cdk` wrapper in `src/cashu/mod.rs`. Pure library:
+parse/validate tokens and talk to a mint. **Not wired into the daemon.**
+
+**Files.**
+- `Cargo.toml` — add `cdk` (+ `cdk-http-client` if needed), pinned.
+- `src/cashu/mod.rs` — `pub struct CashuClient` and an `Error` enum
+  (`impl std::error::Error`). Public API:
+  - `async fn connect(mint_url: &str) -> Result<Self, Error>` — verifies the mint
+    is reachable and supports the required NUTs (07 state, 11 P2PK, 12 DLEQ).
+  - `async fn check_state(&self, ys) -> Result<CheckStateResponse, Error>` — NUT-07.
+  - `fn verify_2of3_condition(token, p_b, p_s, p_m) -> Result<Token, Error>` —
+    parses, asserts exactly 2 required sigs, no locktime, no refund keys, and the
+    three expected pubkeys present (NUT-10/11).
+  - `async fn verify_token_dleq(&self, token) -> Result<(), Error>` — NUT-12.
+  - `async fn verify_escrow_token(&self, token, p_b, p_s, p_m, expected_amount)` —
+    composes the above into one acceptance check (condition + mint binding +
+    amount + DLEQ + unspent).
+  - `fn cashu_pubkey_from_xonly_hex(hex) -> Result<PublicKey, Error>` — maps a
+    Nostr x-only trade pubkey to a Cashu `PublicKey`.
+- `src/main.rs` — register `pub mod cashu;` **only** (a `mod` declaration is not
+  a behaviour change). No call sites.
+
+**Must NOT.** Be called from any handler, `AppContext`, or the boot path. No
+global state beyond what the unit tests need.
+
+**Backwards-compat guarantee.** Adding a dependency and an unreferenced module
+changes no runtime behaviour. The Lightning path never constructs a `CashuClient`.
+
+**Tests.** Unit tests for `verify_2of3_condition` (accept valid 2-of-3; reject
+wrong sig count, locktime present, refund keys present, missing/extra pubkey) and
+`cashu_pubkey_from_xonly_hex`. Mint-backed tests (`connect`, `check_state`,
+`verify_token_dleq`) run against the CF-3 container and are `#[ignore]`d /
+env-gated when the mint is absent, so they don't break offline CI.
+
+**Dependencies.** `cdk` only. **Conflict surface.** New module + `Cargo.toml`
+dep block + one `mod` line. **Parallel with.** CF-1, CF-3, CF-4.
+
+---
+
+### CF-3 · Cashu test harness
+
+**Scope.** Make a real Cashu mint available to CI and local runs so CF-2 and the
+later tracks have something to test against.
+
+**Files.**
+- `docker-compose.cashu.yml` — a throwaway test mint (e.g. `nutshell` FakeWallet
+  backend). The mint key is a documented **non-sensitive fixture**.
+- A **dedicated workflow** (its own file, e.g. `.github/workflows/cashu.yml`, not
+  the default `ci.yml`) that starts the mint and runs the env-gated Cashu
+  integration tests. **Trigger = scheduled + opt-in by label** (the same pattern
+  the repo already adopted for mutation testing — see the
+  `ci(mutation): run as scheduled audit + opt-in, not on every push` change):
+  - **Scheduled:** a nightly `cron` run against `main` as a recurring safety net,
+    so a regression is caught even if a PR author forgets the label.
+  - **Opt-in:** runs on a PR only when it carries the **`cashu`** label, giving
+    immediate pre-merge feedback to anyone working on Cashu.
+  - It is **never** part of the default required PR checks, so non-Cashu PRs and
+    the Lightning path never pay its cost or flakiness.
+- `tests/cashu_mint.rs` + `tests/common/mod.rs` — integration test skeleton and
+  shared helpers (spin-up wait, fund a wallet, build a 2-of-3 token) the tracks
+  reuse. Gated behind an env var (e.g. `CASHU_TEST_MINT_URL`) so they `#[ignore]`
+  / skip when no mint is present.
+
+**Must NOT.** Add the mint to the default required CI checks, modify `ci.yml`'s
+required jobs, or make any unit test depend on network access by default.
+
+**Backwards-compat guarantee.** Pure test/infra; no daemon code.
+
+**Tests.** A smoke test that the mint is reachable and returns mint info when the
+container is up; a no-op/skip when the env var is unset.
+
+**Dependencies.** None. **Conflict surface.** CI yaml + new test files.
+**Parallel with.** CF-1, CF-2, CF-4.
+
+---
+
+### CF-4 · DB escrow helpers
+
+**Scope.** Additive query helpers over the **already-migrated** `cashu_*`
+columns. Used later by the lock track and by restore/monitoring; added now so the
+schema-adjacent code is frozen and reviewed once.
+
+**Files.**
+- `src/db.rs`:
+  - `async fn update_order_cashu_escrow(pool, order_id, mint_url, token,
+    locked_at, expected_status, new_status) -> Result<bool, MostroError>` —
+    **atomic compare-and-set**: persists the three columns *and* transitions the
+    status in one `UPDATE … WHERE id = ? AND status = ? AND
+    cashu_escrow_locked_at IS NULL`, returning whether a row matched. No
+    lock-without-advance window; replay-safe.
+  - `async fn find_locked_cashu_orders(pool) -> Result<Vec<Order>, MostroError>`
+    — `WHERE cashu_escrow_locked_at IS NOT NULL AND status = <Active>` (bind the
+    `Status` enum, not a literal).
+
+**Must NOT.** Add or alter any migration. Be called from a hot path yet.
+
+**Backwards-compat guarantee.** New, unreferenced functions. The columns already
+exist on `main`, so no schema change ships here.
+
+**Tests.** Unit tests on an in-memory SQLite: CAS succeeds once and is idempotent
+on replay; status-mismatch matches zero rows; `find_locked_cashu_orders` excludes
+unlocked and non-active orders.
+
+**Dependencies.** None (schema already on `main`). **Conflict surface.** `db.rs`
+(additive functions + their tests). **Parallel with.** CF-1, CF-2, CF-3.
+
+---
+
+### CF-5 · Cashu boot + `run_cashu` + AppContext wiring (integration)
+
+**Scope.** The single integration PR. Make a `cashu`-mode node **boot and run**
+with no LND, connect to its mint, and route events through a Cashu event loop in
+which **every trade action returns `CantDo(InvalidAction)`** (nothing is
+implemented yet). This is what proves the foundation works end to end while
+keeping it inert for real trades.
+
+**Files.**
+- `src/app/context.rs` — `AppContext` carries the active escrow backend
+  (`Arc<dyn EscrowBackend>` or equivalent) and an `Option<Arc<CashuClient>>`;
+  accessors `escrow()` / `cashu_client()`. Lightning mode leaves the client
+  `None`.
+- `src/main.rs` — branch on `Settings::is_cashu_enabled()`:
+  - **Lightning (default):** unchanged path — `LndConnector::new()`, LN status
+    probe, held-invoice resubscribe, `run(ctx, &mut ln_client)`.
+  - **Cashu:** skip `LndConnector::new()` and the LN status probe entirely;
+    `CashuClient::connect(mint_url)` (fail fast with a clear error if the mint is
+    unreachable); attach the client to `ctx`; `return run_cashu(ctx).await`.
+- `src/app.rs` — `run_cashu(ctx)`: mirrors `run()`'s event/decrypt/verify/
+  trade-index pipeline (reuse the same `unwrap_incoming` transport path as `run`)
+  but dispatches every trade action to `CantDo(InvalidAction)` for now. Factor the
+  shared event-decode prologue so `run` and `run_cashu` cannot drift
+  (anti-duplication; see Risks).
+- `src/scheduler.rs` — gate LN-only jobs (`find_held_invoices` resubscribe, bond
+  jobs, payment retries) behind `!is_cashu_enabled()`; leave mode-agnostic jobs
+  (order expiry, rate publishing) running.
+
+**Must NOT.** Implement any handler body. Change the Lightning boot path in any
+observable way. Start the mint connection in Lightning mode.
+
+**Backwards-compat guarantee.** With Cashu disabled, `main.rs` takes the
+identical existing branch and `run()` is called exactly as today; the scheduler
+gates are no-ops (`is_cashu_enabled() == false`). Existing tests stay green
+unmodified.
+
+**Tests.** Unit/integration: boot resolves `EscrowMode::Cashu` and reaches
+`run_cashu` without constructing an LND client (inject/mocked); a trade action in
+Cashu mode yields `CantDo(InvalidAction)`; scheduler skips LN jobs in Cashu mode.
+The "Lightning mode unchanged" guarantee is covered by the existing suite.
+
+**Dependencies.** **CF-1** (mode + `is_cashu_enabled`) and **CF-2** (mint
+connect) are hard prerequisites; **CF-4** is a soft prerequisite (used for
+in-flight Cashu discovery / restore if included). **Conflict surface.** `main.rs`,
+`app.rs`, `app/context.rs`, `scheduler.rs` — the high-traffic shared files. This
+is why it merges **last and alone** in the milestone. **Parallel with.** Nothing
+in this milestone — it is the join point.
+
+#### CF-5 detail — the shared event-loop prologue (zero-drift refactor)
+
+`run()` on `main` (`src/app.rs`) is one `loop { while let … recv() }` whose body
+has two clearly separable parts:
+
+1. **Prologue (transport + validation) — identical for both modes.** In order:
+   `event.check_pow(pow)` → `event.kind == accepted_kind` filter → the
+   protocol-v2 spam-gate pre-check (replay dedup + first-contact PoW, `is_v2`
+   only) → `event.verify()` → `unwrap_incoming(&event, my_keys)` → 10-second
+   replay window (`unwrapped.created_at`) → identity≠sender-without-signature
+   bail → `check_trade_index(...)` → `inner_message.verify()` →
+   `message.inner_action()`. Every failure is a `continue`.
+2. **Dispatch + error tail — the only mode-specific part.** `run` calls
+   `handle_message_action(action, msg, &unwrapped, my_keys, ln_client, &ctx)`;
+   then the `downcast::<MostroError>()` → `manage_errors(...)` / `warning_msg(...)`
+   tail. `run_cashu` needs the *same* tail but a *different* dispatch (no
+   `ln_client`).
+
+**The rule:** the prologue must exist in exactly one place so `run` and
+`run_cashu` cannot drift. Extract it; do not copy-paste the loop body.
+
+Proposed extraction (signatures only — bodies are a literal cut of today's
+prologue with each `continue` becoming `return None`):
+
+```rust
+/// Decode + fully validate one relay event into a dispatchable triple, or
+/// `None` if it must be skipped (PoW, wrong kind, spam-gate, decrypt failure,
+/// stale, bad signature, failed trade-index, failed inner verify). Shared
+/// VERBATIM by `run` (Lightning) and `run_cashu` (Cashu).
+async fn accept_event(
+    ctx: &AppContext,
+    event: &Event,
+    my_keys: &Keys,
+    pow: u8,
+    pow_first_contact: u8,
+    accepted_kind: Kind,
+    is_v2: bool,
+) -> Option<(Action, Message, UnwrappedMessage)>;
+
+/// Shared post-dispatch error handling (identical in both loops today).
+async fn finalize_dispatch(
+    result: anyhow::Result<()>,
+    message: Message,
+    unwrapped: UnwrappedMessage,
+    action: &Action,
+);
+```
+
+Both loops then reduce to the same skeleton, differing in **one line**:
+
+```rust
+// run() — Lightning
+while let Ok(RelayPoolNotification::Event { event, .. }) = notifications.recv().await {
+    let Some((action, message, unwrapped)) =
+        accept_event(&ctx, &event, my_keys, pow, pow_first_contact, accepted_kind, is_v2).await
+    else { continue };
+    let result = handle_message_action(&action, message.clone(), &unwrapped, my_keys, ln_client, &ctx).await;
+    finalize_dispatch(result, message, unwrapped, &action).await;
+}
+
+// run_cashu() — Cashu (no ln_client)
+while let Ok(RelayPoolNotification::Event { event, .. }) = notifications.recv().await {
+    let Some((action, message, unwrapped)) =
+        accept_event(&ctx, &event, my_keys, pow, pow_first_contact, accepted_kind, is_v2).await
+    else { continue };
+    let result = dispatch_cashu(&action, message.clone(), &unwrapped, my_keys, &ctx).await;
+    finalize_dispatch(result, message, unwrapped, &action).await;
+}
+```
+
+**`dispatch_cashu` in this PR — closed decision.** The routing rule is a strict
+allow-list, drawn at *"escrow-independent actions that neither create nor advance
+an order"*:
+
+- **Allowed** (route through the existing `handle_message_action_no_ln(...)`;
+  read-only / session, never touch escrow, LND, or order lifecycle):
+  **`Orders`**, **`LastTradeIndex`**, **`RestoreSession`**, **`TradePubkey`**.
+  A Cashu-foundation node can therefore still serve the order book, restore
+  sessions, and sync trade indexes — all zero-risk for funds.
+- **Blocked** → `Err(MostroCantDo(CantDoReason::InvalidAction))` — everything that
+  creates, advances, or settles an order, because there is no escrow behind it
+  yet: `NewOrder`, `TakeBuy`, `TakeSell`, `AddInvoice`, `FiatSent`, `Release`,
+  `Cancel`, `Dispute`, `RateUser`, `AddCashuEscrow`, `AdminCancel`,
+  `AdminSettle`, `AddBondInvoice`, and any admin/dispute action. The feature
+  tracks replace these arms one at a time, in their own files.
+
+Rationale: allowing, say, `NewOrder` would populate the order book with orders
+that can never be taken to completion (no escrow), producing orphan/half-state
+orders. The allow-list is deliberately the *narrowest* set that keeps the node
+observable without ever moving an order's lifecycle. `RateUser` is blocked
+because nothing can reach a rateable terminal state during foundation.
+
+**Backwards-compatibility proof obligation.** Extracting `accept_event` /
+`finalize_dispatch` is a pure refactor of `run`. The merge gate is: the existing
+`app.rs` test module (`check_trade_index_tests`, `handle_message_action_tests`,
+`message_validation_tests`, `event_processing_tests`) passes **unmodified**, and
+a new test asserts `run`'s skeleton calls `accept_event` then
+`handle_message_action` in order (e.g. by routing a known-good event through a
+test double). Because the Lightning loop keeps calling the *same*
+`handle_message_action` with the *same* `ln_client`, no Lightning behaviour can
+change.
+
+**AppContext shape (this PR).** Add `escrow: Arc<dyn EscrowBackend>` (or an enum
+wrapper) and `cashu_client: Option<Arc<CashuClient>>`, with `escrow()` /
+`cashu_client()` accessors. Lightning constructs `LndConnector`-backed escrow and
+`cashu_client = None`; Cashu constructs the `CashuBackend` (still stubbed) and
+`cashu_client = Some(connected)`. The narrow `EscrowBackend` trait is unchanged
+(see §4.7) — handlers reach Cashu behaviour by branching on
+`Settings::escrow_mode()`, not through new trait methods.
+
+---
+
+## 7. Issues table — sequential vs parallel
+
+> These become the GitHub issues for the milestone. IDs are stable references for
+> cross-linking PRs. "Wave" indicates merge ordering; everything in a wave can be
+> worked and merged in any order relative to its wave-mates.
+
+| ID | Title | Wave | Depends on | Can run in parallel with | Conflict-prone files | Risk |
+|----|-------|------|-----------|--------------------------|----------------------|------|
+| **CF-1** | Config + escrow mode (`CashuSettings`, `EscrowMode`, validation, wizard/template) | 1 | — | CF-2, CF-3, CF-4 | `config/*`, `settings.tpl.toml` | Low |
+| **CF-2** | `CashuClient` library (`cdk` wrapper, token/condition/DLEQ verification) | 1 | — (`cdk` only) | CF-1, CF-3, CF-4 | new `src/cashu/mod.rs`, `Cargo.toml` | Medium (crypto) |
+| **CF-3** | Cashu test harness (mint container + opt-in CI + integration skeleton) | 1 | — | CF-1, CF-2, CF-4 | `.github/workflows/ci.yml`, new test files | Low |
+| **CF-4** | DB escrow helpers (`update_order_cashu_escrow` CAS, `find_locked_cashu_orders`) | 1 | — (schema on `main`) | CF-1, CF-2, CF-3 | `src/db.rs` (additive) | Low |
+| **CF-5** | Cashu boot + `run_cashu` + `AppContext` wiring + scheduler gating | 2 | **CF-1, CF-2** (hard), CF-4 (soft) | — (integration join) | `main.rs`, `app.rs`, `app/context.rs`, `scheduler.rs` | Medium-High |
+
+### Critical path
+`CF-1` + `CF-2` → `CF-5`. Everything else (`CF-3`, `CF-4`) hangs off the side and
+never blocks the critical path. With four developers, Wave 1 collapses to the
+duration of the slowest of `CF-1`/`CF-2`, then `CF-5`.
+
+### Suggested assignment (4 devs)
+- Dev A → **CF-1** (config), then pairs on **CF-5**.
+- Dev B → **CF-2** (mint client) — the longest pole; start first.
+- Dev C → **CF-3** (harness), then unblocks CF-2's mint-backed tests.
+- Dev D → **CF-4** (db helpers), then reviews **CF-5**.
+
+---
+
+## 8. Milestone Definition of Done
+
+The foundation is complete when **all** hold:
+
+1. `CF-1`…`CF-5` are merged to `main`, each as its own PR.
+2. A node with `[cashu] enabled = true` and a reachable `mint_url` **boots**,
+   logs that it is in Cashu mode, connects to the mint, and runs `run_cashu`
+   **without an LND node present**.
+3. In Cashu mode, every trade action returns a clear `CantDo(InvalidAction)`
+   (or the appropriate `CantDoReason`) — no panics, no half-states.
+4. With Cashu disabled, `mostrod` is behaviourally identical to pre-milestone
+   `main`; the pre-existing test suite passes unmodified.
+5. `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and
+   `cargo test` are green; the mint-backed integration tests pass against the
+   CF-3 harness.
+6. Bonds-vs-Cashu mutual exclusion is enforced and tested.
+
+At that point the four feature tracks (docs 02–05) can start in parallel.
+
+---
+
+## 9. Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| `CF-5` touches the hottest files (`main.rs`, `app.rs`) and could destabilise the LN path | Merge it last and alone; keep the Lightning branch byte-identical; cover with the existing suite; require a focused review |
+| `run` / `run_cashu` event-loop duplication drifts over time | In `CF-5`, factor the shared decode/verify/trade-index prologue into one helper both call; do not copy-paste the loop body |
+| `mostro-core 0.13.0` Cashu surface turns out insufficient for a track | Out of scope for foundation; if discovered, raise a `mostro-core` change as a separate, clearly-versioned release before the affected track |
+| Mint-backed tests make CI flaky/slow | CF-3 keeps them opt-in/scheduled and env-gated; default PR CI never depends on a live mint |
+| Operator enables Cashu **and** bonds | Hard config-validation error at startup (CF-1), with a test |
+
+---
+
+## 10. Interface contracts to freeze on day one
+
+So Wave-1 PRs can proceed before each other merges, agree these signatures up
+front (they are the seams; bodies can follow):
+
+- **`CashuClient`** public methods (CF-2) — exact signatures in §6.
+- **`Settings::{get_cashu, is_cashu_enabled, escrow_mode}`** (CF-1).
+- **`db::{update_order_cashu_escrow, find_locked_cashu_orders}`** (CF-4).
+- **`AppContext::{escrow, cashu_client}`** accessors (CF-5) — so tracks can mock
+  the backend.
+
+Once these four signatures are written down (even as stubs returning
+`unimplemented!()` / `None`), each PR can be coded and unit-tested in isolation.
+
+---
+
+## 11. Out of scope → next documents
+
+The trade flows are specified separately and depend only on this milestone:
+
+- **02 · Track A — Lock / escrow setup** (`AddCashuEscrow`, `verify_escrow_token`,
+  CAS lock, notify buyer). Depends on CF-1, CF-2, CF-4, CF-5.
+- **03 · Track B — Release happy path** (seller→buyer NIP-59 signature; daemon
+  only advances state). Depends on CF-5.
+- **04 · Track C — Cooperative cancel** (buyer→seller signature P2P). Depends on
+  CF-5.
+- **05 · Track D — Dispute resolution** (`admin_settle`/`admin_cancel` deliver the
+  `P_M` signature via `CashuPmSignature`). Depends on CF-2, CF-5.
+
+Each will get its own document mirroring this structure (scope → per-PR specs →
+issues table → DoD) once fundamentals is approved.

--- a/docs/cashu/02-track-a-lock.md
+++ b/docs/cashu/02-track-a-lock.md
@@ -241,7 +241,7 @@ for a second token. **`mostro-core 0.14.0` added the one field Option 2 needs**
 (`src/message.rs`); this is the *complete* change that landed, nothing else in
 the crate changed. Track A consumes it and requires `mostro-core ≥ 0.14.0`.
 
-**1 · The struct field** (`src/message.rs:592`). Add a single optional field,
+**1 · The struct field** (`CashuLockProof` in `src/message.rs`). Add a single optional field,
 with serde attributes that make it both backward- and forward-compatible on the
 wire:
 
@@ -266,7 +266,7 @@ pub struct CashuLockProof {
   **byte-identically** to today (the key is omitted, not emitted as `null`), so
   existing wire fixtures and signatures over the JSON are unaffected.
 
-**2 · The constructor** (`src/message.rs:609`). Keep the existing 5-arg `new()`
+**2 · The constructor** (`CashuLockProof::new` in `src/message.rs`). Keep the existing 5-arg `new()`
 exactly as-is (it sets `fee_token: None`), and add an **immutable builder** so
 the field is opt-in and no existing caller breaks:
 
@@ -287,7 +287,7 @@ impl CashuLockProof {
 
 `from_json` / `as_json` need no change (serde-derived).
 
-**3 · `MessageKind::verify()` — NO change** (`src/message.rs:825`). The
+**3 · `MessageKind::verify()` — NO change** (the `AddCashuEscrow` arm in `src/message.rs`). The
 `AddCashuEscrow` arm checks only `id.is_some()` and that the payload is
 `CashuLockProof(_)`. It stays exactly as-is, on purpose: `verify()` is a
 **protocol-shape** check with no access to `Settings`, so it **cannot** know
@@ -297,7 +297,7 @@ a protocol invariant. When `mostro.fee > 0` the handler rejects a `None` or
 mis-valued `fee_token` with `CantDo(CashuSignatureMissing)` /
 `InvalidCashuToken`; when `mostro.fee == 0` a `None` is valid.
 
-**4 · Tests** (`src/message.rs`, existing Cashu test module ~`:2083`). Extend
+**4 · Tests** (the Cashu test module in `src/message.rs`). Extend
 `sample_lock_proof()`/round-trip coverage with two cases: (a) a proof built via
 `with_fee_token(..)` round-trips through `as_json`/`from_json` preserving
 `Some`; (b) a legacy JSON string **without** the `fee_token` key deserialises to

--- a/docs/cashu/02-track-a-lock.md
+++ b/docs/cashu/02-track-a-lock.md
@@ -1,0 +1,307 @@
+# Cashu Escrow — Track A: Lock / Escrow Setup
+
+**Status:** Draft for review · **Target:** `main` (`mostro-core 0.13.0`) ·
+**Depends on:** Fundamentals **CF-1, CF-2, CF-4, CF-5** (see
+[`01-fundamentals.md`](./01-fundamentals.md)) · **Feature flag:** `[cashu].enabled`
+
+Track A is the **first functional Cashu flow**: the seller locks the trade amount
+in a Cashu 2-of-3 multisig token, Mostro validates and records it, and the order
+advances so the buyer can send fiat. It is "box 2" of the sequence diagram in
+[`../CASHU_ESCROW_ARCHITECTURE.md`](../CASHU_ESCROW_ARCHITECTURE.md). It touches
+the most fundamentals pieces of any track, so writing it also **validates that
+the foundation is correctly dimensioned** — see §11.
+
+This document assumes Fundamentals is implemented and merged. It only adds
+behaviour *inside the Cashu branch*; the Lightning path is never changed.
+
+---
+
+## 1. Goal and scope
+
+### Goal
+Make a `cashu`-mode node able to **lock escrow** for a taken order:
+1. When an order is taken, ask the **seller** to lock funds in a 2-of-3 token
+   (instead of paying a Lightning hold invoice).
+2. Accept the seller's `AddCashuEscrow` submission, **fully validate** the token
+   against the mint and the order's trade keys, **atomically** persist it and
+   advance the order, and **notify the buyer** to send fiat.
+
+### In scope
+- The `add_cashu_escrow_action` handler (validation + atomic lock + notify).
+- The Cashu branch of `take_sell` / `take_buy` that emits the escrow request.
+- Restore/monitor of in-flight locked escrows after a restart.
+
+### Out of scope (other tracks / future)
+- **Release** (seller hands the buyer the redeem signature) → Track B.
+- **Cooperative cancel** → Track C. **Dispute resolution** (`P_M` signs) → Track D.
+- **Fee collection in Cashu mode.** What amount the token must carry relative to
+  the Mostro fee is an open architectural question (see arch doc "Open
+  Questions"). Track A validates the token amount against a single
+  `expected_amount` and treats fee policy as a knob decided elsewhere; it does
+  **not** invent a fee mechanism. See §11.
+
+---
+
+## 2. Where Track A sits — flow and state transitions
+
+```mermaid
+sequenceDiagram
+    participant S as Seller
+    participant M as Mostro (cashu mode)
+    participant B as Buyer
+    participant Mint as Cashu Mint
+
+    Note over S,B: Order already taken — Mostro holds both trade pubkeys
+    M->>S: Escrow request: lock <amount> at <mint_url><br/>2-of-3 over {P_B, P_S, P_M}
+    S->>Mint: Swap unencumbered ecash → 2-of-3 locked token
+    S->>M: AddCashuEscrow { token, mint_url, P_B, P_S, P_M }
+    M->>Mint: verify_escrow_token (condition + mint + amount + DLEQ + unspent)
+    M->>M: update_order_cashu_escrow (atomic CAS: WaitingPayment → Active)
+    M->>B: CashuEscrowLocked + "send fiat" notification
+```
+
+**State transition (the only one Track A performs):**
+`WaitingPayment` → `Active`, gated by the CF-4 compare-and-set so the token is
+persisted and the status advanced in a single `UPDATE` (no lock-without-advance
+window, replay-safe). The `expected_status`/`new_status` pair passed to the CAS
+must match whatever the take flow sets when waiting for the seller to fund — the
+Cashu analogue of "seller paid the hold invoice → Active".
+
+> **Why the seller, not the buyer, submits the lock:** in a Cashu trade the buyer
+> redeems the locked token themselves later (with two signatures), so — unlike the
+> Lightning flow — the buyer never provides a payout invoice. The `add-invoice`
+> (buyer-invoice) step is simply **absent** in Cashu mode. Track A wires the
+> seller-funds path; it does not touch `add_invoice.rs`.
+
+---
+
+## 3. What Track A consumes from Fundamentals
+
+This is the dependency contract. If any row is missing or shaped differently when
+Track A starts, fundamentals was under-specified (that is the point of writing
+this now — see §11).
+
+| Needs | From | Exact item |
+|-------|------|------------|
+| Mode + mint config | CF-1 | `Settings::is_cashu_enabled()`, `Settings::escrow_mode()`, `get_cashu().mint_url` |
+| Token validation | CF-2 | `CashuClient::verify_escrow_token(token, p_b, p_s, p_m, expected_amount)`, `verify_2of3_condition`, `check_state`, `verify_token_dleq`, `cashu_pubkey_from_xonly_hex` |
+| Atomic lock | CF-4 | `db::update_order_cashu_escrow(pool, order_id, mint_url, token, locked_at, expected_status, new_status) -> Result<bool>` |
+| In-flight discovery | CF-4 | `db::find_locked_cashu_orders(pool)` |
+| Client handle | CF-5 | `AppContext::cashu_client() -> Option<&Arc<CashuClient>>` |
+| Dispatch seam | CF-5 | `AddCashuEscrow` routed to `add_cashu_escrow_action` (a CF-5 stub Track A fills in) — see §11 |
+| Mint connectivity | CF-5 | mint connected at boot in cashu mode |
+
+Protocol (already in `mostro-core 0.13.0`, frozen):
+- `Action::AddCashuEscrow` carrying `Payload::CashuLockProof(CashuLockProof)`,
+  where `CashuLockProof = { token, mint_url, buyer_pubkey, seller_pubkey,
+  mostro_pubkey }` (all hex/strings).
+- `Action::CashuEscrowLocked` (informational, buyer notification).
+- `CantDoReason::{InvalidCashuToken, CashuMintUnavailable, InvalidMintUrl,
+  CashuEscrowNotLocked}`.
+- `Order.{cashu_mint_url, cashu_escrow_token, cashu_escrow_locked_at}`.
+
+No new `mostro-core` variant is required by Track A.
+
+---
+
+## 4. The lock handler — `add_cashu_escrow_action`
+
+New file `src/app/add_cashu_escrow.rs`. The handler is the Cashu analogue of the
+"seller funds the escrow" step. Validation ordering matters: **validate fully
+before mutating any state**, then commit atomically — the same discipline applied
+to `release_action` (compute/verify first, persist second, notify last).
+
+**Algorithm:**
+
+1. **Resolve order & request id.** `get_order(&msg, pool)`; reject if not found.
+2. **Authorise the sender.** The submitter MUST be the order's **seller trade
+   key**: `order.get_seller_pubkey()? == event.sender`, else
+   `CantDo(InvalidPeer)`. (Same identity check shape as `release_action`.)
+3. **Check status.** The order must be in the "waiting for seller to fund" status
+   (`WaitingPayment`); otherwise `CantDo(NotAllowedByStatus)`.
+4. **Extract the proof.** `Payload::CashuLockProof(proof)`; absent ⇒
+   `CantDo(InvalidCashuToken)`. (`MessageKind::verify()` already guarantees the
+   payload shape, but the handler re-checks defensively.)
+5. **Bind the mint.** `proof.mint_url` MUST equal the node's configured
+   `get_cashu().mint_url` (normalised); else `CantDo(InvalidMintUrl)`. The node
+   only escrows on its own mint.
+6. **Bind the pubkeys to THIS order.** Convert each hex pubkey with
+   `cashu_pubkey_from_xonly_hex`:
+   - `proof.buyer_pubkey` MUST equal the order's **buyer trade pubkey**
+     (`order.get_buyer_pubkey()?`).
+   - `proof.seller_pubkey` MUST equal the order's **seller trade pubkey**
+     (`event.sender`).
+   - `proof.mostro_pubkey` MUST equal Mostro's arbitrator key (`my_keys`).
+   Any mismatch ⇒ `CantDo(InvalidCashuToken)`. This is the security core:
+   the 2-of-3 must lock to the keys Mostro already holds for this order, never
+   attacker-chosen keys.
+7. **Validate the token against the mint.**
+   `ctx.cashu_client()` → `verify_escrow_token(&proof.token, p_b, p_s, p_m,
+   expected_amount)`. This composes: 2-of-3 condition (exactly 2 sigs, no
+   locktime, no refund keys, the three expected pubkeys present), mint binding,
+   amount, NUT-12 DLEQ (proofs really issued by the mint), and NUT-07 unspent
+   check. Map failures: malformed/condition → `CantDo(InvalidCashuToken)`;
+   mint unreachable → `CantDo(CashuMintUnavailable)`. `expected_amount` is the
+   order amount per the fee policy in §11.
+8. **Atomically lock + advance.**
+   `db::update_order_cashu_escrow(pool, order.id, &proof.mint_url, &proof.token,
+   now, /*expected*/ WaitingPayment, /*new*/ Active)`. If it returns `false`
+   (status changed concurrently, or escrow already locked — replay), log and
+   return `Ok(())` without notifying (idempotent; same pattern as the
+   `rows_affected() == 0` guard in `release_action`).
+9. **Publish the updated order event** (kind 38383) via `update_order_event`, as
+   the LN funding path does, so the order's public state stays consistent.
+10. **Notify the buyer.** Enqueue `Action::CashuEscrowLocked` to the buyer plus
+    the existing "send fiat" notification, so the buyer learns the escrow is live
+    and the fiat phase can begin.
+
+All notifications happen **after** the successful CAS — never before — so a
+validation or persistence failure leaves the order exactly as it was and the
+seller can retry.
+
+---
+
+## 5. `take_sell` / `take_buy` — the Cashu branch
+
+`take_sell_action` / `take_buy_action` keep one handler each; they branch on
+`Settings::escrow_mode()` near the point where the Lightning path creates the
+seller hold invoice:
+
+- **Lightning (unchanged):** create the hold invoice, ask the seller to pay it.
+- **Cashu:** instead emit an **escrow request** to the seller carrying everything
+  needed to build the 2-of-3: the amount to lock, the node `mint_url`, the
+  buyer trade pubkey `P_B`, and Mostro's arbitrator pubkey `P_M`. (This is the
+  `show_cashu_escrow_request(...)` helper.) The order is left in `WaitingPayment`,
+  exactly where the CAS in step 8 expects it.
+
+The buyer-invoice request that the Lightning flow issues is **skipped** in Cashu
+mode (the buyer redeems ecash directly later).
+
+These two files are **owned by Track A** — no other track edits them, so there is
+no cross-track conflict here.
+
+---
+
+## 6. PR breakdown (atomic, backwards-compatible)
+
+Track A is small enough for two core PRs plus one optional hardening PR. Each is
+off-by-default and leaves `main` shippable.
+
+### TA-1 · `add_cashu_escrow_action` handler
+Fill in the CF-5 stub for `AddCashuEscrow` in its **own** file
+`src/app/add_cashu_escrow.rs`: the full validation algorithm (§4), the CF-4
+atomic CAS, the order-event publish, and the buyer notification. Unit-tested
+against the CF-3 mint (valid lock → `Active` + buyer notified; each rejection
+path; replay → idempotent no-op).
+*Depends on CF-2, CF-4, CF-5. Conflict surface: new file only.*
+
+### TA-2 · `take_*` escrow request
+Add the Cashu branch to `take_sell_action` / `take_buy_action` and the
+`show_cashu_escrow_request` helper, so a taken order asks the seller to lock
+instead of to pay a hold invoice. Completes the lock flow end-to-end with TA-1.
+*Depends on CF-1, CF-5 (and TA-1 for a full e2e test). Conflict surface:
+`take_sell.rs`, `take_buy.rs`, `util.rs` — Track-A-owned.*
+
+### TA-3 · Restore / monitor in-flight locks (optional, recommended)
+On startup in cashu mode, use `db::find_locked_cashu_orders` to re-hydrate
+in-flight escrows (and optionally re-`check_state` them), mirroring the
+`find_held_invoices` resubscribe the Lightning path does. Keeps locked escrows
+visible across restarts.
+*Depends on CF-4, CF-5. Conflict surface: `main.rs`/restore module — small,
+additive, cashu-gated.*
+
+---
+
+## 7. Issues table — sequential vs parallel
+
+| ID | Title | Depends on | Parallel with | Conflict surface | Risk |
+|----|-------|-----------|---------------|------------------|------|
+| **TA-1** | `add_cashu_escrow_action` handler (validate + atomic lock + notify) | CF-2, CF-4, CF-5 | TA-2 (until e2e) | new `src/app/add_cashu_escrow.rs` | Medium (crypto + state) |
+| **TA-2** | `take_sell`/`take_buy` Cashu escrow request | CF-1, CF-5 | TA-1 | `take_*.rs`, `util.rs` | Low-Medium |
+| **TA-3** | Restore/monitor in-flight locked escrows | CF-4, CF-5 | TA-1, TA-2 | `main.rs`/restore (additive) | Low |
+
+**Sequencing:** TA-1 and TA-2 can be developed in parallel (different files) and
+merged in either order; the **end-to-end** lock test needs both, so whichever
+merges second carries the e2e test. TA-3 is independent and can land any time
+after CF-4 + CF-5. Relative to other tracks, **all of Track A is parallel with
+Tracks B/C/D** — it only edits its own files plus the pre-wired CF-5 stub.
+
+---
+
+## 8. Definition of Done
+
+1. A `cashu`-mode node, after an order is taken, asks the seller to lock a 2-of-3
+   escrow and accepts a valid `AddCashuEscrow`, advancing `WaitingPayment →
+   Active` and notifying the buyer to send fiat — verified end-to-end against the
+   CF-3 mint.
+2. Every rejection path returns the correct `CantDoReason` and leaves the order
+   unchanged (wrong sender, wrong status, wrong mint, pubkey mismatch, malformed
+   token, mint unavailable, double-spent, replay).
+3. The lock is atomic and idempotent (concurrent/replayed submission matches zero
+   rows and is a safe no-op).
+4. With Cashu disabled, behaviour is identical to `main`; existing tests pass
+   unmodified.
+5. `cargo fmt --check`, `clippy -D warnings`, `cargo test`, and the mint-backed
+   integration tests are green.
+
+---
+
+## 9. Principles inherited from Fundamentals
+
+All four merge gates from [`01-fundamentals.md`](./01-fundamentals.md) §2 apply
+unchanged: off-by-default & behaviour-preserving, atomic & shippable, additive
+only (no schema change — the columns exist), and inert-until-enabled. Track A adds
+behaviour **only** inside the cashu branch; the Lightning lock/funding path is
+untouched.
+
+---
+
+## 11. Gaps found while writing this track (feedback into Fundamentals)
+
+Writing Track A surfaced the following — fold these into the fundamentals spec
+**before** freezing it:
+
+### G-1 · `dispatch_cashu` must route to per-action handlers, not an in-`app.rs` match
+**Problem.** Fundamentals CF-5 describes `dispatch_cashu` as a `match` (in
+`app.rs`) that returns `InvalidAction` for blocked actions. If every track later
+edits its arm of that match, `app.rs` becomes a **cross-track merge-conflict
+hotspot** — breaking the "tracks edit disjoint files" guarantee.
+
+**Fix (update CF-5).** Apply the "stub every integration point in foundation"
+principle: in CF-5, route each trade action to its **real handler function**
+(like `handle_message_action` does for Lightning), and:
+- create `src/app/add_cashu_escrow.rs` with a stub `add_cashu_escrow_action`
+  returning `InvalidAction`;
+- give each existing trade handler (`take_*`, `release`, `cancel`, `admin_*`) a
+  minimal, behaviour-preserving `if is_cashu_enabled() { return
+  Err(CantDo(InvalidAction)) }` guard **in its own file**.
+
+Then each track fills in **its own** handler's cashu branch and never touches
+`app.rs`. CF-5's `dispatch_cashu` is frozen after the milestone. The §6 allow-list
+(`Orders`, `LastTradeIndex`, `RestoreSession`, `TradePubkey` → `no_ln`) is
+unaffected — only the *mechanism* for the blocked/escrow actions changes.
+
+### G-2 · `expected_amount` / fee policy is undefined
+**Problem.** `verify_escrow_token` needs an `expected_amount`, but whether the
+locked token includes the Mostro fee (and who bears it) is undecided — the arch
+doc lists Cashu fee collection as open.
+
+**Fix.** Not a fundamentals blocker, but Track A must be handed an explicit rule.
+Recommended interim: the token locks the **order amount** (no fee folded in), and
+Cashu-mode fee collection is deferred to a dedicated design — documented as a
+known limitation so Track A's amount check is unambiguous.
+
+### G-3 · Confirm the take-flow status the CAS expects
+**Problem.** The CF-4 CAS takes `expected_status`/`new_status`. Track A assumes
+`WaitingPayment → Active`. CF-5/Track A must confirm the take flow actually leaves
+a Cashu order in `WaitingPayment` (and not `WaitingBuyerInvoice`, which is skipped
+in Cashu mode).
+
+**Fix.** Pin the exact status the Cashu take flow sets in TA-2, and pass the
+matching pair to the CAS. No new fundamentals surface needed — just an agreed
+constant.
+
+**No gaps found in:** the protocol surface (`mostro-core 0.13.0` carries
+`AddCashuEscrow`/`CashuLockProof`/`CashuEscrowLocked` and the needed
+`CantDoReason`s), the DB schema (columns exist on `main`), the CAS helper shape,
+or the `CashuClient` API — all are sufficient for Track A as specified.

--- a/docs/cashu/02-track-a-lock.md
+++ b/docs/cashu/02-track-a-lock.md
@@ -193,7 +193,8 @@ Fill in the CF-5 stub for `AddCashuEscrow` in its **own** file
 atomic CAS, the order-event publish, and the buyer notification. Unit-tested
 against the CF-3 mint (valid lock → `Active` + buyer notified; each rejection
 path; replay → idempotent no-op).
-*Depends on CF-2, CF-4, CF-5. Conflict surface: new file only.*
+*Depends on CF-2, CF-3, CF-4, CF-5 (CF-3 supplies the mint harness TA-1 is
+unit-tested against). Conflict surface: new file only.*
 
 ### TA-2 · `take_*` escrow request
 Add the Cashu branch to `take_sell_action` / `take_buy_action` and the
@@ -216,7 +217,7 @@ additive, cashu-gated.*
 
 | ID | Title | Depends on | Parallel with | Conflict surface | Risk |
 |----|-------|-----------|---------------|------------------|------|
-| **TA-1** | `add_cashu_escrow_action` handler (validate + atomic lock + notify) | CF-2, CF-4, CF-5 | TA-2 (until e2e) | new `src/app/add_cashu_escrow.rs` | Medium (crypto + state) |
+| **TA-1** | `add_cashu_escrow_action` handler (validate + atomic lock + notify) | CF-2, CF-3, CF-4, CF-5 | TA-2 (until e2e) | new `src/app/add_cashu_escrow.rs` | Medium (crypto + state) |
 | **TA-2** | `take_sell`/`take_buy` Cashu escrow request | CF-1, CF-5 | TA-1 | `take_*.rs`, `util.rs` | Low-Medium |
 | **TA-3** | Restore/monitor in-flight locked escrows | CF-4, CF-5 | TA-1, TA-2 | `main.rs`/restore (additive) | Low |
 
@@ -268,18 +269,24 @@ edits its arm of that match, `app.rs` becomes a **cross-track merge-conflict
 hotspot** — breaking the "tracks edit disjoint files" guarantee.
 
 **Fix (update CF-5).** Apply the "stub every integration point in foundation"
-principle: in CF-5, route each trade action to its **real handler function**
-(like `handle_message_action` does for Lightning), and:
+principle, but keep CF-5 inside its **own** files. In CF-5:
+- `run_cashu`'s `dispatch_cashu` maps **every** trade action to
+  `CantDo(InvalidAction)` by default — a single central **dispatch stub** in
+  CF-5-owned `app.rs`, which is what keeps cashu mode inert. This default is the
+  frozen seam; tracks do not edit it.
 - create `src/app/add_cashu_escrow.rs` with a stub `add_cashu_escrow_action`
-  returning `InvalidAction`;
-- give each existing trade handler (`take_*`, `release`, `cancel`, `admin_*`) a
-  minimal, behaviour-preserving `if is_cashu_enabled() { return
-  Err(CantDo(InvalidAction)) }` guard **in its own file**.
+  returning `InvalidAction` — the one new integration point that has no existing
+  owner.
 
-Then each track fills in **its own** handler's cashu branch and never touches
-`app.rs`. CF-5's `dispatch_cashu` is frozen after the milestone. The §6 allow-list
-(`Orders`, `LastTradeIndex`, `RestoreSession`, `TradePubkey` → `no_ln`) is
-unaffected — only the *mechanism* for the blocked/escrow actions changes.
+CF-5 does **not** add `is_cashu_enabled()` guards to the existing trade handler
+files (`take_*`, `release`, `cancel`, `admin_*`). Those files are **track-owned**
+(e.g. `take_*` is Track-A-owned per §7), so guarding them from CF-5 would
+reintroduce the very cross-track overlap this fix avoids. Instead, each track adds
+its **own** handler's cashu branch and wires that handler into `dispatch_cashu`
+when it implements it — replacing the default `InvalidAction` for exactly the
+actions it owns. The §6 allow-list (`Orders`, `LastTradeIndex`, `RestoreSession`,
+`TradePubkey` → `no_ln`) is unaffected — only the *mechanism* for the
+blocked/escrow actions changes.
 
 ### G-2 · `expected_amount` / fee policy is undefined
 **Problem.** `verify_escrow_token` needs an `expected_amount`, but whether the

--- a/docs/cashu/02-track-a-lock.md
+++ b/docs/cashu/02-track-a-lock.md
@@ -89,7 +89,8 @@ this now — see §11).
 | Needs | From | Exact item |
 |-------|------|------------|
 | Mode + mint config | CF-1 | `Settings::is_cashu_enabled()`, `Settings::escrow_mode()`, `get_cashu().mint_url` |
-| Token validation | CF-2 | `CashuClient::verify_escrow_token(token, p_b, p_s, p_m, expected_amount)`, `verify_2of3_condition`, `check_state`, `verify_token_dleq`, `cashu_pubkey_from_xonly_hex` |
+| Token validation | CF-2 | `CashuClient::verify_escrow_token(token, p_b, p_s, p_m, expected_amount, min_locktime)` (2-of-3 **plus** the `locktime`/`refund=[P_S]` seller-recovery path, §4B), `verify_2of3_condition`, `check_state`, `verify_token_dleq`, `cashu_pubkey_from_xonly_hex` |
+| Locktime floor | CF-1 | `get_cashu().escrow_locktime_days` (default 15) → `min_locktime = now + days` (§4B) |
 | Fee-token validation | CF-2 | `CashuClient::verify_fee_token(token, p_m, expected_fee)` (new, §4A) |
 | Fee realisation | CF-2 | `CashuClient::sign_with_pm(proofs)` + a mint swap — the fee-only redeem capability (§4A) |
 | Fee amount | existing | `util::get_fee(amount)` → `order.fee` (per-party half); fee token value = `2 * order.fee` |
@@ -150,8 +151,10 @@ to `release_action` (compute/verify first, persist second, notify last).
    attacker-chosen keys.
 7. **Validate the token against the mint.**
    `ctx.cashu_client()` → `verify_escrow_token(&proof.token, p_b, p_s, p_m,
-   expected_amount)`. This composes: 2-of-3 condition (exactly 2 sigs, no
-   locktime, no refund keys, the three expected pubkeys present), mint binding,
+   expected_amount, min_locktime)`. This composes: 2-of-3 condition (exactly 2 sigs
+   over the three expected pubkeys) **with the seller-recovery locktime** (`locktime`
+   present, `refund = [P_S]`, `n_sigs_refund = 1`, and
+   `locktime >= now + cashu.escrow_locktime_days` — §4B), mint binding,
    amount, NUT-12 DLEQ (proofs really issued by the mint), and NUT-07 unspent
    check. Map failures: malformed/condition → `CantDo(InvalidCashuToken)`;
    mint unreachable → `CantDo(CashuMintUnavailable)`. `expected_amount` is the
@@ -389,8 +392,8 @@ TA-1.
 To avoid Mostro having to *proactively* refund (and the "Mostro forgot the token
 across a restart" failure mode), the fee token can instead be locked **P2PK to
 `P_M` with `locktime` = order expiry and `refund` pubkey = `P_S`** (NUT-11
-natively supports locktime + refund keys — note the *escrow* token must still
-forbid both, per `verify_2of3_condition`). Then:
+natively supports locktime + refund keys; the escrow token itself now carries a
+seller-recovery locktime too, see §4B). Then:
 
 - **Before locktime:** only `P_M` can spend ⇒ on success Mostro redeems promptly.
 - **After locktime:** if Mostro never redeemed (trade abandoned/cancelled), the
@@ -415,6 +418,65 @@ committed.
 
 ---
 
+## 4B. Seller-recovery locktime on the escrow token
+
+### Decision
+
+The 2-of-3 escrow token carries a **`locktime` + `refund = [P_S]`** so the seller
+can reclaim the funds **alone** after the locktime **if Mostro disappears *and* the
+buyer refuses to cooperate**. Without it a plain 2-of-3 has no escape hatch: if the
+arbitrator key `P_M` is gone and the buyer won't sign, the funds are locked
+forever. The horizon is configurable: **`cashu.escrow_locktime_days`, default 15**
+(CF-1).
+
+### Construction (NUT-11)
+
+The seller builds the P2PK secret with:
+- `data = P_S`, `pubkeys = [P_B, P_M]`, `n_sigs = 2` — the 2-of-3, unchanged.
+- `locktime = now + cashu.escrow_locktime_days`, `refund = [P_S]`,
+  `n_sigs_refund = 1`.
+
+NUT-11 then exposes two **independent** pathways:
+- **Before locktime:** the normal 2-of-3 (any 2 of `P_S`/`P_B`/`P_M`). Happy path
+  (Track B) and dispute (Track D) are unaffected.
+- **After locktime:** the *refund* pathway — `P_S` alone (1 sig) reclaims. This is
+  the seller's recovery.
+
+> `refund = [P_S]` is **mandatory**, not cosmetic: NUT-11 says a token with a
+> `locktime` but **no** `refund` tag becomes spendable by **anyone** without a
+> signature once it expires. A missing/empty refund tag must be rejected.
+
+### What `verify_escrow_token` enforces (the security floor)
+
+The locktime is double-edged: once it passes, the seller can reclaim the sats **even
+if the buyer already sent fiat**. A malicious seller who set a *short* locktime
+could stall past it and keep both the sats and the fiat. So the daemon never accepts
+an arbitrary locktime — it enforces:
+1. `locktime` present and `>= now + cashu.escrow_locktime_days` (the floor). The
+   seller MAY set it **longer** (slow marketplace trades), never shorter.
+2. `refund == [P_S]` exactly (the order's seller trade key) and `n_sigs_refund == 1`
+   — never an attacker-chosen key.
+
+The floor must comfortably exceed the worst-case settlement + dispute window; 15
+days is generous for that while still letting a node that wants a marketplace extend
+it per trade.
+
+### Buyer obligation
+
+The buyer must **redeem before the locktime** (with the seller's release signature —
+Track B — or `P_M`'s dispute signature — Track D). The locktime is in the token, so
+the client surfaces it and warns the buyer as it approaches. Once the buyer redeems,
+the token is spent and the locktime is moot.
+
+### Consequence for the marketplace motivation
+
+This makes the escrow **time-bounded** rather than indefinite — a deliberate
+trade-off for recoverability. The 15-day default (extendable per trade by the
+seller) keeps the long-lived/marketplace use case viable while guaranteeing the
+seller is never *permanently* locked out when Mostro and the buyer both go silent.
+
+---
+
 ## 5. `take_sell` / `take_buy` — the Cashu branch
 
 `take_sell_action` / `take_buy_action` keep one handler each; they branch on
@@ -425,7 +487,9 @@ seller hold invoice:
 - **Cashu:** instead emit an **escrow request** to the seller carrying everything
   needed to build the 2-of-3: the escrow amount to lock (`order.amount`), the
   **fee amount** to lock separately (`2 * order.fee`, Option 2 §4A), the node
-  `mint_url`, the buyer trade pubkey `P_B`, and Mostro's arbitrator pubkey `P_M`.
+  `mint_url`, the buyer trade pubkey `P_B`, Mostro's arbitrator pubkey `P_M`, and
+  the **locktime horizon** (`cashu.escrow_locktime_days`, §4B) so the seller sets
+  `locktime = now + days` with `refund = [P_S]`.
   (This is the `show_cashu_escrow_request(...)` helper.) The order is left in
   `WaitingPayment`, exactly where the CAS in step 8 expects it. The seller's
   client then builds **two** tokens — the 2-of-3 escrow and the 1-of-1 `P_M` fee

--- a/docs/cashu/02-track-a-lock.md
+++ b/docs/cashu/02-track-a-lock.md
@@ -1,6 +1,6 @@
 # Cashu Escrow — Track A: Lock / Escrow Setup
 
-**Status:** Draft for review · **Target:** `main` (`mostro-core 0.13.0`) ·
+**Status:** Draft for review · **Target:** `main` (**requires `mostro-core ≥ 0.14.0`**) ·
 **Depends on:** Fundamentals **CF-1, CF-2, CF-4, CF-5** (see
 [`01-fundamentals.md`](./01-fundamentals.md)) · **Feature flag:** `[cashu].enabled`
 
@@ -29,16 +29,21 @@ Make a `cashu`-mode node able to **lock escrow** for a taken order:
 ### In scope
 - The `add_cashu_escrow_action` handler (validation + atomic lock + notify).
 - The Cashu branch of `take_sell` / `take_buy` that emits the escrow request.
+- **Fee collection — funder-pays-at-lock (Option 2).** The seller locks the
+  **full** Mostro fee as a second, separate token in the same `AddCashuEscrow`
+  step; the daemon validates and redeems it. This is the only fee model Track A
+  implements (see §4A).
 - Restore/monitor of in-flight locked escrows after a restart.
 
 ### Out of scope (other tracks / future)
 - **Release** (seller hands the buyer the redeem signature) → Track B.
 - **Cooperative cancel** → Track C. **Dispute resolution** (`P_M` signs) → Track D.
-- **Fee collection in Cashu mode.** What amount the token must carry relative to
-  the Mostro fee is an open architectural question (see arch doc "Open
-  Questions"). Track A validates the token amount against a single
-  `expected_amount` and treats fee policy as a knob decided elsewhere; it does
-  **not** invent a fee mechanism. See §11.
+- **Alternative fee models.** Splitting the fee back onto the buyer (a separate
+  buyer-paid token gated at `FiatSent`), per-order fee negotiation, or any
+  fee-on-the-fiat-side scheme are **not** implemented here. Track A commits to
+  Option 2 (funder pays the whole fee at lock); other models are future work.
+  The *refund-on-non-success* mechanics for the fee token are specified here as
+  an obligation but executed by Tracks C/D (see §4A).
 
 ---
 
@@ -85,22 +90,30 @@ this now — see §11).
 |-------|------|------------|
 | Mode + mint config | CF-1 | `Settings::is_cashu_enabled()`, `Settings::escrow_mode()`, `get_cashu().mint_url` |
 | Token validation | CF-2 | `CashuClient::verify_escrow_token(token, p_b, p_s, p_m, expected_amount)`, `verify_2of3_condition`, `check_state`, `verify_token_dleq`, `cashu_pubkey_from_xonly_hex` |
+| Fee-token validation | CF-2 | `CashuClient::verify_fee_token(token, p_m, expected_fee)` (new, §4A) |
+| Fee realisation | CF-2 | `CashuClient::sign_with_pm(proofs)` + a mint swap — the fee-only redeem capability (§4A) |
+| Fee amount | existing | `util::get_fee(amount)` → `order.fee` (per-party half); fee token value = `2 * order.fee` |
 | Atomic lock | CF-4 | `db::update_order_cashu_escrow(pool, order_id, mint_url, token, locked_at, expected_status, new_status) -> Result<bool>` |
 | In-flight discovery | CF-4 | `db::find_locked_cashu_orders(pool)` |
 | Client handle | CF-5 | `AppContext::cashu_client() -> Option<&Arc<CashuClient>>` |
 | Dispatch seam | CF-5 | `AddCashuEscrow` routed to `add_cashu_escrow_action` (a CF-5 stub Track A fills in) — see §11 |
 | Mint connectivity | CF-5 | mint connected at boot in cashu mode |
 
-Protocol (already in `mostro-core 0.13.0`, frozen):
+Protocol (in `mostro-core ≥ 0.14.0`):
 - `Action::AddCashuEscrow` carrying `Payload::CashuLockProof(CashuLockProof)`,
   where `CashuLockProof = { token, mint_url, buyer_pubkey, seller_pubkey,
-  mostro_pubkey }` (all hex/strings).
+  mostro_pubkey, fee_token }` — `fee_token: Option<String>` (the seller-funded
+  fee token, §4A) was added in **0.14.0**; the rest since 0.13.0.
 - `Action::CashuEscrowLocked` (informational, buyer notification).
 - `CantDoReason::{InvalidCashuToken, CashuMintUnavailable, InvalidMintUrl,
   CashuEscrowNotLocked}`.
 - `Order.{cashu_mint_url, cashu_escrow_token, cashu_escrow_locked_at}`.
 
-No new `mostro-core` variant is required by Track A.
+**Track A requires `mostro-core ≥ 0.14.0`.** The one protocol item it needs
+beyond the 0.13.0 surface — the additive `fee_token: Option<String>` field on
+`CashuLockProof`, carrying the seller-funded fee token (Option 2, §4A) — was
+**released in 0.14.0**. It is backwards-compatible (`Option`, defaults `None`).
+Nothing else in Track A needs a protocol change.
 
 ---
 
@@ -159,6 +172,247 @@ All notifications happen **after** the successful CAS — never before — so a
 validation or persistence failure leaves the order exactly as it was and the
 seller can retry.
 
+> **Fee handling slots between steps 7 and 8** — the second token (the Mostro
+> fee) is validated alongside the escrow token (after step 7) and realised
+> around the CAS (step 8). See §4A.
+
+---
+
+## 4A. Fee collection — funder-pays-at-lock (Option 2)
+
+### Why a dedicated mechanism is unavoidable
+
+In the Lightning flow Mostro collects its fee **because it is in the money
+path**: it receives a hold invoice for `amount + seller_fee` and pays the buyer
+`amount - buyer_fee`, keeping the difference. The Cashu model deliberately
+removes Mostro from the money path — the 2-of-3 token is redeemed **in full** by
+the buyer (with `SIG_INPUTS` the redeemer chooses its own outputs), and on the
+happy path Mostro is neither a signer nor a relay of the release. Therefore:
+
+> **Mostro cannot skim a fee output from the escrow token.** A non-signer cannot
+> force an output in a NUT-11 spend; `SIG_ALL` does not help because the two
+> happy-path signers are buyer + seller, not Mostro. The fee must be a
+> **separate payment**, gated by a protocol step Mostro controls.
+
+Option 2 takes the simplest such path: the **funder (the seller) pays the entire
+Mostro fee, as a second token, at the moment it locks the escrow.** There is
+exactly one collection point (`AddCashuEscrow`) and one gate, and it never
+depends on the buyer's later cooperation.
+
+### Amounts (exact)
+
+Mostro's per-order fee helper is unchanged: `util::get_fee(amount)` returns
+`round(mostro.fee * amount / 2)` — i.e. **one party's half**, persisted as
+`order.fee`. The total Mostro fee is therefore `2 * order.fee`.
+
+| Token | Locked to | Value | Who funds | On success |
+|-------|-----------|-------|-----------|------------|
+| **Escrow** | 2-of-3 `{P_B, P_S, P_M}` | `order.amount` | seller | buyer redeems (Track B) |
+| **Fee** | P2PK 1-of-1 `P_M` | `2 * order.fee` | seller | Mostro redeems |
+
+- The **escrow** token value stays `order.amount` exactly — the §4 step-7 check
+  is unchanged. The buyer redeems the full amount; **no buyer fee is deducted**,
+  because nothing can deduct from a token the buyer redeems freely.
+- The **fee** token carries the **whole** Mostro fee (`2 * order.fee`, both
+  halves), because the buyer pays none. Using `2 * order.fee` (rather than
+  recomputing `round(mostro.fee * amount)`) keeps the number bit-identical to the
+  value already stored on the order and used everywhere else.
+- Seller's total outlay = `order.amount + 2 * order.fee`.
+
+> **Economic consequence (must be documented for operators).** Relative to
+> Lightning, where the seller pays `amount + order.fee` and the buyer effectively
+> pays `order.fee`, Option 2 shifts the buyer's half onto the seller: the seller
+> pays **both** halves (`amount + 2*order.fee`) and the buyer pays nothing. The
+> *total* Mostro revenue (`2 * order.fee`) and the **dev-fee accounting are
+> unchanged** — `util::get_dev_fee` still operates on the total Mostro fee, carved
+> from Mostro's earnings exactly as today. Only the buyer/seller split moves.
+
+A node MAY instead charge only the seller's half (`order.fee`) and accept half
+revenue in Cashu mode; that is a one-constant change to the expected fee-token
+value and is left as an operator-policy note, not a separate code path. The
+spec'd default is the **full** fee, to match "the same fee set in
+`settings.toml`".
+
+### Protocol addition — the exact `mostro-core` change set
+
+`Payload::CashuLockProof` was `{ token, mint_url, buyer_pubkey, seller_pubkey,
+mostro_pubkey }` (five `String` fields) through `mostro-core 0.13.x` — no slot
+for a second token. **`mostro-core 0.14.0` added the one field Option 2 needs**
+(`src/message.rs`); this is the *complete* change that landed, nothing else in
+the crate changed. Track A consumes it and requires `mostro-core ≥ 0.14.0`.
+
+**1 · The struct field** (`src/message.rs:592`). Add a single optional field,
+with serde attributes that make it both backward- and forward-compatible on the
+wire:
+
+```rust
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+pub struct CashuLockProof {
+    pub token: String,
+    pub mint_url: String,
+    pub buyer_pubkey: String,
+    pub seller_pubkey: String,
+    pub mostro_pubkey: String,
+    /// NUT-11 P2PK token locked 1-of-1 to `P_M`, carrying the Mostro fee
+    /// (`2 * order.fee`). `None` when the node charges no fee. See Track A §4A.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fee_token: Option<String>,
+}
+```
+
+- `#[serde(default)]` → a message from an **old client** (no `fee_token` key)
+  deserializes to `None` instead of failing (forward-compat).
+- `skip_serializing_if = "Option::is_none"` → an old-style proof serialises
+  **byte-identically** to today (the key is omitted, not emitted as `null`), so
+  existing wire fixtures and signatures over the JSON are unaffected.
+
+**2 · The constructor** (`src/message.rs:609`). Keep the existing 5-arg `new()`
+exactly as-is (it sets `fee_token: None`), and add an **immutable builder** so
+the field is opt-in and no existing caller breaks:
+
+```rust
+impl CashuLockProof {
+    pub fn new(/* …unchanged 5 args… */) -> Self {
+        Self { token, mint_url, buyer_pubkey, seller_pubkey, mostro_pubkey,
+               fee_token: None }
+    }
+
+    /// Attach the seller-funded fee token (Option 2). Returns a new value.
+    pub fn with_fee_token(mut self, fee_token: String) -> Self {
+        self.fee_token = Some(fee_token);
+        self
+    }
+}
+```
+
+`from_json` / `as_json` need no change (serde-derived).
+
+**3 · `MessageKind::verify()` — NO change** (`src/message.rs:825`). The
+`AddCashuEscrow` arm checks only `id.is_some()` and that the payload is
+`CashuLockProof(_)`. It stays exactly as-is, on purpose: `verify()` is a
+**protocol-shape** check with no access to `Settings`, so it **cannot** know
+whether this node charges a fee. Presence/amount of `fee_token` is therefore a
+**daemon-side, config-dependent** check (in `add_cashu_escrow_action`, §4A), not
+a protocol invariant. When `mostro.fee > 0` the handler rejects a `None` or
+mis-valued `fee_token` with `CantDo(CashuSignatureMissing)` /
+`InvalidCashuToken`; when `mostro.fee == 0` a `None` is valid.
+
+**4 · Tests** (`src/message.rs`, existing Cashu test module ~`:2083`). Extend
+`sample_lock_proof()`/round-trip coverage with two cases: (a) a proof built via
+`with_fee_token(..)` round-trips through `as_json`/`from_json` preserving
+`Some`; (b) a legacy JSON string **without** the `fee_token` key deserialises to
+`fee_token: None` (the forward-compat guarantee). The existing `verify()` tests
+stay green unmodified — verify behaviour is unchanged.
+
+**5 · Release + daemon pin.** Adding a public struct field is breaking for
+struct-literal construction, so the field **shipped in `mostro-core 0.14.0`** (a
+pre-1.0 breaking-allowed minor); `new()` and `verify()` stayed source-compatible.
+**Track A requires `mostro-core ≥ 0.14.0`**, pinned in the daemon's `Cargo.toml`.
+This was the only deviation from the "0.13.0 frozen" rule the foundation set —
+exactly the case the fundamentals doc allows: *"if a track later needs a new
+variant, that is a separate `mostro-core` release."*
+
+> **No other `mostro-core` edits.** `Action`, the other `Payload` variants,
+> `CantDoReason` (the needed reasons already exist), `Order` fields, and every
+> other `verify()` arm are untouched. The fee feature is one optional field plus
+> one builder.
+
+### CashuClient addition (CF-2 surface)
+
+One new verification method, mirroring `verify_escrow_token` but for the
+single-key fee token:
+
+```rust
+/// Validate a P2PK fee token: locked to exactly P_M (1-of-1, no extra pubkeys),
+/// value == expected_fee, bound to the configured mint, DLEQ valid (NUT-12),
+/// unspent (NUT-07). Returns the parsed Token on success.
+async fn verify_fee_token(
+    &self,
+    token: &str,
+    p_m: PublicKey,
+    expected_fee: u64,
+) -> Result<Token, Error>;
+```
+
+It reuses the same primitives `verify_escrow_token` composes; the only
+differences are **exactly one** required pubkey (`P_M`) and the expected amount.
+
+### Realising the fee — a narrow, fee-only wallet capability
+
+Collecting the fee means Mostro must **redeem** the fee token (sign with `P_M`
+via the F4 `sign_with_pm`, then swap at the mint for fresh ecash). This is the
+one place the daemon stops being purely a *coordinator* and performs a *wallet*
+op — but **strictly on its own revenue, never on user escrow funds**. The
+non-custodial guarantee is untouched: the `order.amount` stays in the 2-of-3 the
+daemon can never move alone; only the separately-funded fee (already Mostro's
+money once paid) is redeemed.
+
+### Handler algorithm — what §4 gains
+
+Insert into `add_cashu_escrow_action`:
+
+- **After step 7 (escrow validated), validate the fee token.** Extract
+  `proof.fee_token`; if `mostro.fee > 0` and it is absent ⇒
+  `CantDo(CashuSignatureMissing)`. Else
+  `cashu_client.verify_fee_token(&fee_token, p_m, 2 * order.fee as u64)`.
+  Map failures the same way as the escrow token (malformed/condition/amount ⇒
+  `InvalidCashuToken`; mint unreachable ⇒ `CashuMintUnavailable`). **Both tokens
+  must be valid before any state changes** — same validate-fully-then-commit
+  discipline as §4.
+- **Step 8 (CAS) is unchanged** — it advances `WaitingPayment → Active` and
+  persists the escrow columns. The fee token is **not** persisted (no
+  `cashu_fee_token` column exists, and the schema is frozen — see the refinement
+  below for the alternative).
+- **After a successful CAS, redeem the fee token** (`sign_with_pm` + swap). Order
+  matters: advance state first, collect fee second, because the fee was already
+  proven valid-and-unspent during validation and the daemon can retry the redeem.
+  A redeem that fails after the CAS leaves the order correctly `Active` and the
+  fee retryable; it does **not** roll back the trade.
+- **Idempotency / replay.** A replayed `AddCashuEscrow` finds the CAS matching
+  zero rows (already `Active`) → no-op, no second redeem. A fee token already
+  redeemed by a prior attempt fails `verify_fee_token`'s unspent check → rejected
+  cleanly. Never double-charge.
+
+### Refund obligation (executed by Tracks C/D)
+
+Because the fee is realised at **lock**, not at success, the daemon **owes the
+seller a refund** on every path that does not complete the trade (cooperative
+cancel after lock, dispute resolved for the seller, expiry of a locked-but-never-
+paid escrow). The refund = Mostro mints/sends a fresh token of `2 * order.fee` to
+the seller's **trade** pubkey. Track A only **states** this obligation; the
+actual refund call lives in the cancel/dispute/expiry handlers (Tracks C/D and
+Integration), so it is enumerated here as a cross-track contract, not built in
+TA-1.
+
+### Refinement (optional) — self-service refund via NUT-11 locktime
+
+To avoid Mostro having to *proactively* refund (and the "Mostro forgot the token
+across a restart" failure mode), the fee token can instead be locked **P2PK to
+`P_M` with `locktime` = order expiry and `refund` pubkey = `P_S`** (NUT-11
+natively supports locktime + refund keys — note the *escrow* token must still
+forbid both, per `verify_2of3_condition`). Then:
+
+- **Before locktime:** only `P_M` can spend ⇒ on success Mostro redeems promptly.
+- **After locktime:** if Mostro never redeemed (trade abandoned/cancelled), the
+  seller (`P_S`) reclaims the fee **unilaterally** — no daemon action needed.
+
+This trades **one migration** (a `cashu_fee_token` column to remember the token
+until release) and a slightly richer `verify_fee_token` (accept locktime +
+`P_S` refund) for self-service refunds and "fee only on success" semantics. It
+is a clean follow-up, not a TA-1 blocker; TA-1 ships the simpler 1-of-1 form.
+
+### What Option 2 does *not* solve
+
+A seller and buyer who collude out-of-band could agree the seller funds a
+*smaller* escrow and settles the rest off-protocol, starving Mostro of the fee —
+but only by the seller under-funding, which the buyer would have to accept (they
+receive less). The realistic evasion is the **seller** simply not taking orders
+on a fee-charging node. This is acceptable for the trust-based communities the
+Cashu mode targets, and is the honest price of removing Mostro from the money
+path. It is **strictly better** than the buyer-side fee (Option 1), where an
+honest-looking buyer can skip its fee at `FiatSent` after the seller is already
+committed.
+
 ---
 
 ## 5. `take_sell` / `take_buy` — the Cashu branch
@@ -169,10 +423,13 @@ seller hold invoice:
 
 - **Lightning (unchanged):** create the hold invoice, ask the seller to pay it.
 - **Cashu:** instead emit an **escrow request** to the seller carrying everything
-  needed to build the 2-of-3: the amount to lock, the node `mint_url`, the
-  buyer trade pubkey `P_B`, and Mostro's arbitrator pubkey `P_M`. (This is the
-  `show_cashu_escrow_request(...)` helper.) The order is left in `WaitingPayment`,
-  exactly where the CAS in step 8 expects it.
+  needed to build the 2-of-3: the escrow amount to lock (`order.amount`), the
+  **fee amount** to lock separately (`2 * order.fee`, Option 2 §4A), the node
+  `mint_url`, the buyer trade pubkey `P_B`, and Mostro's arbitrator pubkey `P_M`.
+  (This is the `show_cashu_escrow_request(...)` helper.) The order is left in
+  `WaitingPayment`, exactly where the CAS in step 8 expects it. The seller's
+  client then builds **two** tokens — the 2-of-3 escrow and the 1-of-1 `P_M` fee
+  token — and submits both in `AddCashuEscrow`.
 
 The buyer-invoice request that the Lightning flow issues is **skipped** in Cashu
 mode (the buyer redeems ecash directly later).
@@ -196,6 +453,21 @@ path; replay → idempotent no-op).
 *Depends on CF-2, CF-3, CF-4, CF-5 (CF-3 supplies the mint harness TA-1 is
 unit-tested against). Conflict surface: new file only.*
 
+### TA-1f · Fee token (Option 2)
+The fee half of TA-1, separable for review. Three pieces:
+1. **`mostro-core` ≥ 0.14.0 (released):** the `fee_token: Option<String>` field
+   on `CashuLockProof` is already available; the daemon pins `≥ 0.14.0`.
+2. **CF-2 surface:** `CashuClient::verify_fee_token(token, p_m, expected_fee)`
+   and the fee-only redeem (`sign_with_pm` + swap), unit-tested against the CF-3
+   mint.
+3. **Handler:** validate the fee token after the escrow token, then redeem it
+   after the CAS (§4A). Tests: valid fee → `Active` + fee redeemed; missing/
+   mis-valued fee_token when `mostro.fee > 0` → rejected, order unchanged; replay
+   → no double-charge.
+*Depends on `mostro-core ≥ 0.14.0` + CF-2 + TA-1. Conflict surface: `add_cashu_escrow.rs`
+(same new file as TA-1) + `cashu/mod.rs` (additive method). Can be folded into
+TA-1 or landed right after it.*
+
 ### TA-2 · `take_*` escrow request
 Add the Cashu branch to `take_sell_action` / `take_buy_action` and the
 `show_cashu_escrow_request` helper, so a taken order asks the seller to lock
@@ -218,6 +490,7 @@ additive, cashu-gated.*
 | ID | Title | Depends on | Parallel with | Conflict surface | Risk |
 |----|-------|-----------|---------------|------------------|------|
 | **TA-1** | `add_cashu_escrow_action` handler (validate + atomic lock + notify) | CF-2, CF-3, CF-4, CF-5 | TA-2 (until e2e) | new `src/app/add_cashu_escrow.rs` | Medium (crypto + state) |
+| **TA-1f** | Fee token Option 2 (`verify_fee_token` + redeem; uses `CashuLockProof.fee_token`) | `mostro-core` ≥ 0.14.0, CF-2, TA-1 | TA-2 | `add_cashu_escrow.rs`, `cashu/mod.rs` | Medium (crypto + revenue) |
 | **TA-2** | `take_sell`/`take_buy` Cashu escrow request | CF-1, CF-5 | TA-1 | `take_*.rs`, `util.rs` | Low-Medium |
 | **TA-3** | Restore/monitor in-flight locked escrows | CF-4, CF-5 | TA-1, TA-2 | `main.rs`/restore (additive) | Low |
 
@@ -237,9 +510,14 @@ Tracks B/C/D** — it only edits its own files plus the pre-wired CF-5 stub.
    CF-3 mint.
 2. Every rejection path returns the correct `CantDoReason` and leaves the order
    unchanged (wrong sender, wrong status, wrong mint, pubkey mismatch, malformed
-   token, mint unavailable, double-spent, replay).
+   token, mint unavailable, double-spent, replay, **missing/mis-valued
+   fee_token when `mostro.fee > 0`**).
 3. The lock is atomic and idempotent (concurrent/replayed submission matches zero
-   rows and is a safe no-op).
+   rows and is a safe no-op; **the fee token is never redeemed twice**).
+3b. The seller-funded fee token of `2 * order.fee` is validated against the mint
+   and redeemed on success; Mostro's total revenue equals the Lightning-mode
+   `2 * order.fee`, and dev-fee accounting is unchanged (Option 2, §4A). The
+   refund-on-non-success obligation is documented for Tracks C/D.
 4. With Cashu disabled, behaviour is identical to `main`; existing tests pass
    unmodified.
 5. `cargo fmt --check`, `clippy -D warnings`, `cargo test`, and the mint-backed
@@ -288,15 +566,27 @@ actions it owns. The §6 allow-list (`Orders`, `LastTradeIndex`, `RestoreSession
 `TradePubkey` → `no_ln`) is unaffected — only the *mechanism* for the
 blocked/escrow actions changes.
 
-### G-2 · `expected_amount` / fee policy is undefined
+### G-2 · `expected_amount` / fee policy — RESOLVED (Option 2)
 **Problem.** `verify_escrow_token` needs an `expected_amount`, but whether the
-locked token includes the Mostro fee (and who bears it) is undecided — the arch
-doc lists Cashu fee collection as open.
+locked token includes the Mostro fee (and who bears it) was undecided — the arch
+doc listed Cashu fee collection as open.
 
-**Fix.** Not a fundamentals blocker, but Track A must be handed an explicit rule.
-Recommended interim: the token locks the **order amount** (no fee folded in), and
-Cashu-mode fee collection is deferred to a dedicated design — documented as a
-known limitation so Track A's amount check is unambiguous.
+**Decision (this revision).** **Option 2 — funder pays at lock** (§4A). The
+escrow token locks `order.amount` exactly (no fee folded in — folding fails
+because the buyer redeems the token freely with `SIG_INPUTS`). The **whole**
+Mostro fee (`2 * order.fee`, both halves) is funded by the seller as a
+**separate** P2PK-1-of-1-`P_M` token in the same `AddCashuEscrow`, validated by a
+new `verify_fee_token`, and redeemed by the daemon on success. This keeps total
+revenue and dev-fee accounting identical to Lightning; the only shift is that the
+seller bears the buyer's half too.
+
+**Cost.** One additive `mostro-core` field (`CashuLockProof.fee_token:
+Option<String>`, **released in 0.14.0**; Track A requires `≥ 0.14.0`) and a
+narrow fee-only redeem capability in the
+daemon (its own revenue only; user escrow funds stay non-custodial). Refund of
+the fee on non-success paths is an obligation handed to Tracks C/D. The
+self-service-refund refinement (NUT-11 locktime + `P_S` refund, costing one
+`cashu_fee_token` migration) is documented as optional future hardening.
 
 ### G-3 · Confirm the take-flow status the CAS expects
 **Problem.** The CF-4 CAS takes `expected_status`/`new_status`. Track A assumes
@@ -308,7 +598,11 @@ in Cashu mode).
 matching pair to the CAS. No new fundamentals surface needed — just an agreed
 constant.
 
-**No gaps found in:** the protocol surface (`mostro-core 0.13.0` carries
-`AddCashuEscrow`/`CashuLockProof`/`CashuEscrowLocked` and the needed
-`CantDoReason`s), the DB schema (columns exist on `main`), the CAS helper shape,
-or the `CashuClient` API — all are sufficient for Track A as specified.
+**Sufficient as of `mostro-core 0.14.0`:** the protocol surface
+(`AddCashuEscrow`/`CashuLockProof`/`CashuEscrowLocked` and the needed
+`CantDoReason`s, plus the `CashuLockProof.fee_token` field added in 0.14.0), the
+DB schema (escrow columns exist on `main`), and the CAS helper shape are all in
+place. The only daemon-side additions Track A makes are the
+`CashuClient::verify_fee_token` method and the fee-redeem capability (§4A, G-2).
+Track A requires `mostro-core ≥ 0.14.0`; the escrow-token validation path, DB
+CAS, and notification flow need no protocol change.

--- a/docs/cashu/README.md
+++ b/docs/cashu/README.md
@@ -1,0 +1,48 @@
+# Cashu Escrow — Specification Series
+
+This directory holds the **working specification** for adding the optional
+Cashu (NUT-11 P2PK 2-of-3 multisig) escrow mode to `mostrod`. It supersedes the
+single high-level document [`../CASHU_ESCROW_ARCHITECTURE.md`](../CASHU_ESCROW_ARCHITECTURE.md),
+which remains the canonical *architecture & motivation* reference. The documents
+here are the *engineering plan*: how we land the feature on `main` in small,
+safe, independently-mergeable pull requests.
+
+## Why a re-plan
+
+The first Cashu attempt was developed on `feat/cashu-mostro-core-0.12` against an
+older `mostro-core`. `main` has since moved to `mostro-core 0.13.0`, which
+**already ships the Cashu protocol surface** (actions, payloads, order fields,
+errors). Re-landing the daemon work cleanly on top of `main` — rather than
+force-merging the old branch — lets us keep `mostrod` (which is very stable)
+untouched while the feature is off, and lets several developers work in parallel.
+
+## The prime directive
+
+> Every PR in this series must merge to `main` **without changing existing
+> behaviour while Cashu is disabled**, and `main` must stay shippable after each
+> merge. Cashu is **opt-in and defaults to off**. The Lightning hold-invoice flow
+> is never modified in a behaviour-changing way during the foundation work.
+
+## Documents
+
+| # | Document | Scope | Status |
+|---|----------|-------|--------|
+| 00 | [`../CASHU_ESCROW_ARCHITECTURE.md`](../CASHU_ESCROW_ARCHITECTURE.md) | Architecture, motivation, crypto model, trust model | Reference |
+| 01 | [`01-fundamentals.md`](./01-fundamentals.md) | **Foundation milestone** — config, mint client, DB helpers, test harness, boot wiring | **Draft (this PR)** |
+| 02 | `02-track-a-lock.md` | Escrow lock / setup (`AddCashuEscrow`) | Planned |
+| 03 | `03-track-b-release.md` | Release happy path | Planned |
+| 04 | `04-track-c-coop-cancel.md` | Cooperative cancel | Planned |
+| 05 | `05-track-d-dispute.md` | Dispute resolution (`P_M` signs) | Planned |
+
+The **fundamentals** document (01) is the only one that touches shared,
+conflict-prone files. Once it has merged, the feature tracks (02–05) edit
+disjoint files and can proceed independently. Start there.
+
+## How to read this
+
+1. Read [`01-fundamentals.md`](./01-fundamentals.md) end to end.
+2. Look at the **"Already on `main`"** table — do not re-implement those pieces.
+3. Pick a fundamentals PR (`CF-1` … `CF-5`) from the **issues table**; the table
+   says what it depends on and what it can run in parallel with.
+4. Each PR has an explicit **Definition of Done** and **backwards-compatibility
+   guarantee** — both are merge gates.


### PR DESCRIPTION
## What

Adds `docs/cashu/` — a clean, phased engineering plan for landing the optional
Cashu (NUT-11 P2PK 2-of-3) escrow mode onto `main` in small, safe,
independently-mergeable PRs. **Docs only, no code.**

This supersedes the single high-level `docs/CASHU_ESCROW_ARCHITECTURE.md` (which
stays as the architecture/motivation reference) with an actionable engineering
plan, re-based on the current `main` (`mostro-core 0.13.0`) instead of the old
`feat/cashu-mostro-core-0.12` branch.

## Why

The prime directive is recorded in the docs: **every PR must merge to `main`
without changing behaviour while Cashu is disabled, and `main` must stay shippable
after each merge.** `mostrod` is very stable; this plan keeps it that way while
letting several developers work in parallel.

Key finding that shrinks the work: `mostro-core 0.13.0` **already ships the Cashu
protocol surface** (actions, payloads, order fields, errors), and `main` already
has the escrow columns migration + the `EscrowBackend` trait. So the foundation is
intentionally small — no `mostro-core` change, no new migration, no large handler
refactor.

## Contents

- **`README.md`** — spec series index + the off-by-default prime directive.
- **`01-fundamentals.md`** — the Foundation milestone as five atomic,
  backwards-compatible PRs (`CF-1` config/escrow-mode, `CF-2` `CashuClient`
  library, `CF-3` mint test harness, `CF-4` DB escrow helpers, `CF-5`
  boot/`run_cashu`/AppContext wiring), with a sequential-vs-parallel **issues
  table**, a dependency graph, per-PR Definition of Done, the `run`/`run_cashu`
  zero-drift refactor, and the `dispatch_cashu` allow-list decision.
- **`02-track-a-lock.md`** — the first feature track (escrow lock), written now to
  **validate the foundation is correctly dimensioned**. It includes the gaps the
  exercise surfaced.

## Known follow-up before merging code (not blocking this docs PR)

Writing Track A surfaced **G-1**: `CF-5`'s `dispatch_cashu` should route each
action to its own per-handler stub (in each handler's file) rather than a single
`match` in `app.rs`, so the feature tracks edit disjoint files and `app.rs` does
not become a cross-track merge-conflict hotspot. To be folded into `01-fundamentals.md`
during review. (G-2 fee/amount policy and G-3 take-flow status are also noted.)

## Scope

No production code changes. Review is about the **plan**: phase boundaries,
backwards-compat guarantees, parallelisation, and the issues breakdown. Once
approved, the `CF-*` / `TA-*` GitHub issues can be created from the tables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the top-level Cashu escrow specification series entry point with reading guidance and an explicit staged roadmap.
  * Introduced “Cashu Escrow — Fundamentals,” defining scope constraints, merge principles (off-by-default), and frozen interface expectations for follow-on tracks.
  * Added “Cashu Escrow — Track A: Lock / Escrow Setup,” specifying the Cashu lock flow, atomic/idempotent state transition rules, and validation/replay behavior including seller-funded optional fee tokens (Option 2).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->