### PR TITLE
feat: cashu config + escrow mode — Cashu foundation CF-1

### DIFF
--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -202,3 +202,16 @@ port = 50051
 # # Days the winner has to claim their share by submitting a bolt11; after
 # # this the bond closes as `forfeited` and the node retains everything.
 # payout_claim_window_days = 15
+
+# Cashu escrow mode (docs/cashu/). Opt-in, disabled by default. When enabled
+# the node runs WITHOUT LND and escrows trades in NUT-11 2-of-3 Cashu tokens
+# on the single mint configured below. Mutually exclusive with
+# [anti_abuse_bond] — enabling both is a startup error.
+#
+# [cashu]
+# enabled = false
+# # The one mint this node escrows on (http/https). Required when enabled.
+# mint_url = "https://mint.example.com"
+# # Seller-recovery locktime floor in days: escrow tokens must carry
+# # locktime >= now + this. Sellers may set a longer locktime, never shorter.
+# escrow_locktime_days = 15

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -268,6 +268,7 @@ pub mod test_utils {
             rpc: RpcSettings::default(),
             expiration: Some(ExpirationSettings::default()),
             anti_abuse_bond: None,
+            cashu: None,
             price: None,
         }
     }

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -1050,6 +1050,7 @@ mod tests {
             rpc: Default::default(),
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
+            cashu: None,
             price: None,
         });
     }

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -240,6 +240,7 @@ mod tests {
             rpc: Default::default(),
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
+            cashu: None,
             price: None,
         });
     }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,7 +1,7 @@
 use super::{DB_POOL, MOSTRO_CONFIG};
 use crate::config::types::{
-    AntiAbuseBondSettings, DatabaseSettings, ExpirationSettings, LightningSettings, MostroSettings,
-    NostrSettings, RpcSettings,
+    AntiAbuseBondSettings, CashuSettings, DatabaseSettings, EscrowMode, ExpirationSettings,
+    LightningSettings, MostroSettings, NostrSettings, RpcSettings,
 };
 use crate::price::PriceSettings;
 use mostro_core::transport::Transport;
@@ -26,6 +26,11 @@ pub struct Settings {
     /// Anti-abuse bond configuration (issue #711). Absent section ≡ disabled.
     #[serde(default)]
     pub anti_abuse_bond: Option<AntiAbuseBondSettings>,
+    /// Cashu escrow configuration (docs/cashu/, CF-1). Absent section ≡
+    /// disabled (Lightning mode). Mutually exclusive with
+    /// `anti_abuse_bond`; enforced at startup.
+    #[serde(default)]
+    pub cashu: Option<CashuSettings>,
     /// Multi-source price configuration (see `docs/PRICE_PROVIDERS.md`).
     /// Absent section ≡ legacy single-source behaviour (synthesised in
     /// Phase 1's migration).
@@ -128,5 +133,33 @@ impl Settings {
     /// `false` when settings haven't been initialized.
     pub fn is_bond_enabled() -> bool {
         Self::get_bond().is_some_and(|cfg| cfg.enabled)
+    }
+
+    /// Retrieve the Cashu escrow configuration from the global
+    /// `MOSTRO_CONFIG`. Returns `None` when the `[cashu]` block is absent
+    /// (treated as disabled) and also when the global settings haven't
+    /// been initialized yet — the escrow-mode gate will sit on handler hot
+    /// paths, so it must never panic in unit tests that don't bring up the
+    /// full configuration, mirroring [`Settings::get_bond`].
+    pub fn get_cashu() -> Option<&'static CashuSettings> {
+        MOSTRO_CONFIG.get()?.cashu.as_ref()
+    }
+
+    /// True when the `[cashu]` block is present AND explicitly enabled.
+    /// The single gate every Cashu code path must check. Returns `false`
+    /// when settings haven't been initialized.
+    pub fn is_cashu_enabled() -> bool {
+        Self::get_cashu().is_some_and(|cfg| cfg.enabled)
+    }
+
+    /// The node-wide escrow mode (locked decision §4.1). `[cashu]` absent
+    /// or disabled ⇒ `Lightning`. Nothing calls this on a hot path during
+    /// the foundation milestone — CF-1 wires it to nothing at runtime.
+    pub fn escrow_mode() -> EscrowMode {
+        if Self::is_cashu_enabled() {
+            EscrowMode::Cashu
+        } else {
+            EscrowMode::Lightning
+        }
     }
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -158,6 +158,55 @@ impl Default for AntiAbuseBondSettings {
     }
 }
 
