### PR TITLE
chore: standardize v0.19.0 deprecation notices for the v1 transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,9 +1843,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d73bbd0d6b8b283ec477d11330617bd55d3b1e40dc07db8a084e74cc22f01c2"
+checksum = "30391197a9de16ce45b7ee5a92d5b3f74c3d12da4d13d442aff00c93c2424038"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.14", features = ["sqlx"] }
+mostro-core = { version = "0.14.1", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 async-trait = "0.1.83"

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -54,7 +54,9 @@ publish_relays_interval = 60
 pow = 0
 # Wire transport for protocol messages. A node speaks exactly one:
 #   "gift-wrap" - protocol v1, NIP-59 gift wraps (kind 1059). DEPRECATED,
-#                 will be removed in v0.19.0.
+#                 will be removed in v0.19.0 — mostrod will then run protocol
+#                 v2 only and this setting disappears. See
+#                 https://github.com/MostroP2P/mostro/issues/786
 #   "nip44"     - protocol v2, signed kind-14 events with NIP-44 encrypted
 #                 content. Rate-limitable by relays; switch once the clients
 #                 your community uses support protocol v2.

--- a/src/app.rs
+++ b/src/app.rs
@@ -304,6 +304,9 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
     // The node speaks exactly one transport (protocol v1 gift wrap or v2
     // NIP-44 direct); events of any other kind are dropped before any
     // decryption work. See docs/TRANSPORT_V2_SPEC.md.
+    // DEPRECATED(v0.19.0, #786): with the `transport` knob gone this becomes
+    // unconditionally kind 14 and the v1/v2 branching below collapses.
+    #[allow(deprecated)]
     let accepted_kind = ctx.settings().mostro.transport.event_kind();
     // Phase 2 anti-spam gate (docs/TRANSPORT_V2_SPEC.md §6): on the v2 (kind
     // 14) transport the visible author is the trade key, so the daemon can

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -105,7 +105,15 @@ impl Settings {
     /// initialized yet — `send_dm()` sits on every reply path and must
     /// degrade to v1 behavior rather than panic in unit tests that don't
     /// bring up the full configuration, mirroring [`Settings::get_bond`].
+    ///
+    /// DEPRECATED(v0.19.0, #786): goes away with the `transport` setting —
+    /// v0.19.0 hardcodes the protocol-v2 (`nip44`) wire format.
+    #[deprecated(
+        since = "0.18.0",
+        note = "transitional v1/v2 transport selection; removed in v0.19.0 (protocol v2 only) — see issue #786"
+    )]
     pub fn get_transport() -> Transport {
+        #[allow(deprecated)]
         MOSTRO_CONFIG
             .get()
             .map(|s| s.mostro.transport)

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -233,6 +233,8 @@ mod tests {
     }
 
     #[test]
+    // DEPRECATED(v0.19.0, #786): delete along with the `transport` setting.
+    #[allow(deprecated)]
     fn transport_defaults_to_gift_wrap() {
         // v0.18.x default: wire-identical to pre-v2 daemons. The default
         // flips to nip44 in v0.19.0 (docs/TRANSPORT_V2_SPEC.md §5).
@@ -449,8 +451,15 @@ pub struct MostroSettings {
     #[serde(default = "default_exchange_rates_update_interval")]
     pub exchange_rates_update_interval_seconds: u64,
     /// Wire transport for protocol messages: `"gift-wrap"` (protocol v1,
-    /// NIP-59, DEPRECATED) or `"nip44"` (protocol v2, kind-14 direct).
-    /// A node speaks exactly one. See docs/TRANSPORT_V2_SPEC.md.
+    /// NIP-59) or `"nip44"` (protocol v2, kind-14 direct). A node speaks
+    /// exactly one. See docs/TRANSPORT_V2_SPEC.md.
+    ///
+    /// DEPRECATED(v0.19.0, #786): transitional knob for the v1→v2 protocol
+    /// migration. v0.19.0 removes it and runs protocol v2 (`nip44`) only.
+    #[deprecated(
+        since = "0.18.0",
+        note = "transitional v1/v2 transport selection; removed in v0.19.0 (protocol v2 only) — see issue #786"
+    )]
     #[serde(default)]
     pub transport: Transport,
     /// Proof-of-work difficulty (leading-zero bits) demanded of a
@@ -501,6 +510,8 @@ fn default_active_pubkeys_refresh_interval() -> u64 {
 }
 
 impl Default for MostroSettings {
+    // DEPRECATED(v0.19.0, #786): `transport` init goes away with the field.
+    #[allow(deprecated)]
     fn default() -> Self {
         Self {
             fee: 0.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,7 @@ async fn main() -> Result<()> {
         transport.protocol_version(),
         transport.event_kind().as_u16()
     );
+    #[allow(deprecated)]
     if transport == mostro_core::transport::Transport::GiftWrap {
         tracing::warn!(
             "transport = \"gift-wrap\" (protocol v1) is DEPRECATED and will be removed in \

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,9 @@ async fn main() -> Result<()> {
 
     // Subscribe only to the configured transport's kind: 1059 (protocol v1
     // gift wrap) or 14 (protocol v2 NIP-44 direct). See docs/TRANSPORT_V2_SPEC.md.
+    // DEPRECATED(v0.19.0, #786): the `transport` knob disappears in v0.19.0
+    // and this subscription becomes unconditionally kind 14.
+    #[allow(deprecated)]
     let transport = Settings::get_mostro().transport;
     tracing::info!(
         "Transport: {} (protocol v{}, event kind {})",
@@ -83,6 +86,14 @@ async fn main() -> Result<()> {
         transport.protocol_version(),
         transport.event_kind().as_u16()
     );
+    if transport == mostro_core::transport::Transport::GiftWrap {
+        tracing::warn!(
+            "transport = \"gift-wrap\" (protocol v1) is DEPRECATED and will be removed in \
+             v0.19.0; mostrod will then run protocol v2 (transport = \"nip44\") only. Switch \
+             once the clients your community uses support protocol v2. \
+             See https://github.com/MostroP2P/mostro/issues/786"
+        );
+    }
     let subscription = Filter::new()
         .pubkey(mostro_keys.public_key())
         .kind(transport.event_kind())

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -489,6 +489,10 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
     let mostro_settings = Settings::get_mostro();
     let ln_settings = Settings::get_ln();
     let bond_settings = Settings::get_bond();
+    // DEPRECATED(v0.19.0, #786): once the `transport` knob is gone the
+    // `protocol_version` tag is hardcoded to the crate-wide `PROTOCOL_VER`.
+    #[allow(deprecated)]
+    let protocol_version = mostro_settings.transport.protocol_version();
 
     let mut tags_vec: Vec<Tag> = vec![
         Tag::custom(
@@ -537,7 +541,7 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
         // sending anything. See docs/TRANSPORT_V2_SPEC.md.
         Tag::custom(
             TagKind::Custom(Cow::Borrowed("protocol_version")),
-            vec![mostro_settings.transport.protocol_version().to_string()],
+            vec![protocol_version.to_string()],
         ),
         Tag::custom(
             TagKind::Custom(Cow::Borrowed("hold_invoice_expiration_window")),

--- a/src/util.rs
+++ b/src/util.rs
@@ -625,6 +625,14 @@ async fn prepare_new_order(
 /// this every reply would advertise v2 even when it is served over the v1
 /// gift-wrap transport. Keeping the inner version aligned with the transport
 /// lets the protocol version follow the negotiated wire format.
+///
+/// DEPRECATED(v0.19.0, #786): transitional mechanism from PR #785. v0.19.0
+/// runs protocol v2 only, the inner version becomes the `PROTOCOL_VER`
+/// constant again and this function is deleted.
+#[deprecated(
+    since = "0.18.0",
+    note = "transitional version-follows-transport stamping; removed in v0.19.0 (protocol v2 only) — see issue #786"
+)]
 fn stamp_protocol_version(message: &mut Message, transport: Transport) {
     let version = transport.protocol_version();
     match message {
@@ -653,11 +661,15 @@ pub async fn send_dm(
 
     // Non-panicking accessor: send_dm sits on every reply path and is
     // exercised by unit tests that don't initialize the global config.
+    // DEPRECATED(v0.19.0, #786): both calls below go away with the
+    // `transport` setting.
+    #[allow(deprecated)]
     let transport = Settings::get_transport();
 
     // Stamp the inner protocol version to match the active wire transport.
     // Done before wrapping so the version is covered by the message/trade
     // signatures.
+    #[allow(deprecated)]
     stamp_protocol_version(&mut message, transport);
 
     // Kind-14 events are visible to relays, so they always carry a NIP-40
@@ -1536,6 +1548,8 @@ mod tests {
     }
 
     #[test]
+    // DEPRECATED(v0.19.0, #786): delete along with `stamp_protocol_version`.
+    #[allow(deprecated)]
     fn stamp_protocol_version_follows_transport() {
         use mostro_core::message::Action;
 
@@ -1557,6 +1571,8 @@ mod tests {
     }
 
     #[test]
+    // DEPRECATED(v0.19.0, #786): delete along with `stamp_protocol_version`.
+    #[allow(deprecated)]
     fn stamp_protocol_version_covers_all_variants() {
         use mostro_core::message::Action;
 


### PR DESCRIPTION
## Summary

Before tagging v0.18.0, mark everything that #786 schedules for removal in v0.19.0 (the `transport` knob and the version-follows-transport stamping from #785) with a standard, three-layer deprecation notice:

1. **Runtime warning (operator-facing).** On startup with `transport = "gift-wrap"` — the v0.18 default — mostrod now logs a `WARN` saying protocol v1 is deprecated, v0.19.0 runs protocol v2 only, and linking to #786. This is the notice that actually reaches node operators during the transition window.

2. **Rust `#[deprecated]` attribute (compiler-enforced).** Applied to the three items that get deleted:
   - `MostroSettings::transport` (`src/config/types.rs`)
   - `Settings::get_transport()` (`src/config/settings.rs`)
   - `stamp_protocol_version()` (`src/util.rs`)

   Every internal use now carries an explicit `#[allow(deprecated)]`, so when preparing v0.19.0 a grep for `allow(deprecated)` lists every call site to revert.

3. **Greppable comment convention.** `DEPRECATED(v0.19.0, #786): <what goes away>` at each affected site (`main.rs` subscription, `app.rs` kind filter, `nip33.rs` `protocol_version` tag, `settings.tpl.toml`). `grep -rn "DEPRECATED(v0.19.0"` yields the complete removal checklist for that release.

4. **mostro-core 0.14.1 bump.** MostroP2P/mostro-core#158 (released as 0.14.1) marks `Transport::GiftWrap` itself `#[deprecated]`, so the compiler layer also covers direct uses of the v1 variant. The one intentional use it surfaced here — the startup deprecation-warning check in `main.rs` — carries the same explicit `#[allow(deprecated)]` marker.

No behavior change beyond the new startup warning: the `protocol_version` info tag, the subscription kind, and all message stamping are byte-identical.

Related: #786 (lifecycle plan), #785 (transitional mechanism being marked), MostroP2P/mostro-core#158 (core-side deprecation).

## Test plan

- [x] `cargo build` — clean, no deprecation warnings escape their `allow` markers (including serde derive on the config struct)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean, on mostro-core 0.14.1
- [x] `cargo test` — 501 passed, 0 failed
- [x] `cargo fmt`
- [ ] Manual: start mostrod with default settings and confirm the gift-wrap deprecation `WARN` appears once at startup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer runtime warnings when the soon-to-be-removed transport option is selected, including a deprecation notice and transition to protocol v2-only behavior.
  * Updated protocol version tagging to avoid deprecated access patterns.

* **Documentation**
  * Expanded configuration inline comments to clarify the v0.19.0 removal timeline and reference the related issue.

* **Chores**
  * Marked the transport-related setting/accessors as deprecated and suppressed resulting deprecation warnings across relevant code paths and tests.
  * Bumped the `mostro-core` dependency patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->