### PR TITLE
fix(ci): build windows-gnu release binary natively, not with cross

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,19 +87,40 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # cross 0.2.5's windows-gnu image ships a mingw-w64 older than 2021,
+      # whose libws2_32.a lacks GetHostNameW — a symbol current Rust std
+      # references (std::sys::net::hostname) — so linking fails. The runner's
+      # own mingw-w64 (>= 11, Ubuntu 24.04) exports it, so that target builds
+      # natively with cargo instead of cross.
+      - name: Install mingw-w64 (Windows target only)
+        if: matrix.target == 'x86_64-pc-windows-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-mingw-w64-x86-64 protobuf-compiler
+          rustup target add x86_64-pc-windows-gnu
+
       - name: Cache cross binary
         id: cache-cross
+        if: matrix.target != 'x86_64-pc-windows-gnu'
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/cross
           key: cross-${{ runner.os }}-0.2.5
 
       - name: Install cross ( pinned version for reproducibility )
-        if: steps.cache-cross.outputs.cache-hit != 'true'
+        if: matrix.target != 'x86_64-pc-windows-gnu' && steps.cache-cross.outputs.cache-hit != 'true'
         run: cargo install cross --version 0.2.5
 
       - name: Build release
-        run: cross build --release --locked --target ${{ matrix.target }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ matrix.target }}" == "x86_64-pc-windows-gnu" ]]; then
+            export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc
+            cargo build --release --locked --target ${{ matrix.target }}
+          else
+            cross build --release --locked --target ${{ matrix.target }}
+          fi
 
       - name: Prepare conventional artifact name
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,13 +113,15 @@ jobs:
 
       - name: Build release
         shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           set -euo pipefail
-          if [[ "${{ matrix.target }}" == "x86_64-pc-windows-gnu" ]]; then
+          if [[ "$TARGET" == "x86_64-pc-windows-gnu" ]]; then
             export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc
-            cargo build --release --locked --target ${{ matrix.target }}
+            cargo build --release --locked --target "$TARGET"
           else
-            cross build --release --locked --target ${{ matrix.target }}
+            cross build --release --locked --target "$TARGET"
           fi
 
       - name: Prepare conventional artifact name


### PR DESCRIPTION
## Summary

The v0.18.0 release run ([28676670518](https://github.com/MostroP2P/mostro/actions/runs/28676670518)) failed on `build (x86_64-pc-windows-gnu)` with:

```
undefined reference to `GetHostNameW'
```

**Root cause:** current Rust std references `GetHostNameW` (`std/src/sys/net/hostname/windows.rs`, from `ws2_32.dll`), but cross 0.2.5's windows-gnu Docker image ships a mingw-w64 older than 2021, whose `libws2_32.a` doesn't export that symbol — mingw-w64 only added it in July 2021. cross 0.2.5 (2023) is the latest cross release, so there is no newer image to pin; the toolchain skew also explains the flood of `.drectve unrecognized` / `corrupt .drectve` warnings in the log (the image's GNU ld predates the `-exclude-symbols` directives modern rustc emits).

**Fix:** build `x86_64-pc-windows-gnu` natively on the runner with cargo + Ubuntu 24.04's own mingw-w64 **11.0.1**, which does export `GetHostNameW` (verified with `nm` on the package's `libws2_32.a`: `T GetHostNameW` / `I __imp_GetHostNameW`). All other targets keep building with cross exactly as before; the cross install/cache steps are skipped for the windows job.

**Impact on the pending release:** `publish` (crates.io) and `release` were `skipped`, so nothing partial shipped. After merging, delete and re-push the `v0.18.0` tag on the fixed main to re-run the whole pipeline.

## Test plan

- [x] YAML validated
- [x] `GetHostNameW` presence confirmed in ubuntu-24.04's mingw-w64 11.0.1 `libws2_32.a` (the exact package the runner installs)
- [ ] Green `build (x86_64-pc-windows-gnu)` job on the re-pushed `v0.18.0` tag run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows build handling to make release artifacts more reliable for the `x86_64-pc-windows-gnu` target.
  * Reduced unnecessary setup work in cross-platform builds by only installing build tools when needed.

* **Chores**
  * Streamlined CI build steps across targets for more consistent and efficient release processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->