+/// Cashu escrow configuration (Cashu foundation CF-1,
+/// `docs/cashu/01-fundamentals.md` §6).
+///
+/// Opt-in. When the `[cashu]` block is absent or `enabled = false` (the
+/// default) every Cashu code path remains inert — the daemon behaves
+/// exactly as a Lightning node. Mutually exclusive with
+/// `[anti_abuse_bond]` (locked decision §4.5); enforced at startup.
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CashuSettings {
+    /// Master switch. When false, the node runs in Lightning mode.
+    #[serde(default)]
+    pub enabled: bool,
+    /// The one mint this node escrows on (locked decision §4.2:
+    /// node-configured, fixed — no per-order mint). Required (non-empty,
+    /// `http`/`https`) when `enabled = true`; validated at startup.
+    #[serde(default)]
+    pub mint_url: String,
+    /// Seller-recovery locktime floor, in days (Track A §4B): escrow
+    /// tokens must carry `locktime >= now + escrow_locktime_days`. The
+    /// seller may set a longer locktime, never a shorter one. Must be
+    /// `>= 1`; validated at startup.
+    #[serde(default = "default_escrow_locktime_days")]
+    pub escrow_locktime_days: u32,
+}
+
+fn default_escrow_locktime_days() -> u32 {
+    15
+}
+
+impl Default for CashuSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            mint_url: String::new(),
+            escrow_locktime_days: default_escrow_locktime_days(),
+        }
+    }
+}
+
+/// The node-wide escrow mode (locked decision §4.1: a node runs in exactly
+/// one mode, fixed in `settings.toml` — never per-order).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EscrowMode {
+    /// LND hold-invoice escrow (the default).
+    Lightning,
+    /// Cashu NUT-11 2-of-3 escrow.
+    Cashu,
+}
+
 /// Event expiration configuration settings
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]
 pub struct ExpirationSettings {
@@ -702,5 +751,63 @@ payout_claim_window_days = 30"#,
         // Other fields on the same block must still deserialize correctly.
         assert_eq!(parsed.anti_abuse_bond.slash_node_share_pct, 0.25);
         assert_eq!(parsed.anti_abuse_bond.payout_claim_window_days, 30);
+    }
+}
+
+#[cfg(test)]
+mod cashu_settings_tests {
+    use super::*;
+
+    #[derive(serde::Deserialize)]
+    struct Stub {
+        #[serde(default)]
+        cashu: Option<CashuSettings>,
+    }
+
+    #[test]
+    fn defaults_are_off() {
+        let cfg = CashuSettings::default();
+        assert!(!cfg.enabled);
+        assert!(cfg.mint_url.is_empty());
+        assert_eq!(cfg.escrow_locktime_days, 15);
+    }
+
+    #[test]
+    fn toml_omits_block() {
+        // CF-1 backwards-compat guarantee: a config that does not mention
+        // Cashu parses exactly as before.
+        let parsed: Stub = toml::from_str("").expect("empty toml is valid");
+        assert!(parsed.cashu.is_none());
+    }
+
+    #[test]
+    fn toml_minimal_block_defaults() {
+        let parsed: Stub = toml::from_str("[cashu]\n").expect("minimal block");
+        let cashu = parsed.cashu.expect("block present");
+        assert!(!cashu.enabled);
+        assert!(cashu.mint_url.is_empty());
+        assert_eq!(cashu.escrow_locktime_days, 15);
+    }
+
+    #[test]
+    fn toml_disabled_block() {
+        let parsed: Stub =
+            toml::from_str("[cashu]\nenabled = false\nmint_url = \"https://mint.example.com\"\n")
+                .expect("disabled block");
+        let cashu = parsed.cashu.expect("block present");
+        assert!(!cashu.enabled);
+        assert_eq!(cashu.mint_url, "https://mint.example.com");
+    }
+
+    #[test]
+    fn toml_enabled_block_with_overrides() {
+        let parsed: Stub = toml::from_str(
+            "[cashu]\nenabled = true\nmint_url = \"https://mint.example.com\"\nescrow_locktime_days = 30\n",
+        )
+        .expect("enabled block");
+        let cashu = parsed.cashu.expect("block present");
+        assert!(cashu.enabled);
+        assert_eq!(cashu.mint_url, "https://mint.example.com");
+        assert_eq!(cashu.escrow_locktime_days, 30);
     }
 }

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -68,6 +68,67 @@ fn validate_mostro_settings(settings: &Settings) -> Result<(), MostroError> {
         ))));
     }
 
