### PR TITLE
ci: cashu test-mint harness — Cashu foundation CF-3

### DIFF
--- a/.github/workflows/cashu.yml
+++ b/.github/workflows/cashu.yml
@@ -1,0 +1,56 @@
+name: Cashu Integration
+
+on:
+  # NOTE: intentionally NOT part of the default required PR checks (CF-3,
+  # docs/cashu/01-fundamentals.md §6): non-Cashu PRs and the Lightning path
+  # never pay the cost or flakiness of a live mint. Mirrors the mutation
+  # workflow's pattern — nightly audit (schedule) + on demand
+  # (workflow_dispatch) + opt-in per-PR via the `cashu` label.
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+  schedule:
+    # Nightly against main at 4 AM UTC, so a mint-facing regression is
+    # caught even if a PR author forgets the label.
+    - cron: '0 4 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+  CASHU_TEST_MINT_URL: http://127.0.0.1:3338
+
+jobs:
+  mint-integration:
+    runs-on: ubuntu-latest
+    # Opt-in only on PRs: add the `cashu` label when needed.
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'cashu')
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protobuf
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Start test mint
+        run: docker compose -f docker-compose.cashu.yml up -d
+
+      - name: Run mint-backed integration tests
+        run: cargo test --test cashu_mint -- --nocapture
+
+      - name: Run env-gated in-tree cashu tests
+        # Picks up any `#[ignore]`-gated mint-backed tests later PRs add
+        # inside src (e.g. CashuClient's connect/check_state/DLEQ paths).
+        # Zero matching tests is a clean pass.
+        run: cargo test cashu -- --ignored --nocapture
+
+      - name: Stop test mint
+        if: always()
+        run: docker compose -f docker-compose.cashu.yml down -v

--- a/.github/workflows/cashu.yml
+++ b/.github/workflows/cashu.yml
@@ -59,7 +59,9 @@ jobs:
         run: docker compose -f docker-compose.cashu.yml up -d
 
       - name: Run mint-backed integration tests
-        run: cargo test --test cashu_mint -- --nocapture
+        # `--ignored`: the smoke test is `#[ignore]`d so a plain local
+        # `cargo test` reports it as skipped rather than a hollow pass.
+        run: cargo test --test cashu_mint -- --ignored --nocapture
 
       - name: Run env-gated in-tree cashu tests
         # Picks up any `#[ignore]`-gated mint-backed tests later PRs add

--- a/.github/workflows/cashu.yml
+++ b/.github/workflows/cashu.yml
@@ -12,12 +12,25 @@ on:
   workflow_dispatch:
   schedule:
     # Nightly against main at 4 AM UTC, so a mint-facing regression is
-    # caught even if a PR author forgets the label.
+    # caught even if a PR author forgets the label. Off the weekly slots
+    # used by mutation (Sun 03:00) and coverage (Sun 05:00) so the three
+    # long jobs don't contend for runners.
     - cron: '0 4 * * *'
 
 env:
   CARGO_TERM_COLOR: always
   CASHU_TEST_MINT_URL: http://127.0.0.1:3338
+  # Turn a missing/empty mint URL into a hard failure instead of a silent
+  # skip: libtest reports a skipped test as `1 passed`, so without this a
+  # broken `env:` block above would leave this job green having tested
+  # nothing. See `mint_url_from_env` in tests/common/mod.rs.
+  CASHU_REQUIRE_MINT: '1'
+
+# Read-only: this job builds and tests, it never writes back to the repo.
+# Dropping the default write scopes keeps the token out of the mint
+# container and the long test run (zizmor `artipacked`).
+permissions:
+  contents: read
 
 jobs:
   mint-integration:
