### PR TITLE
feat: CashuClient mint library (cdk 0.17.2) — Cashu foundation CF-2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,10 +125,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-trait"
@@ -276,6 +312,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
  "bitcoin_hashes",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -287,6 +325,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
 dependencies = [
  "base58ck",
+ "base64 0.21.7",
  "bech32",
  "bitcoin-io",
  "bitcoin-units",
@@ -322,6 +361,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
 dependencies = [
  "bitcoin-consensus-encoding",
+]
+
+[[package]]
+name = "bitcoin-payment-instructions"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c300c948b2ff78c965ea3a613372352125448a22f1acf49e95e3878149824091"
+dependencies = [
+ "bitcoin",
+ "lightning",
+ "lightning-invoice 0.34.1",
 ]
 
 [[package]]
@@ -403,6 +453,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "build_const"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,6 +513,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
+name = "cashu"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e47bf3a30a044bfad3b1e222aa22d432c5895b28a743f68b8e338af4f12a01"
+dependencies = [
+ "bitcoin",
+ "cbor-diag",
+ "ciborium",
+ "lightning",
+ "lightning-invoice 0.34.1",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "strum_macros",
+ "thiserror 2.0.18",
+ "tracing",
+ "unicode-normalization",
+ "url",
+ "uuid",
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,13 +548,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cdk"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911586800fc82527ebad109f25470715fd6e6a4f2c98d60cdf0cfed09ab5f75d"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "async-trait",
+ "bitcoin",
+ "bitcoin-payment-instructions",
+ "cbor-diag",
+ "cdk-common",
+ "cdk-signatory",
+ "ciborium",
+ "futures",
+ "getrandom 0.2.17",
+ "gloo-timers",
+ "jsonwebtoken",
+ "lightning",
+ "lightning-invoice 0.34.1",
+ "regex",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "cdk-common"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6157c494a479042c78ce995b62dc10e9b1fe15ba8dfd9fd03c43765f7f87a819"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitcoin",
+ "cashu",
+ "cbor-diag",
+ "cdk-http-client",
+ "ciborium",
+ "futures",
+ "getrandom 0.2.17",
+ "jsonwebtoken",
+ "lightning",
+ "lightning-invoice 0.34.1",
+ "parking_lot",
+ "paste",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.6",
+ "tracing",
+ "url",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "cdk-http-client"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c808588b6d33f67c72b9e5d52661295166bff0661b38b281803a8eea6cf97f"
+dependencies = [
+ "futures",
+ "futures-channel",
+ "js-sys",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "cdk-signatory"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c024fd98d57f0d4ea22bf562b8e765b9a0e87199670de69a2b8a1d5d8b47f8c7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bip39",
+ "bitcoin",
+ "cdk-common",
+ "clap",
+ "getrandom 0.2.17",
+ "home",
+ "rustls",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -507,8 +749,36 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -588,6 +858,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +897,16 @@ dependencies = [
  "once_cell",
  "unicode-width",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -694,6 +994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,10 +1029,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "dialoguer"
@@ -805,10 +1154,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dnssec-prover"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
+dependencies = [
+ "bitcoin_hashes",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "easy-hasher"
@@ -1160,12 +1524,35 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -1266,6 +1653,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,6 +1747,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1500,6 +1897,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,12 +1925,25 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1580,6 +1996,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +2014,21 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1612,6 +2053,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +2079,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a1ab99a13ab3343a9b4d1d25c455bf72322819fc5a5f05c5182e704528a583"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "dnssec-prover",
+ "hashbrown 0.13.2",
+ "libm",
+ "lightning-invoice 0.34.1",
+ "lightning-macros",
+ "lightning-types 0.3.2",
+ "possiblyrandom",
+]
+
+[[package]]
 name = "lightning-invoice"
 version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,7 +2103,30 @@ checksum = "b39b494954ed8f1d774d86473224fadf9f0dfcca38c2d16a7dbdf2b5800c8943"
 dependencies = [
  "bech32",
  "bitcoin",
- "lightning-types",
+ "lightning-types 0.2.1",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d83bd798e04ab9eecc8bbef1fa17d3808859bcdc0406bd16c55d51c8834444"
+dependencies = [
+ "bech32",
+ "bitcoin",
+ "lightning-types 0.3.2",
+ "serde",
+]
+
+[[package]]
+name = "lightning-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1647,6 +2134,15 @@ name = "lightning-types"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16acfbf632be138618a255b353b1c4577f06cf85972aff1cf59f46554528751f"
+dependencies = [
+ "bitcoin",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c211dfcff95ca308247da8b1e0e81604bc9e568239967cd2c34572558511e869"
 dependencies = [
  "bitcoin",
 ]
@@ -1810,6 +2306,7 @@ dependencies = [
  "axum",
  "bech32",
  "bitcoin",
+ "cdk",
  "chrono",
  "clap",
  "clearscreen",
@@ -1819,7 +2316,7 @@ dependencies = [
  "easy-hasher",
  "fedimint-tonic-lnd",
  "futures",
- "lightning-invoice",
+ "lightning-invoice 0.33.3",
  "lnurl-rs",
  "mostro-core",
  "mutants",
@@ -1984,6 +2481,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2548,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2063,6 +2602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +2615,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -2085,7 +2640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2096,7 +2651,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2181,6 +2736,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "possiblyrandom"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c564dbf654befd49035528299f1208a40508f6e07efb11c163444e304e4484f"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,6 +2752,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -2515,6 +3085,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2564,6 +3154,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2630,6 +3221,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2681,6 +3284,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2718,6 +3354,35 @@ checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
@@ -2792,6 +3457,38 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2916,6 +3613,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,7 +3707,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "hashlink",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "percent-encoding",
@@ -3170,6 +3879,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,6 +4008,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,6 +4132,7 @@ dependencies = [
  "futures-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3401,7 +4159,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -3553,7 +4311,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -3570,12 +4328,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -4310,3 +5073,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ clearscreen = "4.0.1"
 tonic = "0.14.2"
 prost = "0.14.1"
 tonic-prost = "0.14.1"
+cdk = { version = "0.17.2", default-features = false, features = ["wallet"] }
 
 [dev-dependencies]
 tokio = { version = "1.47.1", features = ["full", "test-util", "macros"] }

--- a/src/cashu/mod.rs
+++ b/src/cashu/mod.rs
@@ -11,6 +11,7 @@
 
 use std::collections::HashSet;
 use std::str::FromStr;
+use std::time::Duration;
 
 use cdk::error::Error as CdkClientError;
 use cdk::mint_url::MintUrl;
@@ -21,6 +22,12 @@ use cdk::nuts::{
 };
 use cdk::wallet::MintConnector;
 use cdk::HttpClient;
+
+/// Per-request bound on every mint HTTP call. `HttpClient` wraps a
+/// `reqwest` client with **no default timeout**, so without this a slow or
+/// unreachable mint could hang `connect`, `check_state` or the DLEQ keyset
+/// fetch indefinitely, stranding the calling handler.
+const MINT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Error type for Cashu client operations.
 #[derive(Debug)]
@@ -85,10 +92,9 @@ impl CashuClient {
             client,
         };
 
-        let info = cashu_client
-            .client
-            .get_mint_info()
+        let info = tokio::time::timeout(MINT_REQUEST_TIMEOUT, cashu_client.client.get_mint_info())
             .await
+            .map_err(|_| Error::MintConnection("timed out fetching mint info".into()))?
             .map_err(|e| Error::MintConnection(e.to_string()))?;
         if !info.nuts.nut11.supported {
             return Err(Error::MintConnection(
@@ -106,11 +112,11 @@ impl CashuClient {
             ));
         }
 
-        let keysets = cashu_client
-            .client
-            .get_mint_keysets()
-            .await
-            .map_err(|e| Error::MintConnection(e.to_string()))?;
+        let keysets =
+            tokio::time::timeout(MINT_REQUEST_TIMEOUT, cashu_client.client.get_mint_keysets())
+                .await
+                .map_err(|_| Error::MintConnection("timed out fetching mint keysets".into()))?
+                .map_err(|e| Error::MintConnection(e.to_string()))?;
         if !keysets
             .keysets
             .iter()
@@ -309,6 +315,12 @@ impl CashuClient {
             )));
         }
 
+        // Reject a token that repeats a proof before its value is trusted: a
+        // duplicated proof inflates `value()` below and is reported unspent
+        // once per copy by checkstate (step 5), so one proof could satisfy a
+        // larger escrow than it is actually worth.
+        reject_duplicate_proofs(&token)?;
+
         // 3: the locked amount must equal the order amount exactly, and be
         // denominated in sats. `value()` is a bare integer, so without the
         // unit guard a mint exposing multiple units would let a
@@ -370,11 +382,11 @@ impl CashuClient {
     /// use [`Self::verify_token_dleq`] for that.
     pub async fn check_state(&self, ys: Vec<PublicKey>) -> Result<CheckStateResponse, Error> {
         let request = CheckStateRequest { ys };
-        let response = self
-            .client
-            .post_check_state(request)
-            .await
-            .map_err(Error::Client)?;
+        let response =
+            tokio::time::timeout(MINT_REQUEST_TIMEOUT, self.client.post_check_state(request))
+                .await
+                .map_err(|_| Error::MintConnection("timed out checking proof state".into()))?
+                .map_err(Error::Client)?;
         Ok(response)
     }
 
@@ -390,7 +402,10 @@ impl CashuClient {
         // is safe, but before Track B verifies older tokens this must fall
         // back to fetching the specific keyset via `/v1/keys/{keyset_id}`
         // for inactive keyset ids.
-        let keysets = self.client.get_mint_keys().await.map_err(Error::Client)?;
+        let keysets = tokio::time::timeout(MINT_REQUEST_TIMEOUT, self.client.get_mint_keys())
+            .await
+            .map_err(|_| Error::MintConnection("timed out fetching mint keys".into()))?
+            .map_err(Error::Client)?;
 
         match token {
             Token::TokenV3(token_v3) => {
@@ -477,6 +492,29 @@ fn reject_duplicate_standard_tags(secret: &Nut10Secret) -> Result<(), Error> {
             return Err(Error::Condition(format!(
                 "duplicate NUT-11 `{key}` tag (malformed per NUT-11)"
             )));
+        }
+    }
+    Ok(())
+}
+
+/// Reject a token that repeats a proof, keyed by its secret (which fixes
+/// the checkstate `Y = hash_to_curve(secret)`).
+///
+/// [`Token::value`] sums *every* proof and NUT-07 `/v1/checkstate` answers
+/// in request order, so a duplicated proof is both counted toward the
+/// escrow amount **and** reported `Unspent` once per copy: a token backed by
+/// a single 50-sat proof repeated twice would satisfy a 100-sat escrow even
+/// though the mint will only ever let that proof be spent once. Deduplicate
+/// the proof secrets before [`CashuClient::verify_escrow_token`]'s amount
+/// and unspent checks trust the token value.
+fn reject_duplicate_proofs(token: &Token) -> Result<(), Error> {
+    let secrets = token.token_secrets();
+    let mut seen: HashSet<&cdk::secret::Secret> = HashSet::with_capacity(secrets.len());
+    for secret in secrets {
+        if !seen.insert(secret) {
+            return Err(Error::Token(
+                "token repeats a proof (duplicate secret)".into(),
+            ));
         }
     }
     Ok(())
@@ -875,6 +913,47 @@ mod tests {
         // Below the floor: a malicious seller could stall past a short
         // locktime and reclaim after the buyer sent fiat (Track A §4B).
         assert!(verify_escrow_conditions(&token, p_b, p_s, p_m, LOCKTIME + 1).is_err());
+    }
+
+    #[test]
+    fn rejects_duplicate_proofs_in_token() {
+        let proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::from(50u64),
+            secret: Secret::generate(),
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        // The same proof twice: `value()` would double-count to 100 and
+        // checkstate would report each copy unspent, so a 50-sat proof could
+        // satisfy a 100-sat escrow. `reject_duplicate_proofs` must catch it.
+        let dup = Token::new(
+            MintUrl::from_str(TEST_MINT).unwrap(),
+            vec![proof.clone(), proof],
+            None,
+            CurrencyUnit::Sat,
+        );
+        assert!(reject_duplicate_proofs(&dup).is_err());
+
+        // Two distinct proofs (different secrets) pass.
+        let mk = |amount: u64| Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::from(amount),
+            secret: Secret::generate(),
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        let distinct = Token::new(
+            MintUrl::from_str(TEST_MINT).unwrap(),
+            vec![mk(50), mk(50)],
+            None,
+            CurrencyUnit::Sat,
+        );
+        assert!(reject_duplicate_proofs(&distinct).is_ok());
     }
 
     #[test]

--- a/src/cashu/mod.rs
+++ b/src/cashu/mod.rs
@@ -15,8 +15,10 @@ use std::str::FromStr;
 use cdk::error::Error as CdkClientError;
 use cdk::mint_url::MintUrl;
 use cdk::nuts::nut02::ShortKeysetId;
-use cdk::nuts::nut10::SpendingConditions;
-use cdk::nuts::{CheckStateRequest, CheckStateResponse, CurrencyUnit, PublicKey, State, Token};
+use cdk::nuts::nut10::{Secret as Nut10Secret, SpendingConditions, TagKind};
+use cdk::nuts::{
+    CheckStateRequest, CheckStateResponse, CurrencyUnit, PublicKey, SigFlag, State, Token,
+};
 use cdk::wallet::MintConnector;
 use cdk::HttpClient;
 
@@ -166,7 +168,19 @@ impl CashuClient {
         }
 
         for secret in secrets {
-            let spending_conditions = SpendingConditions::try_from(secret)
+            // NUT-11 marks a secret carrying duplicate standard tags as
+            // malformed, but cdk's `Conditions` parser silently keeps only
+            // the first occurrence of each and drops the rest. Inspect the
+            // raw NUT-10 tag list and reject duplicates *before* that lossy
+            // conversion; otherwise a forged second `refund`/`locktime`/
+            // `n_sigs`/`sigflag`/… tag passes every check below while a
+            // non-cdk mint could settle the token under different spend
+            // conditions than the daemon verified.
+            let nut10_secret =
+                Nut10Secret::try_from(secret).map_err(|e| Error::Condition(e.to_string()))?;
+            reject_duplicate_standard_tags(&nut10_secret)?;
+
+            let spending_conditions = SpendingConditions::try_from(nut10_secret)
                 .map_err(|e| Error::Condition(e.to_string()))?;
 
             // Only NUT-11 P2PK backs the escrow; an HTLC condition with
@@ -182,6 +196,19 @@ impl CashuClient {
             };
             let conditions = conditions
                 .ok_or_else(|| Error::Condition("P2PK condition carries no NUT-11 tags".into()))?;
+
+            // The documented release/refund flow signs inputs only
+            // (`SIG_INPUTS`): the seller signs the escrow once and the buyer
+            // later chooses their own swap outputs at redeem time. A
+            // `SIG_ALL` token instead binds specific outputs and cannot be
+            // redeemed by that flow, stranding the locked order — reject any
+            // escrow whose sig flag is not `SIG_INPUTS`.
+            if conditions.sig_flag != SigFlag::SigInputs {
+                return Err(Error::Condition(format!(
+                    "escrow sig flag {:?} is not SIG_INPUTS",
+                    conditions.sig_flag
+                )));
+            }
 
             if conditions.num_sigs != Some(2) {
                 return Err(Error::Condition(
@@ -423,6 +450,38 @@ impl CashuClient {
     }
 }
 
+/// Reject a NUT-10 secret that repeats any standard NUT-11 tag.
+///
+/// NUT-11 marks a secret carrying duplicate standard tags as malformed, but
+/// cdk's [`SpendingConditions`] parser keeps only the *first* occurrence of
+/// each and silently drops the rest. Without this guard a forged secret
+/// with a second `refund`, `locktime`, `n_sigs`, `n_sigs_refund`, `pubkeys`
+/// or `sigflag` tag satisfies every check in
+/// [`CashuClient::verify_2of3_condition`], yet a non-cdk mint could accept
+/// or settle it under spend conditions the daemon never verified. Custom
+/// (non-standard) tags may legitimately repeat and are ignored.
+fn reject_duplicate_standard_tags(secret: &Nut10Secret) -> Result<(), Error> {
+    let Some(tags) = secret.secret_data().tags() else {
+        return Ok(());
+    };
+    let mut seen: HashSet<TagKind> = HashSet::new();
+    for tag in tags {
+        let Some(key) = tag.first() else {
+            continue;
+        };
+        let kind = TagKind::from(key);
+        if matches!(kind, TagKind::Custom(_)) {
+            continue;
+        }
+        if !seen.insert(kind) {
+            return Err(Error::Condition(format!(
+                "duplicate NUT-11 `{key}` tag (malformed per NUT-11)"
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Offline half of the escrow-token acceptance check: the 2-of-3 condition
 /// ([`CashuClient::verify_2of3_condition`]) plus the **locktime floor** —
 /// every proof's `locktime` must be `>= min_locktime`. Split out of
@@ -558,6 +617,29 @@ mod tests {
         .to_string()
     }
 
+    /// Build a serialized single-proof token from a raw NUT-10 secret JSON
+    /// string. Used to forge tag shapes cdk's own `Conditions`/constructor
+    /// would reject or silently normalize (duplicate tags, `SIG_ALL`,
+    /// `n_sigs_refund` extremes), which an attacker hands us directly.
+    fn raw_secret_token(raw_secret: &str) -> String {
+        let proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::from(100u64),
+            secret: Secret::new(raw_secret.to_string()),
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        Token::new(
+            MintUrl::from_str(TEST_MINT).unwrap(),
+            vec![proof],
+            None,
+            CurrencyUnit::Sat,
+        )
+        .to_string()
+    }
+
     /// The §4B escrow shape: data = P_S, pubkeys = [P_B, P_M], n_sigs = 2,
     /// locktime present, refund = [P_S].
     fn valid_escrow_token(p_b: PublicKey, p_s: PublicKey, p_m: PublicKey) -> String {
@@ -671,27 +753,69 @@ mod tests {
                 p_m.to_hex(),
                 p_s.to_hex(),
             );
-            let proof = Proof {
-                keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
-                amount: Amount::from(100u64),
-                secret: Secret::new(raw_secret),
-                c: PublicKey::from_str(TEST_C).unwrap(),
-                witness: None,
-                dleq: None,
-                p2pk_e: None,
-            };
-            let token = Token::new(
-                MintUrl::from_str(TEST_MINT).unwrap(),
-                vec![proof],
-                None,
-                CurrencyUnit::Sat,
-            )
-            .to_string();
+            let token = raw_secret_token(&raw_secret);
             assert!(
                 CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err(),
                 "a forged n_sigs_refund {n_sigs_refund} must be rejected"
             );
         }
+    }
+
+    #[test]
+    fn rejects_sig_all_escrow_token() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        // A `SIG_ALL` escrow binds specific outputs and cannot be redeemed
+        // by the documented SIG_INPUTS release/refund flow. cdk parses the
+        // flag but `verify_2of3_condition` must reject it. Forge a raw
+        // secret since `token_with_condition` hardcodes `SIG_INPUTS`.
+        let raw_secret = format!(
+            r#"["P2PK",{{"nonce":"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f","data":"{}","tags":[["pubkeys","{}","{}"],["locktime","{LOCKTIME}"],["refund","{}"],["n_sigs","2"],["sigflag","SIG_ALL"]]}}]"#,
+            p_s.to_hex(),
+            p_b.to_hex(),
+            p_m.to_hex(),
+            p_s.to_hex(),
+        );
+        let token = raw_secret_token(&raw_secret);
+        assert!(
+            CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err(),
+            "a SIG_ALL escrow token must be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_standard_tags() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        // cdk keeps the first `locktime` (valid) and drops the second, but a
+        // non-cdk mint could honour the second (`1`, long past) instead —
+        // NUT-11 marks duplicate tags malformed, so reject before parsing.
+        let dup_locktime = format!(
+            r#"["P2PK",{{"nonce":"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f","data":"{}","tags":[["pubkeys","{}","{}"],["locktime","{LOCKTIME}"],["locktime","1"],["refund","{}"],["n_sigs","2"],["sigflag","SIG_INPUTS"]]}}]"#,
+            p_s.to_hex(),
+            p_b.to_hex(),
+            p_m.to_hex(),
+            p_s.to_hex(),
+        );
+        let token = raw_secret_token(&dup_locktime);
+        assert!(
+            CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err(),
+            "a duplicate `locktime` tag must be rejected"
+        );
+
+        // A second `refund` tag pointing at the buyer: cdk keeps the seller
+        // refund, but the malformed token must not be accepted at all.
+        let dup_refund = format!(
+            r#"["P2PK",{{"nonce":"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f","data":"{}","tags":[["pubkeys","{}","{}"],["locktime","{LOCKTIME}"],["refund","{}"],["refund","{}"],["n_sigs","2"],["sigflag","SIG_INPUTS"]]}}]"#,
+            p_s.to_hex(),
+            p_b.to_hex(),
+            p_m.to_hex(),
+            p_s.to_hex(),
+            p_b.to_hex(),
+        );
+        let token = raw_secret_token(&dup_refund);
+        assert!(
+            CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err(),
+            "a duplicate `refund` tag must be rejected"
+        );
     }
 
     #[test]

--- a/src/cashu/mod.rs
+++ b/src/cashu/mod.rs
@@ -1,0 +1,860 @@
+//! Cashu mint client — Cashu foundation **CF-2**
+//! (see `docs/cashu/01-fundamentals.md` §6).
+//!
+//! A self-contained `cdk` wrapper: parse/validate escrow tokens and talk to
+//! a mint. Pure library — **not wired into the daemon** (CF-5 does the boot
+//! wiring; Track A adds the first caller). Adapted from the reviewed
+//! first-attempt module (PR #765), updated to `cdk 0.17.2` and to the
+//! re-planned spec: the 2-of-3 escrow condition now **requires** the
+//! seller-recovery locktime pathway (`locktime` + `refund = [P_S]`,
+//! Track A §4B) and every amount check is pinned to `sat` keysets (M-3).
+
+use std::collections::HashSet;
+use std::str::FromStr;
+
+use cdk::error::Error as CdkClientError;
+use cdk::mint_url::MintUrl;
+use cdk::nuts::nut02::ShortKeysetId;
+use cdk::nuts::nut10::SpendingConditions;
+use cdk::nuts::{CheckStateRequest, CheckStateResponse, CurrencyUnit, PublicKey, State, Token};
+use cdk::wallet::MintConnector;
+use cdk::HttpClient;
+
+/// Error type for Cashu client operations.
+#[derive(Debug)]
+pub enum Error {
+    /// The configured mint URL could not be parsed.
+    InvalidMintUrl(String),
+    /// The mint is unreachable or missing a required NUT / `sat` keyset.
+    MintConnection(String),
+    /// The token is malformed, on the wrong mint/unit, mis-valued, not
+    /// mint-issued, or not unspent.
+    Token(String),
+    /// The NUT-10/11 spending condition does not match the escrow shape.
+    Condition(String),
+    /// An underlying `cdk` client error.
+    Client(CdkClientError),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::InvalidMintUrl(s) => write!(f, "Invalid mint URL: {}", s),
+            Error::MintConnection(s) => write!(f, "Mint connection error: {}", s),
+            Error::Token(s) => write!(f, "Token error: {}", s),
+            Error::Condition(s) => write!(f, "Condition error: {}", s),
+            Error::Client(e) => write!(f, "Client error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<CdkClientError> for Error {
+    fn from(e: CdkClientError) -> Self {
+        Error::Client(e)
+    }
+}
+
+/// A client for communicating with a Cashu mint.
+#[derive(Clone)]
+pub struct CashuClient {
+    mint_url: MintUrl,
+    client: HttpClient,
+}
+
+impl CashuClient {
+    /// Connect to a mint URL and verify it can back the escrow flows.
+    ///
+    /// Refuses to connect (rather than failing every later
+    /// `AddCashuEscrow`, stranding orders in `WaitingPayment`) when the
+    /// mint is unreachable, is missing a required NUT — 11 (P2PK 2-of-3),
+    /// 07 (`/v1/checkstate`), 12 (DLEQ) — or exposes **no active `sat`
+    /// keyset** (M-3: every amount comparison downstream is in sats, so a
+    /// mint that cannot issue sat ecash is unusable; mints that *also*
+    /// serve other units are fine — the per-proof keyset-unit check in
+    /// [`Self::verify_token_dleq`] keeps foreign-unit tokens out).
+    pub async fn connect(mint_url: &str) -> Result<Self, Error> {
+        let url = MintUrl::from_str(mint_url).map_err(|e| Error::InvalidMintUrl(e.to_string()))?;
+
+        let client = HttpClient::new(url.clone(), None);
+        let cashu_client = Self {
+            mint_url: url,
+            client,
+        };
+
+        let info = cashu_client
+            .client
+            .get_mint_info()
+            .await
+            .map_err(|e| Error::MintConnection(e.to_string()))?;
+        if !info.nuts.nut11.supported {
+            return Err(Error::MintConnection(
+                "Mint does not support NUT-11 P2PK".into(),
+            ));
+        }
+        if !info.nuts.nut07.supported {
+            return Err(Error::MintConnection(
+                "Mint does not support NUT-07 token state check".into(),
+            ));
+        }
+        if !info.nuts.nut12.supported {
+            return Err(Error::MintConnection(
+                "Mint does not support NUT-12 DLEQ proofs".into(),
+            ));
+        }
+
+        let keysets = cashu_client
+            .client
+            .get_mint_keysets()
+            .await
+            .map_err(|e| Error::MintConnection(e.to_string()))?;
+        if !keysets
+            .keysets
+            .iter()
+            .any(|ks| ks.active && ks.unit == CurrencyUnit::Sat)
+        {
+            return Err(Error::MintConnection(
+                "Mint has no active sat keyset".into(),
+            ));
+        }
+
+        Ok(cashu_client)
+    }
+
+    /// The mint URL this client is bound to.
+    ///
+    /// Track A's lock handler reads this to persist the order's
+    /// `cashu_mint_url` and to assert the seller's token was minted by the
+    /// operator-configured mint.
+    pub fn mint_url(&self) -> &MintUrl {
+        &self.mint_url
+    }
+
+    /// Verify the escrow spending condition on every proof of a token
+    /// (Track A §4/§4B). Each proof must be P2PK-locked with:
+    ///
+    /// - exactly 2 required signatures (`n_sigs = 2`) over exactly the
+    ///   three expected pubkeys `{p_b, p_s, p_m}` (no missing, wrong,
+    ///   extra, or duplicated key);
+    /// - a **`locktime` tag present** — NUT-11 makes a locktime'd token
+    ///   with no `refund` tag spendable by *anyone* after expiry, so —
+    /// - **`refund = [p_s]`** exactly (the seller-recovery pathway) with
+    ///   `n_sigs_refund = 1` (absent means 1 per NUT-11).
+    ///
+    /// The locktime *value* (floor check) is verified by
+    /// [`verify_escrow_conditions`] / [`Self::verify_escrow_token`], which
+    /// receive the config-derived minimum.
+    pub fn verify_2of3_condition(
+        token: &str,
+        p_b: PublicKey,
+        p_s: PublicKey,
+        p_m: PublicKey,
+    ) -> Result<Token, Error> {
+        let token = Token::from_str(token).map_err(|e| Error::Token(e.to_string()))?;
+
+        let secrets = token.token_secrets();
+        if secrets.is_empty() {
+            return Err(Error::Token("Token contains no secrets".into()));
+        }
+
+        let expected: HashSet<PublicKey> = [p_b, p_s, p_m].into_iter().collect();
+        if expected.len() != 3 {
+            return Err(Error::Condition(
+                "Buyer, seller and Mostro pubkeys must be distinct".into(),
+            ));
+        }
+
+        for secret in secrets {
+            let spending_conditions = SpendingConditions::try_from(secret)
+                .map_err(|e| Error::Condition(e.to_string()))?;
+
+            // Only NUT-11 P2PK backs the escrow; an HTLC condition with
+            // matching tags must not slip through.
+            let (data, conditions) = match spending_conditions {
+                SpendingConditions::P2PKConditions { data, conditions } => (data, conditions),
+                other => {
+                    return Err(Error::Condition(format!(
+                        "Spending condition kind {:?} is not P2PK",
+                        other.kind()
+                    )));
+                }
+            };
+            let conditions = conditions
+                .ok_or_else(|| Error::Condition("P2PK condition carries no NUT-11 tags".into()))?;
+
+            if conditions.num_sigs != Some(2) {
+                return Err(Error::Condition(
+                    "Spending condition must require exactly 2 signatures".into(),
+                ));
+            }
+
+            // The signing set is `data` plus the `pubkeys` tag; it must be
+            // exactly the three expected keys, with no duplicates faking a
+            // larger set.
+            let mut signing_set: HashSet<PublicKey> = HashSet::from([data]);
+            let extra_pubkeys = conditions.pubkeys.clone().unwrap_or_default();
+            let stated_len = 1 + extra_pubkeys.len();
+            signing_set.extend(extra_pubkeys);
+            if signing_set.len() != stated_len {
+                return Err(Error::Condition(
+                    "Spending condition repeats a pubkey".into(),
+                ));
+            }
+            if signing_set != expected {
+                return Err(Error::Condition(
+                    "Spending condition pubkeys do not match the expected {buyer, seller, mostro}"
+                        .into(),
+                ));
+            }
+
+            // Seller-recovery pathway (Track A §4B). A locktime with no
+            // refund key would make the token anyone-can-spend after
+            // expiry; a missing locktime would lock the funds forever if
+            // Mostro disappears and the buyer won't cooperate.
+            if conditions.locktime.is_none() {
+                return Err(Error::Condition(
+                    "Spending condition must carry a locktime (seller-recovery pathway)".into(),
+                ));
+            }
+            match conditions.refund_keys.as_deref() {
+                Some([refund]) if *refund == p_s => {}
+                _ => {
+                    return Err(Error::Condition(
+                        "Refund keys must be exactly [seller]".into(),
+                    ));
+                }
+            }
+            // NUT-11: absent n_sigs_refund defaults to 1.
+            if let Some(n) = conditions.num_sigs_refund {
+                if n != 1 {
+                    return Err(Error::Condition(format!(
+                        "n_sigs_refund must be 1, got {n}"
+                    )));
+                }
+            }
+        }
+
+        Ok(token)
+    }
+
+    /// Full escrow-token validation for Track A's lock handler.
+    ///
+    /// Composes every check Mostro performs on a seller-submitted escrow
+    /// token before accepting it as the locked trade funds, returning the
+    /// parsed [`Token`] on success:
+    ///
+    /// 1. **Condition + locktime floor** ([`verify_escrow_conditions`]):
+    ///    2-of-3 over `{p_b, p_s, p_m}` with the seller-recovery pathway,
+    ///    and every `locktime >= min_locktime` (the caller passes
+    ///    `now + cashu.escrow_locktime_days`; a seller may set a *longer*
+    ///    locktime, never a shorter one — Track A §4B).
+    /// 2. **Mint binding.** The token's mint URL must match the node's
+    ///    configured mint; Mostro only escrows on its own mint.
+    /// 3. **Amount.** Token-level unit must be `sat` and the total value
+    ///    must equal `expected_amount` (sats).
+    /// 4. **Mint-issued (DLEQ) + per-proof `sat` keyset**
+    ///    ([`Self::verify_token_dleq`]). Without DLEQ a seller could
+    ///    fabricate unspent-but-worthless proofs, since `check_state`
+    ///    reports any unknown secret as `Unspent`.
+    /// 5. **Unspent** (NUT-07 `/v1/checkstate`), failing closed if the
+    ///    mint returns fewer states than proofs queried.
+    pub async fn verify_escrow_token(
+        &self,
+        token_str: &str,
+        p_b: PublicKey,
+        p_s: PublicKey,
+        p_m: PublicKey,
+        expected_amount: u64,
+        min_locktime: u64,
+    ) -> Result<Token, Error> {
+        // 1: spending condition + locktime floor (offline checks).
+        let token = verify_escrow_conditions(token_str, p_b, p_s, p_m, min_locktime)?;
+
+        // 2: the token must be hosted on the node's configured mint.
+        let token_mint = token
+            .mint_url()
+            .map_err(|e| Error::Token(format!("token mint url: {e}")))?;
+        if token_mint != self.mint_url {
+            return Err(Error::Token(format!(
+                "token mint {token_mint} does not match configured mint {}",
+                self.mint_url
+            )));
+        }
+
+        // 3: the locked amount must equal the order amount exactly, and be
+        // denominated in sats. `value()` is a bare integer, so without the
+        // unit guard a mint exposing multiple units would let a
+        // 100_000-msat (or usd-cent) token satisfy a 100_000-sat order.
+        match token.unit() {
+            Some(CurrencyUnit::Sat) => {}
+            other => {
+                return Err(Error::Token(format!("token unit {other:?} is not sat")));
+            }
+        }
+        let value = token
+            .value()
+            .map_err(|e| Error::Token(format!("token value: {e}")))?
+            .to_u64();
+        if value != expected_amount {
+            return Err(Error::Token(format!(
+                "token amount {value} does not match expected {expected_amount}"
+            )));
+        }
+
+        // 4: the proofs must be genuine, mint-issued ecash on sat keysets.
+        // `check_state` (step 5) only proves a secret is unspent — an
+        // honest mint reports any *unknown* secret as `Unspent`, so a
+        // seller could fabricate proofs with the right 2-of-3 condition and
+        // amount but no mint signature and still pass every other check,
+        // tricking the buyer into sending fiat against worthless ecash.
+        // DLEQ (NUT-12) authenticates each proof's blind signature against
+        // the mint's keyset offline, closing that hole.
+        self.verify_token_dleq(&token).await?;
+
+        // 5: every proof must be unspent at the mint. Derive the checkstate
+        // Y points from the proof secrets (Y = hash_to_curve(secret)).
+        let secrets = token.token_secrets();
+        let ys = secrets
+            .iter()
+            .map(|s| cdk::dhke::hash_to_curve(s.as_bytes()))
+            .collect::<Result<Vec<PublicKey>, _>>()
+            .map_err(|e| Error::Token(format!("proof Y: {e}")))?;
+        let expected_states = ys.len();
+        let states = self.check_state(ys).await?;
+        // Fail closed if the mint returns fewer states than proofs queried:
+        // a missing entry must never be treated as implicitly `Unspent`.
+        if states.states.len() != expected_states {
+            return Err(Error::Token(format!(
+                "checkstate returned {} states for {expected_states} proofs",
+                states.states.len()
+            )));
+        }
+        if states.states.iter().any(|s| s.state != State::Unspent) {
+            return Err(Error::Token("one or more proofs are not unspent".into()));
+        }
+
+        Ok(token)
+    }
+
+    /// Check the state of proofs against the mint's `/v1/checkstate`
+    /// endpoint (NUT-07). This only proves the secrets are unspent — it
+    /// does **not** authenticate that the proofs were signed by the mint;
+    /// use [`Self::verify_token_dleq`] for that.
+    pub async fn check_state(&self, ys: Vec<PublicKey>) -> Result<CheckStateResponse, Error> {
+        let request = CheckStateRequest { ys };
+        let response = self
+            .client
+            .post_check_state(request)
+            .await
+            .map_err(Error::Client)?;
+        Ok(response)
+    }
+
+    /// Verify the NUT-12 DLEQ proof of every proof in a token — this
+    /// authenticates the ecash as genuinely mint-issued — and that every
+    /// proof belongs to a **`sat` keyset** (M-3: a token may mix keysets,
+    /// so the connect-time check alone does not cover it).
+    pub async fn verify_token_dleq(&self, token: &Token) -> Result<(), Error> {
+        // TODO(track-b): `get_mint_keys` returns only ACTIVE keysets
+        // (NUT-01), so a proof minted under a since-rotated keyset is
+        // rejected here as "Unknown keyset" even though the mint still
+        // honours it. Track A only ever sees freshly-minted tokens so this
+        // is safe, but before Track B verifies older tokens this must fall
+        // back to fetching the specific keyset via `/v1/keys/{keyset_id}`
+        // for inactive keyset ids.
+        let keysets = self.client.get_mint_keys().await.map_err(Error::Client)?;
+
+        match token {
+            Token::TokenV3(token_v3) => {
+                let proofs = token_v3
+                    .token
+                    .iter()
+                    .flat_map(|t| t.proofs.clone())
+                    .collect::<Vec<_>>();
+                for proof in proofs {
+                    let keyset = keysets
+                        .iter()
+                        .find(|k| ShortKeysetId::from(k.id) == proof.keyset_id)
+                        .ok_or_else(|| Error::Token("Unknown keyset".into()))?;
+                    if keyset.unit != CurrencyUnit::Sat {
+                        return Err(Error::Token(format!(
+                            "proof keyset unit {:?} is not sat",
+                            keyset.unit
+                        )));
+                    }
+                    let mint_pubkey = keyset
+                        .keys
+                        .get(&proof.amount)
+                        .ok_or_else(|| Error::Token("Unknown amount for keyset".into()))?;
+
+                    let p = proof.into_proof(&keyset.id);
+                    p.verify_dleq(*mint_pubkey)
+                        .map_err(|_| Error::Token("Invalid DLEQ proof".into()))?;
+                }
+            }
+            Token::TokenV4(token_v4) => {
+                for token_entry in &token_v4.token {
+                    let keyset = keysets
+                        .iter()
+                        .find(|k| ShortKeysetId::from(k.id) == token_entry.keyset_id)
+                        .ok_or_else(|| Error::Token("Unknown keyset".into()))?;
+                    if keyset.unit != CurrencyUnit::Sat {
+                        return Err(Error::Token(format!(
+                            "proof keyset unit {:?} is not sat",
+                            keyset.unit
+                        )));
+                    }
+
+                    for proof_v4 in &token_entry.proofs {
+                        let mint_pubkey = keyset
+                            .keys
+                            .get(&proof_v4.amount)
+                            .ok_or_else(|| Error::Token("Unknown amount for keyset".into()))?;
+                        let p = proof_v4.into_proof(&keyset.id);
+                        p.verify_dleq(*mint_pubkey)
+                            .map_err(|_| Error::Token("Invalid DLEQ proof".into()))?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Offline half of the escrow-token acceptance check: the 2-of-3 condition
+/// ([`CashuClient::verify_2of3_condition`]) plus the **locktime floor** —
+/// every proof's `locktime` must be `>= min_locktime`. Split out of
+/// [`CashuClient::verify_escrow_token`] so it is unit-testable without a
+/// mint; the async method composes this with the mint-backed checks.
+///
+/// The floor is the security edge of Track A §4B: once a locktime passes,
+/// the seller can reclaim the sats *even if the buyer already sent fiat*,
+/// so a seller-chosen short locktime must never be accepted.
+pub fn verify_escrow_conditions(
+    token_str: &str,
+    p_b: PublicKey,
+    p_s: PublicKey,
+    p_m: PublicKey,
+    min_locktime: u64,
+) -> Result<Token, Error> {
+    let token = CashuClient::verify_2of3_condition(token_str, p_b, p_s, p_m)?;
+
+    for secret in token.token_secrets() {
+        let conditions = match SpendingConditions::try_from(secret) {
+            Ok(SpendingConditions::P2PKConditions {
+                conditions: Some(c),
+                ..
+            }) => c,
+            // verify_2of3_condition already guaranteed P2PK-with-tags.
+            _ => unreachable!("verify_2of3_condition accepted a non-P2PK secret"),
+        };
+        // Presence already enforced by verify_2of3_condition; here we
+        // enforce the floor.
+        let locktime = conditions
+            .locktime
+            .expect("verify_2of3_condition requires a locktime");
+        if locktime < min_locktime {
+            return Err(Error::Condition(format!(
+                "locktime {locktime} is below the required floor {min_locktime}"
+            )));
+        }
+    }
+
+    Ok(token)
+}
+
+/// Convert a Nostr (BIP340 x-only) public key, given as 64-char hex, into a
+/// Cashu (compressed secp256k1) [`PublicKey`].
+///
+/// Mostro's per-order trade keys and node identity key are x-only (32
+/// bytes); a NUT-11 P2PK spending condition needs the 33-byte compressed
+/// form. We prepend the `0x02` (even-Y) parity byte, which is the same
+/// convention the Cashu P2PK tooling uses; NUT-11 signatures are BIP340
+/// Schnorr over the x-only coordinate, so a signature produced by the trade
+/// key validates against this derived pubkey regardless of the source
+/// point's parity (proven by the
+/// `odd_y_nostr_key_signs_for_derived_cashu_pubkey` test).
+///
+/// Track A uses this to derive the expected `{P_B, P_S, P_M}` from the
+/// order's trade pubkeys and Mostro's key, rather than trusting the pubkeys
+/// the seller states in the submitted lock proof.
+pub fn cashu_pubkey_from_xonly_hex(xonly_hex: &str) -> Result<PublicKey, Error> {
+    if xonly_hex.len() != 64 {
+        return Err(Error::Condition(format!(
+            "expected 64-char x-only hex, got {}",
+            xonly_hex.len()
+        )));
+    }
+    PublicKey::from_hex(format!("02{xonly_hex}"))
+        .map_err(|e| Error::Condition(format!("pubkey convert: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cdk::nuts::nut00::{Proof, Proofs};
+    use cdk::nuts::nut01::SecretKey as NutSecretKey;
+    use cdk::nuts::nut02::Id;
+    use cdk::nuts::nut10::Conditions;
+    use cdk::nuts::SigFlag;
+    use cdk::secret::Secret;
+    use cdk::Amount;
+
+    /// A valid 32-byte x-only hex (a known secp256k1 x coordinate).
+    const XONLY_HEX: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+    const TEST_KEYSET_ID: &str = "009a1f293253e41e";
+    const TEST_C: &str = "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904";
+    const TEST_MINT: &str = "https://mint.example.com";
+    const LOCKTIME: u64 = 2_000_000_000;
+
+    fn keypair(n: u8) -> PublicKey {
+        let sk = NutSecretKey::from_hex(format!("{:064x}", n as u64 + 1)).unwrap();
+        sk.public_key()
+    }
+
+    /// Build a serialized token whose single proof carries the given P2PK
+    /// condition shape. `data` is the NUT-10 data pubkey; the rest land in
+    /// the NUT-11 tags.
+    fn token_with_condition(
+        data: PublicKey,
+        pubkeys: Vec<PublicKey>,
+        num_sigs: Option<u64>,
+        locktime: Option<u64>,
+        refund_keys: Option<Vec<PublicKey>>,
+        num_sigs_refund: Option<u64>,
+    ) -> String {
+        let secret: Secret = SpendingConditions::P2PKConditions {
+            data,
+            conditions: Some(Conditions {
+                locktime,
+                pubkeys: Some(pubkeys),
+                refund_keys,
+                num_sigs,
+                sig_flag: SigFlag::SigInputs,
+                num_sigs_refund,
+            }),
+        }
+        .try_into()
+        .expect("valid p2pk secret");
+
+        let proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::from(100u64),
+            secret,
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        let proofs: Proofs = vec![proof];
+        Token::new(
+            MintUrl::from_str(TEST_MINT).unwrap(),
+            proofs,
+            None,
+            CurrencyUnit::Sat,
+        )
+        .to_string()
+    }
+
+    /// The §4B escrow shape: data = P_S, pubkeys = [P_B, P_M], n_sigs = 2,
+    /// locktime present, refund = [P_S].
+    fn valid_escrow_token(p_b: PublicKey, p_s: PublicKey, p_m: PublicKey) -> String {
+        token_with_condition(
+            p_s,
+            vec![p_b, p_m],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_s]),
+            None,
+        )
+    }
+
+    #[test]
+    fn accepts_valid_2of3_with_locktime_and_seller_refund() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let token = valid_escrow_token(p_b, p_s, p_m);
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_ok());
+
+        // Explicit n_sigs_refund = 1 is equally valid (absent defaults to 1).
+        let token = token_with_condition(
+            p_s,
+            vec![p_b, p_m],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_s]),
+            Some(1),
+        );
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_ok());
+
+        // Key arrangement is set-based: data = P_B works too.
+        let token = token_with_condition(
+            p_b,
+            vec![p_s, p_m],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_s]),
+            None,
+        );
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_ok());
+    }
+
+    #[test]
+    fn rejects_wrong_sig_count() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        for n in [None, Some(1), Some(3)] {
+            let token = token_with_condition(
+                p_s,
+                vec![p_b, p_m],
+                n,
+                Some(LOCKTIME),
+                Some(vec![p_s]),
+                None,
+            );
+            assert!(
+                CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err(),
+                "n_sigs {n:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_locktime() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let token = token_with_condition(p_s, vec![p_b, p_m], Some(2), None, Some(vec![p_s]), None);
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err());
+    }
+
+    #[test]
+    fn rejects_missing_wrong_or_extra_refund_key() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        // Missing refund tag: NUT-11 would make the token anyone-can-spend
+        // after the locktime.
+        let token = token_with_condition(p_s, vec![p_b, p_m], Some(2), Some(LOCKTIME), None, None);
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err());
+        // Wrong refund key (buyer instead of seller).
+        let token = token_with_condition(
+            p_s,
+            vec![p_b, p_m],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_b]),
+            None,
+        );
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err());
+        // Extra refund key alongside the seller.
+        let token = token_with_condition(
+            p_s,
+            vec![p_b, p_m],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_s, p_b]),
+            None,
+        );
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err());
+    }
+
+    #[test]
+    fn rejects_num_sigs_refund_other_than_one() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        // cdk's own constructor refuses both shapes (ZeroSignaturesRequired
+        // / ImpossibleRefundMultisigConfiguration) — but an attacker doesn't
+        // use the constructor, they hand us a raw NUT-10 secret. Forge them
+        // and make sure the daemon-side check still rejects the token (cdk
+        // had a known refund-path zero-sigs bypass hazard).
+        for n_sigs_refund in [0u64, 2] {
+            let raw_secret = format!(
+                r#"["P2PK",{{"nonce":"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f","data":"{}","tags":[["pubkeys","{}","{}"],["locktime","{LOCKTIME}"],["refund","{}"],["n_sigs","2"],["n_sigs_refund","{n_sigs_refund}"],["sigflag","SIG_INPUTS"]]}}]"#,
+                p_s.to_hex(),
+                p_b.to_hex(),
+                p_m.to_hex(),
+                p_s.to_hex(),
+            );
+            let proof = Proof {
+                keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+                amount: Amount::from(100u64),
+                secret: Secret::new(raw_secret),
+                c: PublicKey::from_str(TEST_C).unwrap(),
+                witness: None,
+                dleq: None,
+                p2pk_e: None,
+            };
+            let token = Token::new(
+                MintUrl::from_str(TEST_MINT).unwrap(),
+                vec![proof],
+                None,
+                CurrencyUnit::Sat,
+            )
+            .to_string();
+            assert!(
+                CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err(),
+                "a forged n_sigs_refund {n_sigs_refund} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_missing_wrong_or_extra_pubkey() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let intruder = keypair(4);
+        // Missing: only two keys in the set.
+        let token = token_with_condition(
+            p_s,
+            vec![p_b],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_s]),
+            None,
+        );
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err());
+        // Wrong: intruder replaces Mostro's key.
+        let token = token_with_condition(
+            p_s,
+            vec![p_b, intruder],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_s]),
+            None,
+        );
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err());
+        // Extra: a fourth key inflates the set.
+        let token = token_with_condition(
+            p_s,
+            vec![p_b, p_m, intruder],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_s]),
+            None,
+        );
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err());
+        // Duplicate: p_m repeated to fake a 3-key set while only two
+        // distinct keys can actually sign.
+        let token = token_with_condition(
+            p_s,
+            vec![p_m, p_m],
+            Some(2),
+            Some(LOCKTIME),
+            Some(vec![p_s]),
+            None,
+        );
+        assert!(CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err());
+    }
+
+    #[test]
+    fn locktime_floor_is_enforced() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let token = valid_escrow_token(p_b, p_s, p_m);
+        // At or above the floor: accepted (seller may set a longer one).
+        assert!(verify_escrow_conditions(&token, p_b, p_s, p_m, LOCKTIME).is_ok());
+        assert!(verify_escrow_conditions(&token, p_b, p_s, p_m, LOCKTIME - 1).is_ok());
+        // Below the floor: a malicious seller could stall past a short
+        // locktime and reclaim after the buyer sent fiat (Track A §4B).
+        assert!(verify_escrow_conditions(&token, p_b, p_s, p_m, LOCKTIME + 1).is_err());
+    }
+
+    #[test]
+    fn xonly_to_cashu_pubkey_prepends_even_parity() {
+        let pk = cashu_pubkey_from_xonly_hex(XONLY_HEX).expect("valid x-only converts");
+        // The compressed form is the even-parity (0x02) point over the x-only.
+        assert_eq!(pk.to_hex(), format!("02{XONLY_HEX}"));
+    }
+
+    #[test]
+    fn xonly_to_cashu_pubkey_rejects_wrong_length() {
+        // 63 chars (too short) and the already-prefixed 66-char form must
+        // both be rejected: the helper expects exactly the 64-char x-only.
+        assert!(cashu_pubkey_from_xonly_hex(&XONLY_HEX[..63]).is_err());
+        assert!(cashu_pubkey_from_xonly_hex(&format!("02{XONLY_HEX}")).is_err());
+    }
+
+    #[test]
+    fn xonly_to_cashu_pubkey_rejects_non_hex() {
+        // Right length, but not valid hex / not a curve point.
+        let not_hex = "z".repeat(64);
+        assert!(cashu_pubkey_from_xonly_hex(&not_hex).is_err());
+    }
+
+    /// The derivation always prepends `02`, but a Nostr trade key's point
+    /// may have ODD-Y parity (`03`). NUT-11 P2PK uses BIP340 Schnorr, which
+    /// verifies against the x-only coordinate (the even-Y lift), so a
+    /// signature by such a key must still validate against the
+    /// `02`-derived pubkey. If this failed, the parity handling would be
+    /// wrong and Track B (where the buyer redeems with trade-key
+    /// signatures) would break. This is the sign/verify roundtrip proving
+    /// it.
+    #[test]
+    fn odd_y_nostr_key_signs_for_derived_cashu_pubkey() {
+        use cdk::nuts::nut00::Witness;
+        use cdk::nuts::nut11::P2PKWitness;
+        use nostr_sdk::Keys;
+
+        // Find a Nostr key whose secp256k1 point has odd-Y parity (`0x03`).
+        let (keys, nut_sk) = loop {
+            let keys = Keys::generate();
+            let nut_sk = NutSecretKey::from_hex(keys.secret_key().to_secret_hex())
+                .expect("nostr secret converts to a cdk secret key");
+            if nut_sk.public_key().to_bytes()[0] == 0x03 {
+                break (keys, nut_sk);
+            }
+        };
+
+        let xonly_hex = keys.public_key().to_hex();
+        let cashu_pk = cashu_pubkey_from_xonly_hex(&xonly_hex).expect("derive cashu pubkey");
+        // Derivation forced even-Y even though the source key is odd-Y.
+        assert_eq!(cashu_pk.to_bytes()[0], 0x02);
+
+        // Lock a proof to a 1-of-1 P2PK over the derived pubkey, sign with
+        // the odd-Y Nostr key, and verify.
+        let secret: Secret = SpendingConditions::P2PKConditions {
+            data: cashu_pk,
+            conditions: None,
+        }
+        .try_into()
+        .expect("p2pk secret");
+        let mut proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::ZERO,
+            secret,
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: Some(Witness::P2PKWitness(P2PKWitness { signatures: vec![] })),
+            dleq: None,
+            p2pk_e: None,
+        };
+        proof.sign_p2pk(nut_sk).expect("sign with the odd-Y key");
+        assert!(
+            proof.verify_p2pk().is_ok(),
+            "an odd-Y Nostr key must sign validly for the 02-derived cashu pubkey"
+        );
+    }
+
+    /// Mint-authentication (step 4 of `verify_escrow_token` →
+    /// `verify_token_dleq` → `Proof::verify_dleq`) closes the
+    /// fabricated-token hole only because cdk rejects a proof carrying NO
+    /// DLEQ. Pin that pinned-dependency behavior so a future cdk bump can't
+    /// silently reopen it: an absent DLEQ must error with
+    /// `MissingDleqProof`. (The full `verify_escrow_token` path needs a
+    /// live mint and is covered by the env-gated CF-3 integration suite;
+    /// this is the offline regression guard for the exact attack
+    /// primitive.)
+    #[test]
+    fn proof_without_dleq_is_rejected() {
+        let proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::ZERO,
+            secret: Secret::generate(),
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        let mint_pubkey = PublicKey::from_str(TEST_C).unwrap();
+        assert!(
+            matches!(
+                proof.verify_dleq(mint_pubkey),
+                Err(cdk::nuts::nut12::Error::MissingDleqProof)
+            ),
+            "a proof with no DLEQ must be rejected (fabricated-token defense)"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 pub mod app;
 mod bitcoin_price;
+pub mod cashu;
 pub mod cli;
 pub mod config;
 pub mod db;


### PR DESCRIPTION
## Summary

**CF-2** of the Cashu foundation ([`docs/cashu/01-fundamentals.md` §6](../blob/main/docs/cashu/01-fundamentals.md)): a self-contained `cdk 0.17.2` wrapper in `src/cashu/mod.rs`. Pure library — registered as a module (`pub mod cashu;`) but **called by nothing**; CF-5 does the boot wiring and Track A adds the first caller. Adapted from the reviewed first-attempt module (PR #765), updated to the re-planned spec.

### Surface (frozen contract, spec §10)

- **`connect(mint_url)`** — mint reachable, supports NUTs **07** (checkstate), **11** (P2PK), **12** (DLEQ), and exposes **≥ 1 active `sat` keyset** (M-3). Fails fast instead of stranding orders later.
- **`verify_2of3_condition(token, p_b, p_s, p_m)`** — per proof: P2PK only (HTLC rejected), `n_sigs = 2` over exactly `{P_B, P_S, P_M}` (set-based; duplicates faking a 3-key set rejected), **and the Track A §4B seller-recovery pathway**: `locktime` tag present, `refund = [P_S]` exactly, `n_sigs_refund = 1` (absent = 1 per NUT-11). This is inverted vs. the first attempt, which *rejected* locktime/refund — the spec now mandates them (a locktime'd token with no refund is anyone-can-spend after expiry).
- **`verify_escrow_conditions(…, min_locktime)`** — offline half (condition + **locktime floor**), split out so it's unit-testable without a mint.
- **`verify_escrow_token(…, expected_amount, min_locktime)`** — composes: condition + floor → mint binding → `sat` unit + exact amount → DLEQ → unspent (fail-closed if checkstate returns fewer states than proofs).
- **`verify_token_dleq`** — NUT-12 mint authentication **+ per-proof `sat` keyset check** (M-3: tokens may mix keysets, so the connect check alone doesn't cover it).
- **`check_state`** (NUT-07), **`cashu_pubkey_from_xonly_hex`** (x-only → compressed even-Y).

### Notes for reviewers

- `cdk = { version = "0.17.2", default-features = false, features = ["wallet"] }` — wallet-side client only, no mint-server code.
- **Connect-time unit check is "≥ 1 active sat keyset"**, not "all keysets sat": multi-unit mints are legitimate, and the per-proof keyset check is the security floor keeping foreign-unit tokens out. The spec's wording was ambiguous here — flagging for confirmation (docs can be amended either way).
- The `n_sigs_refund` tests forge **raw NUT-10 secrets** (0 and 2): cdk's own constructor refuses both shapes, but an attacker hands us raw secrets, not constructor output — the daemon-side check is what stands between a forged `n_sigs_refund=0` (cdk has a known refund-path zero-sigs bypass hazard) and the escrow.
- Kept the first attempt's hard-won regression guards: DLEQ-before-unspent rationale (fabricated-token hole), `MissingDleqProof` pin, odd-Y parity sign/verify roundtrip.
- `TODO(track-b)` documented: active-keyset-only DLEQ lookup needs a `/v1/keys/{id}` fallback before Track B verifies aged tokens.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 515 passed (503 pre-existing unmodified + 12 new, all offline)
- [ ] Mint-backed paths (`connect`, `check_state`, `verify_token_dleq`, full `verify_escrow_token`) → env-gated CF-3 integration suite (next PR)

Wave-1 PR of the CF-0…CF-5 series (CF-0 #795, CF-1 #796, CF-4 #797). Remaining: CF-3 (mint harness), CF-5 (integration, last).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cashu wallet support for validating escrow tokens and mint-backed conditions.
  * Implemented mint URL connection and async mint capability checks before verification.
  * Added escrow condition validation and x-only public key conversion helpers.

* **Bug Fixes**
  * Strengthened escrow/token verification against malformed and forged tokens.
  * Added fail-closed mint unspent state checks and rejected mismatched state results.
  * Improved authenticity validation, including per-proof verification, missing DLEQ rejection, and duplicate-proof prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->