+    validate_cashu_settings(
+        settings.cashu.as_ref(),
+        settings
+            .anti_abuse_bond
+            .as_ref()
+            .is_some_and(|bond| bond.enabled),
+    )?;
+
+    Ok(())
+}
+
+/// Validate the `[cashu]` block (Cashu foundation CF-1,
+/// `docs/cashu/01-fundamentals.md` §6). Standalone so it is unit-testable
+/// without building a full `Settings`.
+///
+/// Rules (all startup-fatal, so the daemon refuses to boot rather than
+/// silently misbehave):
+/// - `cashu.enabled` and `anti_abuse_bond.enabled` are mutually exclusive
+///   (locked decision §4.5).
+/// - When enabled, `mint_url` must be non-empty and parse as `http`/`https`.
+/// - When enabled, `escrow_locktime_days >= 1` (the seller-recovery
+///   locktime floor of Track A §4B cannot be zero).
+fn validate_cashu_settings(
+    cashu: Option<&crate::config::types::CashuSettings>,
+    bond_enabled: bool,
+) -> Result<(), MostroError> {
+    let Some(cashu) = cashu else {
+        return Ok(());
+    };
+    if !cashu.enabled {
+        return Ok(());
+    }
+
+    if bond_enabled {
+        return Err(MostroInternalErr(ServiceError::IOError(
+            "cashu.enabled and anti_abuse_bond.enabled are mutually exclusive: \
+             a node runs bonds or Cashu escrow, never both"
+                .to_string(),
+        )));
+    }
+
+    let url = reqwest::Url::parse(&cashu.mint_url).map_err(|e| {
+        MostroInternalErr(ServiceError::IOError(format!(
+            "cashu.mint_url ({:?}) is not a valid URL: {e}",
+            cashu.mint_url
+        )))
+    })?;
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return Err(MostroInternalErr(ServiceError::IOError(format!(
+            "cashu.mint_url must use http or https, got scheme {:?}",
+            url.scheme()
+        ))));
+    }
+
+    if cashu.escrow_locktime_days < 1 {
+        return Err(MostroInternalErr(ServiceError::IOError(format!(
+            "cashu.escrow_locktime_days ({}) must be >= 1",
+            cashu.escrow_locktime_days
+        ))));
+    }
+
     Ok(())
 }
 
@@ -199,6 +260,7 @@ mod tests {
             rpc: RpcSettings::default(),
             expiration: None,
             anti_abuse_bond: None,
+            cashu: None,
             price: None,
         }
     }