@@ -26,6 +39,9 @@ jobs:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'cashu')
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Nothing here needs the checkout credential after clone.
+          persist-credentials: false
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/docker-compose.cashu.yml
+++ b/docker-compose.cashu.yml
@@ -1,0 +1,30 @@
+# Throwaway Cashu test mint — Cashu foundation CF-3
+# (docs/cashu/01-fundamentals.md §6).
+#
+# A nutshell mint on the FakeWallet backend: no Lightning node, no real
+# funds — mint requests are auto-settled, which is exactly what the
+# env-gated integration tests (tests/cashu_mint.rs and the in-tree
+# `--ignored` cashu tests) need to build and verify real 2-of-3 tokens.
+#
+# NEVER point production config at this. MINT_PRIVATE_KEY below is a
+# NON-SENSITIVE, documented test fixture (per the CF-3 spec) so the mint's
+# keysets are deterministic across runs; it guards nothing.
+#
+# Usage:
+#   docker compose -f docker-compose.cashu.yml up -d
+#   CASHU_TEST_MINT_URL=http://127.0.0.1:3338 cargo test --test cashu_mint
+#   docker compose -f docker-compose.cashu.yml down -v
+
+services:
+  mint:
+    image: cashubtc/nutshell:0.20.1
+    container_name: mostro-cashu-test-mint
+    ports:
+      - "3338:3338"
+    environment:
+      - MINT_BACKEND_BOLT11_SAT=FakeWallet
+      - MINT_LISTEN_HOST=0.0.0.0
+      - MINT_LISTEN_PORT=3338
+      # Non-sensitive test fixture (see header note).
+      - MINT_PRIVATE_KEY=TEST_PRIVATE_KEY
+    command: ["poetry", "run", "mint"]

--- a/docker-compose.cashu.yml
+++ b/docker-compose.cashu.yml
@@ -18,7 +18,9 @@
 services:
   mint:
     image: cashubtc/nutshell:0.20.1
-    container_name: mostro-cashu-test-mint
+    # No fixed container_name: a pinned name blocks two runs on one host
+    # (a stale container from an aborted run, or a second checkout) with a
+    # name collision. Compose derives a unique name per project instead.
     ports:
       - "3338:3338"
     environment:

--- a/tests/cashu_mint.rs
+++ b/tests/cashu_mint.rs
@@ -1,0 +1,40 @@
+//! CF-3 mint-backed integration suite (skeleton)
+//! (`docs/cashu/01-fundamentals.md` §6).
+//!
+//! Runs against the throwaway nutshell mint from
+//! `docker-compose.cashu.yml`, driven by `.github/workflows/cashu.yml`
+//! (nightly + opt-in `cashu` PR label — never a default required check).
+//! Env-gated: every test skips cleanly when `CASHU_TEST_MINT_URL` is
+//! unset, so `cargo test` stays offline by default.
+
+mod common;
+
+/// CF-3 Definition of Done: the mint is reachable and returns its info.
+/// Also sanity-checks the same escrow prerequisites
+/// `CashuClient::connect` enforces (NUT-07 checkstate, NUT-11 P2PK,
+/// NUT-12 DLEQ) so a mint-image bump that drops one fails loudly here
+/// instead of inside a track's e2e test.
+#[tokio::test]
+async fn mint_is_reachable_and_supports_escrow_nuts() {
+    let Some(mint_url) = common::mint_url_from_env() else {
+        eprintln!("CASHU_TEST_MINT_URL unset; skipping mint-backed integration test");
+        return;
+    };
+
+    let info = common::wait_for_mint(&mint_url, std::time::Duration::from_secs(90))
+        .await
+        .expect("test mint must come up within the timeout");
+
+    let nuts = info.get("nuts").cloned().unwrap_or_default();
+    for nut in ["7", "11", "12"] {
+        let supported = nuts
+            .get(nut)
+            .and_then(|n| n.get("supported"))
+            .and_then(|v| v.as_bool());
+        assert_eq!(
+            supported,
+            Some(true),
+            "test mint must support NUT-{nut} (escrow prerequisite); mint info: {info}"
+        );
+    }
+}

--- a/tests/cashu_mint.rs
+++ b/tests/cashu_mint.rs
@@ -4,17 +4,27 @@
 //! Runs against the throwaway nutshell mint from
 //! `docker-compose.cashu.yml`, driven by `.github/workflows/cashu.yml`
 //! (nightly + opt-in `cashu` PR label — never a default required check).
-//! Env-gated: every test skips cleanly when `CASHU_TEST_MINT_URL` is
-//! unset, so `cargo test` stays offline by default.
+//! `#[ignore]`d and env-gated: a plain `cargo test` reports it as *ignored*,
+//! and even under `--ignored` it returns early when `CASHU_TEST_MINT_URL` is
+//! unset, so the suite stays offline by default.
 
 mod common;
 
