### PR TITLE
feat: cashu escrow DB helpers — Cashu foundation CF-4

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -805,6 +805,68 @@ pub async fn update_order_invoice_held_at_time(
     Ok(rows_affected > 0)
 }
 
+/// Atomically persist a validated Cashu escrow and advance the order status
+/// (Cashu foundation CF-4, `docs/cashu/01-fundamentals.md` §6).
+///
+/// Compare-and-set: the three `cashu_*` columns and the status transition
+/// are written in one `UPDATE … WHERE id = ? AND status = ? AND
+/// cashu_escrow_locked_at IS NULL`, so there is no lock-without-advance
+/// window, and a replayed or concurrent submission (already locked, or the
+/// status moved on) matches zero rows instead of double-writing. Returns
+/// whether a row matched.
+pub async fn update_order_cashu_escrow(
+    pool: &SqlitePool,
+    order_id: Uuid,
+    mint_url: &str,
+    token: &str,
+    locked_at: i64,
+    expected_status: Status,
+    new_status: Status,
+) -> Result<bool, MostroError> {
+    let result = sqlx::query(
+        r#"
+            UPDATE orders
+            SET
+            cashu_mint_url = ?1,
+            cashu_escrow_token = ?2,
+            cashu_escrow_locked_at = ?3,
+            status = ?4
+            WHERE id = ?5 AND status = ?6 AND cashu_escrow_locked_at IS NULL
+        "#,
+    )
+    .bind(mint_url)
+    .bind(token)
+    .bind(locked_at)
+    .bind(new_status.to_string())
+    .bind(order_id)
+    .bind(expected_status.to_string())
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Every order with a locked Cashu escrow, for restore/monitoring after a
+/// restart (CF-4). Deliberately **no** `status` predicate:
+/// [`update_order_cashu_escrow`] advances the status in the same write as
+/// the lock, so filtering on a status would skip legitimately locked rows
+/// that have already moved on. Only re-add a status predicate if a separate
+/// invariant guarantees locked rows never leave that status.
+pub async fn find_locked_cashu_orders(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
+    sqlx::query_as::<_, Order>(
+        r#"
+          SELECT *
+          FROM orders
+          WHERE cashu_escrow_locked_at IS NOT NULL
+          ORDER BY cashu_escrow_locked_at ASC
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
 pub async fn find_held_invoices(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
     let order = sqlx::query_as::<_, Order>(
         r#"
@@ -2844,6 +2906,154 @@ mod tests {
         assert!(
             (other.4 - 32.0).abs() < f64::EPSILON,
             "other user's total_rating must not change"
+        );
+    }
+
+    // -- Tests for the CF-4 cashu escrow helpers --
+
+    use mostro_core::order::Status;
+
+    async fn insert_cashu_test_order(pool: &SqlitePool, id: uuid::Uuid, status: &str) {
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid)
+            VALUES (?1, 'sell', ?2, ?3, 0, 'face to face',
+                    100000, 'EUR', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0)"#,
+        )
+        .bind(id)
+        .bind(format!("ev-{id}"))
+        .bind(status)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn cashu_columns(
+        pool: &SqlitePool,
+        id: uuid::Uuid,
+    ) -> (Option<String>, Option<String>, Option<i64>, String) {
+        sqlx::query_as(
+            "SELECT cashu_mint_url, cashu_escrow_token, cashu_escrow_locked_at, status
+             FROM orders WHERE id = ?1",
+        )
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn cashu_escrow_cas_locks_once_and_replay_is_noop() {
+        let pool = setup_orders_db().await.unwrap();
+        let id = uuid::Uuid::new_v4();
+        insert_cashu_test_order(&pool, id, &Status::WaitingPayment.to_string()).await;
+
+        // First submission: persists the escrow and advances the status in
+        // one write.
+        let locked = super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://mint.example.com",
+            "cashuAtoken",
+            1700000100,
+            Status::WaitingPayment,
+            Status::Active,
+        )
+        .await
+        .unwrap();
+        assert!(locked, "first CAS must match the row");
+
+        let (mint, token, locked_at, status) = cashu_columns(&pool, id).await;
+        assert_eq!(mint.as_deref(), Some("https://mint.example.com"));
+        assert_eq!(token.as_deref(), Some("cashuAtoken"));
+        assert_eq!(locked_at, Some(1700000100));
+        assert_eq!(status, Status::Active.to_string());
+
+        // Replay: cashu_escrow_locked_at is no longer NULL (and the status
+        // moved on), so the CAS matches zero rows and nothing is rewritten.
+        let replayed = super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://evil.example.com",
+            "cashuAother",
+            1700009999,
+            Status::WaitingPayment,
+            Status::Active,
+        )
+        .await
+        .unwrap();
+        assert!(!replayed, "replayed CAS must match zero rows");
+
+        let (mint, token, locked_at, _) = cashu_columns(&pool, id).await;
+        assert_eq!(mint.as_deref(), Some("https://mint.example.com"));
+        assert_eq!(token.as_deref(), Some("cashuAtoken"));
+        assert_eq!(locked_at, Some(1700000100), "original lock must survive");
+    }
+
+    #[tokio::test]
+    async fn cashu_escrow_cas_status_mismatch_matches_zero_rows() {
+        let pool = setup_orders_db().await.unwrap();
+        let id = uuid::Uuid::new_v4();
+        insert_cashu_test_order(&pool, id, &Status::Pending.to_string()).await;
+
+        let locked = super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://mint.example.com",
+            "cashuAtoken",
+            1700000100,
+            Status::WaitingPayment,
+            Status::Active,
+        )
+        .await
+        .unwrap();
+        assert!(!locked, "status mismatch must match zero rows");
+
+        let (mint, token, locked_at, status) = cashu_columns(&pool, id).await;
+        assert!(mint.is_none(), "escrow columns must stay untouched");
+        assert!(token.is_none());
+        assert!(locked_at.is_none());
+        assert_eq!(status, Status::Pending.to_string());
+    }
+
+    #[tokio::test]
+    async fn find_locked_cashu_orders_includes_locked_regardless_of_status() {
+        let pool = setup_orders_db().await.unwrap();
+        let locked_id = uuid::Uuid::new_v4();
+        let unlocked_id = uuid::Uuid::new_v4();
+        insert_cashu_test_order(&pool, locked_id, &Status::WaitingPayment.to_string()).await;
+        insert_cashu_test_order(&pool, unlocked_id, &Status::Active.to_string()).await;
+
+        assert!(super::update_order_cashu_escrow(
+            &pool,
+            locked_id,
+            "https://mint.example.com",
+            "cashuAtoken",
+            1700000100,
+            Status::WaitingPayment,
+            Status::Active,
+        )
+        .await
+        .unwrap());
+
+        // Move the locked order past Active: the finder must still return
+        // it (CF-4: no status predicate — the escrow is what matters).
+        sqlx::query("UPDATE orders SET status = ?1 WHERE id = ?2")
+            .bind(Status::FiatSent.to_string())
+            .bind(locked_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let locked = super::find_locked_cashu_orders(&pool).await.unwrap();
+        assert_eq!(locked.len(), 1, "only the locked order is returned");
+        assert_eq!(locked[0].id, locked_id);
+        assert_eq!(
+            locked[0].status,
+            Status::FiatSent.to_string(),
+            "a locked order past Active must still be found"
         );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3056,4 +3056,64 @@ mod tests {
             "a locked order past Active must still be found"
         );
     }
+
+    #[tokio::test]
+    async fn cashu_escrow_cas_on_missing_order_matches_zero_rows() {
+        // A CAS against an id that isn't in the table must report no match
+        // (not error), the same "matches zero rows" contract a replay hits.
+        let pool = setup_orders_db().await.unwrap();
+        let locked = super::update_order_cashu_escrow(
+            &pool,
+            uuid::Uuid::new_v4(),
+            "https://mint.example.com",
+            "cashuAtoken",
+            1700000100,
+            Status::WaitingPayment,
+            Status::Active,
+        )
+        .await
+        .unwrap();
+        assert!(!locked, "CAS on a non-existent order must match zero rows");
+    }
+
+    #[tokio::test]
+    async fn find_locked_cashu_orders_includes_terminal_status_orders() {
+        // Pins the deliberate CF-4 design (M-1): the finder has no status
+        // predicate and nothing ever clears `cashu_escrow_locked_at`, so a
+        // locked order that reached a terminal status is STILL returned.
+        // This is a conscious, tested contract — if CF-5 needs terminal
+        // orders excluded, it must clear the lock or filter, not rely on
+        // this finder to drop them.
+        let pool = setup_orders_db().await.unwrap();
+        let id = uuid::Uuid::new_v4();
+        insert_cashu_test_order(&pool, id, &Status::WaitingPayment.to_string()).await;
+
+        assert!(super::update_order_cashu_escrow(
+            &pool,
+            id,
+            "https://mint.example.com",
+            "cashuAtoken",
+            1700000100,
+            Status::WaitingPayment,
+            Status::Active,
+        )
+        .await
+        .unwrap());
+
+        sqlx::query("UPDATE orders SET status = ?1 WHERE id = ?2")
+            .bind(Status::Canceled.to_string())
+            .bind(id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let locked = super::find_locked_cashu_orders(&pool).await.unwrap();
+        assert_eq!(
+            locked.len(),
+            1,
+            "a canceled-but-locked order is still found"
+        );
+        assert_eq!(locked[0].id, id);
+        assert_eq!(locked[0].status, Status::Canceled.to_string());
+    }
 }


### PR DESCRIPTION
## Summary

**CF-4** of the Cashu foundation ([`docs/cashu/01-fundamentals.md` §6](../blob/main/docs/cashu/01-fundamentals.md)). Additive query helpers over the **already-migrated** `cashu_*` columns; new, unreferenced functions — zero behaviour change. Frozen-contract signatures from §10 of the spec.

- **`update_order_cashu_escrow(pool, order_id, mint_url, token, locked_at, expected_status, new_status) -> Result<bool>`** — atomic **compare-and-set**: persists the three columns *and* transitions the status in one `UPDATE … WHERE id = ? AND status = ? AND cashu_escrow_locked_at IS NULL`. No lock-without-advance window; a replayed or concurrent submission matches zero rows instead of double-writing.
- **`find_locked_cashu_orders(pool)`** — `WHERE cashu_escrow_locked_at IS NOT NULL`, deliberately **without a status predicate**: the CAS advances the status in the same write as the lock, so filtering on a status would skip legitimately locked rows that already moved on (per the spec's design note, incl. the M-1 review fix).

No migration ships here — the columns landed on `main` in `20260530120000_cashu_escrow_fields.sql`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 506 passed (503 pre-existing unmodified + 3 new):
  - CAS locks once; replay matches zero rows and the original lock survives (attempted overwrite with different mint/token is ignored)
  - status mismatch matches zero rows, columns stay `NULL`
  - finder includes locked orders **regardless of status** (locked → moved to `FiatSent` → still found) and excludes unlocked ones

Independent Wave-1 PR of the CF-0…CF-5 series (CF-0 #795, CF-1 #796). Remaining: CF-2 (CashuClient/cdk), CF-3 (mint harness), CF-5 (integration, last).