@@ -271,5 +333,67 @@ mod tests {
             toml::from_str(toml_without_nsec).expect("nsec_privkey should be optional in TOML");
         assert_eq!(nostr.nsec_privkey, "");
         assert_eq!(nostr.relays, vec!["wss://relay.test"]);
+    }
+}
+
+#[cfg(test)]
+mod cashu_validation_tests {
+    use super::*;
+    use crate::config::types::CashuSettings;
+
+    fn enabled(mint_url: &str, days: u32) -> CashuSettings {
+        CashuSettings {
+            enabled: true,
+            mint_url: mint_url.to_string(),
+            escrow_locktime_days: days,
+        }
+    }
+
+    #[test]
+    fn absent_block_is_valid_regardless_of_bonds() {
+        assert!(validate_cashu_settings(None, false).is_ok());
+        assert!(validate_cashu_settings(None, true).is_ok());
+    }
+
+    #[test]
+    fn disabled_block_is_valid_even_with_bonds() {
+        let cashu = CashuSettings::default();
+        assert!(validate_cashu_settings(Some(&cashu), true).is_ok());
+    }
+
+    #[test]
+    fn rejects_cashu_and_bonds_together() {
+        // Locked decision §4.5: a node runs bonds or Cashu, never both.
+        let cashu = enabled("https://mint.example.com", 15);
+        assert!(validate_cashu_settings(Some(&cashu), true).is_err());
+    }
+
+    #[test]
+    fn accepts_valid_enabled_config() {
+        let cashu = enabled("https://mint.example.com", 15);
+        assert!(validate_cashu_settings(Some(&cashu), false).is_ok());
+        let cashu_http = enabled("http://localhost:3338", 1);
+        assert!(validate_cashu_settings(Some(&cashu_http), false).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_or_malformed_mint_url() {
+        assert!(validate_cashu_settings(Some(&enabled("", 15)), false).is_err());
+        assert!(validate_cashu_settings(Some(&enabled("not a url", 15)), false).is_err());
+    }
+
+    #[test]
+    fn rejects_non_http_scheme() {
+        let cashu = enabled("ftp://mint.example.com", 15);
+        assert!(validate_cashu_settings(Some(&cashu), false).is_err());
+        let cashu_ws = enabled("wss://mint.example.com", 15);
+        assert!(validate_cashu_settings(Some(&cashu_ws), false).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_locktime_days() {
+        // Track A §4B: the seller-recovery locktime floor cannot be zero.
+        let cashu = enabled("https://mint.example.com", 0);
+        assert!(validate_cashu_settings(Some(&cashu), false).is_err());
     }
 }

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -73,6 +73,7 @@ fn run_setup_wizard(settings_dir: &Path, config_file_path: &Path) -> Result<Sett
         rpc: RpcSettings::default(),
         expiration: None,
         anti_abuse_bond: None,
+        cashu: None,
         price: None,
     };
 

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -437,6 +437,7 @@ mod tests {
             rpc: Default::default(),
             expiration: Some(Default::default()),
             anti_abuse_bond: None,
+            cashu: None,
             price: None,
         });
     }


### PR DESCRIPTION
## Summary

**CF-1** of the Cashu foundation ([`docs/cashu/01-fundamentals.md` §6](../blob/main/docs/cashu/01-fundamentals.md)). Introduces Cashu configuration and escrow-mode resolution, **wired to nothing at runtime** — only config validation reads it.

- **`CashuSettings`** (`src/config/types.rs`): `{ enabled, mint_url, escrow_locktime_days }`, all `#[serde(default)]`; `escrow_locktime_days` defaults to **15** (the Track A §4B seller-recovery locktime floor). **`EscrowMode { Lightning, Cashu }`** enum (locked decision §4.1: one mode per node, never per-order).
- **`Settings.cashu: Option<CashuSettings>`** + panic-free accessors `get_cashu()` / `is_cashu_enabled()` / `escrow_mode()`, mirroring the `anti_abuse_bond` pattern (`get_bond`).
- **Startup validation** (`validate_cashu_settings`, standalone & unit-testable):
  - `cashu.enabled && anti_abuse_bond.enabled` → hard config error (locked decision §4.5, bonds ⊕ cashu).
  - When enabled: `mint_url` must parse as `http`/`https`; `escrow_locktime_days >= 1`.
- **`settings.tpl.toml`**: commented `[cashu]` block. **Wizard**: emits `cashu: None` (no interactive prompt added — the spec marks it optional; can follow up if maintainers want it).

## Backwards-compat guarantee (CF-1 merge gate)

`[cashu]` absent ⇒ `get_cashu() == None` ⇒ `is_cashu_enabled() == false` ⇒ `escrow_mode() == Lightning`. A config that does not mention Cashu validates and boots exactly as before — covered by `toml_omits_block`. The only touch to existing tests is mechanical: test-helper `Settings` literals gain `cashu: None` (compile fallout of the new field; no assertion changed).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 515 passed (503 pre-existing + 12 new: serde defaults ×5, validation ×7 incl. mutual-exclusion, scheme, and zero-locktime rejections)

Independent of CF-0 (#795); both are Wave-0/1 of the CF-0…CF-5 series. CF-4 (DB helpers) next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Cashu escrow configuration, including support for choosing Cashu or Lightning escrow mode.
  * Added settings for enabling the mode, specifying a mint URL, and setting an escrow locktime minimum.

* **Bug Fixes**
  * Added validation to prevent incompatible escrow modes from being enabled together.
  * Improved configuration checks for invalid or unsupported mint URLs and missing locktime values.

* **Tests**
  * Expanded test coverage for Cashu configuration parsing and validation.
  * Updated test setup defaults to include the new optional configuration field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->