-/// CF-3 Definition of Done: the mint is reachable and returns its info.
-/// Also sanity-checks the same escrow prerequisites
-/// `CashuClient::connect` enforces (NUT-07 checkstate, NUT-11 P2PK,
-/// NUT-12 DLEQ) so a mint-image bump that drops one fails loudly here
-/// instead of inside a track's e2e test.
+/// CF-3 Definition of Done: the mint is reachable and meets **every**
+/// prerequisite `CashuClient::connect` enforces (`src/cashu/mod.rs`), so a
+/// mint-image bump that drops one fails loudly here instead of inside a
+/// track's e2e test. Those are: NUT-07 (token state check), NUT-11 (P2PK),
+/// NUT-12 (DLEQ), **and an active `sat` keyset** — `connect` rejects a mint
+/// with `"no active sat keyset"` (M-3: every downstream amount check is in
+/// sats), so the harness has to assert it too or it would pass while
+/// `connect` fails.
+///
+/// `#[ignore]`d so a plain `cargo test` skips it as *ignored* rather than
+/// reporting a hollow `1 passed`. CI runs it with `--ignored` and sets
+/// `CASHU_REQUIRE_MINT`, which turns a missing URL into a hard failure (see
+/// `common::mint_url_from_env`).
 #[tokio::test]
+#[ignore = "requires a running mint and CASHU_TEST_MINT_URL; run via cashu.yml or `--ignored`"]
 async fn mint_is_reachable_and_supports_escrow_nuts() {
     let Some(mint_url) = common::mint_url_from_env() else {
         eprintln!("CASHU_TEST_MINT_URL unset; skipping mint-backed integration test");
@@ -25,6 +35,7 @@ async fn mint_is_reachable_and_supports_escrow_nuts() {
         .await
         .expect("test mint must come up within the timeout");
 
+    // NUT-07 / NUT-11 / NUT-12 support, from /v1/info.
     let nuts = info.get("nuts").cloned().unwrap_or_default();
     for nut in ["7", "11", "12"] {
         let supported = nuts
@@ -37,4 +48,28 @@ async fn mint_is_reachable_and_supports_escrow_nuts() {
             "test mint must support NUT-{nut} (escrow prerequisite); mint info: {info}"
         );
     }
+
+    // Active `sat` keyset, from /v1/keysets (NUT-02). This mirrors the
+    // `ks.active && ks.unit == CurrencyUnit::Sat` check in
+    // `CashuClient::connect`; without it the harness would go green against a
+    // mint serving only usd/msat, on which `connect` returns
+    // "Mint has no active sat keyset".
+    let keysets = common::mint_get_json(&mint_url, "/v1/keysets")
+        .await
+        .expect("mint must serve /v1/keysets");
+    let has_active_sat = keysets
+        .get("keysets")
+        .and_then(|k| k.as_array())
+        .map(|arr| {
+            arr.iter().any(|ks| {
+                ks.get("unit").and_then(|u| u.as_str()) == Some("sat")
+                    // NUT-02: `active` defaults to true when absent.
+                    && ks.get("active").and_then(|a| a.as_bool()).unwrap_or(true)
+            })
+        })
+        .unwrap_or(false);
+    assert!(
+        has_active_sat,
+        "test mint must expose an active `sat` keyset (escrow prerequisite); keysets: {keysets}"
+    );
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,13 +12,37 @@
 
 use std::time::{Duration, Instant};
 
+/// Set by CI to turn a missing mint URL from "skip" into a hard failure.
+const REQUIRE_MINT_VAR: &str = "CASHU_REQUIRE_MINT";
+
 /// The test-mint URL, if the harness is active. Trailing slashes are
 /// trimmed so callers can naively join paths.
+///
+/// Returns `None` when `CASHU_TEST_MINT_URL` is unset so a plain local
+/// `cargo test` stays offline — but panics instead when `CASHU_REQUIRE_MINT`
+/// is set, which `.github/workflows/cashu.yml` does.
+///
+/// The distinction matters because skipping is indistinguishable from
+/// succeeding in libtest output: a skipped mint test still reports
+/// `1 passed`, not `ignored`. Without this guard a renamed variable, a typo
+/// or a dropped `env:` block would leave the Cashu job green while it
+/// exercised nothing at all — the one failure mode a mint harness must not
+/// have.
 pub fn mint_url_from_env() -> Option<String> {
-    std::env::var("CASHU_TEST_MINT_URL")
+    let url = std::env::var("CASHU_TEST_MINT_URL")
         .ok()
         .map(|s| s.trim().trim_end_matches('/').to_string())
-        .filter(|s| !s.is_empty())
+        .filter(|s| !s.is_empty());
+
+    assert!(
+        !(url.is_none() && std::env::var_os(REQUIRE_MINT_VAR).is_some()),
+        "{REQUIRE_MINT_VAR} is set but CASHU_TEST_MINT_URL is empty or missing: \
+         the mint-backed suite would have silently reported success without \
+         testing anything. Check the `env:` block in \
+         .github/workflows/cashu.yml."
+    );
+
+    url
 }
 
 /// Poll the mint's NUT-06 info endpoint until it answers or `timeout`

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -61,10 +61,20 @@ fn http_client() -> reqwest::Client {
         .expect("reqwest client with a timeout must build")
 }
 
-/// GET `{mint_url}{path}` once and parse the body as JSON. Each call is
+/// GET `{mint_url}/{path}` once and parse the body as JSON. Each call is
 /// bounded by [`REQUEST_TIMEOUT`].
+///
+/// The join is normalized to exactly one `/` between base and path,
+/// regardless of a trailing slash on `mint_url` or a leading slash on
+/// `path`, so callers can pass either form. This matches the naive-join
+/// convention `mint_url_from_env` already sets up by trimming trailing
+/// slashes.
 pub async fn mint_get_json(mint_url: &str, path: &str) -> Result<serde_json::Value, String> {
-    let url = format!("{mint_url}{path}");
+    let url = format!(
+        "{}/{}",
+        mint_url.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    );
     let resp = http_client()
         .get(&url)
         .send()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -45,11 +45,45 @@ pub fn mint_url_from_env() -> Option<String> {
     url
 }
 
+/// Per-request cap. A bare `reqwest::Client` has no default timeout, so a
+/// mint that accepts the TCP connection but never answers `/v1/info` would
+/// hang `send().await` forever — the `wait_for_mint` deadline is only
+/// re-checked *between* requests, so it would never fire, and the job would
+/// run until GitHub's global timeout. This bounds every individual probe.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Client with a per-request timeout, so a hung endpoint surfaces as a
+/// retryable error instead of an unbounded await.
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .expect("reqwest client with a timeout must build")
+}
+
+/// GET `{mint_url}{path}` once and parse the body as JSON. Each call is
+/// bounded by [`REQUEST_TIMEOUT`].
+pub async fn mint_get_json(mint_url: &str, path: &str) -> Result<serde_json::Value, String> {
+    let url = format!("{mint_url}{path}");
+    let resp = http_client()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url} failed: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("GET {url} returned {}", resp.status()));
+    }
+    resp.json::<serde_json::Value>()
+        .await
+        .map_err(|e| format!("{url} body was not JSON: {e}"))
+}
+
 /// Poll the mint's NUT-06 info endpoint until it answers or `timeout`
 /// elapses (the container needs a few seconds to come up in CI). Returns
-/// the parsed `/v1/info` JSON.
+/// the parsed `/v1/info` JSON. Each probe is bounded by [`REQUEST_TIMEOUT`],
+/// so a hung endpoint cannot stall the loop past the deadline.
 pub async fn wait_for_mint(mint_url: &str, timeout: Duration) -> Result<serde_json::Value, String> {
-    let client = reqwest::Client::new();
+    let client = http_client();
     let info_url = format!("{mint_url}/v1/info");
     let deadline = Instant::now() + timeout;
     loop {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,47 @@
+//! Shared helpers for the CF-3 mint-backed integration suite
+//! (`docs/cashu/01-fundamentals.md` §6).
+//!
+//! Everything here is env-gated on `CASHU_TEST_MINT_URL`: when the variable
+//! is unset (offline CI, local runs without the mint container) callers
+//! skip instead of failing, so the default test suite never depends on
+//! network access.
+//!
+//! Wallet-level helpers (fund a test wallet, build a 2-of-3 escrow token)
+//! land here once the `cdk` dependency is on `main` (CF-2, PR #798) — the
+//! feature tracks reuse them for their end-to-end lock/release tests.
+
+use std::time::{Duration, Instant};
+
+/// The test-mint URL, if the harness is active. Trailing slashes are
+/// trimmed so callers can naively join paths.
+pub fn mint_url_from_env() -> Option<String> {
+    std::env::var("CASHU_TEST_MINT_URL")
+        .ok()
+        .map(|s| s.trim().trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Poll the mint's NUT-06 info endpoint until it answers or `timeout`
+/// elapses (the container needs a few seconds to come up in CI). Returns
+/// the parsed `/v1/info` JSON.
+pub async fn wait_for_mint(mint_url: &str, timeout: Duration) -> Result<serde_json::Value, String> {
+    let client = reqwest::Client::new();
+    let info_url = format!("{mint_url}/v1/info");
+    let deadline = Instant::now() + timeout;
+    loop {
+        match client.get(&info_url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                return resp
+                    .json::<serde_json::Value>()
+                    .await
+                    .map_err(|e| format!("mint info was not JSON: {e}"));
+            }
+            _ if Instant::now() >= deadline => {
+                return Err(format!(
+                    "mint at {info_url} not reachable within {timeout:?}"
+                ));
+            }
+            _ => tokio::time::sleep(Duration::from_secs(2)).await,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**CF-3** of the Cashu foundation ([`docs/cashu/01-fundamentals.md` §6](../blob/main/docs/cashu/01-fundamentals.md)): a real Cashu mint for CI and local runs, so CF-2 (#798) and the feature tracks have something to test against. Pure test/infra — **no daemon code**.

- **`docker-compose.cashu.yml`** — throwaway **nutshell 0.20.1** mint on the FakeWallet backend (no Lightning node; mint requests auto-settle). `MINT_PRIVATE_KEY=TEST_PRIVATE_KEY` is the documented **non-sensitive fixture** the spec calls for (deterministic keysets across runs; guards nothing).
- **`.github/workflows/cashu.yml`** — dedicated workflow, **never a default required check**: nightly cron on `main` (safety net) + opt-in per-PR via the **`cashu` label** + `workflow_dispatch`, mirroring the mutation-testing trigger pattern. It also runs `cargo test cashu -- --ignored`, so mint-backed `#[ignore]` tests that later PRs add inside `src` (e.g. `CashuClient::connect`/`check_state`/DLEQ) are picked up with zero workflow changes.
- **`tests/cashu_mint.rs` + `tests/common/mod.rs`** — env-gated integration skeleton (`CASHU_TEST_MINT_URL`): spin-up wait helper + a smoke test asserting the mint is reachable and supports **NUT-07/11/12** (the same prerequisites `CashuClient::connect` enforces, so a mint-image bump that drops one fails loudly here). Skips cleanly when the env var is unset — default `cargo test` stays offline.

### Note

The spec also lists wallet-level helpers (fund a wallet, build a 2-of-3 token) in `tests/common/`. Those need the `cdk` dependency, which lands with CF-2 (#798) — they'll follow once it merges (documented in the module header). Everything else in the CF-3 spec ships here.

## Test plan

- [x] Without `CASHU_TEST_MINT_URL`: test compiles and skips cleanly (offline default preserved)
- [x] Against the real dockerized mint locally: `docker compose -f docker-compose.cashu.yml up -d` → `CASHU_TEST_MINT_URL=http://127.0.0.1:3338 cargo test --test cashu_mint` → **1 passed** (mint up, NUT-07/11/12 supported) → `down -v`
- [x] `cargo fmt --all` / `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `ci.yml` file untouched. Note this PR does add the repo's first `tests/` integration target, so `cargo test` (the required `test` job) now compiles and runs it — verified green (1015 + 1 passed, clippy --all-targets --all-features -D warnings clean). No `ci.yml` job definition changed, but the required suite's surface does grow.

Wave-1 PR of the CF-0…CF-5 series (CF-0 #795, CF-1 #796, CF-4 #797, CF-2 #798). Remaining: CF-5 (integration — needs CF-0+CF-1+CF-2 merged, ships last).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI**
  * Added a scheduled and on-demand “Cashu Integration” workflow running containerized mint integration tests, with opt-in execution for pull requests marked accordingly.
* **Tests**
  * Added mint-backed integration coverage that checks mint reachability and validates supported escrow nuts and an active `sat` keyset.
  * Tests are environment-gated to stay offline by default, and now fail clearly if the required test mint URL is missing when required.
  * Containerized test services are automatically started and cleaned up after the run.
* **Documentation**
  * Added guidance and warnings for using the local containerized test mint configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->