### PR TITLE
test: raise line coverage 67%→93% + deep review findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1055,6 +1055,28 @@ cd mostro-regtest
 # Follow README for complete regtest environment
 ```
 
+**Code Coverage**: Measured with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov)
+```bash
+# One-time install
+cargo install cargo-llvm-cov
+
+# Per-file + total line coverage in the terminal
+cargo llvm-cov --summary-only
+
+# Generate an HTML report and open it
+cargo llvm-cov --html         # writes target/llvm-cov/html/index.html
+cargo llvm-cov --open         # ...and opens it in the browser
+
+# Emit lcov for CI or editor gutters
+cargo llvm-cov --lcov --output-path lcov.info
+```
+
+The unit-test suite runs entirely offline (in-memory SQLite, locally-built
+invoices — no relay, LND, or network). The remaining uncovered lines are the
+paths that structurally require a live LND node, a Cashu mint, a network relay,
+interactive stdin (the config wizard), or the `main()` / `app::run` bootstrap
+loop — none of which are exercisable in an offline unit test.
+
 ---
 
 ### Documentation

--- a/src/app.rs
+++ b/src/app.rs
@@ -583,6 +583,148 @@ mod tests {
             assert!(result.is_ok());
         }
 
+        async fn create_migrated_ctx() -> AppContext {
+            let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+            sqlx::migrate!("./migrations")
+                .run(pool.as_ref())
+                .await
+                .unwrap();
+            TestContextBuilder::new()
+                .with_pool(pool)
+                .with_settings(test_settings())
+                .build()
+        }
+
+        /// Insert a user row for `identity` with the given last_trade_index.
+        async fn insert_user(ctx: &AppContext, identity: &PublicKey, index: i64) {
+            add_new_user(
+                ctx.pool(),
+                User {
+                    pubkey: identity.to_string(),
+                    last_trade_index: index,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("insert user");
+        }
+
+        /// Build a signed trade-index message: the trade key (event.sender)
+        /// signs the serialized message, mirroring what clients do.
+        fn signed_event_and_message(trade_index: u32) -> (UnwrappedMessage, Message) {
+            let identity = create_test_keys();
+            let trade = create_test_keys();
+            let message = create_test_message(Action::NewOrder, Some(trade_index));
+            let sig = Message::sign(message.as_json().expect("json"), &trade);
+            let event = UnwrappedMessage {
+                message: message.clone(),
+                signature: Some(sig),
+                sender: trade.public_key(),
+                identity: identity.public_key(),
+                created_at: Timestamp::now(),
+            };
+            (event, message)
+        }
+
+        #[tokio::test]
+        async fn known_user_with_fresh_index_and_valid_signature_passes() {
+            let ctx = create_migrated_ctx().await;
+            let (event, message) = signed_event_and_message(3);
+            insert_user(&ctx, &event.identity, 2).await;
+
+            let result = check_trade_index(&ctx, &event, &message).await;
+            assert!(
+                result.is_ok(),
+                "fresh index + valid sig must pass: {result:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn known_user_with_stale_index_is_rejected() {
+            let ctx = create_migrated_ctx().await;
+            let (event, message) = signed_event_and_message(3);
+            insert_user(&ctx, &event.identity, 5).await;
+
+            let result = check_trade_index(&ctx, &event, &message).await;
+            assert!(matches!(
+                result,
+                Err(MostroError::MostroCantDo(CantDoReason::InvalidTradeIndex))
+            ));
+        }
+
+        #[tokio::test]
+        async fn known_user_with_wrong_signature_is_rejected() {
+            let ctx = create_migrated_ctx().await;
+            let (mut event, message) = signed_event_and_message(3);
+            // Signature from an unrelated key must not verify against the
+            // trade key that authored the rumor.
+            let interloper = create_test_keys();
+            event.signature = Some(Message::sign(message.as_json().expect("json"), &interloper));
+            insert_user(&ctx, &event.identity, 0).await;
+
+            let result = check_trade_index(&ctx, &event, &message).await;
+            assert!(matches!(
+                result,
+                Err(MostroError::MostroCantDo(CantDoReason::InvalidSignature))
+            ));
+        }
+
+        #[tokio::test]
+        async fn known_user_missing_signature_is_rejected() {
+            let ctx = create_migrated_ctx().await;
+            let (mut event, message) = signed_event_and_message(3);
+            event.signature = None;
+            insert_user(&ctx, &event.identity, 0).await;
+
+            let result = check_trade_index(&ctx, &event, &message).await;
+            assert!(matches!(
+                result,
+                Err(MostroError::MostroCantDo(CantDoReason::InvalidSignature))
+            ));
+        }
+
+        #[tokio::test]
+        async fn known_user_with_index_zero_skips_index_checks() {
+            let ctx = create_migrated_ctx().await;
+            let identity = create_test_keys();
+            insert_user(&ctx, &identity.public_key(), 5).await;
+            let mut event = create_test_unwrapped_message();
+            event.identity = identity.public_key();
+            // trade_index None → trade_index() == 0 → `1..` arm not taken.
+            let message = create_test_message(Action::NewOrder, None);
+
+            let result = check_trade_index(&ctx, &event, &message).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn unknown_user_with_index_zero_is_rejected() {
+            let ctx = create_migrated_ctx().await;
+            let event = create_test_unwrapped_message();
+            let message = create_test_message(Action::NewOrder, Some(0));
+
+            let result = check_trade_index(&ctx, &event, &message).await;
+            assert!(matches!(
+                result,
+                Err(MostroError::MostroCantDo(CantDoReason::InvalidTradeIndex))
+            ));
+        }
+
+        #[tokio::test]
+        async fn unknown_user_with_valid_index_is_registered() {
+            let ctx = create_migrated_ctx().await;
+            let event = create_test_unwrapped_message();
+            let message = create_test_message(Action::TakeBuy, Some(4));
+
+            let result = check_trade_index(&ctx, &event, &message).await;
+            assert!(result.is_ok(), "new user must be created: {result:?}");
+
+            let user = is_user_present(ctx.pool(), event.identity.to_string())
+                .await
+                .expect("user must have been created");
+            assert_eq!(user.last_trade_index, 4);
+        }
+
         #[tokio::test]
         async fn test_check_trade_index_with_valid_index() {
             let ctx = create_test_ctx().await;
@@ -680,6 +822,51 @@ mod tests {
             // Routing assertion: we only require that the specific handler path is invoked
             // and its result is propagated; the exact business error is handler-owned.
             assert!(result.is_err());
+        }
+
+        #[tokio::test]
+        async fn routes_every_no_ln_action_to_its_handler_without_panicking() {
+            // Globals some handlers reach for; installing them is idempotent.
+            let _ =
+                crate::config::MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
+            let _ = crate::NOSTR_CLIENT.set(nostr_sdk::Client::default());
+
+            let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+            sqlx::migrate!("./migrations")
+                .run(pool.as_ref())
+                .await
+                .unwrap();
+
+            let ctx = TestContextBuilder::new()
+                .with_pool(pool)
+                .with_settings(test_settings())
+                .build();
+
+            let my_keys = create_test_keys();
+            let event = create_test_unwrapped_message();
+
+            // Every arm of the no-LN router: against an empty database each
+            // handler returns its own business error (or Ok for no-op paths).
+            // The routing contract under test is "dispatch + propagate, never
+            // panic".
+            for action in [
+                Action::NewOrder,
+                Action::TakeSell,
+                Action::TakeBuy,
+                Action::FiatSent,
+                Action::AddInvoice,
+                Action::AddBondInvoice,
+                Action::Dispute,
+                Action::RateUser,
+                Action::AdminAddSolver,
+                Action::AdminTakeDispute,
+                Action::TradePubkey,
+                // Not routed by the no-LN handler → default informational arm.
+                Action::Release,
+            ] {
+                let msg = create_test_message(action.clone(), None);
+                let _ = handle_message_action_no_ln(&action, msg, &event, &my_keys, &ctx).await;
+            }
         }
 
         #[tokio::test]

--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -127,3 +127,231 @@ pub async fn add_invoice_action(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+
+    async fn setup_pool() -> Arc<SqlitePool> {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+        sqlx::migrate!("./migrations")
+            .run(pool.as_ref())
+            .await
+            .unwrap();
+        pool
+    }
+
+    fn build_ctx(pool: Arc<SqlitePool>) -> AppContext {
+        // update_order_event reads the global config (expiration/nostr);
+        // seeding it is idempotent and safe under concurrent tests.
+        let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+        TestContextBuilder::new()
+            .with_pool(pool)
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// `event.sender` is the buyer trade key (only the buyer may add an
+    /// invoice); `identity` is an unrelated key so tests reflect the
+    /// dual-key flow.
+    fn buyer_event(buyer: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::new_order(
+                Some(uuid::Uuid::new_v4()),
+                Some(1),
+                None,
+                Action::AddInvoice,
+                None,
+            ),
+            signature: None,
+            sender: buyer,
+            identity: Keys::generate().public_key(),
+            created_at: Timestamp::now(),
+        }
+    }
+
+    /// A sell order where the buyer is the taker adding a payout invoice.
+    fn waiting_invoice_sell_order(seller: PublicKey, buyer: PublicKey) -> Order {
+        Order {
+            id: uuid::Uuid::new_v4(),
+            status: Status::WaitingBuyerInvoice.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: seller.to_string(),
+            seller_pubkey: Some(seller.to_string()),
+            master_seller_pubkey: Some(seller.to_string()),
+            buyer_pubkey: Some(buyer.to_string()),
+            master_buyer_pubkey: Some(buyer.to_string()),
+            amount: 21_000,
+            fee: 210,
+            ..Default::default()
+        }
+    }
+
+    fn add_invoice_msg(order_id: uuid::Uuid) -> Message {
+        Message::new_order(Some(order_id), Some(1), None, Action::AddInvoice, None)
+    }
+
+    async fn queued_actions_for(destination: PublicKey) -> Vec<Action> {
+        crate::config::MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(_, pk)| *pk == destination)
+            .map(|(m, _)| m.get_inner_message_kind().action.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn add_invoice_action_fails_when_order_missing() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool);
+        let buyer = Keys::generate();
+        let event = buyer_event(buyer.public_key());
+
+        let result = add_invoice_action(
+            &ctx,
+            add_invoice_msg(uuid::Uuid::new_v4()),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+    }
+
+    #[tokio::test]
+    async fn add_invoice_action_rejects_non_buyer_sender() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = waiting_invoice_sell_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+
+        // The event is authored by an intruder, not the buyer.
+        let event = buyer_event(Keys::generate().public_key());
+        let result =
+            add_invoice_action(&ctx, add_invoice_msg(order.id), &event, &Keys::generate()).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPeer))
+        ));
+    }
+
+    #[tokio::test]
+    async fn add_invoice_action_rejects_disallowed_status() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = waiting_invoice_sell_order(seller, buyer);
+        order.status = Status::Active.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = buyer_event(buyer);
+        let result =
+            add_invoice_action(&ctx, add_invoice_msg(order.id), &event, &Keys::generate()).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+    }
+
+    /// A `SettledHoldInvoice` order routes through `pay_new_invoice`: the
+    /// payment-attempts counter is reset and the buyer is told the invoice
+    /// was updated. No LND is involved so the handler returns `Ok`.
+    #[tokio::test]
+    async fn add_invoice_action_settled_hold_invoice_resets_and_notifies_buyer() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = waiting_invoice_sell_order(seller, buyer);
+        order.status = Status::SettledHoldInvoice.to_string();
+        order.payment_attempts = 3;
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = buyer_event(buyer);
+        let result =
+            add_invoice_action(&ctx, add_invoice_msg(order.id), &event, &Keys::generate()).await;
+
+        assert!(
+            result.is_ok(),
+            "settled-hold-invoice path must succeed: {result:?}"
+        );
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(stored.payment_attempts, 0, "attempts must be reset");
+        assert!(queued_actions_for(buyer)
+            .await
+            .contains(&Action::InvoiceUpdated));
+    }
+
+    /// Happy path for a `WaitingBuyerInvoice` order that already has a
+    /// preimage (seller paid the hold invoice first): the order is
+    /// promoted to `Active`, the seller is told the buyer took the order,
+    /// and the buyer is told the hold invoice payment was accepted. The
+    /// buyer's invoice is stripped from the seller-facing message.
+    #[tokio::test]
+    async fn add_invoice_action_with_preimage_activates_and_notifies_both() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = waiting_invoice_sell_order(seller, buyer);
+        order.preimage = Some("deadbeef".to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = buyer_event(buyer);
+        let result =
+            add_invoice_action(&ctx, add_invoice_msg(order.id), &event, &Keys::generate()).await;
+
+        assert!(result.is_ok(), "preimage path must succeed: {result:?}");
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, Status::Active.to_string());
+        assert!(queued_actions_for(seller)
+            .await
+            .contains(&Action::BuyerTookOrder));
+        assert!(queued_actions_for(buyer)
+            .await
+            .contains(&Action::HoldInvoicePaymentAccepted));
+    }
+
+    /// Without a preimage the handler falls through to `show_hold_invoice`,
+    /// which calls `LndConnector::new()` and fails offline. Everything up to
+    /// that LND seam is covered; the hold-invoice creation itself is
+    /// exercised by integration tests against a live LND.
+    #[tokio::test]
+    async fn add_invoice_action_without_preimage_hits_hold_invoice_seam() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = waiting_invoice_sell_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+
+        let event = buyer_event(buyer);
+        let result =
+            add_invoice_action(&ctx, add_invoice_msg(order.id), &event, &Keys::generate()).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::HoldInvoiceError(_)))
+        ));
+    }
+}

--- a/src/app/admin_add_solver.rs
+++ b/src/app/admin_add_solver.rs
@@ -143,4 +143,209 @@ mod tests {
             mostro_core::error::MostroError::MostroCantDo(CantDoReason::InvalidParameters)
         );
     }
+
+    #[test]
+    fn parse_solver_payload_rejects_non_text_payload() {
+        let err = parse_solver_payload(&Payload::Dispute(uuid::Uuid::new_v4(), None)).unwrap_err();
+        assert_eq!(
+            err,
+            mostro_core::error::MostroError::MostroCantDo(CantDoReason::InvalidTextMessage)
+        );
+    }
+
+    #[test]
+    fn parse_solver_payload_rejects_empty_and_whitespace_only_text() {
+        for raw in ["", "   "] {
+            let err = parse_solver_payload(&Payload::TextMessage(raw.to_string())).unwrap_err();
+            assert_eq!(
+                err,
+                mostro_core::error::MostroError::MostroCantDo(CantDoReason::InvalidTextMessage)
+            );
+        }
+    }
+
+    #[test]
+    fn parse_solver_payload_rejects_empty_npub_with_permission() {
+        let err = parse_solver_payload(&Payload::TextMessage(":read".to_string())).unwrap_err();
+        assert_eq!(
+            err,
+            mostro_core::error::MostroError::MostroCantDo(CantDoReason::InvalidTextMessage)
+        );
+    }
+
+    #[test]
+    fn parse_solver_payload_rejects_extra_tokens() {
+        let err = parse_solver_payload(&Payload::TextMessage("npub1test:read:extra".to_string()))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            mostro_core::error::MostroError::MostroCantDo(CantDoReason::InvalidParameters)
+        );
+    }
+
+    mod action {
+        use super::super::admin_add_solver_action;
+        use super::{SOLVER_CATEGORY_READ_ONLY, SOLVER_CATEGORY_READ_WRITE};
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        use crate::app::context::AppContext;
+        use crate::db::is_user_present;
+        use mostro_core::prelude::*;
+        use nostr_sdk::prelude::*;
+        use sqlx::SqlitePool;
+        use std::sync::Arc;
+
+        async fn create_test_pool() -> SqlitePool {
+            let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+            sqlx::migrate!().run(&pool).await.unwrap();
+            pool
+        }
+
+        fn build_ctx(pool: &SqlitePool) -> AppContext {
+            // send_dm reads the global config (event expiration); seed it
+            // once, ignoring the error when another test already did.
+            let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+            TestContextBuilder::new()
+                .with_pool(Arc::new(pool.clone()))
+                .with_settings(test_settings())
+                .build()
+        }
+
+        fn add_solver_msg(payload: Option<Payload>) -> Message {
+            Message::new_dispute(None, Some(1), None, Action::AdminAddSolver, payload)
+        }
+
+        /// Event whose identity is `identity` — the handler only accepts the
+        /// admin's own identity key.
+        fn create_event(identity: PublicKey) -> UnwrappedMessage {
+            UnwrappedMessage {
+                message: add_solver_msg(None),
+                signature: None,
+                sender: identity,
+                identity,
+                created_at: Timestamp::now(),
+            }
+        }
+
+        #[tokio::test]
+        async fn rejects_message_without_payload() {
+            let pool = create_test_pool().await;
+            let ctx = build_ctx(&pool);
+            let my_keys = Keys::generate();
+            let event = create_event(my_keys.public_key());
+
+            let result =
+                admin_add_solver_action(&ctx, add_solver_msg(None), &event, &my_keys).await;
+
+            assert!(matches!(
+                result,
+                Err(MostroCantDo(CantDoReason::InvalidTextMessage))
+            ));
+        }
+
+        #[tokio::test]
+        async fn rejects_non_admin_identity() {
+            let pool = create_test_pool().await;
+            let ctx = build_ctx(&pool);
+            let my_keys = Keys::generate();
+            // Identity does NOT match my_keys
+            let event = create_event(Keys::generate().public_key());
+            let npub = Keys::generate().public_key().to_bech32().unwrap();
+            let msg = add_solver_msg(Some(Payload::TextMessage(npub)));
+
+            let result = admin_add_solver_action(&ctx, msg, &event, &my_keys).await;
+
+            assert!(matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::InvalidPubkey))
+            ));
+        }
+
+        #[tokio::test]
+        async fn rejects_invalid_npub_string() {
+            let pool = create_test_pool().await;
+            let ctx = build_ctx(&pool);
+            let my_keys = Keys::generate();
+            let event = create_event(my_keys.public_key());
+            let msg = add_solver_msg(Some(Payload::TextMessage("not-an-npub".to_string())));
+
+            let result = admin_add_solver_action(&ctx, msg, &event, &my_keys).await;
+
+            assert!(matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::InvalidPubkey))
+            ));
+        }
+
+        /// Happy path: solver is inserted with the parsed category and the
+        /// confirmation DM succeeds offline (no global Nostr client set).
+        #[tokio::test]
+        async fn adds_solver_with_read_only_category() {
+            let pool = create_test_pool().await;
+            let ctx = build_ctx(&pool);
+            let my_keys = Keys::generate();
+            let event = create_event(my_keys.public_key());
+            let solver_pubkey = Keys::generate().public_key();
+            let npub = solver_pubkey.to_bech32().unwrap();
+            let msg = add_solver_msg(Some(Payload::TextMessage(format!("{npub}:read"))));
+
+            let result = admin_add_solver_action(&ctx, msg, &event, &my_keys).await;
+
+            assert!(result.is_ok());
+            let user = is_user_present(&pool, solver_pubkey.to_string())
+                .await
+                .unwrap();
+            assert_eq!(user.is_solver, 1);
+            assert_eq!(user.category, SOLVER_CATEGORY_READ_ONLY);
+        }
+
+        #[tokio::test]
+        async fn adds_solver_with_default_read_write_category() {
+            let pool = create_test_pool().await;
+            let ctx = build_ctx(&pool);
+            let my_keys = Keys::generate();
+            let event = create_event(my_keys.public_key());
+            let solver_pubkey = Keys::generate().public_key();
+            let npub = solver_pubkey.to_bech32().unwrap();
+            let msg = add_solver_msg(Some(Payload::TextMessage(npub)));
+
+            let result = admin_add_solver_action(&ctx, msg, &event, &my_keys).await;
+
+            assert!(result.is_ok());
+            let user = is_user_present(&pool, solver_pubkey.to_string())
+                .await
+                .unwrap();
+            assert_eq!(user.category, SOLVER_CATEGORY_READ_WRITE);
+        }
+
+        #[tokio::test]
+        async fn rejects_duplicate_solver_insert() {
+            let pool = create_test_pool().await;
+            let ctx = build_ctx(&pool);
+            let my_keys = Keys::generate();
+            let event = create_event(my_keys.public_key());
+            let npub = Keys::generate().public_key().to_bech32().unwrap();
+
+            let first = admin_add_solver_action(
+                &ctx,
+                add_solver_msg(Some(Payload::TextMessage(npub.clone()))),
+                &event,
+                &my_keys,
+            )
+            .await;
+            assert!(first.is_ok());
+
+            let second = admin_add_solver_action(
+                &ctx,
+                add_solver_msg(Some(Payload::TextMessage(npub))),
+                &event,
+                &my_keys,
+            )
+            .await;
+
+            assert!(matches!(
+                second,
+                Err(MostroInternalErr(ServiceError::DbAccessError(_)))
+            ));
+        }
+    }
 }

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -263,3 +263,380 @@ pub async fn admin_cancel_action(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use crate::lightning::LndConnector;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+
+    async fn setup_pool() -> Arc<SqlitePool> {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+        sqlx::migrate!("./migrations")
+            .run(pool.as_ref())
+            .await
+            .unwrap();
+        pool
+    }
+
+    fn build_ctx(pool: Arc<SqlitePool>) -> AppContext {
+        let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+        TestContextBuilder::new()
+            .with_pool(pool)
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// Real `LndConnector` against a dead endpoint: `connect` is lazy so it
+    /// always builds; every RPC fails fast. Required because the handler
+    /// takes `&mut LndConnector` even on paths that return before any LND
+    /// call.
+    async fn dead_lnd() -> LndConnector {
+        let dir = std::env::temp_dir().join(format!("mostro-test-lnd-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cert = dir.join("tls.cert");
+        let mac = dir.join("admin.macaroon");
+        std::fs::write(&cert, b"").unwrap();
+        std::fs::write(&mac, [1u8, 2u8]).unwrap();
+        let client = fedimint_tonic_lnd::connect(
+            "https://127.0.0.1:1".to_string(),
+            cert.to_str().unwrap().to_string(),
+            mac.to_str().unwrap().to_string(),
+        )
+        .await
+        .expect("lazy connect never dials");
+        LndConnector { client }
+    }
+
+    fn admin_event(identity: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::new_order(None, Some(1), None, Action::AdminCancel, None),
+            signature: None,
+            sender: Keys::generate().public_key(),
+            identity,
+            created_at: Timestamp::now(),
+        }
+    }
+
+    fn dispute_order(seller: PublicKey, buyer: PublicKey) -> Order {
+        Order {
+            id: uuid::Uuid::new_v4(),
+            status: Status::Dispute.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: seller.to_string(),
+            seller_pubkey: Some(seller.to_string()),
+            buyer_pubkey: Some(buyer.to_string()),
+            amount: 21_000,
+            fee: 210,
+            ..Default::default()
+        }
+    }
+
+    async fn assign_solver(pool: &SqlitePool, order_id: uuid::Uuid, solver: &PublicKey) {
+        let mut dispute = Dispute::new(order_id, Status::Dispute.to_string());
+        dispute.status = DisputeStatus::InProgress.to_string();
+        dispute.solver_pubkey = Some(solver.to_string());
+        dispute.create(pool).await.unwrap();
+    }
+
+    fn cancel_msg(order_id: uuid::Uuid) -> Message {
+        Message::new_order(Some(order_id), Some(1), None, Action::AdminCancel, None)
+    }
+
+    async fn queued_actions_for(destination: PublicKey) -> Vec<Action> {
+        crate::config::MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(_, pk)| *pk == destination)
+            .map(|(m, _)| m.get_inner_message_kind().action.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn fails_when_order_missing() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool);
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(uuid::Uuid::new_v4()),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+    }
+
+    #[tokio::test]
+    async fn rejects_caller_not_assigned_and_no_admin_takeover() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(Keys::generate().public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::IsNotYourDispute))
+        ));
+    }
+
+    #[tokio::test]
+    async fn reports_admin_takeover_when_dispute_in_progress_with_admin() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(Keys::generate().public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::DisputeTakenByAdmin))
+        ));
+    }
+
+    #[tokio::test]
+    async fn rejects_assigned_solver_without_write_permission() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let solver = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        assign_solver(ctx.pool(), order.id, &solver.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(solver.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::NotAuthorized))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cooperatively_cancelled_order_acknowledges_admin() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.status = Status::CooperativelyCanceled.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "coop-cancel must ack and return Ok: {result:?}"
+        );
+        assert!(queued_actions_for(admin.public_key())
+            .await
+            .contains(&Action::CooperativeCancelAccepted));
+    }
+
+    #[tokio::test]
+    async fn rejects_order_not_in_dispute() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.status = Status::Active.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+    }
+
+    /// A dispute order with no `hash` skips the LND cancel and, when
+    /// neither `seller_dispute` nor `buyer_dispute` is set, fails the
+    /// dispute-initiator resolution with `DisputeEventError`.
+    #[tokio::test]
+    async fn dispute_without_initiator_flag_errors() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        // hash is None, seller_dispute/buyer_dispute both false.
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DisputeEventError))
+        ));
+    }
+
+    /// A dispute order carrying a hold-invoice `hash` returns funds to the
+    /// seller via `cancel_hold_invoice`, which fails against the dead LND
+    /// endpoint and surfaces as `LnNodeError`.
+    #[tokio::test]
+    async fn dispute_with_hash_reaches_ln_cancel_seam() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.seller_dispute = true;
+        // Valid 32-byte hex hash so `cancel_hold_invoice` reaches the RPC
+        // (it panics on non-hex input) and then fails on the dead node.
+        order.hash = Some("11".repeat(32));
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::LnNodeError(_)))
+        ));
+    }
+
+    /// Full no-LND cancel path: a seller-initiated dispute with no hold
+    /// invoice hash. The dispute row is moved to `SellerRefunded` and the
+    /// order to `CanceledByAdmin` before the DM fan-out. Those DB writes are
+    /// deterministic; the terminal `send_dm` depends on the process-global
+    /// Nostr client, so the top-level result is not asserted.
+    #[tokio::test]
+    async fn seller_dispute_without_hash_refunds_and_cancels() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.seller_dispute = true;
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+        let dispute_id = find_dispute_by_order_id(ctx.pool(), order.id)
+            .await
+            .unwrap()
+            .id;
+
+        let _ = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        let stored_order = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(stored_order.status, Status::CanceledByAdmin.to_string());
+        let stored_dispute = Dispute::by_id(ctx.pool(), dispute_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stored_dispute.status,
+            DisputeStatus::SellerRefunded.to_string()
+        );
+    }
+}

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -258,6 +258,322 @@ pub async fn admin_settle_action(
 }
 
 #[cfg(test)]
+mod handler_tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use crate::lightning::LndConnector;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+
+    async fn setup_pool() -> Arc<SqlitePool> {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+        sqlx::migrate!("./migrations")
+            .run(pool.as_ref())
+            .await
+            .unwrap();
+        pool
+    }
+
+    fn build_ctx(pool: Arc<SqlitePool>) -> AppContext {
+        let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+        TestContextBuilder::new()
+            .with_pool(pool)
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// Real `LndConnector` against a dead endpoint: `connect` is lazy so it
+    /// always builds, but every RPC fails fast. Handlers take `&mut
+    /// LndConnector` by value, so tests must supply one even for paths that
+    /// return before any LND call.
+    async fn dead_lnd() -> LndConnector {
+        let dir = std::env::temp_dir().join(format!("mostro-test-lnd-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cert = dir.join("tls.cert");
+        let mac = dir.join("admin.macaroon");
+        std::fs::write(&cert, b"").unwrap();
+        std::fs::write(&mac, [1u8, 2u8]).unwrap();
+        let client = fedimint_tonic_lnd::connect(
+            "https://127.0.0.1:1".to_string(),
+            cert.to_str().unwrap().to_string(),
+            mac.to_str().unwrap().to_string(),
+        )
+        .await
+        .expect("lazy connect never dials");
+        LndConnector { client }
+    }
+
+    /// `event.identity` is the seal signer the admin-gating checks against;
+    /// `sender` is the trade key.
+    fn admin_event(identity: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::new_order(None, Some(1), None, Action::AdminSettle, None),
+            signature: None,
+            sender: Keys::generate().public_key(),
+            identity,
+            created_at: Timestamp::now(),
+        }
+    }
+
+    fn dispute_order(seller: PublicKey, buyer: PublicKey) -> Order {
+        Order {
+            id: uuid::Uuid::new_v4(),
+            status: Status::Dispute.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: seller.to_string(),
+            seller_pubkey: Some(seller.to_string()),
+            buyer_pubkey: Some(buyer.to_string()),
+            amount: 21_000,
+            fee: 210,
+            ..Default::default()
+        }
+    }
+
+    async fn assign_solver(pool: &SqlitePool, order_id: uuid::Uuid, solver: &PublicKey) {
+        // `Dispute::new` always starts in `Initiated`; the admin-takeover
+        // detection queries for `in-progress`, so set it explicitly.
+        let mut dispute = Dispute::new(order_id, Status::Dispute.to_string());
+        dispute.status = DisputeStatus::InProgress.to_string();
+        dispute.solver_pubkey = Some(solver.to_string());
+        dispute.create(pool).await.unwrap();
+    }
+
+    fn settle_msg(order_id: uuid::Uuid) -> Message {
+        Message::new_order(Some(order_id), Some(1), None, Action::AdminSettle, None)
+    }
+
+    async fn queued_actions_for(destination: PublicKey) -> Vec<Action> {
+        crate::config::MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(_, pk)| *pk == destination)
+            .map(|(m, _)| m.get_inner_message_kind().action.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn fails_when_order_missing() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool);
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(uuid::Uuid::new_v4()),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+    }
+
+    #[tokio::test]
+    async fn rejects_caller_not_assigned_and_no_admin_takeover() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+
+        // No dispute row → not assigned and not taken by admin.
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(Keys::generate().public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::IsNotYourDispute))
+        ));
+    }
+
+    #[tokio::test]
+    async fn reports_admin_takeover_when_dispute_in_progress_with_admin() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        // Dispute is in-progress and taken over by the admin (mostro) key.
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        // Caller is some unrelated solver key, not assigned.
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(Keys::generate().public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::DisputeTakenByAdmin))
+        ));
+    }
+
+    /// Caller is the assigned solver but is neither the admin key nor a
+    /// read-write solver user row → `ensure_dispute_finalize_permission`
+    /// rejects with `NotAuthorized`.
+    #[tokio::test]
+    async fn rejects_assigned_solver_without_write_permission() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let solver = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        assign_solver(ctx.pool(), order.id, &solver.public_key()).await;
+
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(solver.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::NotAuthorized))
+        ));
+    }
+
+    /// A cooperatively-cancelled order short-circuits: the admin (whose
+    /// identity == the mostro key, so the finalize-permission admin
+    /// shortcut applies) is acknowledged and the handler returns `Ok`
+    /// before any settle.
+    #[tokio::test]
+    async fn cooperatively_cancelled_order_acknowledges_admin() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.status = Status::CooperativelyCanceled.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+        // Admin identity is the assigned solver → finalize permission via
+        // the caller==admin shortcut.
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "coop-cancel must ack and return Ok: {result:?}"
+        );
+        assert!(queued_actions_for(admin.public_key())
+            .await
+            .contains(&Action::CooperativeCancelAccepted));
+    }
+
+    /// An order that is neither cooperatively-cancelled nor in dispute is
+    /// rejected by the status guard.
+    #[tokio::test]
+    async fn rejects_order_not_in_dispute() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.status = Status::Active.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidOrderStatus))
+        ));
+    }
+
+    /// A genuine dispute settle reaches `settle_seller_hold_invoice`, which
+    /// short-circuits on the missing preimage before any LND call and is
+    /// mapped to `LnNodeError`. The LND settle + `do_payment` tail beyond
+    /// this seam requires a live node and is covered by integration tests.
+    #[tokio::test]
+    async fn dispute_order_reaches_settle_seam() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.seller_dispute = true;
+        order.preimage = None; // settle short-circuits with InvalidInvoice
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::LnNodeError(_)))
+        ));
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use mostro_core::error::CantDoReason;
 

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -304,9 +304,11 @@ pub async fn admin_take_dispute_action(
 mod tests {
     use super::*;
     use crate::app::admin_add_solver::{SOLVER_CATEGORY_READ_ONLY, SOLVER_CATEGORY_READ_WRITE};
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
     use crate::db::add_new_user;
     use mostro_core::user::User;
     use sqlx::SqlitePool;
+    use std::sync::Arc;
 
     async fn create_test_pool() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
@@ -318,6 +320,543 @@ mod tests {
         add_new_user(pool, User::new(pubkey.to_string(), 0, 1, 0, category, 0))
             .await
             .unwrap();
+    }
+
+    fn build_ctx(pool: &SqlitePool) -> AppContext {
+        // The DM/publish path reads the global config (event expiration);
+        // seed it once, ignoring the error when another test already did.
+        let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+        TestContextBuilder::new()
+            .with_pool(Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// Build an `UnwrappedMessage` whose seal signer (`identity`) is
+    /// `identity` — `admin_take_dispute_action` gates on the identity key.
+    fn create_admin_event(identity: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::new_dispute(None, Some(1), None, Action::AdminTakeDispute, None),
+            signature: None,
+            sender: identity,
+            identity,
+            created_at: Timestamp::now(),
+        }
+    }
+
+    fn create_dispute_order(buyer: PublicKey, seller: PublicKey) -> Order {
+        Order {
+            id: uuid::Uuid::new_v4(),
+            status: Status::Dispute.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: seller.to_string(),
+            seller_pubkey: Some(seller.to_string()),
+            buyer_pubkey: Some(buyer.to_string()),
+            amount: 21_000,
+            ..Default::default()
+        }
+    }
+
+    fn take_dispute_msg(dispute_id: Option<uuid::Uuid>) -> Message {
+        Message::new_dispute(dispute_id, Some(1), None, Action::AdminTakeDispute, None)
+    }
+
+    // ------------------------------------------------------------------
+    // prepare_solver_info_message
+    // ------------------------------------------------------------------
+
+    /// Seller-initiated dispute where both parties are in full privacy mode
+    /// (no master pubkeys): no user rows are looked up and both privacy
+    /// flags stay set.
+    #[tokio::test]
+    async fn prepare_solver_info_message_seller_dispute_full_privacy() {
+        let pool = create_test_pool().await;
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let mut order = create_dispute_order(buyer, seller);
+        order.seller_dispute = true;
+        let dispute = Dispute::new(order.id, Status::Active.to_string());
+
+        let info = prepare_solver_info_message(&pool, &order, &dispute)
+            .await
+            .unwrap();
+
+        assert_eq!(info.initiator_pubkey, seller.to_string());
+        assert!(info.initiator_full_privacy);
+        assert!(info.counterpart_full_privacy);
+        assert!(info.initiator_info.is_none());
+        assert!(info.counterpart_info.is_none());
+    }
+
+    /// Buyer-initiated dispute where the buyer is an identified user
+    /// (master pubkey differs from trade pubkey and has a user row): the
+    /// initiator's reputation snapshot is included, the seller stays in
+    /// full privacy.
+    #[tokio::test]
+    async fn prepare_solver_info_message_buyer_dispute_with_identified_buyer() {
+        let pool = create_test_pool().await;
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+        let buyer_master = Keys::generate().public_key();
+
+        add_new_user(&pool, User::new(buyer_master.to_string(), 0, 0, 0, 0, 0))
+            .await
+            .unwrap();
+
+        let mut order = create_dispute_order(buyer, seller);
+        order.buyer_dispute = true;
+        order.master_buyer_pubkey = Some(buyer_master.to_string());
+        let dispute = Dispute::new(order.id, Status::Active.to_string());
+
+        let info = prepare_solver_info_message(&pool, &order, &dispute)
+            .await
+            .unwrap();
+
+        assert_eq!(info.initiator_pubkey, buyer.to_string());
+        assert!(!info.initiator_full_privacy);
+        assert!(info.initiator_info.is_some());
+        assert!(info.counterpart_full_privacy);
+        assert!(info.counterpart_info.is_none());
+    }
+
+    #[tokio::test]
+    async fn prepare_solver_info_message_without_dispute_flags_fails() {
+        let pool = create_test_pool().await;
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        // Neither seller_dispute nor buyer_dispute set
+        let order = create_dispute_order(buyer, seller);
+        let dispute = Dispute::new(order.id, Status::Active.to_string());
+
+        let result = prepare_solver_info_message(&pool, &order, &dispute).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DisputeEventError))
+        ));
+    }
+
+    /// A master pubkey that has no matching user row makes `is_user_present`
+    /// fail and the error must propagate.
+    #[tokio::test]
+    async fn prepare_solver_info_message_propagates_missing_user_row() {
+        let pool = create_test_pool().await;
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let mut order = create_dispute_order(buyer, seller);
+        order.seller_dispute = true;
+        order.master_seller_pubkey = Some(Keys::generate().public_key().to_string());
+        let dispute = Dispute::new(order.id, Status::Active.to_string());
+
+        let result = prepare_solver_info_message(&pool, &order, &dispute).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DbAccessError(_)))
+        ));
+    }
+
+    // ------------------------------------------------------------------
+    // pubkey_event_can_solve
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn mostro_admin_can_solve_initiated_and_inprogress_disputes() {
+        let pool = create_test_pool().await;
+        let mostro_keys = Keys::generate();
+
+        for status in [DisputeStatus::Initiated, DisputeStatus::InProgress] {
+            assert!(
+                pubkey_event_can_solve(
+                    &pool,
+                    &mostro_keys.public_key(),
+                    status,
+                    None,
+                    &mostro_keys
+                )
+                .await
+            );
+        }
+    }
+
+    /// The admin shortcut only applies to Initiated/InProgress; for any
+    /// other status the admin key falls through to the solver lookup and
+    /// fails because it has no user row.
+    #[tokio::test]
+    async fn mostro_admin_cannot_solve_settled_dispute() {
+        let pool = create_test_pool().await;
+        let mostro_keys = Keys::generate();
+
+        assert!(
+            !pubkey_event_can_solve(
+                &pool,
+                &mostro_keys.public_key(),
+                DisputeStatus::Settled,
+                None,
+                &mostro_keys,
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_pubkey_cannot_solve() {
+        let pool = create_test_pool().await;
+
+        assert!(
+            !pubkey_event_can_solve(
+                &pool,
+                &Keys::generate().public_key(),
+                DisputeStatus::Initiated,
+                None,
+                &Keys::generate(),
+            )
+            .await
+        );
+    }
+
+    /// A user row with `is_solver = 0` never comes back from
+    /// `find_solver_pubkey` (the query filters on `is_solver == true`), so
+    /// the sender is rejected.
+    #[tokio::test]
+    async fn non_solver_user_cannot_solve() {
+        let pool = create_test_pool().await;
+        let user_keys = Keys::generate();
+
+        add_new_user(
+            &pool,
+            User::new(user_keys.public_key().to_string(), 0, 0, 0, 0, 0),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !pubkey_event_can_solve(
+                &pool,
+                &user_keys.public_key(),
+                DisputeStatus::Initiated,
+                None,
+                &Keys::generate(),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn any_solver_can_take_initiated_dispute() {
+        let pool = create_test_pool().await;
+        let solver_keys = Keys::generate();
+        insert_solver(
+            &pool,
+            &solver_keys.public_key().to_string(),
+            SOLVER_CATEGORY_READ_ONLY,
+        )
+        .await;
+
+        assert!(
+            pubkey_event_can_solve(
+                &pool,
+                &solver_keys.public_key(),
+                DisputeStatus::Initiated,
+                None,
+                &Keys::generate(),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn solver_cannot_act_on_settled_dispute() {
+        let pool = create_test_pool().await;
+        let solver_keys = Keys::generate();
+        insert_solver(
+            &pool,
+            &solver_keys.public_key().to_string(),
+            SOLVER_CATEGORY_READ_WRITE,
+        )
+        .await;
+
+        assert!(
+            !pubkey_event_can_solve(
+                &pool,
+                &solver_keys.public_key(),
+                DisputeStatus::Settled,
+                None,
+                &Keys::generate(),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn solver_cannot_act_on_inprogress_dispute_without_assigned_solver() {
+        let pool = create_test_pool().await;
+        let solver_keys = Keys::generate();
+        insert_solver(
+            &pool,
+            &solver_keys.public_key().to_string(),
+            SOLVER_CATEGORY_READ_WRITE,
+        )
+        .await;
+
+        assert!(
+            !pubkey_event_can_solve(
+                &pool,
+                &solver_keys.public_key(),
+                DisputeStatus::InProgress,
+                None,
+                &Keys::generate(),
+            )
+            .await
+        );
+    }
+
+    #[tokio::test]
+    async fn currently_assigned_solver_can_continue_inprogress_dispute() {
+        let pool = create_test_pool().await;
+        let solver_keys = Keys::generate();
+        insert_solver(
+            &pool,
+            &solver_keys.public_key().to_string(),
+            SOLVER_CATEGORY_READ_ONLY,
+        )
+        .await;
+
+        let current = solver_keys.public_key().to_string();
+        assert!(
+            pubkey_event_can_solve(
+                &pool,
+                &solver_keys.public_key(),
+                DisputeStatus::InProgress,
+                Some(current.as_str()),
+                &Keys::generate(),
+            )
+            .await
+        );
+    }
+
+    /// Takeover requires the current solver to exist in the users table;
+    /// an unknown current solver blocks the takeover.
+    #[tokio::test]
+    async fn takeover_fails_when_current_solver_is_unknown() {
+        let pool = create_test_pool().await;
+        let write_keys = Keys::generate();
+        insert_solver(
+            &pool,
+            &write_keys.public_key().to_string(),
+            SOLVER_CATEGORY_READ_WRITE,
+        )
+        .await;
+
+        let ghost_solver = Keys::generate().public_key().to_string();
+        assert!(
+            !pubkey_event_can_solve(
+                &pool,
+                &write_keys.public_key(),
+                DisputeStatus::InProgress,
+                Some(ghost_solver.as_str()),
+                &Keys::generate(),
+            )
+            .await
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // admin_take_dispute_action
+    // ------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn admin_take_dispute_action_without_dispute_id_fails() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let mostro_keys = Keys::generate();
+        let event = create_admin_event(mostro_keys.public_key());
+
+        let result =
+            admin_take_dispute_action(&ctx, take_dispute_msg(None), &event, &mostro_keys).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidDisputeId))
+        ));
+    }
+
+    #[tokio::test]
+    async fn admin_take_dispute_action_with_unknown_dispute_id_fails() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let mostro_keys = Keys::generate();
+        let event = create_admin_event(mostro_keys.public_key());
+
+        let result = admin_take_dispute_action(
+            &ctx,
+            take_dispute_msg(Some(uuid::Uuid::new_v4())),
+            &event,
+            &mostro_keys,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidDisputeId))
+        ));
+    }
+
+    /// A dispute row whose status string cannot be parsed as a
+    /// `DisputeStatus` must be rejected with `InvalidDisputeId`.
+    #[tokio::test]
+    async fn admin_take_dispute_action_with_garbage_dispute_status_fails() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let mostro_keys = Keys::generate();
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_dispute_order(buyer, seller)
+            .create(&pool)
+            .await
+            .unwrap();
+        let mut dispute = Dispute::new(order.id, Status::Active.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+        dispute.status = "garbage-status".to_string();
+        dispute.clone().update(&pool).await.unwrap();
+
+        let event = create_admin_event(mostro_keys.public_key());
+        let result = admin_take_dispute_action(
+            &ctx,
+            take_dispute_msg(Some(dispute.id)),
+            &event,
+            &mostro_keys,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidDisputeId))
+        ));
+    }
+
+    #[tokio::test]
+    async fn admin_take_dispute_action_rejects_unauthorized_pubkey() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let mostro_keys = Keys::generate();
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_dispute_order(buyer, seller)
+            .create(&pool)
+            .await
+            .unwrap();
+        let dispute = Dispute::new(order.id, Status::Active.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        // Identity is neither the admin key nor a solver
+        let event = create_admin_event(Keys::generate().public_key());
+        let result = admin_take_dispute_action(
+            &ctx,
+            take_dispute_msg(Some(dispute.id)),
+            &event,
+            &mostro_keys,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+    }
+
+    #[tokio::test]
+    async fn admin_take_dispute_action_fails_when_order_is_missing() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let mostro_keys = Keys::generate();
+        let solver_keys = Keys::generate();
+        insert_solver(
+            &pool,
+            &solver_keys.public_key().to_string(),
+            SOLVER_CATEGORY_READ_WRITE,
+        )
+        .await;
+
+        // Dispute referencing an order id that has no order row
+        let dispute = Dispute::new(uuid::Uuid::new_v4(), Status::Active.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_admin_event(solver_keys.public_key());
+        let result = admin_take_dispute_action(
+            &ctx,
+            take_dispute_msg(Some(dispute.id)),
+            &event,
+            &mostro_keys,
+        )
+        .await;
+
+        assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+    }
+
+    /// Happy path up to the final Nostr publish: the dispute is assigned to
+    /// the solver and persisted, the solver info message is built and the
+    /// three DMs succeed offline; the last `send_event` fails because the
+    /// default client has no relays, so the function ends in `NostrError`.
+    /// The trailing `Ok(())` is unreachable in unit tests.
+    #[tokio::test]
+    async fn admin_take_dispute_action_assigns_solver_and_persists_dispute() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let mostro_keys = Keys::generate();
+        let solver_keys = Keys::generate();
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        insert_solver(
+            &pool,
+            &solver_keys.public_key().to_string(),
+            SOLVER_CATEGORY_READ_WRITE,
+        )
+        .await;
+
+        let mut order = create_dispute_order(buyer, seller);
+        order.buyer_dispute = true;
+        let order = order.create(&pool).await.unwrap();
+        let dispute = Dispute::new(order.id, Status::Active.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_admin_event(solver_keys.public_key());
+        let result = admin_take_dispute_action(
+            &ctx,
+            take_dispute_msg(Some(dispute.id)),
+            &event,
+            &mostro_keys,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::NostrError(_)))
+        ));
+
+        // All DB side effects happened before the failing publish
+        let stored = Dispute::by_id(&pool, dispute.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, DisputeStatus::InProgress.to_string());
+        assert_eq!(
+            stored.solver_pubkey,
+            Some(solver_keys.public_key().to_string())
+        );
+        assert!(stored.taken_at > 0);
     }
 
     #[tokio::test]

--- a/src/app/bond/db.rs
+++ b/src/app/bond/db.rs
@@ -359,6 +359,23 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_slice_slash_unique migration");
+        // Later ALTER-only migrations add columns `Order::by_id` SELECTs
+        // (dev_fee, cashu escrow). Apply each statement separately —
+        // sqlx::query treats the whole string as one statement.
+        for stmt in include_str!("../../../migrations/20251126120000_dev_fee.sql")
+            .split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && !s.lines().all(|l| l.trim_start().starts_with("--")))
+        {
+            sqlx::query(stmt).execute(&pool).await.expect("dev_fee");
+        }
+        for stmt in include_str!("../../../migrations/20260530120000_cashu_escrow_fields.sql")
+            .split(';')
+            .map(str::trim)
+            .filter(|s| !s.is_empty() && !s.lines().all(|l| l.trim_start().starts_with("--")))
+        {
+            sqlx::query(stmt).execute(&pool).await.expect("cashu");
+        }
         // SQLite doesn't enforce FKs unless asked. Turn them on so the FK to
         // `orders` is a real constraint in tests (mirrors production).
         sqlx::query("PRAGMA foreign_keys = ON")
@@ -886,5 +903,53 @@ mod tests {
             .await
             .unwrap();
         assert!(after_release.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_range_root_order_stops_at_missing_parent_row() {
+        // A dangling `range_parent_id` (parent row deleted / never
+        // created) must terminate the walk at the deepest order we could
+        // load instead of erroring — the caller still gets a usable
+        // "root" to resolve the maker bond against.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_parent_order(&pool, order_id).await;
+        let missing_parent = Uuid::new_v4(); // never inserted
+        sqlx::query("UPDATE orders SET range_parent_id = ? WHERE id = ?")
+            .bind(missing_parent)
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let order = Order::by_id(&pool, order_id).await.unwrap().unwrap();
+        let root = find_range_root_order(&pool, order).await.unwrap();
+        assert_eq!(
+            root.id, order_id,
+            "walk must stop at the deepest loadable order"
+        );
+    }
+
+    #[tokio::test]
+    async fn find_range_root_order_rejects_parent_cycle() {
+        // A self-referencing `range_parent_id` is a corrupted chain: the
+        // walk must terminate after MAX_RANGE_CHAIN_DEPTH hops with an
+        // explicit error instead of looping forever.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_parent_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET range_parent_id = ? WHERE id = ?")
+            .bind(order_id)
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let order = Order::by_id(&pool, order_id).await.unwrap().unwrap();
+        let err = find_range_root_order(&pool, order).await.unwrap_err();
+        assert!(
+            err.to_string().contains("max depth"),
+            "cycle must surface the max-depth error, got: {err}"
+        );
     }
 }

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -2024,4 +2024,1147 @@ mod tests {
             );
         }
     }
+
+    /// Initialize the process-wide settings so paths that reach
+    /// `Settings::get_ln()` / `Settings::get_nostr()` don't panic. The
+    /// `anti_abuse_bond` block stays `None`, matching every other test
+    /// init in the binary (the OnceCell is first-set-wins).
+    fn init_test_settings() {
+        use crate::config::MOSTRO_CONFIG;
+        let _ = MOSTRO_CONFIG.set(Settings {
+            database: Default::default(),
+            nostr: crate::config::NostrSettings {
+                // Valid canonical test nsec: whichever module wins the
+                // MOSTRO_CONFIG race must install a parseable key, or tests
+                // that reach get_keys() flake on init ordering.
+                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
+                    .to_string(),
+                relays: vec![],
+            },
+            mostro: Default::default(),
+            lightning: Default::default(),
+            rpc: Default::default(),
+            expiration: Some(Default::default()),
+            anti_abuse_bond: None,
+            cashu: None,
+            price: None,
+        });
+    }
+
+    async fn load_order(pool: &Pool<Sqlite>, id: Uuid) -> Order {
+        Order::by_id(pool, id).await.unwrap().unwrap()
+    }
+
+    /// Count queued messages for `order_id` with `action` in the global
+    /// message queue. Each test uses a fresh order id, so the count is
+    /// deterministic under parallel tests.
+    async fn count_msgs(order_id: Uuid, action: Action) -> usize {
+        use crate::config::MESSAGE_QUEUES;
+        MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(m, _)| {
+                let k = m.get_inner_message_kind();
+                k.id == Some(order_id) && k.action == action
+            })
+            .count()
+    }
+
+    #[tokio::test]
+    async fn request_taker_bond_errors_when_bond_config_missing() {
+        // The take handlers only call this when `taker_bond_required()`
+        // is true, but a raced config reload can leave the block absent:
+        // the function must fail loudly, not panic.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let order = load_order(&pool, order_id).await;
+
+        let ctx = TakerContext {
+            identity: "i".repeat(64),
+            trade_index: 1,
+            buyer_invoice: None,
+            fiat_amount: 10,
+            amount: 1_000,
+            fee: 1,
+            dev_fee: 0,
+        };
+        let taker = Keys::generate().public_key();
+        let result = request_taker_bond(&pool, &order, taker, None, ctx).await;
+        assert!(result.is_err(), "missing anti_abuse_bond block must error");
+        // And no bond row was persisted.
+        let active = find_active_bonds_for_order(&pool, order_id).await.unwrap();
+        assert!(active.is_empty());
+    }
+
+    #[tokio::test]
+    async fn request_maker_bond_errors_when_bond_config_missing() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let order = load_order(&pool, order_id).await;
+
+        let maker = Keys::generate().public_key();
+        let result = request_maker_bond(&pool, &order, maker, 100_000, None, Some(1)).await;
+        assert!(result.is_err(), "missing anti_abuse_bond block must error");
+        let active = find_active_bonds_for_order(&pool, order_id).await.unwrap();
+        assert!(active.is_empty());
+    }
+
+    #[tokio::test]
+    async fn release_bond_with_unparseable_state_errors() {
+        // A malformed `state` column must short-circuit with an error
+        // instead of transitioning the row.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let mut bond = make_bond(order_id, BondState::Requested);
+        bond.state = "definitely-not-a-state".to_string();
+        let err = release_bond(&pool, &bond).await.unwrap_err();
+        assert!(!err.to_string().is_empty());
+    }
+
+    #[tokio::test]
+    async fn release_bond_with_hash_stays_active_when_lnd_unreachable() {
+        // Safety contract: a transient LND failure (unreachable node in
+        // this harness) must leave the bond in its active state and
+        // propagate the error — never mark Released while the HTLC may
+        // still be encumbered.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let bond = create_bond(&pool, make_bond(order_id, BondState::Requested))
+            .await
+            .unwrap();
+
+        let result = release_bond(&pool, &bond).await;
+        assert!(result.is_err(), "transient LND failure must propagate");
+
+        let after = find_bond_by_hash(&pool, &"c".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            after.state,
+            BondState::Requested.to_string(),
+            "bond must stay active for a later retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn release_bonds_for_order_swallows_per_bond_failures() {
+        // The order-level helper warns and continues on individual bond
+        // failures; the call itself succeeds.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        create_bond(&pool, make_bond(order_id, BondState::Requested))
+            .await
+            .unwrap();
+
+        release_bonds_for_order(&pool, order_id).await.unwrap();
+
+        // The bond is still active (LND unreachable → left for retry).
+        let active = find_active_bonds_for_order(&pool, order_id).await.unwrap();
+        assert_eq!(active.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn release_bonds_for_order_or_warn_never_propagates() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        create_bond(&pool, make_bond(order_id, BondState::Requested))
+            .await
+            .unwrap();
+
+        // Must not panic or propagate despite the unreachable LND.
+        release_bonds_for_order_or_warn(&pool, order_id, "unit_test").await;
+    }
+
+    #[tokio::test]
+    async fn release_taker_bonds_retains_locked_maker_bond() {
+        // Waiting-timeout republish path: the maker's Locked bond stays
+        // put; only the taker side is released.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.state = BondState::Locked.to_string();
+        maker.hash = Some("d".repeat(64));
+        create_bond(&pool, maker).await.unwrap();
+
+        // Hashless taker bond → release succeeds without LND.
+        let mut taker = make_bond(order_id, BondState::Requested);
+        taker.pubkey = "t".repeat(64);
+        taker.hash = None;
+        create_bond(&pool, taker).await.unwrap();
+
+        release_taker_bonds_for_order_or_warn(&pool, order_id, "unit_test").await;
+
+        let active = find_active_bonds_for_order(&pool, order_id).await.unwrap();
+        assert_eq!(active.len(), 1, "only the maker bond may remain");
+        assert_eq!(active[0].role, BondRole::Maker.to_string());
+        assert_eq!(active[0].state, BondState::Locked.to_string());
+    }
+
+    #[tokio::test]
+    async fn bond_invoice_subscribe_errors_when_lnd_unreachable() {
+        init_test_settings();
+        let result = bond_invoice_subscribe(vec![0u8; 32], None).await;
+        assert!(result.is_err(), "no LND in the unit-test harness");
+    }
+
+    #[tokio::test]
+    async fn resubscribe_active_bonds_survives_bad_hash_and_no_lnd() {
+        // One malformed hash (hex decode fails → warn) and one valid
+        // hash (subscribe fails on unreachable LND → warn). The restart
+        // hook must swallow both and return Ok.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut malformed = make_bond(order_id, BondState::Requested);
+        malformed.pubkey = "a".repeat(64);
+        malformed.hash = Some("zz-not-hex".to_string());
+        create_bond(&pool, malformed).await.unwrap();
+
+        let mut valid = make_bond(order_id, BondState::Locked);
+        valid.pubkey = "b".repeat(64);
+        valid.hash = Some("ab".repeat(32));
+        create_bond(&pool, valid).await.unwrap();
+
+        let arc_pool = Arc::new(pool);
+        resubscribe_active_bonds(&arc_pool).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_ignores_unknown_hash() {
+        let pool = setup_pool().await;
+        on_bond_invoice_accepted(&"9".repeat(64), &pool, None)
+            .await
+            .expect("unknown hash is a warn-and-return");
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_race_loser_is_notified_and_left_for_retry() {
+        // Bond B fires `Accepted` after bond A already locked. B loses
+        // the CAS, is not Locked on re-read, and gets the loser
+        // treatment: release attempt (fails here: unreachable LND, so
+        // the row stays Requested for a later retry) + `Canceled`
+        // notification to its taker.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut a = make_bond(order_id, BondState::Locked);
+        a.pubkey = "a".repeat(64);
+        a.hash = Some("a".repeat(64));
+        create_bond(&pool, a).await.unwrap();
+
+        let mut b = make_bond(order_id, BondState::Requested);
+        b.pubkey = Keys::generate().public_key().to_string();
+        b.hash = Some("b".repeat(64));
+        create_bond(&pool, b).await.unwrap();
+
+        let before = count_msgs(order_id, Action::Canceled).await;
+        on_bond_invoice_accepted(&"b".repeat(64), &pool, None)
+            .await
+            .expect("loser path returns Ok");
+        let after = count_msgs(order_id, Action::Canceled).await;
+        assert_eq!(after - before, 1, "loser taker must be messaged Canceled");
+
+        let b_after = find_bond_by_hash(&pool, &"b".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            b_after.state,
+            BondState::Requested.to_string(),
+            "release failed transiently (no LND) → left active for retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_terminal_loser_skips_release() {
+        // A loser whose row is already terminal (Released) must not be
+        // re-released; it is only notified.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut a = make_bond(order_id, BondState::Locked);
+        a.pubkey = "a".repeat(64);
+        a.hash = Some("a".repeat(64));
+        create_bond(&pool, a).await.unwrap();
+
+        let mut b = make_bond(order_id, BondState::Released);
+        b.pubkey = Keys::generate().public_key().to_string();
+        b.hash = Some("b".repeat(64));
+        create_bond(&pool, b).await.unwrap();
+
+        let before = count_msgs(order_id, Action::Canceled).await;
+        on_bond_invoice_accepted(&"b".repeat(64), &pool, None)
+            .await
+            .expect("terminal loser path returns Ok");
+        let after = count_msgs(order_id, Action::Canceled).await;
+        assert_eq!(after - before, 1);
+
+        let b_after = find_bond_by_hash(&pool, &"b".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(b_after.state, BondState::Released.to_string());
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_winner_tears_down_requested_siblings() {
+        // The winner's CAS lands; every other still-Requested bond on
+        // the order is released (hashless here, so no LND involved) and
+        // its taker messaged Canceled. The resume then fails in this
+        // harness (no LND/keys), but the winner's Locked state and the
+        // promoted taker context must already be durable.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let winner_pk = Keys::generate().public_key().to_string();
+        let mut w = make_bond(order_id, BondState::Requested);
+        w.pubkey = winner_pk.clone();
+        w.hash = Some("a".repeat(64));
+        w.taker_identity = Some("i".repeat(64));
+        w.taker_trade_index = Some(7);
+        w.taker_fiat_amount = Some(42);
+        w.taker_amount = Some(2_000);
+        w.taker_fee = Some(3);
+        w.taker_dev_fee = Some(1);
+        create_bond(&pool, w).await.unwrap();
+
+        let mut s = make_bond(order_id, BondState::Requested);
+        s.pubkey = Keys::generate().public_key().to_string();
+        s.hash = None; // hashless → release succeeds without LND
+        create_bond(&pool, s).await.unwrap();
+
+        let before = count_msgs(order_id, Action::Canceled).await;
+        let result = on_bond_invoice_accepted(&"a".repeat(64), &pool, None).await;
+        assert!(
+            result.is_err(),
+            "resume must fail in the unit harness (no LND / nostr keys)"
+        );
+        let after = count_msgs(order_id, Action::Canceled).await;
+        assert_eq!(after - before, 1, "losing sibling must be notified");
+
+        // Winner locked; sibling released.
+        let w_after = find_bond_by_hash(&pool, &"a".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(w_after.state, BondState::Locked.to_string());
+        let active = find_active_bonds_for_order(&pool, order_id).await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].id, w_after.id);
+
+        // Taker context was promoted onto the order (buy order → seller
+        // side) before the resume attempt.
+        let order = load_order(&pool, order_id).await;
+        assert_eq!(order.seller_pubkey.as_deref(), Some(winner_pk.as_str()));
+        assert_eq!(
+            order.master_seller_pubkey.as_deref(),
+            Some(&*"i".repeat(64))
+        );
+        assert_eq!(order.trade_index_seller, Some(7));
+        assert_eq!(order.fiat_amount, 42);
+        assert_eq!(order.amount, 2_000);
+        assert_eq!(order.fee, 3);
+        assert_eq!(order.dev_fee, 1);
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_skips_resume_when_order_moved_on() {
+        // Winner locks, but the order already advanced past the
+        // pre-trade states (e.g. maker cancel) → no resume, Ok.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = 'canceled' WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut w = make_bond(order_id, BondState::Requested);
+        w.pubkey = "w".repeat(64);
+        w.hash = Some("a".repeat(64));
+        create_bond(&pool, w).await.unwrap();
+
+        on_bond_invoice_accepted(&"a".repeat(64), &pool, None)
+            .await
+            .expect("moved-on order must skip resume with Ok");
+
+        let w_after = find_bond_by_hash(&pool, &"a".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(w_after.state, BondState::Locked.to_string());
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_errors_on_missing_order_row() {
+        // Bond exists but its order row vanished — an invariant
+        // violation surfaced as an error, not a panic.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let mut w = make_bond(order_id, BondState::Requested);
+        w.hash = Some("a".repeat(64));
+        create_bond(&pool, w).await.unwrap();
+
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM orders WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let result = on_bond_invoice_accepted(&"a".repeat(64), &pool, None).await;
+        assert!(result.is_err(), "missing order row must error");
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_skips_bond_with_unparseable_state() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let mut b = make_bond(order_id, BondState::Requested);
+        b.state = "garbage-state".to_string();
+        b.hash = Some("a".repeat(64));
+        create_bond(&pool, b).await.unwrap();
+
+        on_bond_invoice_accepted(&"a".repeat(64), &pool, None)
+            .await
+            .expect("unparseable state is warn-and-return");
+    }
+
+    #[tokio::test]
+    async fn maker_accepted_locks_and_skips_publish_when_not_waiting() {
+        // A maker bond firing Accepted while the order is NOT parked at
+        // WaitingMakerBond (already published) locks the row and skips
+        // the publish idempotently.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await; // status 'pending'
+
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.hash = Some("e".repeat(64));
+        create_bond(&pool, maker).await.unwrap();
+
+        on_bond_invoice_accepted(&"e".repeat(64), &pool, None)
+            .await
+            .expect("published order → skip publish, Ok");
+
+        let after = find_bond_by_hash(&pool, &"e".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.state, BondState::Locked.to_string());
+    }
+
+    #[tokio::test]
+    async fn maker_accepted_skips_when_bond_no_longer_locked() {
+        // Duplicate firing after the bond was already released (order
+        // expired): re-read sees a terminal state and skips.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.state = BondState::Released.to_string();
+        maker.hash = Some("e".repeat(64));
+        create_bond(&pool, maker).await.unwrap();
+
+        on_bond_invoice_accepted(&"e".repeat(64), &pool, None)
+            .await
+            .expect("released maker bond → skip, Ok");
+
+        let after = find_bond_by_hash(&pool, &"e".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.state, BondState::Released.to_string());
+    }
+
+    #[tokio::test]
+    async fn maker_accepted_skips_unparseable_state() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.state = "garbage-state".to_string();
+        maker.hash = Some("e".repeat(64));
+        create_bond(&pool, maker).await.unwrap();
+
+        on_bond_invoice_accepted(&"e".repeat(64), &pool, None)
+            .await
+            .expect("unparseable maker state is warn-and-return");
+    }
+
+    #[tokio::test]
+    async fn maker_accepted_attempts_resume_when_order_waiting_maker_bond() {
+        // Order parked at WaitingMakerBond: the callback locks the bond
+        // and attempts the deferred publication. In this harness the
+        // publication path cannot complete meaningfully; the load-bearing
+        // assertion is the durable Requested → Locked transition.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = ? WHERE id = ?")
+            .bind(Status::WaitingMakerBond.to_string())
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.hash = Some("e".repeat(64));
+        create_bond(&pool, maker).await.unwrap();
+
+        // Result depends on which settings init won the process-wide
+        // race (keys may or may not parse); the durable state must not.
+        let _ = on_bond_invoice_accepted(&"e".repeat(64), &pool, None).await;
+
+        let after = find_bond_by_hash(&pool, &"e".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.state, BondState::Locked.to_string());
+    }
+
+    #[tokio::test]
+    async fn canceled_callback_ignores_unknown_hash() {
+        let pool = setup_pool().await;
+        on_bond_invoice_canceled(&"9".repeat(64), &pool)
+            .await
+            .expect("unknown hash is a no-op");
+    }
+
+    #[tokio::test]
+    async fn canceled_callback_noop_for_terminal_bond() {
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let mut b = make_bond(order_id, BondState::Slashed);
+        b.hash = Some("a".repeat(64));
+        let created = create_bond(&pool, b).await.unwrap();
+
+        on_bond_invoice_canceled(&"a".repeat(64), &pool)
+            .await
+            .expect("terminal bond is a no-op");
+
+        let after = find_bond_by_hash(&pool, &"a".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.state, BondState::Slashed.to_string());
+        assert_eq!(after.released_at, created.released_at);
+    }
+
+    #[tokio::test]
+    async fn canceled_callback_releases_last_bond_and_drops_to_pending() {
+        // The last active taker bond is canceled by LND: the row flips
+        // to Released and the order drops WaitingTakerBond → Pending.
+        // The NIP-33 republish is best-effort and must not affect the
+        // durable transitions in this harness.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = ? WHERE id = ?")
+            .bind(Status::WaitingTakerBond.to_string())
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut b = make_bond(order_id, BondState::Requested);
+        b.hash = Some("a".repeat(64));
+        create_bond(&pool, b).await.unwrap();
+
+        on_bond_invoice_canceled(&"a".repeat(64), &pool)
+            .await
+            .expect("cancel path returns Ok");
+
+        let after = find_bond_by_hash(&pool, &"a".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(after.state, BondState::Released.to_string());
+        assert!(after.released_at.is_some());
+
+        let order = load_order(&pool, order_id).await;
+        assert_eq!(order.status, Status::Pending.to_string());
+    }
+
+    #[tokio::test]
+    async fn promote_taker_context_buy_order_fills_seller_side() {
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await; // kind 'buy'
+        let order = load_order(&pool, order_id).await;
+
+        let mut bond = make_bond(order_id, BondState::Locked);
+        bond.pubkey = "s".repeat(64);
+        bond.taker_identity = Some("i".repeat(64));
+        bond.taker_trade_index = Some(3);
+        bond.taker_fiat_amount = Some(55);
+        bond.taker_amount = Some(4_000);
+        bond.taker_fee = Some(9);
+        bond.taker_dev_fee = Some(2);
+
+        let updated = promote_taker_context_to_order(&pool, order, &bond)
+            .await
+            .unwrap();
+        assert_eq!(updated.seller_pubkey.as_deref(), Some(&*"s".repeat(64)));
+        assert_eq!(
+            updated.master_seller_pubkey.as_deref(),
+            Some(&*"i".repeat(64))
+        );
+        assert_eq!(updated.trade_index_seller, Some(3));
+        assert_eq!(updated.fiat_amount, 55);
+        assert_eq!(updated.amount, 4_000);
+        assert_eq!(updated.fee, 9);
+        assert_eq!(updated.dev_fee, 2);
+        // Buyer side untouched on a buy order.
+        assert!(updated.buyer_pubkey.is_none());
+    }
+
+    #[tokio::test]
+    async fn promote_taker_context_sell_order_fills_buyer_side_and_invoice() {
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET kind = 'sell' WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let order = load_order(&pool, order_id).await;
+
+        let mut bond = make_bond(order_id, BondState::Locked);
+        bond.pubkey = "b".repeat(64);
+        bond.taker_identity = Some("i".repeat(64));
+        bond.taker_trade_index = Some(4);
+        bond.taker_invoice = Some("lnbc1pTEST".to_string());
+
+        let updated = promote_taker_context_to_order(&pool, order, &bond)
+            .await
+            .unwrap();
+        assert_eq!(updated.buyer_pubkey.as_deref(), Some(&*"b".repeat(64)));
+        assert_eq!(
+            updated.master_buyer_pubkey.as_deref(),
+            Some(&*"i".repeat(64))
+        );
+        assert_eq!(updated.trade_index_buyer, Some(4));
+        assert_eq!(updated.buyer_invoice.as_deref(), Some("lnbc1pTEST"));
+        assert!(updated.seller_pubkey.is_none());
+    }
+
+    #[tokio::test]
+    async fn resume_take_errors_on_bad_kind_and_missing_pubkeys() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let my_keys = Keys::generate();
+
+        // Unparseable order kind.
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let mut order = load_order(&pool, order_id).await;
+        order.kind = "bogus".to_string();
+        assert!(resume_take_after_bond(&pool, order, &my_keys, None)
+            .await
+            .is_err());
+
+        // Buy order without buyer pubkey.
+        let order = load_order(&pool, order_id).await;
+        assert!(order.buyer_pubkey.is_none());
+        assert!(resume_take_after_bond(&pool, order, &my_keys, None)
+            .await
+            .is_err());
+
+        // Buy order with buyer but no seller.
+        let mut order = load_order(&pool, order_id).await;
+        order.buyer_pubkey = Some(Keys::generate().public_key().to_string());
+        assert!(resume_take_after_bond(&pool, order, &my_keys, None)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn resume_take_buy_order_fails_at_hold_invoice_without_lnd() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        let mut order = load_order(&pool, order_id).await;
+        order.buyer_pubkey = Some(Keys::generate().public_key().to_string());
+        order.seller_pubkey = Some(Keys::generate().public_key().to_string());
+
+        let result = resume_take_after_bond(&pool, order, &Keys::generate(), None).await;
+        assert!(result.is_err(), "show_hold_invoice requires LND");
+    }
+
+    #[tokio::test]
+    async fn resume_take_sell_order_with_invoice_fails_without_lnd() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET kind = 'sell' WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let mut order = load_order(&pool, order_id).await;
+        order.buyer_pubkey = Some(Keys::generate().public_key().to_string());
+        order.seller_pubkey = Some(Keys::generate().public_key().to_string());
+        order.buyer_invoice = Some("lnbc1pWHATEVER".to_string());
+
+        let result = resume_take_after_bond(&pool, order, &Keys::generate(), None).await;
+        assert!(result.is_err(), "show_hold_invoice requires LND");
+    }
+
+    #[tokio::test]
+    async fn resume_take_sell_order_without_invoice_asks_buyer_for_one() {
+        // Sell take without a buyer invoice: the resume flips the order
+        // to WaitingBuyerInvoice, messages the buyer, and persists — no
+        // LND involved on this leg, so it completes end-to-end.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET kind = 'sell' WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let mut order = load_order(&pool, order_id).await;
+        let buyer = Keys::generate().public_key();
+        order.buyer_pubkey = Some(buyer.to_string());
+        order.seller_pubkey = Some(Keys::generate().public_key().to_string());
+
+        let before = count_msgs(order_id, Action::AddInvoice).await;
+        resume_take_after_bond(&pool, order, &Keys::generate(), None)
+            .await
+            .expect("waiting-buyer-invoice leg has no LND dependency");
+        let after = count_msgs(order_id, Action::AddInvoice).await;
+        assert_eq!(after - before, 1, "buyer must be asked for an invoice");
+
+        let persisted = load_order(&pool, order_id).await;
+        assert_eq!(persisted.status, Status::WaitingBuyerInvoice.to_string());
+    }
+
+    #[tokio::test]
+    async fn release_bonds_for_order_or_warn_swallows_db_error() {
+        // Force `release_bonds_for_order` itself to error (not just an
+        // individual bond release) by dropping the `bonds` table out
+        // from under `find_active_bonds_for_order`. The `_or_warn`
+        // wrapper must log and swallow it, never propagate or panic.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DROP TABLE bonds")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        release_bonds_for_order_or_warn(&pool, order_id, "unit_test").await;
+    }
+
+    #[tokio::test]
+    async fn release_taker_bonds_for_order_or_warn_swallows_db_error() {
+        // Same DB-error swallow contract for the retain-makers variant
+        // used by the waiting-timeout republish path.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DROP TABLE bonds")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        release_taker_bonds_for_order_or_warn(&pool, order_id, "unit_test").await;
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_noop_when_bond_vanishes_after_lock_cas() {
+        // Deterministic stand-in for the bond row disappearing between
+        // the Requested→Locked CAS and the immediately following
+        // re-read: a trigger deletes the row the instant it locks. The
+        // re-read then sees `None` and the callback must no-op rather
+        // than error.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        sqlx::query(
+            "CREATE TRIGGER vanish_after_lock AFTER UPDATE OF state ON bonds \
+             WHEN NEW.state = 'locked' \
+             BEGIN DELETE FROM bonds WHERE id = NEW.id; END",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut b = make_bond(order_id, BondState::Requested);
+        b.hash = Some("a".repeat(64));
+        create_bond(&pool, b).await.unwrap();
+
+        on_bond_invoice_accepted(&"a".repeat(64), &pool, None)
+            .await
+            .expect("bond vanishing after the lock CAS must no-op, not error");
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_warns_when_enumerating_losers_fails() {
+        // After winning the lock, the callback enumerates every other
+        // still-`Requested` bond on the order via
+        // `find_active_bonds_for_order` (a `SELECT *` multi-row fetch).
+        // Plant a sibling row whose `amount_sats` can't decode as `i64`
+        // (SQLite stores the literal as TEXT under INTEGER affinity
+        // since it isn't numeric) — `find_active_bonds_for_order` fails
+        // to decode it and errors, while `find_bond_by_hash` (single row
+        // keyed by a *different* hash) never touches it. This exercises
+        // the warn-and-continue-with-empty-vec branch without dropping
+        // the whole table (which would also break the winner's own
+        // lookups).
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut w = make_bond(order_id, BondState::Requested);
+        w.hash = Some("a".repeat(64));
+        create_bond(&pool, w).await.unwrap();
+
+        sqlx::query(
+            "INSERT INTO bonds (id, order_id, pubkey, role, amount_sats, state, created_at) \
+             VALUES (?, ?, ?, 'taker', 'not-a-number', 'requested', ?)",
+        )
+        .bind(Uuid::new_v4())
+        .bind(order_id)
+        .bind("z".repeat(64))
+        .bind(Utc::now().timestamp())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // The winner's own Locked transition and the resume attempt
+        // proceed regardless of the loser-enumeration failure; resume
+        // then fails in this harness (no LND/keys), so the overall call
+        // still errors — the load-bearing assertion is that the winner
+        // is durably Locked despite the enumeration error.
+        let _ = on_bond_invoice_accepted(&"a".repeat(64), &pool, None).await;
+
+        let w_after = find_bond_by_hash(&pool, &"a".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(w_after.state, BondState::Locked.to_string());
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_winner_warns_when_sibling_release_fails() {
+        // Unlike the hashless-sibling happy path exercised elsewhere, a
+        // losing sibling WITH a hash forces `release_bond` to hit LND
+        // (unreachable in this harness) and fail transiently. The
+        // tear-down loop must still notify the loser and keep going
+        // (warn, not propagate) instead of aborting the whole teardown.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut w = make_bond(order_id, BondState::Requested);
+        w.hash = Some("a".repeat(64));
+        create_bond(&pool, w).await.unwrap();
+
+        let mut s = make_bond(order_id, BondState::Requested);
+        s.pubkey = Keys::generate().public_key().to_string();
+        s.hash = Some("b".repeat(64));
+        create_bond(&pool, s).await.unwrap();
+
+        let before = count_msgs(order_id, Action::Canceled).await;
+        let _ = on_bond_invoice_accepted(&"a".repeat(64), &pool, None).await;
+        let after = count_msgs(order_id, Action::Canceled).await;
+        assert_eq!(
+            after - before,
+            1,
+            "sibling must still be notified despite the release failure"
+        );
+
+        let s_after = find_bond_by_hash(&pool, &"b".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            s_after.state,
+            BondState::Requested.to_string(),
+            "release failed transiently (no LND) → sibling stays active for retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepted_callback_skips_resume_when_bond_flips_away_from_locked_via_trigger() {
+        // Deterministic stand-in for the exceedingly narrow race where
+        // the winning CAS's own re-read observes a state that already
+        // moved past `Locked` (e.g. a same-tick release elsewhere). A
+        // trigger flips the row to `released` the instant it locks, so
+        // `result.rows_affected() == 1` (this statement won the CAS) but
+        // the re-read sees `current_state != Locked` — the tear-down
+        // loop still runs (no other siblings here), then the callback
+        // must bail out before attempting the resume.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        sqlx::query(
+            "CREATE TRIGGER flip_after_lock AFTER UPDATE OF state ON bonds \
+             WHEN NEW.state = 'locked' \
+             BEGIN UPDATE bonds SET state = 'released' WHERE id = NEW.id AND state = 'locked'; END",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut b = make_bond(order_id, BondState::Requested);
+        b.hash = Some("a".repeat(64));
+        create_bond(&pool, b).await.unwrap();
+
+        on_bond_invoice_accepted(&"a".repeat(64), &pool, None)
+            .await
+            .expect("post-lock state flip must bail out before resume, not error");
+
+        let after = find_bond_by_hash(&pool, &"a".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            after.state,
+            BondState::Released.to_string(),
+            "trigger-induced flip must be the durable end state"
+        );
+    }
+
+    #[tokio::test]
+    async fn maker_accepted_noop_when_bond_vanishes_after_lock_cas() {
+        // Maker-bond counterpart of the taker-side vanish-after-lock
+        // test: the row disappears between the plain `Requested→Locked`
+        // CAS and the immediately following re-read.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        sqlx::query(
+            "CREATE TRIGGER vanish_maker_after_lock AFTER UPDATE OF state ON bonds \
+             WHEN NEW.state = 'locked' \
+             BEGIN DELETE FROM bonds WHERE id = NEW.id; END",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.hash = Some("e".repeat(64));
+        create_bond(&pool, maker).await.unwrap();
+
+        on_bond_invoice_accepted(&"e".repeat(64), &pool, None)
+            .await
+            .expect("maker bond vanishing after the lock CAS must no-op, not error");
+    }
+
+    #[tokio::test]
+    async fn maker_accepted_errors_on_missing_order_row() {
+        // Maker-bond counterpart of
+        // `accepted_callback_errors_on_missing_order_row`: the bond row
+        // is durably Locked but its order vanished — an invariant
+        // violation that must surface as an error, not a panic.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+
+        let mut maker = Bond::new_requested(order_id, "m".repeat(64), BondRole::Maker, 1_000);
+        maker.hash = Some("e".repeat(64));
+        create_bond(&pool, maker).await.unwrap();
+
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM orders WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let result = on_bond_invoice_accepted(&"e".repeat(64), &pool, None).await;
+        assert!(result.is_err(), "missing order row must error (maker path)");
+    }
+
+    #[tokio::test]
+    async fn canceled_callback_swallows_maybe_drop_db_error() {
+        // Force `maybe_drop_waiting_taker_bond`'s status-flip UPDATE to
+        // fail by dropping the `orders` table out from under it (the
+        // bond row itself lives in `bonds`, untouched, so the release
+        // half of `on_bond_invoice_canceled` still completes). The
+        // failure must be warn-logged, not propagated: the bond release
+        // is the load-bearing invariant of this callback.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = ? WHERE id = ?")
+            .bind(Status::WaitingTakerBond.to_string())
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut b = make_bond(order_id, BondState::Requested);
+        b.hash = Some("a".repeat(64));
+        create_bond(&pool, b).await.unwrap();
+
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DROP TABLE orders")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        on_bond_invoice_canceled(&"a".repeat(64), &pool)
+            .await
+            .expect("db error dropping status back to Pending must not propagate");
+
+        let after = find_bond_by_hash(&pool, &"a".repeat(64))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            after.state,
+            BondState::Released.to_string(),
+            "bond release itself must remain durable despite the downstream DB error"
+        );
+    }
+
+    #[tokio::test]
+    async fn maybe_drop_waiting_taker_bond_noop_when_order_vanishes_after_transition() {
+        // Deterministic stand-in for the order row disappearing between
+        // the CAS that drops it to `Pending` and the subsequent re-read
+        // used to build the NIP-33 republish: a trigger deletes the row
+        // the instant it flips to `pending`.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = ? WHERE id = ?")
+            .bind(Status::WaitingTakerBond.to_string())
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "CREATE TRIGGER vanish_after_pending AFTER UPDATE OF status ON orders \
+             WHEN NEW.status = 'pending' \
+             BEGIN DELETE FROM orders WHERE id = NEW.id; END",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        maybe_drop_waiting_taker_bond(&pool, order_id)
+            .await
+            .expect("missing order after the drop-to-Pending CAS must no-op, not error");
+    }
+
+    #[tokio::test]
+    async fn maybe_drop_waiting_taker_bond_republishes_and_persists_event_id() {
+        // Full success path: the CAS wins, the fresh order carries a
+        // resolvable identity (`master_buyer_pubkey == buyer_pubkey`, so
+        // the reputation lookup's "no such user" fallback short-circuits
+        // to a default rating instead of erroring), and `NOSTR_CLIENT`
+        // being uninitialized in this harness is handled gracefully by
+        // `update_order_event` (it skips the send, doesn't error) — so
+        // the whole republish completes and the new `event_id` is
+        // persisted back onto the order row.
+        init_test_settings();
+        let pool = setup_pool().await;
+        // `get_ratings_for_pending_order` (reached via `update_order_event`
+        // for a `Pending` republish) reads the *global* DB pool, not the
+        // pool passed to this function. Best-effort install ours (a
+        // sibling test file may have already won this OnceCell with an
+        // unrelated pool — that's fine, `is_user_present` just needs to
+        // fail-not-found there too, which it will for our random pubkey).
+        let _ = crate::config::DB_POOL.set(Arc::new(pool.clone()));
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await; // kind 'buy'
+        let same_pubkey = Keys::generate().public_key().to_string();
+        sqlx::query(
+            "UPDATE orders SET status = ?, buyer_pubkey = ?, master_buyer_pubkey = ? WHERE id = ?",
+        )
+        .bind(Status::WaitingTakerBond.to_string())
+        .bind(&same_pubkey)
+        .bind(&same_pubkey)
+        .bind(order_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        maybe_drop_waiting_taker_bond(&pool, order_id)
+            .await
+            .expect("republish path must not propagate");
+
+        let order = load_order(&pool, order_id).await;
+        assert_eq!(order.status, Status::Pending.to_string());
+        assert!(
+            !order.event_id.is_empty(),
+            "event_id must be persisted after a successful republish"
+        );
+    }
 }

--- a/src/app/bond/math.rs
+++ b/src/app/bond/math.rs
@@ -145,6 +145,16 @@ mod tests {
     }
 
     #[test]
+    fn pct_component_that_rounds_to_zero_falls_back_to_base() {
+        // 0.4 * 1 = 0.4 → round → 0.0 hits the `pct_rounded <= 0.0`
+        // saturation arm; the result is then `max(base)`.
+        let cfg = cfg_with(0.4, 0);
+        assert_eq!(compute_bond_amount(1, &cfg), 0);
+        let cfg = cfg_with(0.4, 7);
+        assert_eq!(compute_bond_amount(1, &cfg), 7);
+    }
+
+    #[test]
     fn saturates_on_absurd_percentage() {
         let cfg = cfg_with(1e18, 0);
         // No overflow; clamps to i64::MAX. Not a realistic config but

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -1897,6 +1897,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn request_payout_invoice_proceeds_after_cadence_window_elapsed() {
+        // The counterpart of `respects_cadence_window`: `last_invoice_request_at`
+        // is `Some`, but old enough that `invoice_window_seconds` has already
+        // elapsed. Execution must fall through the inner `if` (not return
+        // early) and issue a fresh request exactly like the no-prior-request
+        // case — this is the branch the cadence guard's "not yet expired"
+        // twin never exercises.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let now = Utc::now().timestamp();
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            now,
+            None,
+            Some(now - 400), // 400s ago, past the 300s window
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let before = count_add_bond_invoice_msgs(order_id).await;
+        request_payout_invoice(&pool, &bond, 300).await.unwrap();
+        let after = count_add_bond_invoice_msgs(order_id).await;
+
+        let row: (i64, Option<i64>) = sqlx::query_as(
+            "SELECT invoice_request_attempts, last_invoice_request_at FROM bonds WHERE id = ?",
+        )
+        .bind(bond.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1);
+        assert!(row.1.is_some_and(|t| t >= now));
+        assert_eq!(after - before, 1);
+    }
+
+    #[tokio::test]
     async fn request_payout_invoice_skips_enqueue_when_state_moved_off_pending_payout() {
         // Persist-first guarantee: if the row's state moved out of
         // `PendingPayout` between the scheduler snapshot and the
@@ -2284,6 +2323,47 @@ mod tests {
         assert_eq!(after.0, BondState::Slashed.to_string());
     }
 
+    #[tokio::test]
+    async fn finalize_node_only_cas_miss_leaves_row_untouched() {
+        // If the row moved off `PendingPayout` between the scheduler's
+        // snapshot and this CAS (e.g. a concurrent operator transition),
+        // the `WHERE state = 'pending-payout'` predicate must miss and the
+        // function must leave the row exactly as it found it — no
+        // clobbering a state that already advanced under us.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            10_000, // node_share == amount → counterparty_share = 0
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+        sqlx::query("UPDATE bonds SET state = ? WHERE id = ?")
+            .bind(BondState::Forfeited.to_string())
+            .bind(bond.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        finalize_node_only(&pool, &bond).await.unwrap();
+
+        let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            after.0,
+            BondState::Forfeited.to_string(),
+            "CAS miss must not clobber the concurrently-moved state"
+        );
+    }
+
     // ── apply_payout_invoice / resurrection ───────────────────────────
 
     const CLAIM_WINDOW_SECONDS: i64 = 15 * 86_400;
@@ -2668,6 +2748,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn apply_payout_invoice_rejects_unparseable_bond_state() {
+        // Defensive guard at the very top of the helper: a row whose
+        // `state` column doesn't parse via `BondState::from_str` (should
+        // never happen — every writer uses the enum's `Display`) must be
+        // rejected before any SQL runs, not panic or fall into one of the
+        // named-state branches.
+        let pool = setup_pool().await;
+        let now = Utc::now().timestamp();
+        let mut bond =
+            pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, 5_000, now, None, None);
+        bond.state = "quantum-superposition".to_string();
+
+        let outcome = apply_payout_invoice(&pool, &bond, "lnbc1pFRESH", now, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+        assert_eq!(outcome, InvoiceApplyOutcome::Rejected);
+    }
+
+    #[tokio::test]
     async fn apply_payout_invoice_resurrection_clears_payout_payment_hash() {
         // Failed → PendingPayout resurrection must NULL out the
         // `payout_payment_hash` column so the reconciliation branch in
@@ -2928,5 +3027,1152 @@ mod tests {
             .unwrap();
         assert_eq!(state.0, BondState::Slashed.to_string());
         assert_eq!(after.len(), before); // no new notification
+    }
+
+    // ── LND-dependent paths, driven against a lazily-connected client ──
+
+    /// Initialize the process-wide settings (first-set-wins OnceCell;
+    /// every init in the binary uses the same defaults).
+    fn init_test_settings() {
+        use crate::config::MOSTRO_CONFIG;
+        let _ = crate::config::MOSTRO_CONFIG.set(crate::config::settings::Settings {
+            database: Default::default(),
+            nostr: crate::config::NostrSettings {
+                // Valid canonical test nsec: whichever module wins the
+                // MOSTRO_CONFIG race must install a parseable key, or tests
+                // that reach get_keys() flake on init ordering.
+                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
+                    .to_string(),
+                relays: vec![],
+            },
+            mostro: Default::default(),
+            lightning: Default::default(),
+            rpc: Default::default(),
+            expiration: Some(Default::default()),
+            anti_abuse_bond: None,
+            cashu: None,
+            price: None,
+        });
+        let _ = &MOSTRO_CONFIG;
+    }
+
+    /// Build a real `LndConnector` against a dead endpoint.
+    /// `fedimint_tonic_lnd::connect` is lazy (no TCP at build time), so
+    /// this always succeeds; every RPC then fails in ~1ms with a
+    /// transport error — exactly the "LND unreachable" shape the retry
+    /// and reconciliation branches are written for.
+    async fn dead_lnd() -> LndConnector {
+        let dir = std::env::temp_dir().join(format!("mostro-test-lnd-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cert = dir.join("tls.cert");
+        let mac = dir.join("admin.macaroon");
+        std::fs::write(&cert, b"").unwrap();
+        std::fs::write(&mac, [1u8, 2u8]).unwrap();
+        let client = fedimint_tonic_lnd::connect(
+            "https://127.0.0.1:1".to_string(),
+            cert.to_str().unwrap().to_string(),
+            mac.to_str().unwrap().to_string(),
+        )
+        .await
+        .expect("lazy connect never dials");
+        LndConnector { client }
+    }
+
+    /// Freshly-signed bolt11 for `amount_sats`, valid for one hour.
+    /// Signed with a throwaway key — decoding and amount/expiry
+    /// validation don't care whose key it is.
+    fn signed_test_invoice(amount_sats: u64) -> String {
+        use bitcoin::hashes::{sha256, Hash};
+        use bitcoin::secp256k1::{Secp256k1, SecretKey};
+        use lightning_invoice::{Currency, InvoiceBuilder, PaymentSecret};
+
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[42u8; 32]).unwrap();
+        let payment_hash = sha256::Hash::hash(&Uuid::new_v4().into_bytes());
+        InvoiceBuilder::new(Currency::Bitcoin)
+            .description("mostro payout test".into())
+            .payment_hash(payment_hash)
+            .payment_secret(PaymentSecret([7u8; 32]))
+            .amount_milli_satoshis(amount_sats * 1_000)
+            .current_timestamp()
+            .min_final_cltv_expiry_delta(18)
+            .expiry_time(std::time::Duration::from_secs(3_600))
+            .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &sk))
+            .expect("valid invoice")
+            .to_string()
+    }
+
+    #[test]
+    fn counterparty_share_missing_node_share_is_invariant_violation() {
+        let mut bond = pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, 0, 0, None, None);
+        bond.node_share_sats = None;
+        assert!(counterparty_share_sats(&bond).is_err());
+    }
+
+    #[test]
+    fn counterparty_share_out_of_range_node_share_is_rejected() {
+        let bond = pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, -1, 0, None, None);
+        assert!(counterparty_share_sats(&bond).is_err());
+        let bond = pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, 10_001, 0, None, None);
+        assert!(counterparty_share_sats(&bond).is_err());
+    }
+
+    #[tokio::test]
+    async fn child_blocked_when_parent_bond_row_missing() {
+        // Defensive arm: a child row whose parent bond id resolves to
+        // nothing must be skipped (treated as blocked), never driven.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let mut child = pending_payout_bond(order_id, maker_pk(), 400, 0, 0, None, None);
+        child.parent_bond_id = Some(Uuid::new_v4()); // dangling
+        child.child_order_id = Some(order_id);
+        let child = create_bond(&pool, child).await.unwrap();
+
+        assert!(child_payout_blocked_by_locked_parent(&pool, &child)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn run_cycle_no_pending_bonds_is_a_cheap_noop() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let mut ln = dead_lnd().await;
+        run_bond_payout_cycle(&pool, &mut ln).await;
+    }
+
+    #[tokio::test]
+    async fn run_cycle_survives_enumeration_failure() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        sqlx::query("DROP TABLE bonds")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let mut ln = dead_lnd().await;
+        // Must log-and-return, not panic or propagate.
+        run_bond_payout_cycle(&pool, &mut ln).await;
+    }
+
+    #[tokio::test]
+    async fn run_cycle_processes_rows_and_warns_on_bad_ones() {
+        // One row missing `slashed_at` (invariant violation → per-bond
+        // warn) and one node-only row (finalized to Slashed). The cycle
+        // must finish and leave each row in the right state.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+
+        let mut broken = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, 0, None, None);
+        broken.slashed_at = None;
+        let broken = create_bond(&pool, broken).await.unwrap();
+
+        let order2 = Uuid::new_v4();
+        insert_order(&pool, order2, maker_pk(), taker_pk()).await;
+        let node_only = pending_payout_bond(
+            order2,
+            taker_pk(),
+            10_000,
+            10_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        let node_only = create_bond(&pool, node_only).await.unwrap();
+
+        let mut ln = dead_lnd().await;
+        run_bond_payout_cycle(&pool, &mut ln).await;
+
+        let broken_after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(broken.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(broken_after.0, BondState::PendingPayout.to_string());
+        let node_after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(node_only.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(node_after.0, BondState::Slashed.to_string());
+    }
+
+    #[tokio::test]
+    async fn process_one_bond_skips_blocked_child_row() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+
+        let mut parent =
+            Bond::new_requested(order_id, maker_pk().to_string(), BondRole::Maker, 1_000);
+        parent.state = BondState::Locked.to_string();
+        let parent = create_bond(&pool, parent).await.unwrap();
+
+        let mut child = pending_payout_bond(order_id, maker_pk(), 400, 0, 0, None, None);
+        child.parent_bond_id = Some(parent.id);
+        child.child_order_id = Some(order_id);
+        let child = create_bond(&pool, child).await.unwrap();
+
+        let mut ln = dead_lnd().await;
+        process_one_bond(&pool, &mut ln, &child).await.unwrap();
+
+        let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(child.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.0, BondState::PendingPayout.to_string());
+    }
+
+    #[tokio::test]
+    async fn process_one_bond_forfeits_after_claim_window() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let slashed_at = Utc::now().timestamp() - (CLAIM_WINDOW_SECONDS + 86_400);
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, slashed_at, None, None);
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let mut ln = dead_lnd().await;
+        process_one_bond(&pool, &mut ln, &bond).await.unwrap();
+
+        let after: (String,) = sqlx::query_as("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.0, BondState::Forfeited.to_string());
+    }
+
+    #[tokio::test]
+    async fn process_one_bond_requests_invoice_when_none_submitted() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let before = count_add_bond_invoice_msgs(order_id).await;
+        let mut ln = dead_lnd().await;
+        process_one_bond(&pool, &mut ln, &bond).await.unwrap();
+        let after = count_add_bond_invoice_msgs(order_id).await;
+        assert_eq!(after - before, 1);
+    }
+
+    #[tokio::test]
+    async fn process_one_bond_pays_counterparty_when_invoice_present() {
+        // The other arm of `process_one_bond`'s `match bond.payout_invoice`:
+        // when an invoice is already on the row, it must route to
+        // `pay_counterparty` (not `request_payout_invoice`). Against
+        // `dead_lnd`, the send fails immediately (indeterminate), so the
+        // observable signature is `payout_attempts` bumped to 1 while the
+        // row stays `PendingPayout`.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let invoice = signed_test_invoice(5_000);
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some(&invoice),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let mut ln = dead_lnd().await;
+        process_one_bond(&pool, &mut ln, &bond).await.unwrap();
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.payout_attempts, 1);
+        assert_eq!(after.state, BondState::PendingPayout.to_string());
+    }
+
+    #[tokio::test]
+    async fn request_invoice_skips_when_order_row_missing() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM orders WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        request_payout_invoice(&pool, &bond, 300).await.unwrap();
+        // No cadence bump: the helper bailed before the CAS.
+        let row: (i64,) = sqlx::query_as("SELECT invoice_request_attempts FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(row.0, 0);
+    }
+
+    #[tokio::test]
+    async fn request_invoice_errors_on_unparseable_slash_reason() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        bond.slashed_reason = Some("cosmic-rays".to_string());
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        assert!(request_payout_invoice(&pool, &bond, 300).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn request_invoice_skips_when_recipient_unresolvable() {
+        // Order has no buyer pubkey → recipient resolution yields None →
+        // skip-and-retry-next-tick, not an error.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO orders (
+                id, kind, event_id, status, premium, payment_method,
+                amount, fiat_code, fiat_amount, created_at, expires_at,
+                seller_pubkey
+            ) VALUES (?, 'sell', ?, 'dispute', 0, 'cash', 100000, 'USD', 10, 0, 0, ?)"#,
+        )
+        .bind(order_id)
+        .bind(order_id.simple().to_string())
+        .bind(maker_pk())
+        .execute(&pool)
+        .await
+        .unwrap();
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let before = count_add_bond_invoice_msgs(order_id).await;
+        request_payout_invoice(&pool, &bond, 300).await.unwrap();
+        assert_eq!(count_add_bond_invoice_msgs(order_id).await, before);
+    }
+
+    #[tokio::test]
+    async fn request_invoice_errors_when_slashed_at_missing() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let mut bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, 0, None, None);
+        bond.slashed_at = None;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        assert!(request_payout_invoice(&pool, &bond, 300).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn pay_counterparty_undecodable_invoice_is_terminal_failure() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some("not-an-invoice"),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let mut ln = dead_lnd().await;
+        pay_counterparty(
+            &pool,
+            &mut ln,
+            &bond,
+            "not-an-invoice",
+            5,
+            CLAIM_WINDOW_SECONDS,
+        )
+        .await
+        .unwrap();
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.payout_attempts, 1, "terminal failure bumps attempts");
+        assert_eq!(after.state, BondState::PendingPayout.to_string());
+    }
+
+    #[tokio::test]
+    async fn pay_counterparty_fresh_send_persists_hash_then_fails_indeterminate() {
+        // The pre-send CAS must persist the routing-fee cap and the
+        // invoice's payment hash BEFORE send_payment; the dead endpoint
+        // then fails the send → indeterminate failure, attempts bumped,
+        // invoice + hash retained for reconciliation.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let invoice = signed_test_invoice(5_000);
+        let expected_hash =
+            bytes_to_string(decode_invoice(&invoice).unwrap().payment_hash().as_ref());
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some(&invoice),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let mut ln = dead_lnd().await;
+        pay_counterparty(&pool, &mut ln, &bond, &invoice, 5, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.payout_payment_hash.as_deref(), Some(&*expected_hash));
+        assert_eq!(
+            after.payout_routing_fee_sats,
+            Some(routing_fee_cap_sats(5_000))
+        );
+        assert_eq!(after.payout_attempts, 1);
+        assert_eq!(after.payout_invoice.as_deref(), Some(invoice.as_str()));
+        assert_eq!(after.state, BondState::PendingPayout.to_string());
+    }
+
+    #[tokio::test]
+    async fn pay_counterparty_reconcile_lookup_failure_falls_through_to_send() {
+        // A persisted hash matching the invoice triggers the entry
+        // reconciliation; with LND unreachable the lookup errors and the
+        // code must fall through to a fresh send attempt (which also
+        // fails → attempts bumped) instead of aborting.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let invoice = signed_test_invoice(5_000);
+        let hash = bytes_to_string(decode_invoice(&invoice).unwrap().payment_hash().as_ref());
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some(&invoice),
+            None,
+        );
+        bond.payout_payment_hash = Some(hash.clone());
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let mut ln = dead_lnd().await;
+        pay_counterparty(&pool, &mut ln, &bond, &invoice, 5, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.payout_attempts, 1);
+        assert_eq!(after.payout_payment_hash.as_deref(), Some(hash.as_str()));
+    }
+
+    #[tokio::test]
+    async fn pay_counterparty_skips_send_when_row_left_pending_payout() {
+        // Snapshot says PendingPayout but the DB row moved (Forfeited):
+        // the hash-persist CAS misses and the send must be skipped.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let invoice = signed_test_invoice(5_000);
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some(&invoice),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+        sqlx::query("UPDATE bonds SET state = ? WHERE id = ?")
+            .bind(BondState::Forfeited.to_string())
+            .bind(bond.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut ln = dead_lnd().await;
+        pay_counterparty(&pool, &mut ln, &bond, &invoice, 5, CLAIM_WINDOW_SECONDS)
+            .await
+            .unwrap();
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.state, BondState::Forfeited.to_string());
+        assert_eq!(
+            after.payout_attempts, 0,
+            "no failure bump on a skipped send"
+        );
+        assert!(after.payout_payment_hash.is_none());
+    }
+
+    #[tokio::test]
+    async fn slash_after_success_exhausts_cas_retries_on_db_failure() {
+        // A RAISE trigger forces every CAS attempt to error; after
+        // SLASH_CAS_MAX_ATTEMPTS the helper surfaces the DB error so the
+        // next tick reconciles via the persisted payment hash.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some("lnbc1pPAID"),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+        sqlx::query(
+            "CREATE TRIGGER fail_bonds_update BEFORE UPDATE ON bonds \
+             BEGIN SELECT RAISE(ABORT, 'forced bonds failure'); END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = slash_after_success(&pool, &bond, 5_000).await;
+        assert!(
+            result.is_err(),
+            "exhausted CAS retries must surface the error"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_failure_re_arm_cas_miss_leaves_row_as_is() {
+        // Terminal failure at the retry budget, inside the window, but
+        // the row moved off PendingPayout concurrently: the re-arm CAS
+        // misses and the row is left untouched.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some("lnbc1pSTALE"),
+            None,
+        );
+        bond.payout_attempts = 2;
+        let bond = create_bond(&pool, bond).await.unwrap();
+        // Row moves on under us.
+        sqlx::query("UPDATE bonds SET state = ? WHERE id = ?")
+            .bind(BondState::Slashed.to_string())
+            .bind(bond.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        // Snapshot still claims PendingPayout with 2 prior attempts.
+        let mut snapshot = bond.clone();
+        snapshot.state = BondState::PendingPayout.to_string();
+
+        on_send_payment_failure(
+            &pool,
+            &snapshot,
+            3,
+            CLAIM_WINDOW_SECONDS,
+            PaymentFailureKind::Terminal,
+            "unroutable",
+        )
+        .await
+        .unwrap();
+
+        let after: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(after.state, BondState::Slashed.to_string());
+        assert_eq!(after.payout_invoice.as_deref(), Some("lnbc1pSTALE"));
+    }
+
+    #[tokio::test]
+    async fn enqueue_payout_ack_skips_unbuildable_small_order() {
+        // An order with an unparseable kind cannot produce a SmallOrder:
+        // the ack is skipped, never panicking.
+        let order = Order {
+            kind: "bogus".to_string(),
+            ..Order::default()
+        };
+        let recipient = PublicKey::from_str(maker_pk()).unwrap();
+        let before = ack_recipients(order.id, Action::BondInvoiceAccepted)
+            .await
+            .len();
+        enqueue_payout_ack(&order, Action::BondInvoiceAccepted, recipient, 1_000).await;
+        let after = ack_recipients(order.id, Action::BondInvoiceAccepted).await;
+        assert_eq!(after.len(), before);
+    }
+
+    #[tokio::test]
+    async fn notify_helpers_skip_when_order_row_missing() {
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        // Bond references an order that does not exist.
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, 0, None, None);
+        let recipient = PublicKey::from_str(maker_pk()).unwrap();
+        notify_invoice_received(&pool, &bond, recipient, 5_000).await;
+        notify_payout_completed(&pool, &bond, 5_000).await;
+        assert_eq!(
+            ack_recipients(order_id, Action::BondInvoiceAccepted)
+                .await
+                .len(),
+            0
+        );
+        assert_eq!(
+            ack_recipients(order_id, Action::BondPayoutCompleted)
+                .await
+                .len(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_helpers_skip_on_order_load_db_error() {
+        // Distinct from the "order row missing" case (`Ok(None)`): here the
+        // `Order::by_id` query itself errors (dropped table simulates a DB
+        // blip). Both best-effort notifiers must log-and-return rather than
+        // propagate or panic — a failed *notification* must never surface
+        // as an error to callers that already committed the underlying
+        // state transition.
+        let pool = setup_pool().await;
+        sqlx::query("DROP TABLE orders")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let order_id = Uuid::new_v4();
+        let bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, 0, None, None);
+        let recipient = PublicKey::from_str(maker_pk()).unwrap();
+
+        notify_invoice_received(&pool, &bond, recipient, 5_000).await;
+        notify_payout_completed(&pool, &bond, 5_000).await;
+
+        assert_eq!(
+            ack_recipients(order_id, Action::BondInvoiceAccepted)
+                .await
+                .len(),
+            0
+        );
+        assert_eq!(
+            ack_recipients(order_id, Action::BondPayoutCompleted)
+                .await
+                .len(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_payout_completed_skips_bad_reason_and_bad_recipient() {
+        let pool = setup_pool().await;
+
+        // Unparseable slashed_reason.
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let mut bond = pending_payout_bond(order_id, taker_pk(), 10_000, 5_000, 0, None, None);
+        bond.slashed_reason = Some("cosmic-rays".to_string());
+        notify_payout_completed(&pool, &bond, 5_000).await;
+        assert_eq!(
+            ack_recipients(order_id, Action::BondPayoutCompleted)
+                .await
+                .len(),
+            0
+        );
+
+        // Recipient unresolvable: bond pubkey matches neither side.
+        let order_id2 = Uuid::new_v4();
+        insert_order(&pool, order_id2, maker_pk(), taker_pk()).await;
+        let bond2 = pending_payout_bond(order_id2, "unrelated", 10_000, 5_000, 0, None, None);
+        notify_payout_completed(&pool, &bond2, 5_000).await;
+        assert_eq!(
+            ack_recipients(order_id2, Action::BondPayoutCompleted)
+                .await
+                .len(),
+            0
+        );
+
+        // Recipient resolution errors: counterparty pubkey is not valid hex.
+        let order_id3 = Uuid::new_v4();
+        insert_order(&pool, order_id3, "not-a-valid-pubkey", taker_pk()).await;
+        let bond3 = pending_payout_bond(order_id3, taker_pk(), 10_000, 5_000, 0, None, None);
+        notify_payout_completed(&pool, &bond3, 5_000).await;
+        assert_eq!(
+            ack_recipients(order_id3, Action::BondPayoutCompleted)
+                .await
+                .len(),
+            0
+        );
+    }
+
+    // ── add_bond_invoice_action (inbound handler) ─────────────────────
+
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use mostro_core::message::MessageKind;
+    use nostr_sdk::Timestamp;
+
+    fn build_ctx(pool: &Pool<Sqlite>) -> crate::app::context::AppContext {
+        TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build()
+    }
+
+    fn add_invoice_msg(order_id: Option<Uuid>, invoice: Option<&str>) -> Message {
+        Message::Order(MessageKind::new(
+            order_id,
+            None,
+            None,
+            Action::AddBondInvoice,
+            invoice.map(|i| Payload::PaymentRequest(None, i.to_string(), None)),
+        ))
+    }
+
+    fn unwrapped_from(sender: PublicKey, msg: &Message) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: msg.clone(),
+            signature: None,
+            sender,
+            identity: Keys::generate().public_key(),
+            created_at: Timestamp::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn add_bond_invoice_rejects_missing_order_id_and_invoice() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(&pool);
+        let keys = Keys::generate();
+        let sender = PublicKey::from_str(maker_pk()).unwrap();
+
+        // No order id → InvalidPayload.
+        let msg = add_invoice_msg(None, Some("lnbc1p"));
+        let event = unwrapped_from(sender, &msg);
+        assert!(matches!(
+            add_bond_invoice_action(&ctx, msg, &event, &keys).await,
+            Err(MostroCantDo(CantDoReason::InvalidPayload))
+        ));
+
+        // No payment request → InvalidInvoice.
+        let order_id = Uuid::new_v4();
+        let msg = add_invoice_msg(Some(order_id), None);
+        let event = unwrapped_from(sender, &msg);
+        assert!(matches!(
+            add_bond_invoice_action(&ctx, msg, &event, &keys).await,
+            Err(MostroCantDo(CantDoReason::InvalidInvoice))
+        ));
+    }
+
+    #[tokio::test]
+    async fn add_bond_invoice_rejects_when_no_recoverable_bond() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(&pool);
+        let keys = Keys::generate();
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        // No bond rows at all on the order.
+        let msg = add_invoice_msg(Some(order_id), Some("lnbc1p"));
+        let event = unwrapped_from(PublicKey::from_str(maker_pk()).unwrap(), &msg);
+        assert!(matches!(
+            add_bond_invoice_action(&ctx, msg, &event, &keys).await,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+    }
+
+    #[tokio::test]
+    async fn add_bond_invoice_rejects_node_only_bond() {
+        // Counterparty share is 0 (full retention): the sender must be
+        // told there is nothing to invoice for.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(&pool);
+        let keys = Keys::generate();
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            10_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        create_bond(&pool, bond).await.unwrap();
+
+        let msg = add_invoice_msg(Some(order_id), Some("lnbc1p"));
+        let event = unwrapped_from(PublicKey::from_str(maker_pk()).unwrap(), &msg);
+        assert!(matches!(
+            add_bond_invoice_action(&ctx, msg, &event, &keys).await,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+    }
+
+    #[tokio::test]
+    async fn add_bond_invoice_rejects_undecodable_bolt11() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(&pool);
+        let keys = Keys::generate();
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        create_bond(&pool, bond).await.unwrap();
+
+        let msg = add_invoice_msg(Some(order_id), Some("garbage-bolt11"));
+        let event = unwrapped_from(PublicKey::from_str(maker_pk()).unwrap(), &msg);
+        assert!(matches!(
+            add_bond_invoice_action(&ctx, msg, &event, &keys).await,
+            Err(MostroCantDo(CantDoReason::InvalidInvoice))
+        ));
+    }
+
+    #[tokio::test]
+    async fn add_bond_invoice_happy_path_persists_and_acks() {
+        // Full inbound flow: fresh signed bolt11 whose amount equals the
+        // counterparty share, sent by the resolved recipient → invoice
+        // persisted, BondInvoiceAccepted ack enqueued.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(&pool);
+        let keys = Keys::generate();
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let invoice = signed_test_invoice(5_000);
+        let msg = add_invoice_msg(Some(order_id), Some(&invoice));
+        let event = unwrapped_from(PublicKey::from_str(maker_pk()).unwrap(), &msg);
+        let before = ack_recipients(order_id, Action::BondInvoiceAccepted)
+            .await
+            .len();
+        add_bond_invoice_action(&ctx, msg, &event, &keys)
+            .await
+            .expect("valid submission must be accepted");
+        let after = ack_recipients(order_id, Action::BondInvoiceAccepted).await;
+        assert_eq!(after.len() - before, 1);
+
+        let row: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(row.payout_invoice.as_deref(), Some(invoice.as_str()));
+        assert_eq!(row.state, BondState::PendingPayout.to_string());
+    }
+
+    #[tokio::test]
+    async fn add_bond_invoice_resurrects_failed_bond_within_window() {
+        // The `InvoiceApplyOutcome::Resurrected` arm: a `Failed` row, still
+        // inside the claim window, receiving a fresh valid bolt11 from the
+        // resolved recipient. Must be accepted (unlike the `PendingPayout`
+        // happy path already covered) and the row must come back to
+        // `PendingPayout` with both attempt counters reset.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(&pool);
+        let keys = Keys::generate();
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let mut bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(), // recent slash → well within the window
+            Some("lnbc1pOLDFAILED"),
+            None,
+        );
+        bond.state = BondState::Failed.to_string();
+        bond.payout_attempts = 5;
+        bond.invoice_request_attempts = 2;
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let invoice = signed_test_invoice(5_000);
+        let msg = add_invoice_msg(Some(order_id), Some(&invoice));
+        let event = unwrapped_from(PublicKey::from_str(maker_pk()).unwrap(), &msg);
+        add_bond_invoice_action(&ctx, msg, &event, &keys)
+            .await
+            .expect("resurrection within the claim window must be accepted");
+
+        let row: Bond = sqlx::query_as("SELECT * FROM bonds WHERE id = ?")
+            .bind(bond.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(row.state, BondState::PendingPayout.to_string());
+        assert_eq!(row.payout_invoice.as_deref(), Some(invoice.as_str()));
+        assert_eq!(row.payout_attempts, 0);
+        assert_eq!(row.invoice_request_attempts, 0);
+    }
+
+    #[tokio::test]
+    async fn add_bond_invoice_rejects_when_invoice_already_persisted() {
+        // `InvoiceApplyOutcome::Rejected` reached via the `PendingPayout`
+        // CAS's `AND payout_invoice IS NULL` guard: a fresh, otherwise-valid
+        // bolt11 submitted against a row that already has one on file must
+        // be turned away with the same `NotAllowedByStatus` the caller
+        // cannot distinguish from any other unroutable case — the existing
+        // bolt11 is not clobbered.
+        init_test_settings();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(&pool);
+        let keys = Keys::generate();
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            Some("lnbc1pALREADYSET"),
+            None,
+        );
+        let bond = create_bond(&pool, bond).await.unwrap();
+
+        let invoice = signed_test_invoice(5_000);
+        let msg = add_invoice_msg(Some(order_id), Some(&invoice));
+        let event = unwrapped_from(PublicKey::from_str(maker_pk()).unwrap(), &msg);
+        assert!(matches!(
+            add_bond_invoice_action(&ctx, msg, &event, &keys).await,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+
+        let row: (Option<String>,) =
+            sqlx::query_as("SELECT payout_invoice FROM bonds WHERE id = ?")
+                .bind(bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0.as_deref(), Some("lnbc1pALREADYSET"));
+    }
+
+    // ── find_recoverable_bond_for_recipient ───────────────────────────
+
+    #[tokio::test]
+    async fn find_recoverable_bond_returns_none_when_order_row_missing() {
+        // At least one candidate bond row exists for `order_id`, but the
+        // order itself is gone — the finder must bail with `Ok(None)`
+        // rather than error, exactly like the "no candidate at all" case
+        // looks from the caller's perspective.
+        let pool = setup_pool().await;
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let order_id = Uuid::new_v4();
+        // Deliberately no `insert_order` call.
+        let bond = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            10_000,
+            5_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        create_bond(&pool, bond).await.unwrap();
+
+        let result = find_recoverable_bond_for_recipient(&pool, order_id, maker_pk(), None)
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_recoverable_bond_skips_bad_reason_and_recipient_mismatch() {
+        // Three candidate rows on the same order: one with an unparseable
+        // `slashed_reason` (skipped via `continue`), one whose `pubkey`
+        // matches neither side of the order (recipient unresolvable, so it
+        // is never pushed into `matches`), and one legitimate match. Only
+        // the legitimate one may be returned.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await; // seller=maker, buyer=taker
+
+        let mut bad_reason = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            1_000,
+            500,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        bad_reason.slashed_reason = Some("cosmic-rays".to_string());
+        create_bond(&pool, bad_reason).await.unwrap();
+
+        let unrelated = pending_payout_bond(
+            order_id,
+            "unrelated-pubkey",
+            1_000,
+            500,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        create_bond(&pool, unrelated).await.unwrap();
+
+        let good = pending_payout_bond(
+            order_id,
+            taker_pk(), // buyer → recipient is the seller, maker_pk()
+            2_000,
+            1_000,
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        let good = create_bond(&pool, good).await.unwrap();
+
+        let result = find_recoverable_bond_for_recipient(&pool, order_id, maker_pk(), None)
+            .await
+            .unwrap();
+        assert_eq!(result.map(|b| b.id), Some(good.id));
+    }
+
+    #[tokio::test]
+    async fn find_recoverable_bond_disambiguates_multiple_debts_by_share() {
+        // Phase 6: two debts on the same order resolving to the same
+        // recipient (distinct counterparty shares). When the submitted
+        // invoice's amount matches one of them, that row must win over the
+        // "first / most-recently-slashed" fallback used for the
+        // single-candidate case.
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id, maker_pk(), taker_pk()).await;
+
+        let low = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            4_000,
+            1_000, // counterparty share = 3_000
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        create_bond(&pool, low).await.unwrap();
+        let high = pending_payout_bond(
+            order_id,
+            taker_pk(),
+            9_000,
+            2_000, // counterparty share = 7_000
+            Utc::now().timestamp(),
+            None,
+            None,
+        );
+        let high = create_bond(&pool, high).await.unwrap();
+
+        let exact = find_recoverable_bond_for_recipient(&pool, order_id, maker_pk(), Some(7_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            exact.map(|b| b.id),
+            Some(high.id),
+            "exact share match must win the disambiguation"
+        );
+
+        // No candidate matches the submitted amount: falls back to the
+        // first (most-recently-slashed) match rather than erroring.
+        let fallback = find_recoverable_bond_for_recipient(&pool, order_id, maker_pk(), Some(42))
+            .await
+            .unwrap();
+        assert!(
+            fallback.is_some(),
+            "an unmatched amount must still fall back to a candidate, not None"
+        );
     }
 }

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -4102,4 +4102,761 @@ mod tests {
                 .unwrap();
         assert!(second.is_empty(), "retry must not re-notify the maker");
     }
+
+    // ── Coverage: pure-helper / classifier branches ─────────────────────────
+
+    #[tokio::test]
+    async fn is_unique_violation_false_for_non_unique_db_error() {
+        // The message-based fallback branch only runs when `code()` is not
+        // "2067" — a genuine unique-constraint violation on SQLite always
+        // carries that code, so the fallback is only reachable from some
+        // *other* kind of database error. Drive it with a plain SQL error
+        // (unknown column) and confirm it classifies as "not a unique
+        // violation" rather than panicking or misclassifying.
+        let pool = setup_pool().await;
+        let err = sqlx::query("SELECT this_column_does_not_exist FROM bonds")
+            .execute(&pool)
+            .await
+            .expect_err("querying a missing column must fail");
+        assert!(
+            !is_unique_violation(&err),
+            "a non-constraint DB error must not be classified as a unique violation"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_slash_target_ignores_range_root_bond_when_not_locked() {
+        // The range-root fallback (used for a maker slash landing on a
+        // descendant slice) must only resolve a maker bond that is still
+        // `Locked`. A root maker bond that already moved on (e.g. a prior
+        // close released it) must not be picked up as a slash target.
+        let pool = setup_pool().await;
+        let root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        insert_range_order_row(&pool, &root).await;
+        insert_bond_with_role(
+            &pool,
+            root.id,
+            maker_pk(),
+            BondRole::Maker,
+            BondState::Released,
+        )
+        .await;
+
+        let mut slice = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 70);
+        slice.range_parent_id = Some(root.id);
+        insert_range_order_row(&pool, &slice).await;
+
+        let bonds = find_active_bonds_for_order(&pool, slice.id).await.unwrap();
+        let target = resolve_slash_target(&pool, &slice, &bonds, Side::Seller, true)
+            .await
+            .unwrap();
+        assert!(
+            target.is_none(),
+            "a non-Locked root maker bond must not resolve as a slash target"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_dispatch_on_non_waiting_status_releases_defensively() {
+        // The scheduler only calls the timeout dispatch for waiting-state
+        // orders, but the dispatch itself must never assume that — any
+        // other status (here: `Dispute`, `fixture_order`'s default) falls
+        // back to releasing every active bond, never slashing.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Both);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(result.is_none(), "a non-waiting status must never slash");
+        assert!(ln.calls().is_empty());
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::Released.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_slash_armed_but_no_bond_posted_releases_without_slash() {
+        // The gate is armed (enabled, slash_on_waiting_timeout, apply_to
+        // covers the responsible taker), but the taker never posted a bond
+        // at all (e.g. the feature was enabled after the bond stage ran).
+        // No Locked row resolves, so the dispatch must release defensively
+        // and report no slash, instead of erroring.
+        let pool = setup_pool().await;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let mut ln = StubSettle::new();
+
+        let cfg = timeout_cfg(true, true, BondApplyTo::Take);
+        let result = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap();
+
+        assert!(
+            result.is_none(),
+            "an armed gate with no bond to slash must not report a slash"
+        );
+        assert!(ln.calls().is_empty());
+    }
+
+    // ── Coverage: `notify_bond_slashed` error branches ──────────────────────
+
+    #[tokio::test]
+    async fn notify_bond_slashed_skips_when_pubkey_unparseable() {
+        use crate::config::MESSAGE_QUEUES;
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        let mut bond =
+            Bond::new_requested(order.id, taker_pk().to_string(), BondRole::Taker, 10_000);
+        bond.pubkey = "not-a-valid-pubkey".to_string();
+
+        notify_bond_slashed(&order, &bond).await;
+
+        let has_notice = MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .any(|(m, _)| {
+                let k = m.get_inner_message_kind();
+                k.id == Some(order.id) && k.action == Action::BondSlashed
+            });
+        assert!(
+            !has_notice,
+            "an unparseable bonded pubkey must skip the BondSlashed notice"
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_bond_slashed_skips_when_order_kind_unparseable() {
+        use crate::config::MESSAGE_QUEUES;
+        let mut order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        order.kind = "not-a-real-kind".to_string();
+        let bond = Bond::new_requested(order.id, taker_pk().to_string(), BondRole::Taker, 10_000);
+
+        notify_bond_slashed(&order, &bond).await;
+
+        let has_notice = MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .any(|(m, _)| {
+                let k = m.get_inner_message_kind();
+                k.id == Some(order.id) && k.action == Action::BondSlashed
+            });
+        assert!(
+            !has_notice,
+            "an unparseable order kind must skip the BondSlashed notice"
+        );
+    }
+
+    // ── Coverage: `slash_one` edge branches ─────────────────────────────────
+
+    #[tokio::test]
+    async fn slash_one_with_no_preimage_leaves_bond_locked_for_review() {
+        // A `Locked` bond with no preimage is a corrupt/incomplete row
+        // (should never happen in production, but must be handled): the
+        // HTLC can never be settled, so the bond must stay Locked for an
+        // operator to investigate, and `settle_hold_invoice` must never be
+        // called with a bogus preimage.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let mut bond =
+            Bond::new_requested(order.id, taker_pk().to_string(), BondRole::Taker, 10_000);
+        bond.state = BondState::Locked.to_string();
+        // preimage stays None (the `new_requested` default).
+        bond.clone().create(&pool).await.unwrap();
+        let mut ln = StubSettle::new();
+
+        slash_one(&pool, &mut ln, &bond, BondSlashReason::LostDispute, 0.0).await;
+
+        assert!(
+            ln.calls().is_empty(),
+            "no preimage means settle_hold_invoice must never be invoked"
+        );
+        assert_eq!(
+            read_bond_state(&pool, bond.id).await,
+            BondState::Locked.to_string()
+        );
+    }
+
+    #[tokio::test]
+    async fn slash_one_cas_noop_when_bond_already_transitioned_concurrently() {
+        // Simulate a concurrent transition: the row moved to PendingPayout
+        // (e.g. a duplicate admin call already slashed it) between the
+        // active-bonds fetch and this call's CAS. The CAS must match zero
+        // rows and log a no-op instead of clobbering the row.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        sqlx::query("UPDATE bonds SET state = ? WHERE id = ?")
+            .bind(BondState::PendingPayout.to_string())
+            .bind(bond.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let mut ln = StubSettle::new();
+
+        slash_one(&pool, &mut ln, &bond, BondSlashReason::LostDispute, 0.0).await;
+
+        assert_eq!(
+            ln.calls(),
+            vec![stub_preimage()],
+            "settle is still attempted before the CAS no-op is discovered"
+        );
+        let row: (String, Option<String>) =
+            sqlx::query_as("SELECT state, slashed_reason FROM bonds WHERE id = ?")
+                .bind(bond.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, BondState::PendingPayout.to_string());
+        assert!(
+            row.1.is_none(),
+            "a CAS no-op must not stamp slashed_reason for this call"
+        );
+    }
+
+    #[tokio::test]
+    async fn slash_one_cas_db_error_is_logged_not_propagated() {
+        // A DB-level failure on the CAS itself (after the HTLC is already
+        // settled) must be logged, not panic or propagate — `slash_one` is
+        // best-effort by design.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        sqlx::query("DROP TABLE bonds")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let mut ln = StubSettle::new();
+
+        // Must not panic despite the CAS query itself failing.
+        slash_one(&pool, &mut ln, &bond, BondSlashReason::LostDispute, 0.0).await;
+
+        assert_eq!(
+            ln.calls(),
+            vec![stub_preimage()],
+            "settle is attempted before the failed CAS is discovered"
+        );
+    }
+
+    // ── Coverage: `record_maker_slice_slash` edge branches ──────────────────
+
+    #[tokio::test]
+    async fn record_maker_slice_slash_buy_order_uses_buyer_pubkey() {
+        // Every other `record_maker_slice_slash` test uses a sell-order
+        // range (maker = seller). A buy-order range's maker is the buyer,
+        // so the child row's pubkey must come from `buyer_pubkey`.
+        let pool = setup_pool().await;
+        let root = range_slice(Kind::Buy, taker_pk(), maker_pk(), 40, 10, 100);
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+
+        let inserted = record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.0,
+        )
+        .await
+        .unwrap();
+
+        assert!(inserted);
+        let children = find_child_slashes_for_parent(&pool, parent.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            children[0].pubkey,
+            maker_pk(),
+            "a buy-order slice's maker-side pubkey is the buyer's"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_maker_slice_slash_skips_when_slice_missing_maker_pubkey() {
+        // A slice row with no maker-side pubkey (corrupt/incomplete row)
+        // must be skipped rather than inserting a child with a missing
+        // recipient.
+        let pool = setup_pool().await;
+        let mut root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        root.seller_pubkey = None;
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+
+        let inserted = record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        assert!(!inserted);
+        assert!(find_child_slashes_for_parent(&pool, parent.id)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn record_maker_slice_slash_skips_when_root_missing_max_amount() {
+        // A range root with no positive `max_amount` (corrupt/non-range
+        // root passed by mistake) must be skipped, never divide-by-zero or
+        // insert a bogus share.
+        let pool = setup_pool().await;
+        let root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+
+        for bad_max in [None, Some(0)] {
+            let mut bad_root = root.clone();
+            bad_root.max_amount = bad_max;
+            let inserted = record_maker_slice_slash(
+                &pool,
+                &root,
+                &bad_root,
+                &parent,
+                BondSlashReason::LostDispute,
+                0.5,
+            )
+            .await
+            .unwrap();
+            assert!(!inserted, "max_amount={bad_max:?} must be rejected");
+        }
+        assert!(find_child_slashes_for_parent(&pool, parent.id)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn record_maker_slice_slash_skips_when_bond_already_fully_slashed() {
+        // Once the parent's cumulative slashed share already equals the
+        // bond amount, any further slice slash computes a non-positive
+        // remaining share and must be dropped instead of over-allocating.
+        let pool = setup_pool().await;
+        let root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        sqlx::query("UPDATE bonds SET slashed_share_sats = ? WHERE id = ?")
+            .bind(1000_i64)
+            .bind(parent.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let parent = find_bond_by_id(&pool, parent.id).await.unwrap().unwrap();
+
+        let inserted = record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            !inserted,
+            "no remaining bond to slash means the slice is dropped"
+        );
+        assert!(find_child_slashes_for_parent(&pool, parent.id)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn record_maker_slice_slash_propagates_non_unique_db_error() {
+        // A genuine DB error on the child INSERT (not a unique-constraint
+        // violation) must propagate as an `Err`, not be swallowed like the
+        // idempotent-duplicate case.
+        let pool = setup_pool().await;
+        let root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        sqlx::query("DROP TABLE bonds")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let err = record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.5,
+        )
+        .await
+        .unwrap_err();
+        assert!(!err.to_string().is_empty());
+    }
+
+    // ── Coverage: `resolve_range_maker_bond_at_close` edge branches ─────────
+
+    #[tokio::test]
+    async fn range_close_noop_when_no_maker_bond_exists() {
+        // No maker bond posted at all for this order → immediate no-op,
+        // never touching LND.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let mut ln = StubSettle::new();
+
+        resolve_range_maker_bond_at_close(&pool, &mut ln, &order)
+            .await
+            .unwrap();
+
+        assert!(ln.calls().is_empty());
+    }
+
+    #[tokio::test]
+    async fn range_close_releases_non_range_maker_bond() {
+        // A non-range order's maker bond (`max_amount = None`) has no slice
+        // children by construction — the close path must fall through to a
+        // plain release, exactly like the Phase 5 non-range happy path.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        let parent = insert_parent_maker_bond(&pool, order.id, maker_pk(), 1000).await;
+        let mut ln = StubSettle::new();
+
+        resolve_range_maker_bond_at_close(&pool, &mut ln, &order)
+            .await
+            .unwrap();
+
+        assert!(
+            ln.calls().is_empty(),
+            "release (hash=None) must never touch settle_hold_invoice"
+        );
+        let p = find_bond_by_id(&pool, parent.id).await.unwrap().unwrap();
+        assert_eq!(p.state, BondState::Released.to_string());
+    }
+
+    #[tokio::test]
+    async fn range_close_skips_settle_when_parent_preimage_missing() {
+        // A parent bond with a slashed slice but a missing preimage
+        // (corrupt/incomplete row) must be left Locked for operator review
+        // rather than attempting to settle.
+        let pool = setup_pool().await;
+        let root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.5,
+        )
+        .await
+        .unwrap();
+        sqlx::query("UPDATE bonds SET preimage = NULL WHERE id = ?")
+            .bind(parent.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let mut ln = StubSettle::new();
+        resolve_range_maker_bond_at_close(&pool, &mut ln, &root)
+            .await
+            .unwrap();
+
+        assert!(
+            ln.calls().is_empty(),
+            "no preimage means settle must never be attempted"
+        );
+        let p = find_bond_by_id(&pool, parent.id).await.unwrap().unwrap();
+        assert_eq!(
+            p.state,
+            BondState::Locked.to_string(),
+            "left Locked for operator review"
+        );
+    }
+
+    /// `SettleLightning` mock whose `settle_hold_invoice` has a side effect:
+    /// it flips the target bond straight to `Slashed` via a direct DB write,
+    /// simulating a *concurrent* close winning the `Locked -> Slashed` CAS
+    /// race between this call's settle and its own CAS attempt. Used to
+    /// deterministically drive `resolve_range_maker_bond_at_close`'s
+    /// lost-the-race branch without real concurrency.
+    struct RaceWinningSettle {
+        pool: Pool<Sqlite>,
+        bond_id: Uuid,
+    }
+
+    impl SettleLightning for RaceWinningSettle {
+        fn settle_hold_invoice<'a>(
+            &'a mut self,
+            _preimage: &'a str,
+        ) -> Pin<Box<dyn Future<Output = Result<(), MostroError>> + Send + 'a>> {
+            Box::pin(async move {
+                sqlx::query("UPDATE bonds SET state = ? WHERE id = ?")
+                    .bind(BondState::Slashed.to_string())
+                    .bind(self.bond_id)
+                    .execute(&self.pool)
+                    .await
+                    .unwrap();
+                Ok(())
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn range_close_loses_cas_race_and_skips_refund_row() {
+        let pool = setup_pool().await;
+        let mut root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        root.status = Status::CooperativelyCanceled.to_string();
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        let mut racer = RaceWinningSettle {
+            pool: pool.clone(),
+            bond_id: parent.id,
+        };
+        resolve_range_maker_bond_at_close(&pool, &mut racer, &root)
+            .await
+            .unwrap();
+
+        // The CAS lost the race (the mock already moved the parent to
+        // Slashed as a side effect of "settling") — no refund row may be
+        // written, and the parent stays whatever the winner left it as.
+        let p = find_bond_by_id(&pool, parent.id).await.unwrap().unwrap();
+        assert_eq!(p.state, BondState::Slashed.to_string());
+        let children = find_child_slashes_for_parent(&pool, parent.id)
+            .await
+            .unwrap();
+        assert!(
+            children.iter().all(|c| c.child_order_id.is_some()),
+            "a lost CAS race must skip the maker-refund row insert"
+        );
+    }
+
+    #[tokio::test]
+    async fn range_close_full_slash_creates_no_refund_row() {
+        // When the slashed total exactly equals the bond amount there is
+        // nothing left to refund — the maker-refund row insert must be
+        // skipped entirely (not inserted with amount 0).
+        let pool = setup_pool().await;
+        let mut root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 100, 10, 100);
+        root.status = Status::CooperativelyCanceled.to_string();
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.0,
+        )
+        .await
+        .unwrap();
+
+        let mut ln = StubSettle::new();
+        resolve_range_maker_bond_at_close(&pool, &mut ln, &root)
+            .await
+            .unwrap();
+
+        let p = find_bond_by_id(&pool, parent.id).await.unwrap().unwrap();
+        assert_eq!(p.state, BondState::Slashed.to_string());
+        let children = find_child_slashes_for_parent(&pool, parent.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            children.len(),
+            1,
+            "only the slice child; no maker-refund row when fully slashed"
+        );
+        assert!(children[0].child_order_id.is_some());
+    }
+
+    // ── Coverage: `resolve_range_maker_bond_at_close_or_warn` ───────────────
+
+    #[tokio::test]
+    async fn resolve_at_close_or_warn_noop_when_no_locked_maker_bond() {
+        // The cheap pre-check must return without ever attempting to open
+        // LND when there is no Locked maker bond to resolve — this must
+        // hold even though `MOSTRO_CONFIG` is never initialized in this
+        // test binary (an LND attempt would panic on `Settings::get_ln`).
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+
+        resolve_range_maker_bond_at_close_or_warn(&pool, &order, "unit_test").await;
+    }
+
+    #[tokio::test]
+    async fn resolve_at_close_or_warn_logs_when_maker_bond_lookup_errors() {
+        // A DB failure on the maker-bond lookup itself must be logged and
+        // must return before ever reaching the LND connect step.
+        let pool = setup_pool().await;
+        let order = fixture_order(Kind::Sell, maker_pk(), taker_pk());
+        insert_order_row(&pool, &order).await;
+        sqlx::query("DROP TABLE bonds")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        resolve_range_maker_bond_at_close_or_warn(&pool, &order, "unit_test").await;
+    }
+
+    // ── Coverage: reconciliation sweep DB-error branches ────────────────────
+
+    #[tokio::test]
+    async fn collect_stranded_logs_and_skips_when_order_lookup_errors() {
+        // A DB error on the range-root order lookup (not just a missing
+        // row) must be logged and skipped, never propagated — one corrupt
+        // root must not starve the whole sweep tick.
+        let pool = setup_pool().await;
+        let mut root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        root.status = Status::CooperativelyCanceled.to_string();
+        insert_range_order_row(&pool, &root).await;
+        insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+
+        sqlx::query("PRAGMA foreign_keys = OFF")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("DROP TABLE orders")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let stranded = collect_stranded_range_maker_roots(&pool).await.unwrap();
+        assert!(
+            stranded.is_empty(),
+            "an Order::by_id failure must be logged and skipped, not propagated"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_with_returns_zero_when_scan_query_fails() {
+        // A DB failure on the very scan for stranded bonds (not a per-root
+        // failure) must be logged and yield zero resolved, never panic or
+        // propagate.
+        let pool = setup_pool().await;
+        sqlx::query("DROP TABLE bonds")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let stub = StubSettle::new();
+
+        let resolved = reconcile_stranded_range_maker_bonds_with(&pool, &mut stub.clone()).await;
+
+        assert_eq!(resolved, 0);
+    }
+
+    #[tokio::test]
+    async fn reconcile_with_logs_and_continues_when_a_root_close_errors() {
+        // A per-root close failure must be logged and the sweep must move
+        // on (report it as not-resolved) rather than propagate — the next
+        // tick (or the CLTV safety net) retries.
+        let pool = setup_pool().await;
+        let mut root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        root.status = Status::CooperativelyCanceled.to_string();
+        insert_range_order_row(&pool, &root).await;
+        let parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        record_maker_slice_slash(
+            &pool,
+            &root,
+            &root,
+            &parent,
+            BondSlashReason::LostDispute,
+            0.5,
+        )
+        .await
+        .unwrap();
+
+        // Force the close's refund-row insert to fail once it reaches the
+        // transaction (mirrors `range_close_crash_after_settle_is_resumed`).
+        sqlx::query(
+            "CREATE TRIGGER bond_refund_fail_sweep BEFORE INSERT ON bonds \
+             WHEN NEW.parent_bond_id IS NOT NULL AND NEW.child_order_id IS NULL \
+             BEGIN SELECT RAISE(ABORT, 'injected refund insert failure'); END",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let stub = StubSettle::new();
+        let resolved = reconcile_stranded_range_maker_bonds_with(&pool, &mut stub.clone()).await;
+
+        assert_eq!(
+            resolved, 0,
+            "the erroring root must be logged and skipped, not counted as resolved"
+        );
+        let p = find_bond_by_id(&pool, parent.id).await.unwrap().unwrap();
+        assert_eq!(
+            p.state,
+            BondState::Locked.to_string(),
+            "a failed close leaves the parent Locked for a future retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_stranded_range_maker_bonds_returns_early_when_nothing_stranded() {
+        // The public entry point's cheap pre-check must return before ever
+        // attempting to open LND when there is nothing stranded — this
+        // must hold even though `MOSTRO_CONFIG` is never initialized in
+        // this test binary.
+        let pool = setup_pool().await;
+        reconcile_stranded_range_maker_bonds(&pool).await;
+    }
+
+    #[tokio::test]
+    async fn reconcile_stranded_range_maker_bonds_returns_early_when_scan_fails() {
+        // A scan failure must short-circuit before the LND connect step
+        // too, for the same MOSTRO_CONFIG-safety reason.
+        let pool = setup_pool().await;
+        sqlx::query("DROP TABLE bonds")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        reconcile_stranded_range_maker_bonds(&pool).await;
+    }
 }

--- a/src/app/bond/types.rs
+++ b/src/app/bond/types.rs
@@ -246,6 +246,28 @@ mod tests {
     }
 
     #[test]
+    fn parse_error_display_and_error_trait() {
+        // Every `BondParseError` variant must render its offending value
+        // so operator logs can pinpoint the corrupted column. The enum
+        // also implements `std::error::Error`, so it must be usable as a
+        // trait object.
+        let role_err = BondRole::from_str("solver").unwrap_err();
+        assert_eq!(role_err.to_string(), "unknown bond role: solver");
+
+        let state_err = BondState::from_str("in-progress").unwrap_err();
+        assert_eq!(state_err.to_string(), "unknown bond state: in-progress");
+
+        let reason_err = BondSlashReason::from_str("whatever").unwrap_err();
+        assert_eq!(
+            reason_err.to_string(),
+            "unknown bond slash reason: whatever"
+        );
+
+        let boxed: Box<dyn std::error::Error> = Box::new(role_err);
+        assert!(boxed.source().is_none());
+    }
+
+    #[test]
     fn terminal_and_active_helpers() {
         for s in [
             BondState::Released,

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -869,4 +869,588 @@ mod tests {
             "an intruder with no bond row must not be routed to the taker-cancel path"
         );
     }
+
+    async fn setup_pool() -> Arc<SqlitePool> {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+        sqlx::migrate!("./migrations")
+            .run(pool.as_ref())
+            .await
+            .unwrap();
+        pool
+    }
+
+    fn build_ctx(pool: Arc<SqlitePool>) -> AppContext {
+        TestContextBuilder::new()
+            .with_pool(pool)
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// Publishing paths (`update_order_event`) read the global config
+    /// (`Settings::get_nostr` / `get_mostro` / `get_expiration`). The
+    /// `OnceLock` may already be set by a concurrent test — that is fine
+    /// because every unit test uses the same `test_settings()` values.
+    fn set_global_config() {
+        let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+    }
+
+    /// The republish-to-`Pending` path (`update_order_event` with target
+    /// `Status::Pending`) additionally calls `get_db_pool()`, which panics
+    /// unless the global `DB_POOL` is set. Another test may have won the
+    /// race with a different pool; tests relying on this therefore pin
+    /// `master_*_pubkey == trade pubkey` so the rating lookup falls back
+    /// to `(0.0, 0, 0)` deterministically regardless of which pool won.
+    fn set_global_db_pool(pool: &Arc<SqlitePool>) {
+        let _ = crate::config::DB_POOL.set(pool.clone());
+    }
+
+    fn cancel_msg(order_id: uuid::Uuid) -> Message {
+        Message::new_order(Some(order_id), Some(1), None, Action::Cancel, None)
+    }
+
+    /// Actions queued for `destination` on the process-global queue.
+    /// Other tests push to the same queue concurrently, so callers must
+    /// only assert on destinations built from this test's fresh keys.
+    async fn queued_actions_for(destination: PublicKey) -> Vec<Action> {
+        crate::config::MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(_, pk)| *pk == destination)
+            .map(|(m, _)| m.get_inner_message_kind().action.clone())
+            .collect()
+    }
+
+    async fn order_by_id(pool: &SqlitePool, id: uuid::Uuid) -> Order {
+        Order::by_id(pool, id).await.unwrap().unwrap()
+    }
+
+    async fn insert_requested_taker_bond(
+        pool: &SqlitePool,
+        order_id: uuid::Uuid,
+        pubkey: &PublicKey,
+    ) {
+        // `hash: None` keeps `release_bond` off the LND connect path.
+        let bond = crate::app::bond::Bond::new_requested(
+            order_id,
+            pubkey.to_string(),
+            crate::app::bond::BondRole::Taker,
+            1_000,
+        );
+        bond.create(pool).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancel_action_rejects_orders_already_in_terminal_cancel_state() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+        let my_keys = Keys::generate();
+        let mut ln_client = StubLnClient;
+
+        for status in [
+            Status::Canceled,
+            Status::CooperativelyCanceled,
+            Status::CanceledByAdmin,
+        ] {
+            let mut order = create_pending_order(maker, taker);
+            order.status = status.to_string();
+            let order = order.create(ctx.pool()).await.unwrap();
+            let event = create_unwrapped_message_with_pubkey(maker);
+
+            let result =
+                cancel_action_generic(&ctx, cancel_msg(order.id), &event, &my_keys, &mut ln_client)
+                    .await;
+
+            assert!(
+                matches!(
+                    result,
+                    Err(MostroCantDo(CantDoReason::OrderAlreadyCanceled))
+                ),
+                "status {status} must short-circuit as already canceled"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn maker_cancel_of_pending_order_persists_canceled_and_notifies_bonded_taker() {
+        set_global_config();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+        let bonded_taker = Keys::generate().public_key();
+
+        let order = create_pending_order(maker, taker)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        insert_requested_taker_bond(ctx.pool(), order.id, &bonded_taker).await;
+
+        let event = create_unwrapped_message_with_pubkey(maker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(result.is_ok(), "maker cancel must succeed: {result:?}");
+        assert_eq!(
+            order_by_id(ctx.pool(), order.id).await.status,
+            Status::Canceled.to_string()
+        );
+        assert!(
+            queued_actions_for(maker).await.contains(&Action::Canceled),
+            "maker must be notified of the cancellation"
+        );
+        assert!(
+            queued_actions_for(bonded_taker)
+                .await
+                .contains(&Action::Canceled),
+            "the bonded taker must be notified so they stop waiting"
+        );
+        let remaining = crate::app::bond::db::find_active_bonds_for_order(ctx.pool(), order.id)
+            .await
+            .unwrap();
+        assert!(remaining.is_empty(), "the taker bond must be released");
+    }
+
+    #[tokio::test]
+    async fn taker_self_cancel_with_other_active_bonds_keeps_order_parked() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+        let rival_taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::WaitingTakerBond.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+        insert_requested_taker_bond(ctx.pool(), order.id, &taker).await;
+        insert_requested_taker_bond(ctx.pool(), order.id, &rival_taker).await;
+
+        let event = create_unwrapped_message_with_pubkey(taker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "scoped taker cancel must succeed: {result:?}"
+        );
+        // The rival is still racing, so the order must NOT be reset.
+        assert_eq!(
+            order_by_id(ctx.pool(), order.id).await.status,
+            Status::WaitingTakerBond.to_string()
+        );
+        let remaining = crate::app::bond::db::find_active_bonds_for_order(ctx.pool(), order.id)
+            .await
+            .unwrap();
+        assert_eq!(remaining.len(), 1, "only the sender's bond is released");
+        assert_eq!(remaining[0].pubkey, rival_taker.to_string());
+        assert!(queued_actions_for(taker).await.contains(&Action::Canceled));
+    }
+
+    #[tokio::test]
+    async fn taker_self_cancel_of_last_bond_resets_order_to_pending() {
+        set_global_config();
+        let pool = setup_pool().await;
+        set_global_db_pool(&pool);
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        // Deterministic rating fallback: identity pubkey == trade pubkey.
+        order.master_seller_pubkey = Some(maker.to_string());
+        order.price_from_api = true;
+        order.hash = Some("stub-hold-invoice-hash".to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+        insert_requested_taker_bond(ctx.pool(), order.id, &taker).await;
+
+        let event = create_unwrapped_message_with_pubkey(taker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "last-bond taker cancel must succeed: {result:?}"
+        );
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.status, Status::Pending.to_string());
+        assert_eq!(after.amount, 0, "api-priced amount must be reset");
+        assert_eq!(after.fee, 0, "api-priced fee must be reset");
+        assert!(after.hash.is_none(), "hold invoice hash must be cleared");
+        assert!(
+            after.buyer_pubkey.is_none(),
+            "the sell-order taker side must be cleared for republish"
+        );
+        assert!(queued_actions_for(taker).await.contains(&Action::Canceled));
+        assert!(
+            queued_actions_for(maker).await.contains(&Action::NewOrder),
+            "the creator must see the republished order"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_taker_without_bond_row_can_still_self_cancel() {
+        set_global_config();
+        let pool = setup_pool().await;
+        set_global_db_pool(&pool);
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.master_seller_pubkey = Some(maker.to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // No bond row: routing must fall back to the in-memory taker
+        // pubkey match (buyer_pubkey == sender != creator).
+        let event = create_unwrapped_message_with_pubkey(taker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "legacy non-bond taker cancel must succeed: {result:?}"
+        );
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.status, Status::Pending.to_string());
+        assert!(after.buyer_pubkey.is_none());
+    }
+
+    #[tokio::test]
+    async fn maker_cancel_of_waiting_payment_order_cancels_and_notifies_both() {
+        set_global_config();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::WaitingPayment.to_string();
+        order.hash = Some("stub-hold-invoice-hash".to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(maker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(result.is_ok(), "maker cancel must succeed: {result:?}");
+        assert_eq!(
+            order_by_id(ctx.pool(), order.id).await.status,
+            Status::Canceled.to_string()
+        );
+        assert!(queued_actions_for(maker).await.contains(&Action::Canceled));
+        assert!(queued_actions_for(taker).await.contains(&Action::Canceled));
+    }
+
+    #[tokio::test]
+    async fn taker_cancel_of_waiting_buyer_invoice_order_republishes() {
+        set_global_config();
+        let pool = setup_pool().await;
+        set_global_db_pool(&pool);
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::WaitingBuyerInvoice.to_string();
+        order.master_seller_pubkey = Some(maker.to_string());
+        order.hash = Some("stub-hold-invoice-hash".to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(taker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(result.is_ok(), "taker cancel must succeed: {result:?}");
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.status, Status::Pending.to_string());
+        assert!(after.hash.is_none());
+        assert!(after.buyer_pubkey.is_none());
+    }
+
+    #[tokio::test]
+    async fn cancel_not_active_order_rejects_intruder() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::WaitingPayment.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(Keys::generate().public_key());
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_not_active_order_with_foreign_creator_is_internal_error() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::WaitingPayment.to_string();
+        // Corrupt state: the creator matches neither buyer nor seller.
+        order.creator_pubkey = Keys::generate().public_key().to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(taker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_active_order_step_1_records_buyer_as_initiator() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::Active.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // The buyer (taker on this sell order) initiates.
+        let event = create_unwrapped_message_with_pubkey(taker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(result.is_ok(), "step 1 must succeed: {result:?}");
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.cancel_initiator_pubkey, Some(taker.to_string()));
+        assert!(after.buyer_cooperativecancel);
+        assert!(!after.seller_cooperativecancel);
+        assert!(queued_actions_for(taker)
+            .await
+            .contains(&Action::CooperativeCancelInitiatedByYou));
+        assert!(queued_actions_for(maker)
+            .await
+            .contains(&Action::CooperativeCancelInitiatedByPeer));
+    }
+
+    #[tokio::test]
+    async fn cancel_fiat_sent_step_1_records_seller_as_initiator() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::FiatSent.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // The seller (maker on this sell order) initiates.
+        let event = create_unwrapped_message_with_pubkey(maker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(result.is_ok(), "step 1 must succeed: {result:?}");
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.cancel_initiator_pubkey, Some(maker.to_string()));
+        assert!(after.seller_cooperativecancel);
+        assert!(!after.buyer_cooperativecancel);
+    }
+
+    #[tokio::test]
+    async fn cancel_active_order_step_2_rejects_same_party_confirmation() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::Active.to_string();
+        order.cancel_initiator_pubkey = Some(taker.to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // Same party (the buyer/initiator) tries to confirm its own cancel.
+        let event = create_unwrapped_message_with_pubkey(taker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+    }
+
+    #[tokio::test]
+    async fn cancel_dispute_step_2_completes_cooperative_cancel_and_closes_dispute() {
+        set_global_config();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::Dispute.to_string();
+        order.cancel_initiator_pubkey = Some(taker.to_string());
+        order.buyer_dispute = true;
+        order.hash = Some("stub-hold-invoice-hash".to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        Dispute::new(order.id, order.status.clone())
+            .create(ctx.pool())
+            .await
+            .unwrap();
+
+        // The seller (maker) confirms the buyer-initiated cancel.
+        let event = create_unwrapped_message_with_pubkey(maker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(result.is_ok(), "step 2 must succeed: {result:?}");
+        assert_eq!(
+            order_by_id(ctx.pool(), order.id).await.status,
+            Status::CooperativelyCanceled.to_string()
+        );
+        let dispute = crate::db::find_dispute_by_order_id(ctx.pool(), order.id)
+            .await
+            .unwrap();
+        assert_eq!(
+            dispute.status,
+            DisputeStatus::SellerRefunded.to_string(),
+            "the open dispute must be closed as seller-refunded"
+        );
+        assert!(queued_actions_for(maker)
+            .await
+            .contains(&Action::CooperativeCancelAccepted));
+        assert!(queued_actions_for(taker)
+            .await
+            .contains(&Action::CooperativeCancelAccepted));
+    }
+
+    #[tokio::test]
+    async fn cancel_action_rejects_unhandled_status() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::SettledHoldInvoice.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(maker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+    }
+
+    #[tokio::test]
+    async fn notify_creator_enqueues_new_order_and_rejects_invalid_creator() {
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let order = create_pending_order(maker, taker);
+        notify_creator(&order, Some(7)).await.unwrap();
+        assert!(
+            queued_actions_for(maker).await.contains(&Action::NewOrder),
+            "the creator must receive the republished order payload"
+        );
+
+        let mut bad_order = create_pending_order(maker, taker);
+        bad_order.creator_pubkey = "not-a-valid-pubkey".to_string();
+        assert!(matches!(
+            notify_creator(&bad_order, None).await,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+    }
 }

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -296,6 +296,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn context_accessors_expose_injected_dependencies() {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+        let keys = nostr_sdk::Keys::generate();
+        let client = nostr_sdk::Client::default();
+
+        let ctx = TestContextBuilder::new()
+            .with_pool(pool.clone())
+            .with_settings(test_settings())
+            .with_nostr_client(client)
+            .with_keys(keys.clone())
+            .build();
+
+        // pool() and pool_arc() must expose the same injected pool.
+        assert!(Arc::ptr_eq(&ctx.pool_arc(), &pool));
+        assert!(std::ptr::eq(ctx.pool(), pool.as_ref()));
+
+        // keys() must return the injected keys instead of parsing settings.
+        assert_eq!(ctx.keys().public_key(), keys.public_key());
+
+        // nostr_client() returns the injected client (no relays configured).
+        assert!(ctx.nostr_client().relays().await.is_empty());
+
+        // settings() exposes the injected settings.
+        assert_eq!(ctx.settings().database.url, "sqlite::memory:");
+    }
+
+    #[tokio::test]
+    async fn default_builders_and_mock_queue_helpers_work() {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+
+        // Default impls delegate to new().
+        let mock: super::test_utils::MockOrderMsgQueue = Default::default();
+        let builder: super::test_utils::TestContextBuilder = Default::default();
+
+        let ctx = builder
+            .with_pool(pool)
+            .with_settings(test_settings())
+            .with_mock_order_msg_queue(mock.clone())
+            .build();
+
+        // Fresh queue starts empty.
+        assert!(mock.is_empty().await);
+        assert_eq!(mock.len().await, 0);
+
+        // Push through the context handle, observe through the mock handle.
+        let msg = mostro_core::prelude::Message::new_restore(None);
+        let key = nostr_sdk::Keys::generate().public_key();
+        ctx.order_msg_queue().write().await.push((msg, key));
+        assert_eq!(mock.len().await, 1);
+        assert!(!mock.is_empty().await);
+
+        // clear() drains it again.
+        mock.clear().await;
+        assert!(mock.is_empty().await);
+    }
+
+    #[tokio::test]
     async fn builder_can_use_custom_queue() {
         let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
         let queue: super::OrderMsgQueue = Arc::new(tokio::sync::RwLock::new(Vec::new()));

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -1044,7 +1044,14 @@ mod tests {
     fn init_test_settings() {
         let _ = MOSTRO_CONFIG.set(Settings {
             database: Default::default(),
-            nostr: Default::default(),
+            nostr: crate::config::NostrSettings {
+                // Valid canonical test nsec: whichever module wins the
+                // MOSTRO_CONFIG race must install a parseable key, or tests
+                // that reach get_keys() flake on init ordering.
+                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
+                    .to_string(),
+                relays: vec![],
+            },
             mostro: Default::default(),
             lightning: Default::default(),
             rpc: Default::default(),
@@ -1230,6 +1237,15 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_missing_separator_dash() {
+        // Long enough to pass the length check, but byte 36 (where the
+        // UUID/timestamp separator dash must sit) is not '-': must
+        // return None without ever attempting to parse a timestamp.
+        let marker = format!("PENDING-{}", "x".repeat(50));
+        assert_eq!(parse_pending_timestamp(&marker), None);
+    }
+
+    #[test]
     fn test_parse_current_timestamp() {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1321,6 +1337,36 @@ mod tests {
                 .await
                 .unwrap();
         assert_eq!(hash_after, None);
+    }
+
+    #[tokio::test]
+    async fn release_pending_claim_logs_db_failure_without_panic() {
+        // A RAISE trigger forces the release UPDATE to fail; the helper
+        // must log and return without panicking, leaving the marker as-is.
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, Some("PENDING-marker")).await;
+        sqlx::query(
+            "CREATE TRIGGER fail_orders_update BEFORE UPDATE ON orders \
+             BEGIN SELECT RAISE(ABORT, 'forced failure'); END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        release_pending_claim(&pool, id, "PENDING-marker").await;
+
+        let hash: Option<String> =
+            sqlx::query_scalar("SELECT dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            hash.as_deref(),
+            Some("PENDING-marker"),
+            "failed release must leave the marker in place"
+        );
     }
 
     #[tokio::test]
@@ -1443,5 +1489,510 @@ mod tests {
         assert_eq!(row.1, 1);
         assert_eq!(row.2.as_deref(), Some("deadbeef"));
         assert!(confirmed.contains(&order_id));
+    }
+
+    // ── LND-dependent phases against a lazily-connected dead client ──
+
+    use super::{
+        handle_payment_timeout, process_new_dev_fee_payments, recover_partial_payments,
+        resolve_dev_fee_invoice, run_dev_fee_cycle, send_dev_fee_payment, verify_confirmed_orders,
+    };
+    use crate::lightning::LndConnector;
+
+    /// Real `LndConnector` against a dead endpoint: `connect` is lazy,
+    /// so it always builds; every RPC fails in ~1ms with a transport
+    /// error — the "LN node unreachable" shape the recovery phases
+    /// classify as `Unknown`.
+    async fn dead_lnd() -> LndConnector {
+        let dir = std::env::temp_dir().join(format!("mostro-test-lnd-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cert = dir.join("tls.cert");
+        let mac = dir.join("admin.macaroon");
+        std::fs::write(&cert, b"").unwrap();
+        std::fs::write(&mac, [1u8, 2u8]).unwrap();
+        let client = fedimint_tonic_lnd::connect(
+            "https://127.0.0.1:1".to_string(),
+            cert.to_str().unwrap().to_string(),
+            mac.to_str().unwrap().to_string(),
+        )
+        .await
+        .expect("lazy connect never dials");
+        LndConnector { client }
+    }
+
+    /// Freshly-signed bolt11 for `amount_sats` (1h expiry, throwaway key).
+    fn signed_test_invoice(amount_sats: u64) -> String {
+        use bitcoin::hashes::{sha256, Hash};
+        use bitcoin::secp256k1::{Secp256k1, SecretKey};
+        use lightning_invoice::{Currency, InvoiceBuilder, PaymentSecret};
+
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[42u8; 32]).unwrap();
+        let payment_hash = sha256::Hash::hash(&uuid::Uuid::new_v4().into_bytes());
+        InvoiceBuilder::new(Currency::Bitcoin)
+            .description("mostro dev fee test".into())
+            .payment_hash(payment_hash)
+            .payment_secret(PaymentSecret([7u8; 32]))
+            .amount_milli_satoshis(amount_sats * 1_000)
+            .current_timestamp()
+            .min_final_cltv_expiry_delta(18)
+            .expiry_time(std::time::Duration::from_secs(3_600))
+            .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &sk))
+            .expect("valid invoice")
+            .to_string()
+    }
+
+    const VALID_HEX_HASH: &str = "abababababababababababababababababababababababababababababababab";
+
+    #[tokio::test]
+    async fn run_dev_fee_cycle_on_empty_db_is_a_noop() {
+        let pool = setup_orders_db().await;
+        let mut ln = dead_lnd().await;
+        let mut confirmed = HashSet::new();
+        run_dev_fee_cycle(&pool, &mut ln, &mut confirmed).await;
+        assert!(confirmed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cleanup_resets_legacy_marker_without_timestamp() {
+        // A pre-timestamp marker (`PENDING-{uuid}` only) has no age
+        // anchor: it must be treated as stale and reset.
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(
+            &pool,
+            id,
+            "success",
+            100,
+            false,
+            Some("PENDING-550e8400-e29b-41d4-a716-446655440000"),
+        )
+        .await;
+
+        cleanup_stale_pending_markers(&pool).await;
+
+        let row: (i32, Option<String>) =
+            sqlx::query_as("SELECT dev_fee_paid, dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, 0);
+        assert_eq!(row.1, None, "legacy marker must be cleared");
+    }
+
+    #[tokio::test]
+    async fn cleanup_survives_query_and_update_failures() {
+        // UPDATE failure: a RAISE trigger fires on the reset attempt;
+        // cleanup must log and continue, leaving the marker in place.
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(
+            &pool,
+            id,
+            "success",
+            100,
+            false,
+            Some("PENDING-550e8400-e29b-41d4-a716-446655440000-1"),
+        )
+        .await;
+        sqlx::query(
+            "CREATE TRIGGER fail_orders_update BEFORE UPDATE ON orders \
+             BEGIN SELECT RAISE(ABORT, 'forced failure'); END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        cleanup_stale_pending_markers(&pool).await;
+        let hash: Option<String> =
+            sqlx::query_scalar("SELECT dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(hash.is_some(), "marker untouched after failed UPDATE");
+
+        // SELECT failure: no orders table at all → phase returns early.
+        let pool2 = setup_orders_db().await;
+        sqlx::query("DROP TABLE orders")
+            .execute(&pool2)
+            .await
+            .unwrap();
+        cleanup_stale_pending_markers(&pool2).await;
+    }
+
+    #[tokio::test]
+    async fn cleanup_skips_reset_when_marker_changes_concurrently() {
+        // Two stale orders. Once the first is reset (hash -> NULL), a
+        // trigger models a concurrent scheduler cycle claiming the
+        // second order's marker before this cycle's own per-row UPDATE
+        // (guarded on the *original* marker snapshot) gets to run.
+        // That guarded UPDATE must then affect 0 rows, hitting the
+        // "marker changed concurrently" skip branch instead of clobbering
+        // the concurrently-claimed row.
+        let pool = setup_orders_db().await;
+        let first_id = uuid::Uuid::new_v4();
+        let raced_id = uuid::Uuid::new_v4();
+
+        insert_test_order(
+            &pool,
+            first_id,
+            "success",
+            100,
+            false,
+            Some("PENDING-550e8400-e29b-41d4-a716-446655440000-1"),
+        )
+        .await;
+        insert_test_order(
+            &pool,
+            raced_id,
+            "success",
+            100,
+            false,
+            Some("PENDING-550e8400-e29b-41d4-a716-446655440001-1"),
+        )
+        .await;
+
+        sqlx::query(
+            "CREATE TRIGGER simulate_concurrent_claim AFTER UPDATE OF dev_fee_payment_hash ON orders
+             WHEN NEW.dev_fee_payment_hash IS NULL
+             BEGIN
+                 UPDATE orders SET dev_fee_payment_hash = 'PENDING-raced-9999999999'
+                 WHERE dev_fee_payment_hash LIKE 'PENDING-%' AND id != NEW.id;
+             END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        cleanup_stale_pending_markers(&pool).await;
+
+        let first_hash: Option<String> =
+            sqlx::query_scalar("SELECT dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(first_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(first_hash, None, "first stale order resets normally");
+
+        let raced: (i32, Option<String>) =
+            sqlx::query_as("SELECT dev_fee_paid, dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(raced_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            raced.1.as_deref(),
+            Some("PENDING-raced-9999999999"),
+            "concurrently-changed marker must be left untouched, not reset"
+        );
+        assert_eq!(raced.0, 0);
+    }
+
+    #[tokio::test]
+    async fn verify_confirmed_skips_cached_and_leaves_unknown_alone() {
+        let pool = setup_orders_db().await;
+        let cached = uuid::Uuid::new_v4();
+        let unknown_rpc = uuid::Uuid::new_v4();
+        let unknown_hex = uuid::Uuid::new_v4();
+        insert_test_order(&pool, cached, "success", 100, true, Some(VALID_HEX_HASH)).await;
+        insert_test_order(
+            &pool,
+            unknown_rpc,
+            "success",
+            100,
+            true,
+            Some(VALID_HEX_HASH),
+        )
+        .await;
+        // Undecodable hash → Unknown via the hex-decode error path.
+        insert_test_order(&pool, unknown_hex, "success", 100, true, Some("zz-not-hex")).await;
+
+        let mut ln = dead_lnd().await;
+        let mut confirmed = HashSet::new();
+        confirmed.insert(cached);
+        verify_confirmed_orders(&pool, &mut ln, &mut confirmed).await;
+
+        // Unknown outcomes must not add to (or remove from) the set.
+        assert!(confirmed.contains(&cached));
+        assert!(!confirmed.contains(&unknown_rpc));
+        assert!(!confirmed.contains(&unknown_hex));
+
+        // Query-error arm: drop the table and re-run.
+        sqlx::query("DROP TABLE orders")
+            .execute(&pool)
+            .await
+            .unwrap();
+        verify_confirmed_orders(&pool, &mut ln, &mut confirmed).await;
+    }
+
+    #[tokio::test]
+    async fn recover_partial_payment_with_unknown_ln_status_is_left_alone() {
+        // Hash stored, unpaid, LN unreachable → Unknown → the order must
+        // keep its hash (the #620 duplicate-payment guard).
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, Some(VALID_HEX_HASH)).await;
+
+        let mut ln = dead_lnd().await;
+        let mut confirmed = HashSet::new();
+        recover_partial_payments(&pool, &mut ln, &mut confirmed).await;
+
+        let row: (i32, Option<String>) =
+            sqlx::query_as("SELECT dev_fee_paid, dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, 0);
+        assert_eq!(row.1.as_deref(), Some(VALID_HEX_HASH));
+        assert!(confirmed.is_empty());
+
+        // Query-error arm.
+        sqlx::query("DROP TABLE orders")
+            .execute(&pool)
+            .await
+            .unwrap();
+        recover_partial_payments(&pool, &mut ln, &mut confirmed).await;
+    }
+
+    #[tokio::test]
+    async fn payment_timeout_with_unknown_status_keeps_hash() {
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, Some(VALID_HEX_HASH)).await;
+        let order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        let mut ln = dead_lnd().await;
+        let mut confirmed = HashSet::new();
+        handle_payment_timeout(order, &pool, &mut ln, &mut confirmed).await;
+
+        let hash: Option<String> =
+            sqlx::query_scalar("SELECT dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(hash.as_deref(), Some(VALID_HEX_HASH));
+        assert!(confirmed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn payment_timeout_with_untrackable_hash_keeps_row() {
+        // A PENDING- marker is not a trackable hash: status resolves to
+        // Unknown without ever dialing LN.
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, Some("PENDING-x-1")).await;
+        let order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        let mut ln = dead_lnd().await;
+        let mut confirmed = HashSet::new();
+        handle_payment_timeout(order, &pool, &mut ln, &mut confirmed).await;
+        assert!(confirmed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_new_payments_claim_failure_skips_order() {
+        // A RAISE trigger makes the atomic claim UPDATE fail: the order
+        // is skipped (error branch) and nothing else runs — crucially, no
+        // LNURL resolution is attempted for it.
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, None).await;
+        sqlx::query(
+            "CREATE TRIGGER fail_orders_update BEFORE UPDATE ON orders \
+             BEGIN SELECT RAISE(ABORT, 'forced failure'); END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut ln = dead_lnd().await;
+        let mut confirmed = HashSet::new();
+        process_new_dev_fee_payments(&pool, &mut ln, &mut confirmed).await;
+
+        let row: (i32, Option<String>) =
+            sqlx::query_as("SELECT dev_fee_paid, dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, 0);
+        assert_eq!(row.1, None);
+        assert!(confirmed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_new_payments_query_failure_returns_early() {
+        let pool = setup_orders_db().await;
+        sqlx::query("DROP TABLE orders")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let mut ln = dead_lnd().await;
+        let mut confirmed = HashSet::new();
+        process_new_dev_fee_payments(&pool, &mut ln, &mut confirmed).await;
+        assert!(confirmed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn handle_payment_success_warns_on_hash_mismatch_and_uses_lnd_value() {
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, Some("stored-hash")).await;
+        let order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        let mut confirmed = HashSet::new();
+        handle_payment_success(order, &pool, &mut confirmed, "lnd-hash").await;
+
+        let row: (i32, Option<String>) =
+            sqlx::query_as("SELECT dev_fee_paid, dev_fee_payment_hash FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row.0, 1);
+        assert_eq!(row.1.as_deref(), Some("lnd-hash"), "LND's hash wins");
+        assert!(confirmed.contains(&id));
+    }
+
+    #[tokio::test]
+    async fn handle_payment_success_confirms_already_paid_row() {
+        // The guarded UPDATE (`WHERE dev_fee_paid = 0`) misses because a
+        // concurrent path already marked the row paid: the handler must
+        // still add the order to `confirmed` after re-checking the DB.
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, true, Some("deadbeef")).await;
+        let mut order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        // Stale snapshot claims unpaid.
+        order.dev_fee_paid = false;
+
+        let mut confirmed = HashSet::new();
+        handle_payment_success(order, &pool, &mut confirmed, "deadbeef").await;
+        assert!(confirmed.contains(&id));
+    }
+
+    #[tokio::test]
+    async fn handle_payment_success_db_failure_logs_critical_without_panic() {
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, None).await;
+        let order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        sqlx::query(
+            "CREATE TRIGGER fail_orders_update BEFORE UPDATE ON orders \
+             BEGIN SELECT RAISE(ABORT, 'forced failure'); END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut confirmed = HashSet::new();
+        handle_payment_success(order, &pool, &mut confirmed, "deadbeef").await;
+        // Payment was delivered but the DB write failed: the handler
+        // logs CRITICAL and does NOT mark the order confirmed.
+        assert!(!confirmed.contains(&id));
+    }
+
+    #[tokio::test]
+    async fn handle_payment_failure_db_failure_is_logged_not_propagated() {
+        use mostro_core::prelude::ServiceError;
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, Some("h")).await;
+        let order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        sqlx::query(
+            "CREATE TRIGGER fail_orders_update BEFORE UPDATE ON orders \
+             BEGIN SELECT RAISE(ABORT, 'forced failure'); END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let err = MostroError::MostroInternalErr(ServiceError::UnexpectedError("x".into()));
+        handle_payment_failure(order, &pool, id, &err).await;
+    }
+
+    #[tokio::test]
+    async fn resolve_dev_fee_invoice_rejects_non_positive_fee() {
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 0, false, None).await;
+        let order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(resolve_dev_fee_invoice(&order).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_dev_fee_payment_rejects_non_positive_fee() {
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 0, false, None).await;
+        let order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let mut ln = dead_lnd().await;
+        assert!(send_dev_fee_payment(&order, "lnbc1p", &mut ln)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn send_dev_fee_payment_fails_fast_when_lnd_unreachable() {
+        // Full send path against the dead endpoint: the pre-send track
+        // check errors (treated as "never attempted"), the amount check
+        // passes (invoice amount == dev_fee), and send_payment_v2 then
+        // fails with a transport error → the helper surfaces Err.
+        let pool = setup_orders_db().await;
+        let id = uuid::Uuid::new_v4();
+        insert_test_order(&pool, id, "success", 100, false, None).await;
+        let order =
+            sqlx::query_as::<_, mostro_core::order::Order>("SELECT * FROM orders WHERE id = ?")
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        let invoice = signed_test_invoice(100);
+        let mut ln = dead_lnd().await;
+        let result = send_dev_fee_payment(&order, &invoice, &mut ln).await;
+        assert!(result.is_err(), "dead endpoint must fail the send");
     }
 }

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -332,3 +332,431 @@ pub async fn close_dispute_after_user_resolution(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use crate::config::MESSAGE_QUEUES;
+    use nostr_sdk::Keys;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+
+    async fn create_test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        pool
+    }
+
+    fn build_ctx(pool: &SqlitePool) -> AppContext {
+        // The publish path reads the global config (event expiration);
+        // seed it once, ignoring the error when another test already did.
+        let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+        TestContextBuilder::new()
+            .with_pool(Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// Build an `UnwrappedMessage` whose trade key (rumor author / `sender`)
+    /// is `sender`. The identity key is generated separately, mirroring the
+    /// dual-key flow used by the cancel tests.
+    fn create_event(sender: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::new_order(None, Some(1), None, Action::Dispute, None),
+            signature: None,
+            sender,
+            identity: Keys::generate().public_key(),
+            created_at: Timestamp::now(),
+        }
+    }
+
+    fn create_order(buyer: Option<PublicKey>, seller: Option<PublicKey>, status: Status) -> Order {
+        Order {
+            id: uuid::Uuid::new_v4(),
+            status: status.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: seller.map(|p| p.to_string()).unwrap_or_default(),
+            seller_pubkey: seller.map(|p| p.to_string()),
+            buyer_pubkey: buyer.map(|p| p.to_string()),
+            amount: 21_000,
+            ..Default::default()
+        }
+    }
+
+    fn dispute_msg_for(order_id: Option<uuid::Uuid>) -> Message {
+        Message::new_order(order_id, Some(1), None, Action::Dispute, None)
+    }
+
+    #[test]
+    fn get_counterpart_info_identifies_initiator_and_rejects_stranger() {
+        let buyer = "buyer-pubkey";
+        let seller = "seller-pubkey";
+
+        assert_eq!(get_counterpart_info(buyer, buyer, seller), Ok(true));
+        assert_eq!(get_counterpart_info(seller, buyer, seller), Ok(false));
+        assert_eq!(
+            get_counterpart_info("stranger", buyer, seller),
+            Err(CantDoReason::InvalidPubkey)
+        );
+    }
+
+    #[tokio::test]
+    async fn dispute_action_without_order_id_returns_not_found() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let sender = Keys::generate().public_key();
+        let event = create_event(sender);
+
+        let result = dispute_action(&ctx, dispute_msg_for(None), &event, &Keys::generate()).await;
+
+        assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+    }
+
+    #[tokio::test]
+    async fn dispute_action_with_unknown_order_id_returns_not_found() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let sender = Keys::generate().public_key();
+        let event = create_event(sender);
+
+        let result = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(uuid::Uuid::new_v4())),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+    }
+
+    #[tokio::test]
+    async fn dispute_action_rejects_order_that_already_has_a_dispute() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), Some(seller), Status::Active)
+            .create(&pool)
+            .await
+            .unwrap();
+        Dispute::new(order.id, order.status.clone())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_event(buyer);
+        let result = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(order.id)),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DisputeAlreadyExists))
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispute_action_rejects_order_with_non_disputable_status() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), Some(seller), Status::Pending)
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_event(buyer);
+        let result = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(order.id)),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispute_action_rejects_order_missing_seller_pubkey() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), None, Status::Active)
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_event(buyer);
+        let result = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(order.id)),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispute_action_rejects_order_missing_buyer_pubkey() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(None, Some(seller), Status::Active)
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_event(seller);
+        let result = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(order.id)),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispute_action_rejects_sender_that_is_not_a_party() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), Some(seller), Status::Active)
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let intruder = Keys::generate().public_key();
+        let event = create_event(intruder);
+        let result = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(order.id)),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+    }
+
+    /// Full buyer-initiated flow on an `Active` order. All DB side effects
+    /// (order flags/status, dispute row) and both queue notifications happen
+    /// before the final Nostr publish, which fails offline (default client
+    /// with no relays), so the handler ends in `DisputeEventError`. The
+    /// publish-success branch of `publish_dispute_event` is unreachable in
+    /// unit tests.
+    #[tokio::test]
+    async fn dispute_action_buyer_initiated_flow_persists_dispute_and_notifies() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), Some(seller), Status::Active)
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_event(buyer);
+        let result = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(order.id)),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DisputeEventError))
+        ));
+
+        // Order flags and status were persisted before the publish failed
+        let stored_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert!(stored_order.buyer_dispute);
+        assert!(!stored_order.seller_dispute);
+        assert_eq!(stored_order.status, Status::Dispute.to_string());
+
+        // Dispute row was created preserving the previous order status
+        let dispute = find_dispute_by_order_id(&pool, order.id).await.unwrap();
+        assert_eq!(dispute.status, DisputeStatus::Initiated.to_string());
+        assert_eq!(dispute.order_previous_status, Status::Active.to_string());
+
+        // Both parties were notified (queue is global; filter by order id)
+        let queue = MESSAGE_QUEUES.queue_order_msg.read().await;
+        let notifications: Vec<_> = queue
+            .iter()
+            .filter(|(m, _)| m.get_inner_message_kind().id == Some(order.id))
+            .collect();
+        assert_eq!(notifications.len(), 2);
+        assert!(notifications.iter().any(|(m, dest)| {
+            m.get_inner_message_kind().action == Action::DisputeInitiatedByPeer && *dest == seller
+        }));
+        assert!(notifications.iter().any(|(m, dest)| {
+            m.get_inner_message_kind().action == Action::DisputeInitiatedByYou && *dest == buyer
+        }));
+    }
+
+    #[tokio::test]
+    async fn dispute_action_seller_initiated_flow_on_fiat_sent_order() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), Some(seller), Status::FiatSent)
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_event(seller);
+        let result = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(order.id)),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DisputeEventError))
+        ));
+
+        let stored_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert!(stored_order.seller_dispute);
+        assert!(!stored_order.buyer_dispute);
+        assert_eq!(stored_order.status, Status::Dispute.to_string());
+
+        let dispute = find_dispute_by_order_id(&pool, order.id).await.unwrap();
+        assert_eq!(dispute.order_previous_status, Status::FiatSent.to_string());
+
+        let queue = MESSAGE_QUEUES.queue_order_msg.read().await;
+        let notifications: Vec<_> = queue
+            .iter()
+            .filter(|(m, _)| m.get_inner_message_kind().id == Some(order.id))
+            .collect();
+        assert_eq!(notifications.len(), 2);
+        assert!(notifications.iter().any(|(m, dest)| {
+            m.get_inner_message_kind().action == Action::DisputeInitiatedByPeer && *dest == buyer
+        }));
+        assert!(notifications.iter().any(|(m, dest)| {
+            m.get_inner_message_kind().action == Action::DisputeInitiatedByYou && *dest == seller
+        }));
+    }
+
+    #[tokio::test]
+    async fn close_dispute_after_user_resolution_is_noop_without_dispute_row() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+        let order = create_order(Some(buyer), Some(seller), Status::Active);
+
+        // No dispute row exists: must be a silent no-op
+        close_dispute_after_user_resolution(
+            &ctx,
+            &order,
+            DisputeStatus::Settled,
+            &Keys::generate(),
+            "release",
+        )
+        .await;
+
+        assert!(find_dispute_by_order_id(&pool, order.id).await.is_err());
+    }
+
+    /// Consistent flags (`seller_dispute` only) resolve to the "seller"
+    /// initiator branch; the dispute row is updated even though the final
+    /// event publish fails offline (error is only logged).
+    #[tokio::test]
+    async fn close_dispute_after_user_resolution_updates_dispute_status() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let mut order = create_order(Some(buyer), Some(seller), Status::Dispute);
+        order.seller_dispute = true;
+        let order = order.create(&pool).await.unwrap();
+        Dispute::new(order.id, Status::Active.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        close_dispute_after_user_resolution(
+            &ctx,
+            &order,
+            DisputeStatus::SellerRefunded,
+            &Keys::generate(),
+            "cooperative cancel",
+        )
+        .await;
+
+        let dispute = find_dispute_by_order_id(&pool, order.id).await.unwrap();
+        assert_eq!(dispute.status, DisputeStatus::SellerRefunded.to_string());
+    }
+
+    /// Inconsistent flags (both unset) fall into the "unknown" initiator
+    /// branch; the dispute status update must still be persisted.
+    #[tokio::test]
+    async fn close_dispute_after_user_resolution_handles_inconsistent_flags() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        // Neither dispute flag set: inconsistent with an existing dispute row
+        let order = create_order(Some(buyer), Some(seller), Status::Dispute)
+            .create(&pool)
+            .await
+            .unwrap();
+        Dispute::new(order.id, Status::Active.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        close_dispute_after_user_resolution(
+            &ctx,
+            &order,
+            DisputeStatus::Settled,
+            &Keys::generate(),
+            "release",
+        )
+        .await;
+
+        let dispute = find_dispute_by_order_id(&pool, order.id).await.unwrap();
+        assert_eq!(dispute.status, DisputeStatus::Settled.to_string());
+    }
+}

--- a/src/app/fiat_sent.rs
+++ b/src/app/fiat_sent.rs
@@ -91,3 +91,222 @@ pub async fn fiat_sent_action(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use crate::app::context::AppContext;
+    use crate::config::{MESSAGE_QUEUES, MOSTRO_CONFIG};
+    use nostr_sdk::{Keys, Timestamp};
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+
+    /// The `MOSTRO_CONFIG` OnceLock is process-global: set it to the shared
+    /// `test_settings()` defaults (idempotent across concurrent tests).
+    fn init_global_config() {
+        let _ = MOSTRO_CONFIG.set(test_settings());
+    }
+
+    async fn create_test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        pool
+    }
+
+    fn build_ctx(pool: &SqlitePool) -> AppContext {
+        TestContextBuilder::new()
+            .with_pool(Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// Build an `UnwrappedMessage` whose trade key (rumor author / `sender`)
+    /// is `pubkey`, mirroring the fixture used by the cancel handler tests.
+    fn create_unwrapped_message_with_pubkey(pubkey: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::Order(MessageKind::new(
+                Some(uuid::Uuid::new_v4()),
+                Some(1),
+                None,
+                Action::FiatSent,
+                None,
+            )),
+            signature: None,
+            sender: pubkey,
+            identity: Keys::generate().public_key(),
+            created_at: Timestamp::now(),
+        }
+    }
+
+    fn active_sell_order(seller: PublicKey, buyer: PublicKey) -> Order {
+        Order {
+            id: uuid::Uuid::new_v4(),
+            status: Status::Active.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: seller.to_string(),
+            seller_pubkey: Some(seller.to_string()),
+            master_seller_pubkey: Some(seller.to_string()),
+            buyer_pubkey: Some(buyer.to_string()),
+            master_buyer_pubkey: Some(buyer.to_string()),
+            amount: 21_000,
+            fee: 21,
+            fiat_amount: 40,
+            ..Default::default()
+        }
+    }
+
+    fn fiat_sent_message(order_id: uuid::Uuid, payload: Option<Payload>) -> Message {
+        Message::new_order(Some(order_id), Some(1), None, Action::FiatSent, payload)
+    }
+
+    /// Actions queued on the process-global order queue for a given order id.
+    /// The queue is shared across concurrently running tests, so assertions
+    /// must always filter by our own order id.
+    async fn queued_actions_for(order_id: uuid::Uuid) -> Vec<Action> {
+        MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(msg, _)| msg.get_inner_message_kind().id == Some(order_id))
+            .map(|(msg, _)| msg.get_inner_message_kind().action.clone())
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn fiat_sent_action_rejects_order_that_is_not_active() {
+        // Arrange
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = active_sell_order(seller, buyer);
+        order.status = Status::Pending.to_string();
+        let order = order.create(&pool).await.unwrap();
+        let event = create_unwrapped_message_with_pubkey(buyer);
+        let msg = fiat_sent_message(order.id, None);
+        let my_keys = Keys::generate();
+
+        // Act
+        let result = fiat_sent_action(&ctx, msg, &event, &my_keys).await;
+
+        // Assert
+        assert!(matches!(result, Err(MostroCantDo(_))));
+    }
+
+    #[tokio::test]
+    async fn fiat_sent_action_rejects_sender_that_is_not_the_buyer() {
+        // Arrange: the seller (not the buyer) tries to mark fiat as sent.
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = active_sell_order(seller, buyer)
+            .create(&pool)
+            .await
+            .unwrap();
+        let event = create_unwrapped_message_with_pubkey(seller);
+        let msg = fiat_sent_message(order.id, None);
+        let my_keys = Keys::generate();
+
+        // Act
+        let result = fiat_sent_action(&ctx, msg, &event, &my_keys).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+    }
+
+    #[tokio::test]
+    async fn fiat_sent_action_rejects_invalid_next_trade_payload() {
+        // Arrange: a payload that is not NextTrade makes key extraction fail.
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = active_sell_order(seller, buyer)
+            .create(&pool)
+            .await
+            .unwrap();
+        let event = create_unwrapped_message_with_pubkey(buyer);
+        let msg = fiat_sent_message(order.id, Some(Payload::RatingUser(5)));
+        let my_keys = Keys::generate();
+
+        // Act
+        let result = fiat_sent_action(&ctx, msg, &event, &my_keys).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPayload))
+        ));
+    }
+
+    #[tokio::test]
+    async fn fiat_sent_action_marks_order_fiat_sent_and_notifies_both_peers() {
+        // Arrange
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = active_sell_order(seller, buyer)
+            .create(&pool)
+            .await
+            .unwrap();
+        let event = create_unwrapped_message_with_pubkey(buyer);
+        let msg = fiat_sent_message(order.id, None);
+        let my_keys = Keys::generate();
+
+        // Act
+        let result = fiat_sent_action(&ctx, msg, &event, &my_keys).await;
+
+        // Assert: status persisted, both peers got FiatSentOk, no next trade.
+        assert!(result.is_ok());
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(db_order.status, Status::FiatSent.to_string());
+        assert_eq!(db_order.next_trade_pubkey, None);
+        assert_eq!(db_order.next_trade_index, None);
+        let fiat_sent_oks = queued_actions_for(order.id)
+            .await
+            .into_iter()
+            .filter(|action| *action == Action::FiatSentOk)
+            .count();
+        assert_eq!(fiat_sent_oks, 2);
+    }
+
+    #[tokio::test]
+    async fn fiat_sent_action_stores_next_trade_for_range_orders() {
+        // Arrange: range order plus a NextTrade payload from the buyer-maker.
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let next_trade = Keys::generate().public_key();
+        let mut order = active_sell_order(seller, buyer);
+        order.max_amount = Some(100);
+        order.min_amount = Some(10);
+        let order = order.create(&pool).await.unwrap();
+        let event = create_unwrapped_message_with_pubkey(buyer);
+        let msg = fiat_sent_message(
+            order.id,
+            Some(Payload::NextTrade(next_trade.to_string(), 7)),
+        );
+        let my_keys = Keys::generate();
+
+        // Act
+        let result = fiat_sent_action(&ctx, msg, &event, &my_keys).await;
+
+        // Assert: next trade fields persisted alongside the status change.
+        assert!(result.is_ok());
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(db_order.status, Status::FiatSent.to_string());
+        assert_eq!(db_order.next_trade_pubkey, Some(next_trade.to_string()));
+        assert_eq!(db_order.next_trade_index, Some(7));
+    }
+}

--- a/src/app/last_trade_index.rs
+++ b/src/app/last_trade_index.rs
@@ -225,6 +225,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_last_trade_index_zero_index_is_rejected() {
+        // Arrange: user exists but with the invalid sentinel index 0.
+        let pool = setup_test_db().await;
+        let sender_keys = create_test_keys();
+        insert_test_user(&pool, &sender_keys.public_key().to_string(), 0).await;
+
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let event = create_test_unwrapped_message(&sender_keys);
+        let kind = MessageKind::new(None, Some(1), None, Action::LastTradeIndex, None);
+
+        // Act
+        let result = last_trade_index(&ctx, Message::Restore(kind), &event, &sender_keys).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroError::MostroCantDo(CantDoReason::InvalidTradeIndex))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_last_trade_index_success_path_sends_dm() {
+        // Arrange: user exists with a valid index; the DM send is best-effort
+        // (errors are logged, not propagated), so the handler must return Ok.
+        let pool = setup_test_db().await;
+        let sender_keys = create_test_keys();
+        insert_test_user(&pool, &sender_keys.public_key().to_string(), 42).await;
+
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let event = create_test_unwrapped_message(&sender_keys);
+        let kind = MessageKind::new(None, Some(7), None, Action::LastTradeIndex, None);
+
+        // Act
+        let result = last_trade_index(&ctx, Message::Restore(kind), &event, &sender_keys).await;
+
+        // Assert
+        assert!(
+            result.is_ok(),
+            "success path must swallow DM transport errors: {result:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_last_trade_index_correct_value() {
         // Setup: Create database with multiple users with different trade indexes
         let pool = setup_test_db().await;

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -391,6 +391,227 @@ mod tests {
         let _ = order_action(&ctx, msg3, &event2, &keys).await;
     }
 
+    mod calculate_and_check_quote_tests {
+        use super::*;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        use crate::bitcoin_price::BitcoinPriceManager;
+        use std::sync::Arc;
+
+        async fn create_ctx() -> AppContext {
+            let pool = Arc::new(SqlitePool::connect(":memory:").await.unwrap());
+            TestContextBuilder::new()
+                .with_pool(pool)
+                .with_settings(test_settings())
+                .build()
+        }
+
+        fn order_with(amount: i64, fiat_code: &str) -> SmallOrder {
+            SmallOrder {
+                amount,
+                fiat_code: fiat_code.to_string(),
+                ..Default::default()
+            }
+        }
+
+        #[tokio::test]
+        async fn fixed_amount_inside_limits_is_accepted() {
+            let ctx = create_ctx().await;
+            let order = order_with(50_000, "USD");
+            assert!(calculate_and_check_quote(&ctx, &order, &100).await.is_ok());
+        }
+
+        #[tokio::test]
+        async fn fixed_amount_below_min_is_out_of_range() {
+            let ctx = create_ctx().await;
+            // min_payment_amount is 100 sats in test settings.
+            let order = order_with(10, "USD");
+            let err = calculate_and_check_quote(&ctx, &order, &100)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                MostroCantDo(CantDoReason::OutOfRangeSatsAmount)
+            ));
+        }
+
+        #[tokio::test]
+        async fn negative_amount_is_invalid() {
+            let ctx = create_ctx().await;
+            let order = order_with(-5, "USD");
+            let err = calculate_and_check_quote(&ctx, &order, &100)
+                .await
+                .unwrap_err();
+            assert!(matches!(err, MostroCantDo(CantDoReason::InvalidAmount)));
+        }
+
+        #[tokio::test]
+        async fn market_priced_order_uses_cached_price() {
+            let ctx = create_ctx().await;
+            // Unique currency code avoids clobbering the shared override map.
+            BitcoinPriceManager::set_price_for_test("QUOTE1", 50_000.0);
+            let order = order_with(0, "QUOTE1");
+            // 100 / 50_000 * 1e8 = 200_000 sats → inside [100, 1_000_000].
+            assert!(calculate_and_check_quote(&ctx, &order, &100).await.is_ok());
+        }
+
+        #[tokio::test]
+        async fn market_priced_order_without_price_data_fails() {
+            let ctx = create_ctx().await;
+            // No override and no global PriceManager → NoAPIResponse.
+            let order = order_with(0, "QUOTE2");
+            let err = calculate_and_check_quote(&ctx, &order, &100)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                MostroInternalErr(ServiceError::NoAPIResponse)
+            ));
+        }
+
+        #[tokio::test]
+        async fn market_priced_order_above_max_is_out_of_range() {
+            let ctx = create_ctx().await;
+            BitcoinPriceManager::set_price_for_test("QUOTE3", 1.0);
+            // 100 / 1.0 * 1e8 = 10_000_000_000 sats → above max_order_amount.
+            let order = order_with(0, "QUOTE3");
+            let err = calculate_and_check_quote(&ctx, &order, &100)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                err,
+                MostroCantDo(CantDoReason::OutOfRangeSatsAmount)
+            ));
+        }
+    }
+
+    mod order_action_flow_tests {
+        use super::*;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        use std::sync::Arc;
+
+        async fn create_migrated_ctx() -> AppContext {
+            let pool = Arc::new(SqlitePool::connect(":memory:").await.unwrap());
+            sqlx::migrate!("./migrations")
+                .run(pool.as_ref())
+                .await
+                .unwrap();
+            TestContextBuilder::new()
+                .with_pool(pool)
+                .with_settings(test_settings())
+                .build()
+        }
+
+        fn init_globals() {
+            let _ =
+                crate::config::MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
+            let _ = crate::NOSTR_CLIENT.set(nostr_sdk::Client::default());
+        }
+
+        fn order_message(fiat_code: &str, trade_index: Option<i64>) -> Message {
+            let order = SmallOrder {
+                kind: Some(mostro_core::order::Kind::Sell),
+                amount: 1_000,
+                fiat_code: fiat_code.to_string(),
+                fiat_amount: 100,
+                payment_method: "SEPA".to_string(),
+                ..Default::default()
+            };
+            Message::new_order(
+                None,
+                Some(1),
+                trade_index,
+                Action::NewOrder,
+                Some(Payload::Order(order)),
+            )
+        }
+
+        #[tokio::test]
+        async fn unsupported_fiat_currency_is_rejected() {
+            init_globals();
+            let ctx = create_migrated_ctx().await;
+            let keys = create_test_keys();
+            let event = create_test_unwrapped_message();
+
+            let msg = order_message("XXX", Some(1));
+            let err = order_action(&ctx, msg, &event, &keys).await.unwrap_err();
+            assert!(
+                matches!(err, MostroCantDo(_)),
+                "unsupported currency must be a CantDo: {err:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn missing_trade_index_with_distinct_identity_is_invalid_payload() {
+            init_globals();
+            let ctx = create_migrated_ctx().await;
+            let keys = create_test_keys();
+            // identity != sender and no trade_index → InvalidPayload.
+            let event = create_test_unwrapped_message();
+
+            let msg = order_message("USD", None);
+            let err = order_action(&ctx, msg, &event, &keys).await.unwrap_err();
+            assert!(matches!(
+                err,
+                MostroInternalErr(ServiceError::InvalidPayload)
+            ));
+        }
+
+        #[tokio::test]
+        async fn valid_order_reaches_publication_and_persists_row() {
+            init_globals();
+            let ctx = create_migrated_ctx().await;
+            let keys = create_test_keys();
+            // Full-privacy shape: identity == sender → trade_index defaults to 0.
+            let mut event = create_test_unwrapped_message();
+            event.identity = event.sender;
+
+            let msg = order_message("USD", None);
+            let result = order_action(&ctx, msg, &event, &keys).await;
+            // The offline Nostr client cannot broadcast, so the pipeline ends
+            // with a NostrError — but only AFTER the order row was persisted.
+            assert!(
+                matches!(result, Err(MostroInternalErr(ServiceError::NostrError(_)))),
+                "expected broadcast failure at the very end: {result:?}"
+            );
+
+            let row: (String, String) =
+                sqlx::query_as("SELECT status, event_id FROM orders LIMIT 1")
+                    .fetch_one(ctx.pool())
+                    .await
+                    .expect("order row must be persisted");
+            assert_eq!(row.0, "pending");
+            assert!(!row.1.is_empty(), "event_id must be recorded");
+        }
+
+        #[tokio::test]
+        async fn valid_order_with_trade_index_updates_user_index() {
+            init_globals();
+            let ctx = create_migrated_ctx().await;
+            let keys = create_test_keys();
+            let event = create_test_unwrapped_message();
+
+            // A registered identity (check_trade_index would have created it
+            // on first contact) keeps the tags path on the known-user branch.
+            crate::db::add_new_user(
+                ctx.pool(),
+                mostro_core::user::User {
+                    pubkey: event.identity.to_string(),
+                    last_trade_index: 1,
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("insert identity user");
+
+            let msg = order_message("USD", Some(7));
+            let result = order_action(&ctx, msg, &event, &keys).await;
+            assert!(
+                matches!(result, Err(MostroInternalErr(ServiceError::NostrError(_)))),
+                "expected broadcast failure at the very end: {result:?}"
+            );
+        }
+    }
+
     mod quote_calculation_tests {
 
         #[test]

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -56,3 +56,169 @@ pub async fn orders_action(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use mostro_core::db::Crud;
+    use nostr_sdk::{Keys, Timestamp};
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    async fn setup_ctx() -> AppContext {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+        sqlx::migrate!("./migrations")
+            .run(pool.as_ref())
+            .await
+            .unwrap();
+        TestContextBuilder::new()
+            .with_pool(pool)
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// `sender` is the trade key the response is addressed to; `identity`
+    /// is the master key ownership checks run against.
+    fn orders_event(sender: PublicKey, identity: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::Order(MessageKind::new(None, Some(1), None, Action::Orders, None)),
+            signature: None,
+            sender,
+            identity,
+            created_at: Timestamp::now(),
+        }
+    }
+
+    fn orders_msg(payload: Option<Payload>) -> Message {
+        Message::new_order(None, Some(1), None, Action::Orders, payload)
+    }
+
+    fn base_order() -> Order {
+        Order {
+            id: Uuid::new_v4(),
+            status: Status::Pending.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: Keys::generate().public_key().to_string(),
+            amount: 10_000,
+            fee: 10,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn orders_action_rejects_missing_or_non_ids_payload() {
+        let ctx = setup_ctx().await;
+        let sender = Keys::generate().public_key();
+        let identity = Keys::generate().public_key();
+        let event = orders_event(sender, identity);
+
+        let result = orders_action(&ctx, orders_msg(None), &event).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidParameters))
+        ));
+    }
+
+    #[tokio::test]
+    async fn orders_action_rejects_empty_ids_list() {
+        let ctx = setup_ctx().await;
+        let sender = Keys::generate().public_key();
+        let identity = Keys::generate().public_key();
+        let event = orders_event(sender, identity);
+
+        let result = orders_action(&ctx, orders_msg(Some(Payload::Ids(vec![]))), &event).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidParameters))
+        ));
+    }
+
+    #[tokio::test]
+    async fn orders_action_rejects_more_ids_than_configured_maximum() {
+        let ctx = setup_ctx().await;
+        let sender = Keys::generate().public_key();
+        let identity = Keys::generate().public_key();
+        let event = orders_event(sender, identity);
+
+        let too_many = ctx.settings().mostro.max_orders_per_response as usize + 1;
+        let ids: Vec<Uuid> = (0..too_many).map(|_| Uuid::new_v4()).collect();
+
+        let result = orders_action(&ctx, orders_msg(Some(Payload::Ids(ids))), &event).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::TooManyRequests))
+        ));
+    }
+
+    #[tokio::test]
+    async fn orders_action_returns_not_found_for_unknown_or_foreign_orders() {
+        let ctx = setup_ctx().await;
+        let sender = Keys::generate().public_key();
+        let identity = Keys::generate().public_key();
+        let event = orders_event(sender, identity);
+
+        // An order owned by a completely different master key must be
+        // invisible to this identity.
+        let mut foreign_order = base_order();
+        foreign_order.master_buyer_pubkey = Some(Keys::generate().public_key().to_string());
+        let foreign_order = foreign_order.create(ctx.pool()).await.unwrap();
+
+        let ids = vec![Uuid::new_v4(), foreign_order.id];
+        let result = orders_action(&ctx, orders_msg(Some(Payload::Ids(ids))), &event).await;
+
+        assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+    }
+
+    #[tokio::test]
+    async fn orders_action_returns_user_orders_and_clears_buyer_invoice() {
+        let ctx = setup_ctx().await;
+        let sender = Keys::generate().public_key();
+        let identity = Keys::generate().public_key();
+        let event = orders_event(sender, identity);
+
+        let mut as_buyer = base_order();
+        as_buyer.master_buyer_pubkey = Some(identity.to_string());
+        as_buyer.buyer_invoice = Some("lnbc1-private-invoice".to_string());
+        let as_buyer = as_buyer.create(ctx.pool()).await.unwrap();
+
+        let mut as_seller = base_order();
+        as_seller.master_seller_pubkey = Some(identity.to_string());
+        let as_seller = as_seller.create(ctx.pool()).await.unwrap();
+
+        let ids = vec![as_buyer.id, as_seller.id];
+        let result = orders_action(&ctx, orders_msg(Some(Payload::Ids(ids))), &event).await;
+        assert!(result.is_ok(), "owned ids must resolve: {result:?}");
+
+        // The response goes to the process-global queue; filter by this
+        // test's unique sender key to stay isolated from parallel tests.
+        let queued: Vec<Message> = crate::config::MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(_, pk)| *pk == sender)
+            .map(|(m, _)| m.clone())
+            .collect();
+        assert_eq!(queued.len(), 1, "exactly one response for this sender");
+
+        let kind = queued[0].get_inner_message_kind();
+        assert_eq!(kind.action, Action::Orders);
+        match kind.get_payload() {
+            Some(Payload::Orders(small_orders)) => {
+                let returned_ids: Vec<Option<Uuid>> = small_orders.iter().map(|o| o.id).collect();
+                assert_eq!(returned_ids, vec![Some(as_buyer.id), Some(as_seller.id)]);
+                assert!(
+                    small_orders.iter().all(|o| o.buyer_invoice.is_none()),
+                    "buyer_invoice must be stripped from the response"
+                );
+            }
+            other => panic!("expected Payload::Orders, got {other:?}"),
+        }
+    }
+}

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -234,7 +234,14 @@ mod tests {
     fn init_test_settings() {
         let _ = MOSTRO_CONFIG.set(Settings {
             database: Default::default(),
-            nostr: Default::default(),
+            nostr: crate::config::NostrSettings {
+                // Valid canonical test nsec: whichever module wins the
+                // MOSTRO_CONFIG race must install a parseable key, or tests
+                // that reach get_keys() flake on init ordering.
+                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
+                    .to_string(),
+                relays: vec![],
+            },
             mostro: Default::default(),
             lightning: Default::default(),
             rpc: Default::default(),
@@ -692,5 +699,250 @@ mod tests {
         let created_at = (now - 86_400 - 43_200) as i64;
         let days = calculate_days_since_creation(created_at);
         assert_eq!(days, 1);
+    }
+
+    #[test]
+    fn test_prepare_variables_missing_seller_pubkey_errors() {
+        let buyer_keys = create_test_keys();
+        let mut order = create_test_order(
+            Status::Success,
+            create_test_keys().public_key(),
+            buyer_keys.public_key(),
+        );
+        order.seller_pubkey = None;
+        let result = prepare_variables_for_vote(&buyer_keys.public_key().to_string(), &order);
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+    }
+
+    #[test]
+    fn test_prepare_variables_missing_buyer_pubkey_errors() {
+        let seller_keys = create_test_keys();
+        let mut order = create_test_order(
+            Status::Success,
+            seller_keys.public_key(),
+            create_test_keys().public_key(),
+        );
+        order.buyer_pubkey = None;
+        let result = prepare_variables_for_vote(&seller_keys.public_key().to_string(), &order);
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+    }
+
+    #[test]
+    fn test_prepare_variables_unknown_sender_sets_no_flags() {
+        // A sender that is neither buyer nor seller falls through both
+        // arms: no rating flag set and an empty counterpart pubkey.
+        let order = create_test_order(
+            Status::Success,
+            create_test_keys().public_key(),
+            create_test_keys().public_key(),
+        );
+        let stranger = create_test_keys().public_key().to_string();
+        let (counterpart, buyer_rating, seller_rating) =
+            prepare_variables_for_vote(&stranger, &order).unwrap();
+        assert!(counterpart.is_empty());
+        assert!(!buyer_rating);
+        assert!(!seller_rating);
+    }
+
+    #[tokio::test]
+    async fn test_buyer_rating_full_privacy_seller_is_silent_noop() {
+        // Buyer rates, but the seller has no distinct identity key
+        // (full privacy): there is no user row to credit, so the action
+        // returns Ok without touching anything.
+        let pool = create_test_pool().await;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let keys = create_test_keys();
+        let seller_pk = create_test_keys().public_key();
+        let buyer_pk = create_test_keys().public_key();
+
+        // No master_seller_pubkey → seller reads as full-privacy.
+        let mut order = create_test_order(Status::Success, seller_pk, buyer_pk);
+        order.master_buyer_pubkey = Some(create_test_keys().public_key().to_string());
+        let order = order.create(&pool).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(buyer_pk);
+        let msg = create_rate_user_message(order.id, 5);
+        let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_seller_rating_full_privacy_buyer_is_silent_noop() {
+        // Mirror case: seller rates a full-privacy buyer → Ok, no-op.
+        let pool = create_test_pool().await;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let keys = create_test_keys();
+        let seller_pk = create_test_keys().public_key();
+        let buyer_pk = create_test_keys().public_key();
+
+        let mut order = create_test_order(Status::Success, seller_pk, buyer_pk);
+        order.master_seller_pubkey = Some(create_test_keys().public_key().to_string());
+        let order = order.create(&pool).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(seller_pk);
+        let msg = create_rate_user_message(order.id, 5);
+        let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_buyer_rating_with_absent_seller_user_row_errors() {
+        // Seller identity key set, but no matching row in `users`:
+        // `is_user_present` fails and must surface as DbAccessError.
+        let pool = create_test_pool().await;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let keys = create_test_keys();
+        let seller_pk = create_test_keys().public_key();
+        let buyer_pk = create_test_keys().public_key();
+
+        let mut order = create_test_order(Status::Success, seller_pk, buyer_pk);
+        order.master_seller_pubkey = Some(create_test_keys().public_key().to_string());
+        order.master_buyer_pubkey = Some(create_test_keys().public_key().to_string());
+        let order = order.create(&pool).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(buyer_pk);
+        let msg = create_rate_user_message(order.id, 5);
+        let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DbAccessError(_)))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_seller_rating_with_absent_buyer_user_row_errors() {
+        // Mirror case for the seller-rating arm of the privacy lookup.
+        let pool = create_test_pool().await;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let keys = create_test_keys();
+        let seller_pk = create_test_keys().public_key();
+        let buyer_pk = create_test_keys().public_key();
+
+        let mut order = create_test_order(Status::Success, seller_pk, buyer_pk);
+        order.master_seller_pubkey = Some(create_test_keys().public_key().to_string());
+        order.master_buyer_pubkey = Some(create_test_keys().public_key().to_string());
+        let order = order.create(&pool).await.unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(seller_pk);
+        let msg = create_rate_user_message(order.id, 5);
+        let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DbAccessError(_)))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_update_user_rating_db_failure_surfaces_error() {
+        // Force the `users` UPDATE to fail via a RAISE trigger so the
+        // `update_user_rating` error branch is exercised without
+        // touching production code.
+        use crate::db::add_new_user;
+
+        let pool = create_test_pool().await;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let keys = create_test_keys();
+        let seller_pk = create_test_keys().public_key();
+        let buyer_pk = create_test_keys().public_key();
+        let seller_id = create_test_keys().public_key().to_string();
+
+        let seller_user = User {
+            pubkey: seller_id.clone(),
+            ..Default::default()
+        };
+        add_new_user(&pool, seller_user).await.unwrap();
+
+        let mut order = create_test_order(Status::Success, seller_pk, buyer_pk);
+        order.master_seller_pubkey = Some(seller_id.clone());
+        order.master_buyer_pubkey = Some(create_test_keys().public_key().to_string());
+        let order = order.create(&pool).await.unwrap();
+
+        sqlx::query(
+            "CREATE TRIGGER fail_users_update BEFORE UPDATE ON users \
+             BEGIN SELECT RAISE(ABORT, 'forced users failure'); END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(buyer_pk);
+        let msg = create_rate_user_message(order.id, 5);
+        let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DbAccessError(_)))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_update_user_rating_event_db_failure_surfaces_error() {
+        // The user rating write succeeds, but the follow-up order-flag
+        // update (`update_user_rating_event`) fails via a RAISE trigger
+        // on `orders` — the error must map to DbAccessError.
+        use crate::db::add_new_user;
+
+        let pool = create_test_pool().await;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let keys = create_test_keys();
+        let seller_pk = create_test_keys().public_key();
+        let buyer_pk = create_test_keys().public_key();
+        let seller_id = create_test_keys().public_key().to_string();
+
+        let seller_user = User {
+            pubkey: seller_id.clone(),
+            ..Default::default()
+        };
+        add_new_user(&pool, seller_user).await.unwrap();
+
+        let mut order = create_test_order(Status::Success, seller_pk, buyer_pk);
+        order.master_seller_pubkey = Some(seller_id.clone());
+        order.master_buyer_pubkey = Some(create_test_keys().public_key().to_string());
+        let order = order.create(&pool).await.unwrap();
+
+        sqlx::query(
+            "CREATE TRIGGER fail_orders_update BEFORE UPDATE ON orders \
+             BEGIN SELECT RAISE(ABORT, 'forced orders failure'); END;",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(buyer_pk);
+        let msg = create_rate_user_message(order.id, 5);
+        let result = update_user_reputation_action(&ctx, msg, &event, &keys).await;
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::DbAccessError(_)))
+        ));
     }
 }

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -760,3 +760,966 @@ async fn order_for_greater(
 
     Ok((new_order.clone(), event))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use crate::app::context::AppContext;
+    use crate::config::{MESSAGE_QUEUES, MOSTRO_CONFIG};
+    use async_trait::async_trait;
+    use nostr_sdk::{Keys, Timestamp};
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+
+    /// The `MOSTRO_CONFIG` OnceLock is process-global: set it to the shared
+    /// `test_settings()` defaults (idempotent across concurrent tests).
+    fn init_global_config() {
+        let _ = MOSTRO_CONFIG.set(test_settings());
+    }
+
+    async fn create_test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        pool
+    }
+
+    fn build_ctx(pool: &SqlitePool) -> AppContext {
+        TestContextBuilder::new()
+            .with_pool(Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// Build an `UnwrappedMessage` whose trade key (rumor author / `sender`)
+    /// is `pubkey`, mirroring the fixture used by the cancel handler tests.
+    fn create_unwrapped_message_with_pubkey(pubkey: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::Order(MessageKind::new(
+                Some(uuid::Uuid::new_v4()),
+                Some(1),
+                None,
+                Action::Release,
+                None,
+            )),
+            signature: None,
+            sender: pubkey,
+            identity: Keys::generate().public_key(),
+            created_at: Timestamp::now(),
+        }
+    }
+
+    /// Sell order in `FiatSent` with a preimage so the hold invoice can be
+    /// settled. Master keys equal the trade keys (normal mode, deterministic).
+    fn fiat_sent_sell_order(seller: PublicKey, buyer: PublicKey) -> Order {
+        Order {
+            id: uuid::Uuid::new_v4(),
+            status: Status::FiatSent.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: seller.to_string(),
+            seller_pubkey: Some(seller.to_string()),
+            master_seller_pubkey: Some(seller.to_string()),
+            buyer_pubkey: Some(buyer.to_string()),
+            master_buyer_pubkey: Some(buyer.to_string()),
+            preimage: Some("aa".to_string()),
+            amount: 21_000,
+            fee: 21,
+            fiat_amount: 40,
+            ..Default::default()
+        }
+    }
+
+    fn release_message(order_id: uuid::Uuid, payload: Option<Payload>) -> Message {
+        Message::new_order(Some(order_id), Some(1), None, Action::Release, payload)
+    }
+
+    /// Actions queued on the process-global order queue for a given order id.
+    /// The queue is shared across concurrently running tests, so assertions
+    /// must always filter by our own order id.
+    async fn queued_actions_for(order_id: uuid::Uuid) -> Vec<Action> {
+        MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(msg, _)| msg.get_inner_message_kind().id == Some(order_id))
+            .map(|(msg, _)| msg.get_inner_message_kind().action.clone())
+            .collect()
+    }
+
+    struct StubEscrow;
+
+    #[async_trait]
+    impl EscrowBackend for StubEscrow {
+        async fn create_hold_invoice(
+            &mut self,
+            _description: &str,
+            _amount: i64,
+        ) -> Result<(String, Vec<u8>, Vec<u8>), MostroError> {
+            Ok(("lnbc1".to_string(), vec![0u8; 32], vec![1u8; 32]))
+        }
+
+        async fn settle_hold_invoice(&mut self, _preimage: &str) -> Result<(), MostroError> {
+            Ok(())
+        }
+
+        async fn cancel_hold_invoice(&mut self, _hash: &str) -> Result<(), MostroError> {
+            Ok(())
+        }
+    }
+
+    struct FailingSettleEscrow;
+
+    #[async_trait]
+    impl EscrowBackend for FailingSettleEscrow {
+        async fn create_hold_invoice(
+            &mut self,
+            _description: &str,
+            _amount: i64,
+        ) -> Result<(String, Vec<u8>, Vec<u8>), MostroError> {
+            Ok(("lnbc1".to_string(), vec![0u8; 32], vec![1u8; 32]))
+        }
+
+        async fn settle_hold_invoice(&mut self, _preimage: &str) -> Result<(), MostroError> {
+            Err(MostroInternalErr(ServiceError::HoldInvoiceError(
+                "stub settle failure".to_string(),
+            )))
+        }
+
+        async fn cancel_hold_invoice(&mut self, _hash: &str) -> Result<(), MostroError> {
+            Ok(())
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // check_failure_retries
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn check_failure_retries_notifies_buyer_on_first_failure() {
+        // Arrange
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.payment_attempts = 0;
+        order.failed_payment = false;
+        let order = order.create(&pool).await.unwrap();
+
+        // Act
+        let result = check_failure_retries(&ctx, &order, None).await;
+
+        // Assert
+        let updated = result.unwrap();
+        assert!(updated.failed_payment);
+        assert_eq!(updated.payment_attempts, 1);
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert!(db_order.failed_payment);
+        assert_eq!(db_order.payment_attempts, 1);
+        assert!(queued_actions_for(order.id)
+            .await
+            .contains(&Action::PaymentFailed));
+    }
+
+    #[tokio::test]
+    async fn check_failure_retries_sends_add_invoice_when_retries_exhausted() {
+        // Arrange: custom per-ctx settings with a 3-attempt budget.
+        let pool = create_test_pool().await;
+        let mut settings = test_settings();
+        settings.lightning.payment_attempts = 3;
+        let ctx = TestContextBuilder::new()
+            .with_pool(Arc::new(pool.clone()))
+            .with_settings(settings)
+            .build();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.payment_attempts = 3;
+        order.failed_payment = true;
+        order.amount = 5_000;
+        order.fee = 100;
+        let order = order.create(&pool).await.unwrap();
+
+        // Act
+        let result = check_failure_retries(&ctx, &order, None).await;
+
+        // Assert
+        let updated = result.unwrap();
+        assert_eq!(updated.payment_attempts, 3);
+        assert!(queued_actions_for(order.id)
+            .await
+            .contains(&Action::AddInvoice));
+    }
+
+    #[tokio::test]
+    async fn check_failure_retries_rejects_non_positive_amount() {
+        // Arrange: amount minus fee is zero on the retry-exhausted branch.
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.payment_attempts = 1;
+        order.failed_payment = true;
+        order.amount = 100;
+        order.fee = 100;
+
+        // Act
+        let result = check_failure_retries(&ctx, &order, None).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidAmount))
+        ));
+    }
+
+    #[tokio::test]
+    async fn check_failure_retries_rejects_invalid_order_kind() {
+        // Arrange
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.payment_attempts = 1;
+        order.failed_payment = true;
+        order.kind = "bogus-kind".to_string();
+
+        // Act
+        let result = check_failure_retries(&ctx, &order, None).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidOrderKind))
+        ));
+    }
+
+    #[tokio::test]
+    async fn check_failure_retries_rejects_invalid_order_status() {
+        // Arrange
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.payment_attempts = 1;
+        order.failed_payment = true;
+        order.status = "bogus-status".to_string();
+
+        // Act
+        let result = check_failure_retries(&ctx, &order, None).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidOrderStatus))
+        ));
+    }
+
+    // ---------------------------------------------------------------
+    // release_action
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn release_action_rejects_non_seller_sender() {
+        // Arrange
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer)
+            .create(&pool)
+            .await
+            .unwrap();
+        let intruder = Keys::generate().public_key();
+        let event = create_unwrapped_message_with_pubkey(intruder);
+        let msg = release_message(order.id, None);
+        let my_keys = Keys::generate();
+        let mut escrow = StubEscrow;
+
+        // Act
+        let result = release_action(&ctx, msg, &event, &my_keys, &mut escrow).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPeer))
+        ));
+    }
+
+    #[tokio::test]
+    async fn release_action_rejects_order_with_wrong_status() {
+        // Arrange: Active is neither FiatSent nor Dispute.
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.status = Status::Active.to_string();
+        let order = order.create(&pool).await.unwrap();
+        let event = create_unwrapped_message_with_pubkey(seller);
+        let msg = release_message(order.id, None);
+        let my_keys = Keys::generate();
+        let mut escrow = StubEscrow;
+
+        // Act
+        let result = release_action(&ctx, msg, &event, &my_keys, &mut escrow).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+    }
+
+    #[tokio::test]
+    async fn release_action_propagates_escrow_settle_failure() {
+        // Arrange
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer)
+            .create(&pool)
+            .await
+            .unwrap();
+        let event = create_unwrapped_message_with_pubkey(seller);
+        let msg = release_message(order.id, None);
+        let my_keys = Keys::generate();
+        let mut escrow = FailingSettleEscrow;
+
+        // Act
+        let result = release_action(&ctx, msg, &event, &my_keys, &mut escrow).await;
+
+        // Assert: escrow error propagates and the order does not move.
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::HoldInvoiceError(_)))
+        ));
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(db_order.status, Status::FiatSent.to_string());
+    }
+
+    #[tokio::test]
+    async fn release_action_settles_and_notifies_on_happy_path() {
+        // Arrange: non-range order, no buyer invoice (do_payment fails fast).
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer)
+            .create(&pool)
+            .await
+            .unwrap();
+        let event = create_unwrapped_message_with_pubkey(seller);
+        let msg = release_message(order.id, None);
+        let my_keys = Keys::generate();
+        let mut escrow = StubEscrow;
+
+        // Act
+        let result = release_action(&ctx, msg, &event, &my_keys, &mut escrow).await;
+
+        // Assert
+        assert!(result.is_ok());
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(db_order.status, Status::SettledHoldInvoice.to_string());
+        let actions = queued_actions_for(order.id).await;
+        assert!(actions.contains(&Action::Released));
+        assert!(actions.contains(&Action::HoldInvoicePaymentSettled));
+        assert!(actions.contains(&Action::Rate));
+    }
+
+    #[tokio::test]
+    async fn release_action_closes_open_dispute() {
+        // Arrange: disputed order with an open dispute row.
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.status = Status::Dispute.to_string();
+        order.seller_dispute = true;
+        let order = order.create(&pool).await.unwrap();
+        Dispute::new(order.id, Status::Dispute.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+        let event = create_unwrapped_message_with_pubkey(seller);
+        let msg = release_message(order.id, None);
+        let my_keys = Keys::generate();
+        let mut escrow = StubEscrow;
+
+        // Act
+        let result = release_action(&ctx, msg, &event, &my_keys, &mut escrow).await;
+
+        // Assert: order settled and dispute auto-closed as Settled.
+        assert!(result.is_ok());
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(db_order.status, Status::SettledHoldInvoice.to_string());
+        let dispute = crate::db::find_dispute_by_order_id(&pool, order.id)
+            .await
+            .unwrap();
+        assert_eq!(dispute.status, DisputeStatus::Settled.to_string());
+    }
+
+    #[tokio::test]
+    async fn release_action_creates_child_order_for_range_order() {
+        // Arrange: sell range order with remaining budget and a next-trade key.
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let next_seller = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.max_amount = Some(100);
+        order.min_amount = Some(10);
+        order.fiat_amount = 40;
+        let order = order.create(&pool).await.unwrap();
+        let event = create_unwrapped_message_with_pubkey(seller);
+        let msg = release_message(
+            order.id,
+            Some(Payload::NextTrade(next_seller.to_string(), 2)),
+        );
+        let my_keys = Keys::generate();
+        let mut escrow = StubEscrow;
+
+        // Act
+        let result = release_action(&ctx, msg, &event, &my_keys, &mut escrow).await;
+
+        // Assert: a pending child order carries the remaining range.
+        assert!(result.is_ok());
+        let child: Order =
+            sqlx::query_as::<_, Order>("SELECT * FROM orders WHERE range_parent_id = ?")
+                .bind(order.id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(child.status, Status::Pending.to_string());
+        assert_eq!(child.max_amount, Some(60));
+        assert_eq!(child.fiat_amount, 0);
+        assert_eq!(child.seller_pubkey, Some(next_seller.to_string()));
+        assert_eq!(child.trade_index_seller, Some(2));
+        assert!(queued_actions_for(child.id)
+            .await
+            .contains(&Action::NewOrder));
+    }
+
+    #[tokio::test]
+    async fn release_action_still_succeeds_when_child_order_creation_fails() {
+        // Arrange: range order whose child event cannot be built (no master
+        // seller pubkey), driving the `Err` arm of the child-order match.
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.master_seller_pubkey = None;
+        order.max_amount = Some(100);
+        order.min_amount = Some(10);
+        let order = order.create(&pool).await.unwrap();
+        let event = create_unwrapped_message_with_pubkey(seller);
+        let msg = release_message(order.id, None);
+        let my_keys = Keys::generate();
+        let mut escrow = StubEscrow;
+
+        // Act
+        let result = release_action(&ctx, msg, &event, &my_keys, &mut escrow).await;
+
+        // Assert: release completes, no child order was persisted.
+        assert!(result.is_ok());
+        let children = sqlx::query("SELECT id FROM orders WHERE range_parent_id = ?")
+            .bind(order.id)
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+        assert!(children.is_empty());
+    }
+
+    // ---------------------------------------------------------------
+    // handle_buy_child_order / handle_sell_child_order
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn handle_buy_child_order_requires_next_trade_pubkey() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer);
+        let mut child = order.clone();
+
+        let result = handle_buy_child_order(&mut child, &order, None);
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::UnexpectedError(_)))
+        ));
+    }
+
+    #[test]
+    fn handle_buy_child_order_uses_identity_key_in_normal_mode() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let next_buyer = Keys::generate().public_key();
+        let idkey = Keys::generate().public_key().to_string();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.next_trade_pubkey = Some(next_buyer.to_string());
+        order.next_trade_index = Some(5);
+        let mut child = order.clone();
+
+        let (notify_pubkey, trade_index) =
+            handle_buy_child_order(&mut child, &order, Some(idkey.clone())).unwrap();
+
+        assert_eq!(notify_pubkey, Some(next_buyer.to_string()));
+        assert_eq!(trade_index, Some(5));
+        assert_eq!(child.master_buyer_pubkey, Some(idkey));
+        assert_eq!(child.creator_pubkey, next_buyer.to_string());
+        assert_eq!(child.next_trade_pubkey, None);
+        assert_eq!(child.next_trade_index, None);
+    }
+
+    #[test]
+    fn handle_buy_child_order_uses_trade_key_in_full_privacy_mode() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let next_buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.next_trade_pubkey = Some(next_buyer.to_string());
+        order.next_trade_index = Some(7);
+        let mut child = order.clone();
+
+        handle_buy_child_order(&mut child, &order, None).unwrap();
+
+        assert_eq!(child.master_buyer_pubkey, Some(next_buyer.to_string()));
+    }
+
+    #[test]
+    fn handle_sell_child_order_requires_next_trade() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut child = fiat_sent_sell_order(seller, buyer);
+
+        let result = handle_sell_child_order(&mut child, None, None);
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::UnexpectedError(_)))
+        ));
+    }
+
+    #[test]
+    fn handle_sell_child_order_rejects_invalid_pubkey() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut child = fiat_sent_sell_order(seller, buyer);
+
+        let result =
+            handle_sell_child_order(&mut child, Some(("not-a-pubkey".to_string(), 1)), None);
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+    }
+
+    #[test]
+    fn handle_sell_child_order_sets_seller_fields_for_both_privacy_modes() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let next_seller = Keys::generate().public_key();
+        let idkey = Keys::generate().public_key().to_string();
+
+        // Normal mode: identity key becomes the master seller pubkey.
+        let mut child = fiat_sent_sell_order(seller, buyer);
+        let (notify_pubkey, trade_index) = handle_sell_child_order(
+            &mut child,
+            Some((next_seller.to_string(), 3)),
+            Some(idkey.clone()),
+        )
+        .unwrap();
+        assert_eq!(notify_pubkey, Some(next_seller.to_string()));
+        assert_eq!(trade_index, Some(3));
+        assert_eq!(child.master_seller_pubkey, Some(idkey));
+        assert_eq!(child.creator_pubkey, next_seller.to_string());
+
+        // Full privacy mode: the next trade key doubles as master pubkey.
+        let mut child = fiat_sent_sell_order(seller, buyer);
+        handle_sell_child_order(&mut child, Some((next_seller.to_string(), 3)), None).unwrap();
+        assert_eq!(child.master_seller_pubkey, Some(next_seller.to_string()));
+    }
+
+    // ---------------------------------------------------------------
+    // handle_child_order
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn handle_child_order_creates_buy_child_when_creator_is_buyer() {
+        // Arrange
+        let pool = create_test_pool().await;
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let next_buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.kind = mostro_core::order::Kind::Buy.to_string();
+        order.creator_pubkey = buyer.to_string();
+        order.next_trade_pubkey = Some(next_buyer.to_string());
+        order.next_trade_index = Some(4);
+        let mut child = order.clone();
+        child.id = uuid::Uuid::new_v4();
+        child.status = Status::Pending.to_string();
+
+        // Act
+        let result = handle_child_order(child.clone(), &order, None, &pool, None).await;
+
+        // Assert: child persisted and next buyer notified.
+        assert!(result.is_ok());
+        let db_child = Order::by_id(&pool, child.id).await.unwrap().unwrap();
+        assert_eq!(db_child.buyer_pubkey, Some(next_buyer.to_string()));
+        assert_eq!(db_child.trade_index_buyer, Some(4));
+        assert!(queued_actions_for(child.id)
+            .await
+            .contains(&Action::NewOrder));
+    }
+
+    #[tokio::test]
+    async fn handle_child_order_creates_sell_child_when_creator_is_seller() {
+        // Arrange
+        let pool = create_test_pool().await;
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let next_seller = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer);
+        let mut child = order.clone();
+        child.id = uuid::Uuid::new_v4();
+        child.status = Status::Pending.to_string();
+
+        // Act
+        let result = handle_child_order(
+            child.clone(),
+            &order,
+            Some((next_seller.to_string(), 6)),
+            &pool,
+            None,
+        )
+        .await;
+
+        // Assert
+        assert!(result.is_ok());
+        let db_child = Order::by_id(&pool, child.id).await.unwrap().unwrap();
+        assert_eq!(db_child.seller_pubkey, Some(next_seller.to_string()));
+        assert_eq!(db_child.trade_index_seller, Some(6));
+    }
+
+    #[tokio::test]
+    async fn handle_child_order_rejects_invalid_type_or_creator() {
+        // Arrange: sell order whose creator is the buyer — neither branch fits.
+        let pool = create_test_pool().await;
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.creator_pubkey = buyer.to_string();
+        let child = order.clone();
+
+        // Act
+        let result = handle_child_order(child, &order, None, &pool, None).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::UnexpectedError(_)))
+        ));
+    }
+
+    #[tokio::test]
+    async fn handle_child_order_fails_when_next_trade_is_missing() {
+        // Arrange: sell-creator branch without a next trade key.
+        let pool = create_test_pool().await;
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer);
+        let child = order.clone();
+
+        // Act
+        let result = handle_child_order(child, &order, None, &pool, None).await;
+
+        // Assert
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::UnexpectedError(_)))
+        ));
+    }
+
+    // ---------------------------------------------------------------
+    // create_base_order / get_child_order
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn create_base_order_resets_trade_state_for_sell_orders() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer);
+
+        let base = create_base_order(&order).unwrap();
+
+        assert_ne!(base.id, order.id);
+        assert_eq!(base.status, Status::Pending.to_string());
+        assert_eq!(base.amount, 0);
+        assert_eq!(base.preimage, None);
+        assert_eq!(base.buyer_invoice, None);
+        assert_eq!(base.range_parent_id, Some(order.id));
+        // Sell orders clear the buyer side.
+        assert_eq!(base.buyer_pubkey, None);
+        assert_eq!(base.master_buyer_pubkey, None);
+        assert_eq!(base.trade_index_buyer, None);
+        // ... and keep the seller side.
+        assert_eq!(base.seller_pubkey, order.seller_pubkey);
+    }
+
+    #[test]
+    fn create_base_order_clears_seller_side_for_buy_orders() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.kind = mostro_core::order::Kind::Buy.to_string();
+
+        let base = create_base_order(&order).unwrap();
+
+        assert_eq!(base.seller_pubkey, None);
+        assert_eq!(base.master_seller_pubkey, None);
+        assert_eq!(base.trade_index_seller, None);
+        assert_eq!(base.buyer_pubkey, order.buyer_pubkey);
+    }
+
+    #[test]
+    fn create_base_order_rejects_invalid_kind() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.kind = "bogus-kind".to_string();
+
+        assert!(create_base_order(&order).is_err());
+    }
+
+    #[tokio::test]
+    async fn get_child_order_returns_none_for_non_range_order() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer);
+        let my_keys = Keys::generate();
+
+        let (child, event) = get_child_order(&ctx, order, &my_keys).await.unwrap();
+
+        assert!(child.is_none());
+        assert!(event.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_child_order_consumes_range_when_remainder_equals_min() {
+        // Arrange: user present in db → rating branch of create_order_event.
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.max_amount = Some(100);
+        order.min_amount = Some(50);
+        order.fiat_amount = 50;
+        crate::db::add_new_user(
+            &pool,
+            mostro_core::user::User::new(seller.to_string(), 0, 0, 0, 0, 0),
+        )
+        .await
+        .unwrap();
+        let my_keys = Keys::generate();
+
+        // Act
+        let (child, event) = get_child_order(&ctx, order, &my_keys).await.unwrap();
+
+        // Assert: the child becomes a fixed-amount order at the minimum.
+        let child = child.unwrap();
+        let event = event.unwrap();
+        assert_eq!(child.fiat_amount, 50);
+        assert_eq!(child.max_amount, None);
+        assert_eq!(child.min_amount, None);
+        assert_eq!(child.event_id, event.id.to_string());
+    }
+
+    #[tokio::test]
+    async fn get_child_order_keeps_range_when_remainder_exceeds_min() {
+        // Arrange: user absent from db → fallback rating branch.
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.max_amount = Some(100);
+        order.min_amount = Some(10);
+        order.fiat_amount = 40;
+        let my_keys = Keys::generate();
+
+        // Act
+        let (child, event) = get_child_order(&ctx, order, &my_keys).await.unwrap();
+
+        // Assert: the child keeps a shrunk range.
+        let child = child.unwrap();
+        assert!(event.is_some());
+        assert_eq!(child.max_amount, Some(60));
+        assert_eq!(child.min_amount, Some(10));
+        assert_eq!(child.fiat_amount, 0);
+    }
+
+    #[tokio::test]
+    async fn get_child_order_returns_none_when_remainder_below_min() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.max_amount = Some(100);
+        order.min_amount = Some(80);
+        order.fiat_amount = 50;
+        let my_keys = Keys::generate();
+
+        let (child, event) = get_child_order(&ctx, order, &my_keys).await.unwrap();
+
+        assert!(child.is_none());
+        assert!(event.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_child_order_returns_none_on_subtraction_overflow() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.max_amount = Some(i64::MIN);
+        order.min_amount = Some(0);
+        order.fiat_amount = 1;
+        let my_keys = Keys::generate();
+
+        let (child, event) = get_child_order(&ctx, order, &my_keys).await.unwrap();
+
+        assert!(child.is_none());
+        assert!(event.is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // do_payment / payment_success
+    // ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn do_payment_fails_without_buyer_invoice() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let order = fiat_sent_sell_order(seller, buyer);
+
+        let result = do_payment(&ctx, order, None).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError))
+        ));
+    }
+
+    #[tokio::test]
+    async fn do_payment_fails_when_amount_is_consumed_by_fee() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.buyer_invoice = Some("lnbc1notchecked".to_string());
+        order.amount = 100;
+        order.fee = 100;
+
+        let result = do_payment(&ctx, order, None).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError))
+        ));
+    }
+
+    #[tokio::test]
+    async fn do_payment_fails_fast_when_lnd_is_unreachable() {
+        // Arrange: with the global config set to test defaults, the LND cert
+        // path is invalid, so LndConnector::new() returns an error without
+        // any network access.
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.buyer_invoice = Some("lnbc1notchecked".to_string());
+
+        // Act
+        let result = do_payment(&ctx, order, None).await;
+
+        // Assert
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn payment_success_transitions_settled_order_to_success() {
+        // Arrange
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.status = Status::SettledHoldInvoice.to_string();
+        let mut order = order.create(&pool).await.unwrap();
+        let my_keys = Keys::generate();
+
+        // Act
+        let result = payment_success(&ctx, &mut order, buyer, &my_keys, None).await;
+
+        // Assert
+        assert!(result.is_ok());
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(db_order.status, Status::Success.to_string());
+        let actions = queued_actions_for(order.id).await;
+        assert!(actions.contains(&Action::PurchaseCompleted));
+        assert!(actions.contains(&Action::Rate));
+    }
+
+    #[tokio::test]
+    async fn payment_success_skips_orders_already_processed() {
+        // Arrange: DB row is Active, so the guarded UPDATE matches no rows.
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.status = Status::Active.to_string();
+        let mut order = order.create(&pool).await.unwrap();
+        let my_keys = Keys::generate();
+
+        // Act
+        let result = payment_success(&ctx, &mut order, buyer, &my_keys, None).await;
+
+        // Assert: early return — status untouched, no Rate message queued.
+        assert!(result.is_ok());
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(db_order.status, Status::Active.to_string());
+        let actions = queued_actions_for(order.id).await;
+        assert!(actions.contains(&Action::PurchaseCompleted));
+        assert!(!actions.contains(&Action::Rate));
+    }
+}

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -116,3 +116,155 @@ async fn send_restore_session_timeout(trade_key: &str) -> Result<(), MostroError
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use crate::config::MESSAGE_QUEUES;
+    use nostr_sdk::Keys;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+
+    async fn create_test_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        pool
+    }
+
+    fn create_event(identity: PublicKey, sender: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::new_restore(None),
+            signature: None,
+            sender,
+            identity,
+            created_at: Timestamp::now(),
+        }
+    }
+
+    /// Count queued restore-session messages destined for `dest`. The queue
+    /// is a global shared across concurrently running tests, so assertions
+    /// always filter by destination key.
+    async fn queued_restore_msgs_for(dest: &PublicKey) -> Vec<Message> {
+        MESSAGE_QUEUES
+            .queue_restore_session_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(_, key)| key == dest)
+            .map(|(msg, _)| msg.clone())
+            .collect()
+    }
+
+    /// Happy path: real Nostr keys always stringify as 64-char hex, so both
+    /// validation guards pass and the background restore session starts.
+    /// (The hex-format guards on `master_key`/`trade_key` are dead code for
+    /// real `PublicKey` values — see module report.)
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn restore_session_action_starts_background_restore() {
+        let pool = create_test_pool().await;
+        let ctx = TestContextBuilder::new()
+            .with_pool(Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+
+        let identity = Keys::generate().public_key();
+        let trade = Keys::generate().public_key();
+        let event = create_event(identity, trade);
+
+        let result = restore_session_action(&ctx, &event).await;
+
+        assert!(result.is_ok());
+    }
+
+    /// Drives `handle_restore_session_results` through the `Ok(Some(_))`
+    /// branch: the background worker finds no orders/disputes for the master
+    /// key and the (empty) restore payload is queued for the trade key.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_restore_session_results_queues_response() {
+        let pool = create_test_pool().await;
+        let master_key = Keys::generate().public_key().to_string();
+        let trade_pubkey = Keys::generate().public_key();
+        let trade_key = trade_pubkey.to_string();
+
+        let manager = RestoreSessionManager::new();
+        manager
+            .start_restore_session(pool.clone(), master_key)
+            .await
+            .unwrap();
+
+        handle_restore_session_results(manager, trade_key).await;
+
+        let queued = queued_restore_msgs_for(&trade_pubkey).await;
+        assert_eq!(queued.len(), 1);
+        assert!(matches!(
+            queued[0].get_inner_message_kind().payload,
+            Some(Payload::RestoreData(_))
+        ));
+    }
+
+    /// Same flow with an invalid trade key: the result arrives but the
+    /// response cannot be built, exercising the logged-error branch.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn handle_restore_session_results_logs_invalid_trade_key() {
+        let pool = create_test_pool().await;
+        let master_key = Keys::generate().public_key().to_string();
+
+        let manager = RestoreSessionManager::new();
+        manager
+            .start_restore_session(pool.clone(), master_key)
+            .await
+            .unwrap();
+
+        // Must not panic; the send failure is logged and swallowed
+        handle_restore_session_results(manager, "not-a-hex-key".to_string()).await;
+    }
+
+    #[tokio::test]
+    async fn send_restore_session_response_queues_message_for_valid_key() {
+        let trade_pubkey = Keys::generate().public_key();
+
+        let result =
+            send_restore_session_response(&trade_pubkey.to_string(), Vec::new(), Vec::new()).await;
+
+        assert!(result.is_ok());
+        let queued = queued_restore_msgs_for(&trade_pubkey).await;
+        assert_eq!(queued.len(), 1);
+        assert!(matches!(
+            queued[0].get_inner_message_kind().payload,
+            Some(Payload::RestoreData(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn send_restore_session_response_rejects_invalid_key() {
+        let result = send_restore_session_response("invalid-key", Vec::new(), Vec::new()).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+    }
+
+    #[tokio::test]
+    async fn send_restore_session_timeout_queues_message_for_valid_key() {
+        let trade_pubkey = Keys::generate().public_key();
+
+        let result = send_restore_session_timeout(&trade_pubkey.to_string()).await;
+
+        assert!(result.is_ok());
+        let queued = queued_restore_msgs_for(&trade_pubkey).await;
+        assert_eq!(queued.len(), 1);
+        assert!(queued[0].get_inner_message_kind().payload.is_none());
+    }
+
+    #[tokio::test]
+    async fn send_restore_session_timeout_rejects_invalid_key() {
+        let result = send_restore_session_timeout("invalid-key").await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+    }
+}

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -205,3 +205,275 @@ pub async fn take_buy_action(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use mostro_core::db::Crud;
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+
+    async fn setup_pool() -> Arc<SqlitePool> {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+        sqlx::migrate!("./migrations")
+            .run(pool.as_ref())
+            .await
+            .unwrap();
+        pool
+    }
+
+    fn build_ctx(pool: Arc<SqlitePool>) -> AppContext {
+        // With `anti_abuse_bond = None`, `taker_bond_required()` is false,
+        // so takes flow through the legacy `show_hold_invoice` path.
+        let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+        TestContextBuilder::new()
+            .with_pool(pool)
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// For a buy order, the taker is the seller. `event.sender` is that
+    /// taker trade key; `identity` matches `sender` so a `None`
+    /// trade_index resolves to 0.
+    fn taker_event(taker: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::new_order(
+                Some(uuid::Uuid::new_v4()),
+                Some(1),
+                None,
+                Action::TakeBuy,
+                None,
+            ),
+            signature: None,
+            sender: taker,
+            identity: taker,
+            created_at: Timestamp::now(),
+        }
+    }
+
+    /// A pending buy order: the maker is the buyer (creator ==
+    /// buyer_pubkey), no taker yet.
+    fn pending_buy_order(maker_buyer: PublicKey) -> Order {
+        Order {
+            id: uuid::Uuid::new_v4(),
+            status: Status::Pending.to_string(),
+            kind: mostro_core::order::Kind::Buy.to_string(),
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            creator_pubkey: maker_buyer.to_string(),
+            buyer_pubkey: Some(maker_buyer.to_string()),
+            master_buyer_pubkey: Some(maker_buyer.to_string()),
+            amount: 21_000,
+            fee: 210,
+            ..Default::default()
+        }
+    }
+
+    fn take_buy_msg(order_id: uuid::Uuid, trade_index: Option<i64>) -> Message {
+        Message::new_order(Some(order_id), Some(1), trade_index, Action::TakeBuy, None)
+    }
+
+    #[tokio::test]
+    async fn take_buy_action_fails_when_order_missing() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool);
+        let taker = Keys::generate().public_key();
+
+        let result = take_buy_action(
+            &ctx,
+            take_buy_msg(uuid::Uuid::new_v4(), Some(1)),
+            &taker_event(taker),
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+    }
+
+    #[tokio::test]
+    async fn take_buy_action_rejects_taker_with_pending_order() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let order = pending_buy_order(maker).create(ctx.pool()).await.unwrap();
+
+        // The taker already has a waiting-payment order as seller.
+        let mut pending = pending_buy_order(Keys::generate().public_key());
+        pending.status = Status::WaitingPayment.to_string();
+        pending.master_seller_pubkey = Some(taker.to_string());
+        pending.create(ctx.pool()).await.unwrap();
+
+        let result = take_buy_action(
+            &ctx,
+            take_buy_msg(order.id, Some(1)),
+            &taker_event(taker),
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::PendingOrderExists))
+        ));
+    }
+
+    #[tokio::test]
+    async fn take_buy_action_rejects_non_buy_order() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = pending_buy_order(maker);
+        order.kind = mostro_core::order::Kind::Sell.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let result = take_buy_action(
+            &ctx,
+            take_buy_msg(order.id, Some(1)),
+            &taker_event(taker),
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidOrderKind))
+        ));
+    }
+
+    #[tokio::test]
+    async fn take_buy_action_rejects_non_pending_status() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = pending_buy_order(maker);
+        order.status = Status::Active.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let result = take_buy_action(
+            &ctx,
+            take_buy_msg(order.id, Some(1)),
+            &taker_event(taker),
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidOrderStatus))
+        ));
+    }
+
+    /// The maker cannot take their own order: `not_sent_from_maker` fails
+    /// when `event.sender == creator_pubkey`.
+    #[tokio::test]
+    async fn take_buy_action_rejects_maker_taking_own_order() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+
+        let order = pending_buy_order(maker).create(ctx.pool()).await.unwrap();
+
+        let result = take_buy_action(
+            &ctx,
+            take_buy_msg(order.id, Some(1)),
+            &taker_event(maker),
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+    }
+
+    /// A range order for which the taker requested no amount is rejected
+    /// with `OutOfRangeSatsAmount`.
+    #[tokio::test]
+    async fn take_buy_action_rejects_range_order_without_amount() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = pending_buy_order(maker);
+        order.min_amount = Some(10);
+        order.max_amount = Some(1000);
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // Message carries no amount payload for the range order.
+        let result = take_buy_action(
+            &ctx,
+            take_buy_msg(order.id, Some(1)),
+            &taker_event(taker),
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::OutOfRangeSatsAmount))
+        ));
+    }
+
+    /// When `identity != sender` and the message omits a trade index, the
+    /// take is rejected with `InvalidPayload`.
+    #[tokio::test]
+    async fn take_buy_action_requires_trade_index_when_identity_differs() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let order = pending_buy_order(maker).create(ctx.pool()).await.unwrap();
+
+        let mut event = taker_event(taker);
+        event.identity = Keys::generate().public_key(); // differs from sender
+        let result = take_buy_action(
+            &ctx,
+            take_buy_msg(order.id, None),
+            &event,
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPayload))
+        ));
+    }
+
+    /// Full non-bond happy path: all validation passes, the trade index is
+    /// bumped and dev fee computed, and the handler reaches
+    /// `show_hold_invoice`, which fails offline at `LndConnector::new()`.
+    /// The hold-invoice creation tail is covered by integration tests.
+    #[tokio::test]
+    async fn take_buy_action_reaches_hold_invoice_seam_on_happy_path() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let order = pending_buy_order(maker).create(ctx.pool()).await.unwrap();
+
+        let result = take_buy_action(
+            &ctx,
+            take_buy_msg(order.id, Some(1)),
+            &taker_event(taker),
+            &Keys::generate(),
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::HoldInvoiceError(_)))
+        ));
+    }
+}

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -457,4 +457,269 @@ mod tests {
             assert!(expected_fee < amount); // Fee should be less than amount
         }
     }
+
+    /// Full-handler tests that drive `take_sell_action` against a migrated
+    /// in-memory database. Unlike the structural tests above (which run on
+    /// an un-migrated pool and bail at `get_order`), these seed real order
+    /// rows and assert the branch outcomes.
+    mod handler_flow_tests {
+        use super::*;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        use mostro_core::db::Crud;
+        use nostr_sdk::prelude::PublicKey;
+        use std::sync::Arc;
+
+        async fn setup_pool() -> Arc<SqlitePool> {
+            let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+            sqlx::migrate!("./migrations")
+                .run(pool.as_ref())
+                .await
+                .unwrap();
+            pool
+        }
+
+        fn build_ctx(pool: Arc<SqlitePool>) -> AppContext {
+            let _ = crate::config::MOSTRO_CONFIG.set(test_settings());
+            TestContextBuilder::new()
+                .with_pool(pool)
+                .with_settings(test_settings())
+                .build()
+        }
+
+        /// For a sell order the taker is the buyer. `sender` is the taker
+        /// trade key; `identity == sender` so a `None` trade_index → 0.
+        fn taker_event(taker: PublicKey) -> UnwrappedMessage {
+            UnwrappedMessage {
+                message: Message::new_order(
+                    Some(uuid::Uuid::new_v4()),
+                    Some(1),
+                    None,
+                    Action::TakeSell,
+                    None,
+                ),
+                signature: None,
+                sender: taker,
+                identity: taker,
+                created_at: Timestamp::now(),
+            }
+        }
+
+        /// A pending sell order: the maker is the seller (creator ==
+        /// seller_pubkey), no taker yet.
+        fn pending_sell_order(maker_seller: PublicKey) -> Order {
+            Order {
+                id: uuid::Uuid::new_v4(),
+                status: Status::Pending.to_string(),
+                kind: OrderKind::Sell.to_string(),
+                fiat_code: "USD".to_string(),
+                fiat_amount: 100,
+                creator_pubkey: maker_seller.to_string(),
+                seller_pubkey: Some(maker_seller.to_string()),
+                master_seller_pubkey: Some(maker_seller.to_string()),
+                amount: 21_000,
+                fee: 210,
+                ..Default::default()
+            }
+        }
+
+        fn take_sell_msg(order_id: uuid::Uuid, trade_index: Option<i64>) -> Message {
+            Message::new_order(Some(order_id), Some(1), trade_index, Action::TakeSell, None)
+        }
+
+        #[tokio::test]
+        async fn fails_when_order_missing() {
+            let pool = setup_pool().await;
+            let ctx = build_ctx(pool);
+            let taker = Keys::generate().public_key();
+
+            let result = take_sell_action(
+                &ctx,
+                take_sell_msg(uuid::Uuid::new_v4(), Some(1)),
+                &taker_event(taker),
+                &Keys::generate(),
+            )
+            .await;
+
+            assert!(matches!(result, Err(MostroCantDo(CantDoReason::NotFound))));
+        }
+
+        #[tokio::test]
+        async fn rejects_taker_with_pending_order() {
+            let pool = setup_pool().await;
+            let ctx = build_ctx(pool.clone());
+            let maker = Keys::generate().public_key();
+            let taker = Keys::generate().public_key();
+
+            let order = pending_sell_order(maker).create(ctx.pool()).await.unwrap();
+
+            // The taker already has a waiting-buyer-invoice order as buyer.
+            let mut pending = pending_sell_order(Keys::generate().public_key());
+            pending.status = Status::WaitingBuyerInvoice.to_string();
+            pending.master_buyer_pubkey = Some(taker.to_string());
+            pending.create(ctx.pool()).await.unwrap();
+
+            let result = take_sell_action(
+                &ctx,
+                take_sell_msg(order.id, Some(1)),
+                &taker_event(taker),
+                &Keys::generate(),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(MostroCantDo(CantDoReason::PendingOrderExists))
+            ));
+        }
+
+        #[tokio::test]
+        async fn rejects_non_sell_order() {
+            let pool = setup_pool().await;
+            let ctx = build_ctx(pool.clone());
+            let maker = Keys::generate().public_key();
+            let taker = Keys::generate().public_key();
+
+            let mut order = pending_sell_order(maker);
+            order.kind = OrderKind::Buy.to_string();
+            let order = order.create(ctx.pool()).await.unwrap();
+
+            let result = take_sell_action(
+                &ctx,
+                take_sell_msg(order.id, Some(1)),
+                &taker_event(taker),
+                &Keys::generate(),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(MostroCantDo(CantDoReason::InvalidOrderKind))
+            ));
+        }
+
+        #[tokio::test]
+        async fn rejects_non_pending_status() {
+            let pool = setup_pool().await;
+            let ctx = build_ctx(pool.clone());
+            let maker = Keys::generate().public_key();
+            let taker = Keys::generate().public_key();
+
+            let mut order = pending_sell_order(maker);
+            order.status = Status::Active.to_string();
+            let order = order.create(ctx.pool()).await.unwrap();
+
+            let result = take_sell_action(
+                &ctx,
+                take_sell_msg(order.id, Some(1)),
+                &taker_event(taker),
+                &Keys::generate(),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(MostroCantDo(CantDoReason::InvalidOrderStatus))
+            ));
+        }
+
+        #[tokio::test]
+        async fn rejects_maker_taking_own_order() {
+            let pool = setup_pool().await;
+            let ctx = build_ctx(pool.clone());
+            let maker = Keys::generate().public_key();
+
+            let order = pending_sell_order(maker).create(ctx.pool()).await.unwrap();
+
+            let result = take_sell_action(
+                &ctx,
+                take_sell_msg(order.id, Some(1)),
+                &taker_event(maker),
+                &Keys::generate(),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(MostroCantDo(CantDoReason::InvalidPubkey))
+            ));
+        }
+
+        #[tokio::test]
+        async fn rejects_range_order_without_amount() {
+            let pool = setup_pool().await;
+            let ctx = build_ctx(pool.clone());
+            let maker = Keys::generate().public_key();
+            let taker = Keys::generate().public_key();
+
+            let mut order = pending_sell_order(maker);
+            order.min_amount = Some(10);
+            order.max_amount = Some(1000);
+            let order = order.create(ctx.pool()).await.unwrap();
+
+            let result = take_sell_action(
+                &ctx,
+                take_sell_msg(order.id, Some(1)),
+                &taker_event(taker),
+                &Keys::generate(),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(MostroCantDo(CantDoReason::OutOfRangeSatsAmount))
+            ));
+        }
+
+        #[tokio::test]
+        async fn requires_trade_index_when_identity_differs() {
+            let pool = setup_pool().await;
+            let ctx = build_ctx(pool.clone());
+            let maker = Keys::generate().public_key();
+            let taker = Keys::generate().public_key();
+
+            let order = pending_sell_order(maker).create(ctx.pool()).await.unwrap();
+
+            let mut event = taker_event(taker);
+            event.identity = Keys::generate().public_key();
+            let result = take_sell_action(
+                &ctx,
+                take_sell_msg(order.id, None),
+                &event,
+                &Keys::generate(),
+            )
+            .await;
+
+            assert!(matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::InvalidPayload))
+            ));
+        }
+
+        /// Non-bond happy path with no buyer payout invoice supplied: the
+        /// take succeeds and the order is moved to `WaitingBuyerInvoice` via
+        /// `update_order_status` (no LND involved). This covers the
+        /// `payment_request.is_none()` branch and `update_order_status`.
+        #[tokio::test]
+        async fn no_invoice_transitions_to_waiting_buyer_invoice() {
+            let pool = setup_pool().await;
+            let ctx = build_ctx(pool.clone());
+            let maker = Keys::generate().public_key();
+            let taker = Keys::generate().public_key();
+
+            let order = pending_sell_order(maker).create(ctx.pool()).await.unwrap();
+
+            let result = take_sell_action(
+                &ctx,
+                take_sell_msg(order.id, Some(1)),
+                &taker_event(taker),
+                &Keys::generate(),
+            )
+            .await;
+
+            assert!(result.is_ok(), "no-invoice take must succeed: {result:?}");
+            let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+            assert_eq!(stored.status, Status::WaitingBuyerInvoice.to_string());
+            assert_eq!(stored.buyer_pubkey, Some(taker.to_string()));
+        }
+    }
 }

--- a/src/app/trade_pubkey.rs
+++ b/src/app/trade_pubkey.rs
@@ -71,3 +71,177 @@ pub async fn trade_pubkey_action(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use nostr_sdk::{Keys, Timestamp};
+    use sqlx::SqlitePool;
+    use std::sync::Arc;
+    use uuid::Uuid;
+
+    async fn setup_ctx() -> AppContext {
+        let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
+        sqlx::migrate!("./migrations")
+            .run(pool.as_ref())
+            .await
+            .unwrap();
+        TestContextBuilder::new()
+            .with_pool(pool)
+            .with_settings(test_settings())
+            .build()
+    }
+
+    /// `sender` is the fresh trade key being rotated in; `identity` is the
+    /// master key the ownership check runs against.
+    fn trade_pubkey_event(sender: PublicKey, identity: PublicKey) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::Order(MessageKind::new(
+                None,
+                Some(1),
+                None,
+                Action::TradePubkey,
+                None,
+            )),
+            signature: None,
+            sender,
+            identity,
+            created_at: Timestamp::now(),
+        }
+    }
+
+    fn trade_pubkey_msg(order_id: Uuid) -> Message {
+        Message::new_order(Some(order_id), Some(1), None, Action::TradePubkey, None)
+    }
+
+    fn base_order(status: Status) -> Order {
+        Order {
+            id: Uuid::new_v4(),
+            status: status.to_string(),
+            kind: mostro_core::order::Kind::Sell.to_string(),
+            fiat_code: "USD".to_string(),
+            creator_pubkey: Keys::generate().public_key().to_string(),
+            amount: 10_000,
+            fee: 10,
+            ..Default::default()
+        }
+    }
+
+    async fn order_by_id(pool: &SqlitePool, id: Uuid) -> Order {
+        Order::by_id(pool, id).await.unwrap().unwrap()
+    }
+
+    #[tokio::test]
+    async fn trade_pubkey_action_rejects_non_pre_trade_status() {
+        let ctx = setup_ctx().await;
+        let identity = Keys::generate().public_key();
+
+        let mut order = base_order(Status::Active);
+        order.master_buyer_pubkey = Some(identity.to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = trade_pubkey_event(Keys::generate().public_key(), identity);
+        let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidOrderStatus))
+        ));
+    }
+
+    #[tokio::test]
+    async fn trade_pubkey_action_rotates_buyer_trade_key_for_master_buyer() {
+        let ctx = setup_ctx().await;
+        let identity = Keys::generate().public_key();
+        let new_trade_key = Keys::generate().public_key();
+
+        let mut order = base_order(Status::Pending);
+        order.master_buyer_pubkey = Some(identity.to_string());
+        order.buyer_pubkey = Some(Keys::generate().public_key().to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = trade_pubkey_event(new_trade_key, identity);
+        let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
+
+        assert!(result.is_ok(), "buyer rotation must succeed: {result:?}");
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.buyer_pubkey, Some(new_trade_key.to_string()));
+        assert_eq!(after.creator_pubkey, new_trade_key.to_string());
+        // The confirmation goes to the process-global queue; filter by
+        // this test's unique trade key to stay isolated.
+        let confirmations = crate::config::MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(m, pk)| {
+                *pk == new_trade_key && m.get_inner_message_kind().action == Action::TradePubkey
+            })
+            .count();
+        assert_eq!(confirmations, 1);
+    }
+
+    #[tokio::test]
+    async fn trade_pubkey_action_rotates_seller_trade_key_for_master_seller() {
+        let ctx = setup_ctx().await;
+        let identity = Keys::generate().public_key();
+        let new_trade_key = Keys::generate().public_key();
+
+        // `WaitingTakerBond` is the other accepted pre-trade entry point.
+        let mut order = base_order(Status::WaitingTakerBond);
+        order.master_seller_pubkey = Some(identity.to_string());
+        order.seller_pubkey = Some(Keys::generate().public_key().to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = trade_pubkey_event(new_trade_key, identity);
+        let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
+
+        assert!(result.is_ok(), "seller rotation must succeed: {result:?}");
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.seller_pubkey, Some(new_trade_key.to_string()));
+        assert_eq!(after.creator_pubkey, new_trade_key.to_string());
+    }
+
+    #[tokio::test]
+    async fn trade_pubkey_action_rejects_identity_that_does_not_own_the_order() {
+        let ctx = setup_ctx().await;
+
+        let mut order = base_order(Status::Pending);
+        order.master_buyer_pubkey = Some(Keys::generate().public_key().to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // A different identity than the stored master buyer key.
+        let event =
+            trade_pubkey_event(Keys::generate().public_key(), Keys::generate().public_key());
+        let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+        // And the order must be left untouched.
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.creator_pubkey, order.creator_pubkey);
+    }
+
+    #[tokio::test]
+    async fn trade_pubkey_action_errors_when_no_master_key_is_stored() {
+        let ctx = setup_ctx().await;
+
+        // Neither master key present: the master-seller getter errors.
+        let order = base_order(Status::Pending)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+
+        let event =
+            trade_pubkey_event(Keys::generate().public_key(), Keys::generate().public_key());
+        let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+    }
+}

--- a/src/cashu/mod.rs
+++ b/src/cashu/mod.rs
@@ -1060,4 +1060,353 @@ mod tests {
             "a proof with no DLEQ must be rejected (fabricated-token defense)"
         );
     }
+
+    // ── Error type surface ───────────────────────────────────────────────
+
+    #[test]
+    fn error_display_covers_every_variant() {
+        assert_eq!(
+            Error::InvalidMintUrl("bad".into()).to_string(),
+            "Invalid mint URL: bad"
+        );
+        assert_eq!(
+            Error::MintConnection("down".into()).to_string(),
+            "Mint connection error: down"
+        );
+        assert_eq!(Error::Token("odd".into()).to_string(), "Token error: odd");
+        assert_eq!(
+            Error::Condition("shape".into()).to_string(),
+            "Condition error: shape"
+        );
+        let client_err: Error = CdkClientError::UnknownErrorResponse("boom".into()).into();
+        assert!(matches!(client_err, Error::Client(_)));
+        assert!(client_err.to_string().starts_with("Client error:"));
+    }
+
+    // ── Offline connect() / client construction ──────────────────────────
+
+    /// Build a client bound to `mint_url` without touching the network
+    /// (test-module access to the private fields).
+    fn offline_client(mint_url: &str) -> CashuClient {
+        let url = MintUrl::from_str(mint_url).expect("valid mint url");
+        CashuClient {
+            mint_url: url.clone(),
+            client: HttpClient::new(url, None),
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_rejects_unparseable_mint_url() {
+        match CashuClient::connect("not a url").await {
+            Err(Error::InvalidMintUrl(_)) => {}
+            Err(other) => panic!("expected InvalidMintUrl, got {other}"),
+            Ok(_) => panic!("malformed URL must fail before any request"),
+        }
+    }
+
+    #[tokio::test]
+    async fn connect_reports_unreachable_mint() {
+        // Dead localhost port: connection refused immediately, no network.
+        match CashuClient::connect("http://127.0.0.1:1").await {
+            Err(Error::MintConnection(_)) => {}
+            Err(other) => panic!("expected MintConnection, got {other}"),
+            Ok(_) => panic!("dead port must fail"),
+        }
+    }
+
+    #[test]
+    fn mint_url_returns_bound_url() {
+        let client = offline_client(TEST_MINT);
+        assert_eq!(
+            client.mint_url().to_string().trim_end_matches('/'),
+            TEST_MINT
+        );
+    }
+
+    // ── verify_2of3_condition edge shapes ────────────────────────────────
+
+    #[test]
+    fn rejects_non_distinct_expected_pubkeys() {
+        let (p_b, p_m) = (keypair(1), keypair(3));
+        // p_s == p_b: the daemon must refuse before inspecting the token.
+        let token = valid_escrow_token(p_b, p_b, p_m);
+        let err = CashuClient::verify_2of3_condition(&token, p_b, p_b, p_m)
+            .expect_err("non-distinct pubkeys must be rejected");
+        assert!(err.to_string().contains("distinct"));
+    }
+
+    #[test]
+    fn rejects_unparseable_token_string() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        assert!(CashuClient::verify_2of3_condition("cashuAnotatoken", p_b, p_s, p_m).is_err());
+    }
+
+    #[test]
+    fn rejects_htlc_spending_condition() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        // An HTLC secret with escrow-looking tags must not slip through the
+        // P2PK-only gate. (Data is a 32-byte hash preimage-hash for HTLC.)
+        let raw_secret = format!(
+            r#"["HTLC",{{"nonce":"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f","data":"{}","tags":[["pubkeys","{}","{}"],["locktime","{LOCKTIME}"],["refund","{}"],["n_sigs","2"],["sigflag","SIG_INPUTS"]]}}]"#,
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            p_b.to_hex(),
+            p_m.to_hex(),
+            p_s.to_hex(),
+        );
+        let token = raw_secret_token(&raw_secret);
+        assert!(
+            CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m).is_err(),
+            "an HTLC condition must be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_p2pk_condition_without_tags() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        // Bare P2PK (no NUT-11 tag list): also exercises the no-tags early
+        // return of `reject_duplicate_standard_tags`.
+        let secret: Secret = SpendingConditions::P2PKConditions {
+            data: p_s,
+            conditions: None,
+        }
+        .try_into()
+        .expect("valid bare p2pk secret");
+        let proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::from(100u64),
+            secret,
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        let token = Token::new(
+            MintUrl::from_str(TEST_MINT).unwrap(),
+            vec![proof],
+            None,
+            CurrencyUnit::Sat,
+        )
+        .to_string();
+        let err = CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m)
+            .expect_err("tag-less P2PK cannot satisfy the escrow shape");
+        assert!(err.to_string().contains("no NUT-11 tags"));
+    }
+
+    #[test]
+    fn duplicate_custom_and_empty_tags_pass_the_dedup_guard() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        // Custom (non-standard) tags may repeat per NUT-11 and an empty tag
+        // has no key: both must pass `reject_duplicate_standard_tags`
+        // (cdk's stricter `Conditions` parser may still reject the secret
+        // downstream — the guard must just never call it a duplicate).
+        let raw_secret = format!(
+            r#"["P2PK",{{"nonce":"859d4935c4907062a6297cf4e663e2835d90d97ecdd510745d32f6816323a41f","data":"{}","tags":[[],["x_custom","1"],["x_custom","2"],["pubkeys","{}","{}"],["locktime","{LOCKTIME}"],["refund","{}"],["n_sigs","2"],["sigflag","SIG_INPUTS"]]}}]"#,
+            p_s.to_hex(),
+            p_b.to_hex(),
+            p_m.to_hex(),
+            p_s.to_hex(),
+        );
+        let token = raw_secret_token(&raw_secret);
+        if let Err(e) = CashuClient::verify_2of3_condition(&token, p_b, p_s, p_m) {
+            assert!(
+                !e.to_string().contains("duplicate NUT-11"),
+                "custom/empty tags must not trip the duplicate-tag guard, got: {e}"
+            );
+        }
+    }
+
+    // ── verify_escrow_token: offline steps (mint-backed steps need CF-3) ─
+
+    #[tokio::test]
+    async fn escrow_token_on_foreign_mint_is_rejected() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let client = offline_client("https://other-mint.example.com");
+        let token = valid_escrow_token(p_b, p_s, p_m); // minted at TEST_MINT
+        let err = client
+            .verify_escrow_token(&token, p_b, p_s, p_m, 100, LOCKTIME)
+            .await
+            .expect_err("foreign-mint token must be rejected");
+        assert!(err.to_string().contains("does not match configured mint"));
+    }
+
+    #[tokio::test]
+    async fn escrow_token_with_duplicate_proofs_is_rejected_before_amount() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let client = offline_client(TEST_MINT);
+        // Two copies of one valid escrow proof: 2×100 "value" from one
+        // 100-sat proof.
+        let secret: Secret = SpendingConditions::P2PKConditions {
+            data: p_s,
+            conditions: Some(Conditions {
+                locktime: Some(LOCKTIME),
+                pubkeys: Some(vec![p_b, p_m]),
+                refund_keys: Some(vec![p_s]),
+                num_sigs: Some(2),
+                sig_flag: SigFlag::SigInputs,
+                num_sigs_refund: None,
+            }),
+        }
+        .try_into()
+        .expect("valid p2pk secret");
+        let proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::from(100u64),
+            secret,
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        let token = Token::new(
+            MintUrl::from_str(TEST_MINT).unwrap(),
+            vec![proof.clone(), proof],
+            None,
+            CurrencyUnit::Sat,
+        )
+        .to_string();
+        let err = client
+            .verify_escrow_token(&token, p_b, p_s, p_m, 200, LOCKTIME)
+            .await
+            .expect_err("duplicated proof must be rejected");
+        assert!(err.to_string().contains("duplicate secret"));
+    }
+
+    #[tokio::test]
+    async fn escrow_token_amount_mismatch_is_rejected() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let client = offline_client(TEST_MINT);
+        let token = valid_escrow_token(p_b, p_s, p_m); // 100 sats
+        let err = client
+            .verify_escrow_token(&token, p_b, p_s, p_m, 50, LOCKTIME)
+            .await
+            .expect_err("amount mismatch must be rejected");
+        assert!(err.to_string().contains("does not match expected"));
+    }
+
+    #[tokio::test]
+    async fn escrow_token_reaching_dleq_step_fails_on_unreachable_mint() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        // Token minted at (and client bound to) a dead localhost port: all
+        // offline steps pass and the first mint-backed step (DLEQ keyset
+        // fetch) fails with connection refused — still no real network.
+        let dead_mint = "http://127.0.0.1:1";
+        let client = offline_client(dead_mint);
+        let secret: Secret = SpendingConditions::P2PKConditions {
+            data: p_s,
+            conditions: Some(Conditions {
+                locktime: Some(LOCKTIME),
+                pubkeys: Some(vec![p_b, p_m]),
+                refund_keys: Some(vec![p_s]),
+                num_sigs: Some(2),
+                sig_flag: SigFlag::SigInputs,
+                num_sigs_refund: None,
+            }),
+        }
+        .try_into()
+        .expect("valid p2pk secret");
+        let proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::from(100u64),
+            secret,
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        let token = Token::new(
+            MintUrl::from_str(dead_mint).unwrap(),
+            vec![proof],
+            None,
+            CurrencyUnit::Sat,
+        )
+        .to_string();
+        let err = client
+            .verify_escrow_token(&token, p_b, p_s, p_m, 100, LOCKTIME)
+            .await
+            .expect_err("unreachable mint must fail the DLEQ step");
+        assert!(matches!(
+            err,
+            Error::Client(_) | Error::MintConnection(_) | Error::Token(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn check_state_fails_on_unreachable_mint() {
+        let client = offline_client("http://127.0.0.1:1");
+        let ys = vec![PublicKey::from_str(TEST_C).unwrap()];
+        assert!(client.check_state(ys).await.is_err());
+    }
+
+    /// A token whose serialized form carries no proofs must be rejected by
+    /// `verify_2of3_condition` before any per-secret work — otherwise an
+    /// empty token would vacuously "satisfy" every condition. Exercises the
+    /// `secrets.is_empty()` guard.
+    #[test]
+    fn rejects_token_with_no_secrets() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let empty = Token::new(
+            MintUrl::from_str(TEST_MINT).unwrap(),
+            Vec::new(),
+            None,
+            CurrencyUnit::Sat,
+        );
+        // Some cdk versions refuse to *parse* an empty token; either way the
+        // daemon must never accept it. When it does round-trip, the
+        // `secrets.is_empty()` branch is what rejects it.
+        let serialized = empty.to_string();
+        let err = CashuClient::verify_2of3_condition(&serialized, p_b, p_s, p_m)
+            .expect_err("an empty token must never satisfy the escrow shape");
+        // Whether it failed at parse or at the emptiness guard, it is a Token
+        // error, never a spuriously-accepted condition.
+        assert!(matches!(err, Error::Token(_)));
+    }
+
+    /// The token-level unit guard (step 3 of `verify_escrow_token`): a token
+    /// carrying the correct 2-of-3 escrow shape, on the configured mint, but
+    /// denominated in a non-`sat` unit must be rejected before its bare
+    /// integer `value()` is trusted against the sats order amount. Reaches
+    /// the `token.unit()` match's non-Sat arm using only offline steps.
+    #[tokio::test]
+    async fn escrow_token_with_non_sat_unit_is_rejected() {
+        let (p_b, p_s, p_m) = (keypair(1), keypair(2), keypair(3));
+        let client = offline_client(TEST_MINT);
+        let secret: Secret = SpendingConditions::P2PKConditions {
+            data: p_s,
+            conditions: Some(Conditions {
+                locktime: Some(LOCKTIME),
+                pubkeys: Some(vec![p_b, p_m]),
+                refund_keys: Some(vec![p_s]),
+                num_sigs: Some(2),
+                sig_flag: SigFlag::SigInputs,
+                num_sigs_refund: None,
+            }),
+        }
+        .try_into()
+        .expect("valid p2pk secret");
+        let proof = Proof {
+            keyset_id: Id::from_str(TEST_KEYSET_ID).unwrap(),
+            amount: Amount::from(100u64),
+            secret,
+            c: PublicKey::from_str(TEST_C).unwrap(),
+            witness: None,
+            dleq: None,
+            p2pk_e: None,
+        };
+        // Same mint, valid escrow condition, but the token is in msat.
+        let token = Token::new(
+            MintUrl::from_str(TEST_MINT).unwrap(),
+            vec![proof],
+            None,
+            CurrencyUnit::Msat,
+        )
+        .to_string();
+        let err = client
+            .verify_escrow_token(&token, p_b, p_s, p_m, 100, LOCKTIME)
+            .await
+            .expect_err("a non-sat token must be rejected");
+        assert!(
+            err.to_string().contains("is not sat"),
+            "expected the unit guard to reject, got: {err}"
+        );
+    }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -171,3 +171,57 @@ impl Settings {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::test_settings;
+
+    /// Every test-side initializer in this crate installs a default-shaped
+    /// `Settings` (no bond, no cashu, no price, expiration present), so
+    /// these assertions hold regardless of which module's init wins the
+    /// OnceLock race.
+    fn init_test_settings() {
+        let _ = MOSTRO_CONFIG.set(test_settings());
+    }
+
+    #[test]
+    fn typed_getters_read_the_global_config() {
+        init_test_settings();
+        // Mostro / Lightning / RPC blocks are `Default` in every test
+        // initializer — pin a representative field from each.
+        assert_eq!(
+            Settings::get_mostro().expiration_seconds,
+            MostroSettings::default().expiration_seconds
+        );
+        assert_eq!(
+            Settings::get_ln().payment_attempts,
+            LightningSettings::default().payment_attempts
+        );
+        assert_eq!(Settings::get_rpc().port, RpcSettings::default().port);
+        // Nostr/database blocks vary slightly per initializer — only
+        // assert they are readable without panicking.
+        let _ = Settings::get_nostr();
+        let _ = Settings::get_db();
+        assert!(Settings::get_expiration().is_some());
+    }
+
+    #[test]
+    fn optional_blocks_absent_in_test_configuration() {
+        init_test_settings();
+        assert!(Settings::get_bond().is_none());
+        assert!(!Settings::is_bond_enabled());
+        assert!(Settings::get_cashu().is_none());
+        assert!(!Settings::is_cashu_enabled());
+        assert!(Settings::get_price().is_none());
+        assert_eq!(Settings::escrow_mode(), EscrowMode::Lightning);
+    }
+
+    #[test]
+    fn transport_falls_back_to_default() {
+        init_test_settings();
+        #[allow(deprecated)]
+        let transport = Settings::get_transport();
+        assert_eq!(transport, Transport::default());
+    }
+}

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -313,6 +313,29 @@ mod tests {
     }
 
     #[test]
+    fn env_guard_restores_preexisting_value_on_drop() {
+        // When the env var already held a value, the guard must restore that
+        // exact value on drop (the `Some(previous)` restore arm), not leave
+        // the test's override leaking into sibling tests.
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var(NSEC_ENV_VAR, "preexisting_value");
+        {
+            let guard = EnvVarGuard::new(NSEC_ENV_VAR);
+            guard.set("temporary_override");
+            assert_eq!(
+                std::env::var(NSEC_ENV_VAR).as_deref(),
+                Ok("temporary_override")
+            );
+        }
+        // Drop restored the original value.
+        assert_eq!(
+            std::env::var(NSEC_ENV_VAR).as_deref(),
+            Ok("preexisting_value")
+        );
+        std::env::remove_var(NSEC_ENV_VAR);
+    }
+
+    #[test]
     fn env_var_value_is_trimmed() {
         let _lock = ENV_LOCK.lock().unwrap();
         let guard = EnvVarGuard::new(NSEC_ENV_VAR);
@@ -395,5 +418,156 @@ mod cashu_validation_tests {
         // Track A §4B: the seller-recovery locktime floor cannot be zero.
         let cashu = enabled("https://mint.example.com", 0);
         assert!(validate_cashu_settings(Some(&cashu), false).is_err());
+    }
+}
+
+#[cfg(test)]
+mod startup_validation_tests {
+    use super::*;
+    use crate::config::constants::{MAX_DEV_FEE_PERCENTAGE, MIN_DEV_FEE_PERCENTAGE};
+    use crate::config::types::{
+        AntiAbuseBondSettings, CashuSettings, DatabaseSettings, LightningSettings, MostroSettings,
+        NostrSettings, RpcSettings,
+    };
+
+    fn base_settings() -> Settings {
+        Settings {
+            database: DatabaseSettings::default(),
+            lightning: LightningSettings::default(),
+            nostr: NostrSettings::default(),
+            mostro: MostroSettings::default(),
+            rpc: RpcSettings::default(),
+            expiration: None,
+            anti_abuse_bond: None,
+            cashu: None,
+            price: None,
+        }
+    }
+
+    #[test]
+    fn default_settings_pass_validation() {
+        assert!(validate_mostro_settings(&base_settings()).is_ok());
+    }
+
+    #[test]
+    fn dev_fee_below_minimum_is_rejected() {
+        let mut settings = base_settings();
+        settings.mostro.dev_fee_percentage = MIN_DEV_FEE_PERCENTAGE - 0.01;
+        let err = validate_mostro_settings(&settings).expect_err("below-min dev fee must fail");
+        assert!(err.to_string().contains("below minimum"));
+    }
+
+    #[test]
+    fn dev_fee_above_maximum_is_rejected() {
+        let mut settings = base_settings();
+        settings.mostro.dev_fee_percentage = MAX_DEV_FEE_PERCENTAGE + 0.01;
+        let err = validate_mostro_settings(&settings).expect_err("above-max dev fee must fail");
+        assert!(err.to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn cashu_and_bond_conflict_is_rejected_through_full_validation() {
+        let mut settings = base_settings();
+        settings.anti_abuse_bond = Some(AntiAbuseBondSettings {
+            enabled: true,
+            ..Default::default()
+        });
+        settings.cashu = Some(CashuSettings {
+            enabled: true,
+            mint_url: "https://mint.example.com".to_string(),
+            escrow_locktime_days: 15,
+        });
+        assert!(validate_mostro_settings(&settings).is_err());
+    }
+}
+
+#[cfg(test)]
+mod env_file_tests {
+    use super::*;
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("mostro-config-util-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn missing_env_file_is_a_noop() {
+        let dir = temp_dir("no-env");
+        // Must not error or panic when `<dir>/.env` is absent.
+        load_env_file(&dir);
+    }
+
+    #[test]
+    fn env_file_values_become_process_env() {
+        let dir = temp_dir("with-env");
+        // A variable name no other test uses, so parallel runs can't race.
+        std::fs::write(
+            dir.join(ENV_FILENAME),
+            "MOSTRO_TEST_ENV_FILE_MARKER=loaded\n",
+        )
+        .expect("write .env");
+        load_env_file(&dir);
+        assert_eq!(
+            std::env::var("MOSTRO_TEST_ENV_FILE_MARKER").as_deref(),
+            Ok("loaded")
+        );
+    }
+
+    #[test]
+    fn unreadable_env_file_logs_and_continues() {
+        let dir = temp_dir("bad-env");
+        // A directory named `.env` makes dotenvy fail; the loader must warn
+        // and fall back instead of propagating the error.
+        std::fs::create_dir_all(dir.join(ENV_FILENAME)).expect("create .env dir");
+        load_env_file(&dir);
+    }
+}
+
+#[cfg(test)]
+mod init_configuration_file_tests {
+    use super::*;
+
+    fn temp_config_dir(tag: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("mostro-init-config-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    // NOTE: the success path (valid settings.toml) calls
+    // `init_mostro_settings`, which panics when the global OnceLock is
+    // already set by another test — and the missing-file path calls
+    // `std::process::exit(0)` when stdin is not a terminal, which would
+    // kill the whole test binary. Only the error paths are testable here.
+
+    #[test]
+    fn malformed_toml_is_rejected() {
+        let dir = temp_config_dir("bad-toml");
+        std::fs::write(dir.join("settings.toml"), "this is not = [valid toml")
+            .expect("write settings.toml");
+        let result = init_configuration_file(Some(dir.to_string_lossy().into_owned()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn structurally_valid_toml_with_bad_dev_fee_is_rejected() {
+        let dir = temp_config_dir("bad-dev-fee");
+        // Start from the shipped template so the TOML parses, then push the
+        // dev fee out of range so validation (not parsing) rejects it.
+        let template = std::str::from_utf8(include_bytes!("../../settings.tpl.toml"))
+            .expect("template is UTF-8");
+        let tampered =
+            template.replace("dev_fee_percentage = ", "dev_fee_percentage = 99.0 # was: ");
+        assert!(
+            tampered.contains("99.0"),
+            "template must contain dev_fee_percentage for this test to be meaningful"
+        );
+        std::fs::write(dir.join("settings.toml"), tampered).expect("write settings.toml");
+        let result = init_configuration_file(Some(dir.to_string_lossy().into_owned()));
+        assert!(result.is_err());
     }
 }

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -421,4 +421,86 @@ mod tests {
         let path = "/absolute/path";
         assert_eq!(expand_tilde(path), PathBuf::from(path));
     }
+
+    fn temp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("mostro-wizard-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    #[test]
+    fn test_validate_file_exists_accepts_regular_file() {
+        let dir = temp_dir("file-ok");
+        let file = dir.join("tls.cert");
+        std::fs::write(&file, b"cert bytes").expect("write file");
+        assert!(validate_file_exists(&file.to_string_lossy()).is_ok());
+    }
+
+    #[test]
+    fn test_validate_file_exists_rejects_directory() {
+        let dir = temp_dir("file-dir");
+        let err = validate_file_exists(&dir.to_string_lossy())
+            .expect_err("a directory is not a regular file");
+        assert!(err.contains("not a regular file"));
+    }
+
+    #[test]
+    fn test_resolve_file_path_canonicalizes_existing_file() {
+        let dir = temp_dir("resolve-ok");
+        let file = dir.join("admin.macaroon");
+        std::fs::write(&file, b"macaroon").expect("write file");
+        let resolved = resolve_file_path(&file.to_string_lossy()).expect("existing file resolves");
+        assert!(resolved.ends_with("admin.macaroon"));
+        assert!(PathBuf::from(resolved).is_absolute());
+    }
+
+    #[test]
+    fn test_resolve_file_path_errors_on_missing_file() {
+        assert!(resolve_file_path("/definitely/not/here.macaroon").is_err());
+    }
+
+    #[cfg(unix)]
+    fn mode_of(path: &Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .expect("stat env file")
+            .permissions()
+            .mode()
+            & 0o777
+    }
+
+    #[test]
+    fn test_write_env_file_creates_file_with_owner_only_permissions() {
+        let dir = temp_dir("env-new");
+        let env_path = dir.join(ENV_FILENAME);
+
+        write_env_file(&env_path, "nsec1testvalue").expect("write env file");
+
+        let contents = std::fs::read_to_string(&env_path).expect("read env file");
+        assert_eq!(contents, format!("{}=nsec1testvalue\n", NSEC_ENV_VAR));
+        #[cfg(unix)]
+        assert_eq!(mode_of(&env_path), 0o600);
+    }
+
+    #[test]
+    fn test_write_env_file_tightens_preexisting_broader_permissions() {
+        let dir = temp_dir("env-existing");
+        let env_path = dir.join(ENV_FILENAME);
+        std::fs::write(&env_path, "OLD=stale\n").expect("seed env file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&env_path, std::fs::Permissions::from_mode(0o644))
+                .expect("loosen permissions");
+        }
+
+        write_env_file(&env_path, "nsec1replaced").expect("rewrite env file");
+
+        // Old content truncated, permissions tightened back to 0600.
+        let contents = std::fs::read_to_string(&env_path).expect("read env file");
+        assert_eq!(contents, format!("{}=nsec1replaced\n", NSEC_ENV_VAR));
+        #[cfg(unix)]
+        assert_eq!(mode_of(&env_path), 0o600);
+    }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2899,13 +2899,28 @@ mod migration_and_query_tests {
     use crate::app::context::test_utils::test_settings;
     use crate::config::MOSTRO_CONFIG;
     use mostro_core::prelude::CantDoReason;
+    use sqlx::sqlite::SqlitePoolOptions;
 
     fn init_test_settings() {
         let _ = MOSTRO_CONFIG.set(test_settings());
     }
 
+    /// Migrated in-memory pool pinned to **one** connection.
+    ///
+    /// `sqlite::memory:` gives every *connection* its own private database,
+    /// so a multi-connection pool can hand a second caller a blank schema.
+    /// `restore_session_manager_delivers_background_results` clones this pool
+    /// into a `spawn_blocking` worker: on a different connection that worker
+    /// would find neither the migrations nor the inserted order, log an
+    /// error, deliver nothing, and leave the untimed `wait_for_result()`
+    /// blocked forever. Capping at one connection keeps every acquisition on
+    /// the same database.
     async fn migrated_pool() -> SqlitePool {
-        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
         sqlx::migrate!().run(&pool).await.unwrap();
         pool
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1534,6 +1534,48 @@ mod tests {
     /// disputed ones** — and the solvers of active disputes, while excluding
     /// terminal orders and resolved disputes.
     #[tokio::test]
+    async fn find_active_trade_pubkeys_skips_empty_string_pubkeys() {
+        // A present-but-empty pubkey column (`Some("")`) must be skipped, not
+        // inserted as a zero-length "active key" — exercises the
+        // `if !pk.is_empty()` guard for both the orders and disputes loops.
+        let pool = setup_orders_db().await.unwrap();
+        setup_disputes_table(&pool).await;
+
+        insert_order_with_pubkeys(
+            &pool,
+            uuid::Uuid::new_v4(),
+            "waiting-payment",
+            Some("creator_only"),
+            Some(""), // empty buyer pubkey → skipped
+            Some(""), // empty seller pubkey → skipped
+        )
+        .await;
+        // Active dispute whose solver pubkey is the empty string → skipped.
+        sqlx::query(
+            "INSERT INTO disputes (id, order_id, status, order_previous_status, solver_pubkey, created_at) \
+             VALUES (?1, ?2, 'in-progress', 'fiat-sent', '', 1700000000)",
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(uuid::Uuid::new_v4())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let keys: HashSet<String> = super::find_active_trade_pubkeys(&pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+
+        assert!(keys.contains("creator_only"));
+        assert!(
+            !keys.contains(""),
+            "empty-string pubkeys must never be treated as active keys"
+        );
+        assert_eq!(keys.len(), 1, "only the non-empty creator key is active");
+    }
+
+    #[tokio::test]
     async fn find_active_trade_pubkeys_covers_active_and_disputed_excludes_terminal() {
         let pool = setup_orders_db().await.unwrap();
         setup_disputes_table(&pool).await;
@@ -2845,5 +2887,697 @@ mod tests {
             (other.4 - 32.0).abs() < f64::EPSILON,
             "other user's total_rating must not change"
         );
+    }
+}
+
+// Coverage-focused tests running against the real migration set, so schema
+// helpers, admin/dispute permission checks and the restore-session pipeline
+// are exercised on the production schema.
+#[cfg(test)]
+mod migration_and_query_tests {
+    use super::*;
+    use crate::app::context::test_utils::test_settings;
+    use crate::config::MOSTRO_CONFIG;
+    use mostro_core::prelude::CantDoReason;
+
+    fn init_test_settings() {
+        let _ = MOSTRO_CONFIG.set(test_settings());
+    }
+
+    async fn migrated_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        pool
+    }
+
+    const HEX_KEY_A: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const HEX_KEY_B: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    #[allow(clippy::too_many_arguments)]
+    async fn insert_order(
+        pool: &SqlitePool,
+        id: Uuid,
+        kind: &str,
+        status: &str,
+        buyer: Option<&str>,
+        seller: Option<&str>,
+        creator: &str,
+        taken_at: i64,
+    ) {
+        sqlx::query(
+            r#"INSERT INTO orders (
+                id, kind, event_id, creator_pubkey, buyer_pubkey, master_buyer_pubkey,
+                seller_pubkey, master_seller_pubkey, status, payment_method, amount,
+                fiat_code, fiat_amount, premium, taken_at, created_at, expires_at,
+                trade_index_buyer, trade_index_seller
+            ) VALUES (?1, ?2, 'ev', ?3, ?4, ?5, ?6, ?7, ?8, 'bank', 1000, 'USD', 10, 0,
+                      ?9, 0, 0, 7, 9)"#,
+        )
+        .bind(id)
+        .bind(kind)
+        .bind(creator)
+        .bind(buyer)
+        .bind(buyer)
+        .bind(seller)
+        .bind(seller)
+        .bind(status)
+        .bind(taken_at)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_dispute(pool: &SqlitePool, order_id: Uuid, status: &str, solver: Option<&str>) {
+        sqlx::query(
+            r#"INSERT INTO disputes (id, order_id, status, order_previous_status, solver_pubkey, created_at, taken_at)
+               VALUES (?1, ?2, ?3, 'active', ?4, 0, 0)"#,
+        )
+        .bind(Uuid::new_v4())
+        .bind(order_id)
+        .bind(status)
+        .bind(solver)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_user(
+        pool: &SqlitePool,
+        pubkey: &str,
+        is_admin: bool,
+        admin_password: Option<&str>,
+        is_solver: bool,
+        category: i64,
+    ) {
+        sqlx::query(
+            r#"INSERT INTO users (pubkey, is_admin, admin_password, is_solver, is_banned,
+               category, last_trade_index, total_reviews, total_rating, last_rating,
+               max_rating, min_rating, created_at)
+               VALUES (?1, ?2, ?3, ?4, 0, ?5, 0, 0, 0, 0, 0, 0, 0)"#,
+        )
+        .bind(pubkey)
+        .bind(is_admin)
+        .bind(admin_password)
+        .bind(is_solver)
+        .bind(category)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    // ── schema helpers ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn table_column_exists_detects_present_and_absent_columns() {
+        let pool = migrated_pool().await;
+        assert!(table_column_exists(&pool, "orders", "dev_fee")
+            .await
+            .unwrap());
+        assert!(!table_column_exists(&pool, "orders", "no_such_column")
+            .await
+            .unwrap());
+        assert!(!table_column_exists(&pool, "no_such_table", "x")
+            .await
+            .unwrap());
+    }
+
+    #[test]
+    fn strip_sql_comments_removes_only_comment_lines() {
+        let sql = "-- header comment\nALTER TABLE t ADD COLUMN c INTEGER;\n  -- indented comment\nSELECT 1;";
+        let stripped = strip_sql_comments(sql);
+        assert!(!stripped.contains("comment"));
+        assert!(stripped.contains("ALTER TABLE t ADD COLUMN c INTEGER;"));
+        assert!(stripped.contains("SELECT 1;"));
+    }
+
+    #[test]
+    fn normalize_sql_identifier_strips_quotes_and_commas() {
+        assert_eq!(normalize_sql_identifier(" \"orders\","), "orders");
+        assert_eq!(normalize_sql_identifier("`bonds`"), "bonds");
+        assert_eq!(normalize_sql_identifier("[users]"), "users");
+        assert_eq!(normalize_sql_identifier("plain"), "plain");
+    }
+
+    #[test]
+    fn parse_add_column_statements_accepts_only_pure_add_column_migrations() {
+        let ops = parse_add_column_statements(
+            "-- adds two columns\nALTER TABLE orders ADD COLUMN dev_fee INTEGER DEFAULT 0;\nALTER TABLE \"orders\" ADD COLUMN dev_fee_paid INTEGER NOT NULL DEFAULT 0;",
+        )
+        .expect("pure add-column migration parses");
+        assert_eq!(
+            ops,
+            vec![
+                ("orders".to_string(), "dev_fee".to_string()),
+                ("orders".to_string(), "dev_fee_paid".to_string()),
+            ]
+        );
+
+        // Mixed statement kinds: not a pure add-column migration.
+        assert!(parse_add_column_statements(
+            "ALTER TABLE orders ADD COLUMN a INTEGER; CREATE INDEX i ON orders(a);"
+        )
+        .is_none());
+        // Too few tokens.
+        assert!(parse_add_column_statements("ALTER TABLE orders ADD COLUMN").is_none());
+        // Empty input.
+        assert!(parse_add_column_statements("-- only comments\n").is_none());
+    }
+
+    #[tokio::test]
+    async fn applied_migration_versions_lists_all_applied_migrations() {
+        let pool = migrated_pool().await;
+        let versions = applied_migration_versions(&pool).await.unwrap();
+        assert!(!versions.is_empty());
+        let mut sorted = versions.clone();
+        sorted.sort();
+        assert_eq!(versions, sorted, "versions must come back ordered");
+    }
+
+    /// Replaying an add-column migration on a database that already has the
+    /// columns produces the exact "duplicate column name" error `connect`
+    /// reconciles; pin the parser on the real error object.
+    #[tokio::test]
+    async fn parse_duplicate_column_name_extracts_column_from_real_migrate_error() {
+        let pool = migrated_pool().await;
+        // Forget the dev_fee add-column migration was applied.
+        sqlx::query("DELETE FROM _sqlx_migrations WHERE version = 20251126120000")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let err = sqlx::migrate!()
+            .run(&pool)
+            .await
+            .expect_err("replaying the add-column migration must fail");
+        let column = parse_duplicate_column_name(&err).expect("duplicate column error parses");
+        assert_eq!(column, "dev_fee");
+    }
+
+    #[tokio::test]
+    async fn reconcile_add_column_migration_records_and_unblocks_migrator() {
+        let pool = migrated_pool().await;
+        sqlx::query("DELETE FROM _sqlx_migrations WHERE version = 20251126120000")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let migrator = sqlx::migrate!();
+        let reconciled = reconcile_existing_add_column_migration(&pool, &migrator, "dev_fee")
+            .await
+            .unwrap();
+        assert!(reconciled, "existing columns must be recorded as applied");
+
+        // The migrator must now run cleanly again.
+        migrator.run(&pool).await.expect("migrations run clean");
+
+        // A column no pending migration adds is not reconcilable.
+        let not_reconciled =
+            reconcile_existing_add_column_migration(&pool, &migrator, "no_such_column")
+                .await
+                .unwrap();
+        assert!(!not_reconciled);
+    }
+
+    // ── legacy disputes-table token-column migration ─────────────────────
+
+    #[tokio::test]
+    async fn migrate_remove_token_columns_is_noop_without_token_columns() {
+        let pool = migrated_pool().await;
+        migrate_remove_token_columns(&pool).await.unwrap();
+        assert!(!table_column_exists(&pool, "disputes", "buyer_token")
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn migrate_remove_token_columns_drops_legacy_columns_and_keeps_rows() {
+        init_test_settings();
+        let pool = migrated_pool().await;
+        // Recreate the legacy shape.
+        sqlx::query("ALTER TABLE disputes ADD COLUMN buyer_token INTEGER")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("ALTER TABLE disputes ADD COLUMN seller_token INTEGER")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let order_id = Uuid::new_v4();
+        insert_dispute(&pool, order_id, "initiated", Some(HEX_KEY_A)).await;
+
+        migrate_remove_token_columns(&pool).await.unwrap();
+
+        assert!(!table_column_exists(&pool, "disputes", "buyer_token")
+            .await
+            .unwrap());
+        assert!(!table_column_exists(&pool, "disputes", "seller_token")
+            .await
+            .unwrap());
+        let dispute = find_dispute_by_order_id(&pool, order_id).await.unwrap();
+        assert_eq!(dispute.order_id, order_id);
+    }
+
+    #[tokio::test]
+    async fn migrate_remove_token_columns_handles_single_legacy_column() {
+        let pool = migrated_pool().await;
+        sqlx::query("ALTER TABLE disputes ADD COLUMN seller_token INTEGER")
+            .execute(&pool)
+            .await
+            .unwrap();
+        migrate_remove_token_columns(&pool).await.unwrap();
+        assert!(!table_column_exists(&pool, "disputes", "seller_token")
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn rebuild_disputes_table_preserves_rows() {
+        let pool = migrated_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_dispute(&pool, order_id, "in-progress", Some(HEX_KEY_B)).await;
+
+        rebuild_disputes_table_without_tokens(&pool).await.unwrap();
+
+        let dispute = find_dispute_by_order_id(&pool, order_id).await.unwrap();
+        assert_eq!(dispute.order_id, order_id);
+        assert_eq!(dispute.status, "in-progress");
+    }
+
+    // ── admin / permission queries ───────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_admin_password_returns_none_without_admin_row() {
+        let pool = migrated_pool().await;
+        assert_eq!(get_admin_password(&pool).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn get_admin_password_returns_stored_hash() {
+        let pool = migrated_pool().await;
+        insert_user(&pool, HEX_KEY_A, true, Some("argon2-hash"), false, 0).await;
+        assert_eq!(
+            get_admin_password(&pool).await.unwrap(),
+            Some("argon2-hash".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_finalize_permission_rejects_unassigned_caller() {
+        let pool = migrated_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_dispute(&pool, order_id, "in-progress", Some(HEX_KEY_A)).await;
+        let err = ensure_dispute_finalize_permission(&pool, HEX_KEY_B, HEX_KEY_A, order_id)
+            .await
+            .expect_err("unassigned caller must be rejected");
+        assert!(matches!(
+            err,
+            MostroError::MostroCantDo(CantDoReason::IsNotYourDispute)
+        ));
+    }
+
+    #[tokio::test]
+    async fn ensure_finalize_permission_allows_read_write_solver() {
+        let pool = migrated_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_dispute(&pool, order_id, "in-progress", Some(HEX_KEY_A)).await;
+        insert_user(&pool, HEX_KEY_A, false, None, true, 2).await;
+        // Caller is the assigned solver with category 2 (read-write), and is
+        // NOT the daemon key — the solver_has_write_permission branch runs.
+        ensure_dispute_finalize_permission(&pool, HEX_KEY_A, HEX_KEY_B, order_id)
+            .await
+            .expect("read-write assigned solver may finalize");
+    }
+
+    #[tokio::test]
+    async fn user_has_solver_write_permission_requires_category_two() {
+        let pool = migrated_pool().await;
+        insert_user(&pool, HEX_KEY_A, false, None, true, 2).await;
+        insert_user(&pool, HEX_KEY_B, false, None, true, 1).await;
+        assert!(user_has_solver_write_permission(&pool, HEX_KEY_A)
+            .await
+            .unwrap());
+        assert!(!user_has_solver_write_permission(&pool, HEX_KEY_B)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn is_dispute_taken_by_admin_distinguishes_solver_and_admin() {
+        let pool = migrated_pool().await;
+        let admin = HEX_KEY_A;
+
+        // No dispute at all.
+        assert!(!is_dispute_taken_by_admin(&pool, Uuid::new_v4(), admin)
+            .await
+            .unwrap());
+
+        // In-progress dispute taken by the admin key.
+        let admin_order = Uuid::new_v4();
+        insert_dispute(&pool, admin_order, "in-progress", Some(admin)).await;
+        assert!(is_dispute_taken_by_admin(&pool, admin_order, admin)
+            .await
+            .unwrap());
+
+        // In-progress dispute taken by a human solver.
+        let human_order = Uuid::new_v4();
+        insert_dispute(&pool, human_order, "in-progress", Some(HEX_KEY_B)).await;
+        assert!(!is_dispute_taken_by_admin(&pool, human_order, admin)
+            .await
+            .unwrap());
+
+        // In-progress dispute with no solver assigned.
+        let orphan_order = Uuid::new_v4();
+        insert_dispute(&pool, orphan_order, "in-progress", None).await;
+        assert!(!is_dispute_taken_by_admin(&pool, orphan_order, admin)
+            .await
+            .unwrap());
+    }
+
+    #[tokio::test]
+    async fn find_solver_pubkey_returns_solver_row() {
+        let pool = migrated_pool().await;
+        insert_user(&pool, HEX_KEY_A, false, None, true, 2).await;
+        let user = find_solver_pubkey(&pool, HEX_KEY_A.to_string())
+            .await
+            .unwrap();
+        assert_eq!(user.pubkey, HEX_KEY_A);
+        assert!(find_solver_pubkey(&pool, HEX_KEY_B.to_string())
+            .await
+            .is_err());
+    }
+
+    // ── order queries ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn edit_pubkeys_order_clears_counterparty_keys_by_kind() {
+        let pool = migrated_pool().await;
+
+        // Buy order: seller side must be cleared.
+        let buy_id = Uuid::new_v4();
+        insert_order(
+            &pool,
+            buy_id,
+            "buy",
+            "pending",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_A,
+            0,
+        )
+        .await;
+        let buy_order = sqlx::query_as::<_, Order>("SELECT * FROM orders WHERE id = ?1")
+            .bind(buy_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let edited = edit_pubkeys_order(&pool, &buy_order).await.unwrap();
+        assert_eq!(edited.seller_pubkey, None);
+        assert_eq!(edited.master_seller_pubkey, None);
+        assert_eq!(edited.buyer_pubkey.as_deref(), Some(HEX_KEY_A));
+
+        // Sell order: buyer side must be cleared.
+        let sell_id = Uuid::new_v4();
+        insert_order(
+            &pool,
+            sell_id,
+            "sell",
+            "pending",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_B,
+            0,
+        )
+        .await;
+        let sell_order = sqlx::query_as::<_, Order>("SELECT * FROM orders WHERE id = ?1")
+            .bind(sell_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let edited = edit_pubkeys_order(&pool, &sell_order).await.unwrap();
+        assert_eq!(edited.buyer_pubkey, None);
+        assert_eq!(edited.master_buyer_pubkey, None);
+        assert_eq!(edited.seller_pubkey.as_deref(), Some(HEX_KEY_B));
+    }
+
+    #[tokio::test]
+    async fn edit_pubkeys_order_rejects_invalid_kind_and_missing_row() {
+        let pool = migrated_pool().await;
+
+        // Unknown kind string.
+        let bogus = Order {
+            id: Uuid::new_v4(),
+            kind: "swap".to_string(),
+            ..Default::default()
+        };
+        assert!(edit_pubkeys_order(&pool, &bogus).await.is_err());
+
+        // Valid kind but no matching row.
+        let missing = Order {
+            id: Uuid::new_v4(),
+            kind: "sell".to_string(),
+            ..Default::default()
+        };
+        assert!(edit_pubkeys_order(&pool, &missing).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn find_order_by_seconds_returns_only_stale_waiting_orders() {
+        init_test_settings();
+        let pool = migrated_pool().await;
+
+        // Stale waiting-buyer-invoice: eligible.
+        let stale_id = Uuid::new_v4();
+        insert_order(
+            &pool,
+            stale_id,
+            "sell",
+            "waiting-buyer-invoice",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_B,
+            1, // taken long ago
+        )
+        .await;
+        // Fresh waiting-payment: not yet eligible.
+        insert_order(
+            &pool,
+            Uuid::new_v4(),
+            "buy",
+            "waiting-payment",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_A,
+            Timestamp::now().as_secs() as i64 + 10_000,
+        )
+        .await;
+        // Stale but active: wrong status.
+        insert_order(
+            &pool,
+            Uuid::new_v4(),
+            "sell",
+            "active",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_B,
+            1,
+        )
+        .await;
+
+        let stale = find_order_by_seconds(&pool).await.unwrap();
+        assert_eq!(stale.len(), 1);
+        assert_eq!(stale[0].id, stale_id);
+    }
+
+    #[tokio::test]
+    async fn find_dispute_by_order_id_finds_and_misses() {
+        let pool = migrated_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_dispute(&pool, order_id, "initiated", None).await;
+        assert_eq!(
+            find_dispute_by_order_id(&pool, order_id)
+                .await
+                .unwrap()
+                .order_id,
+            order_id
+        );
+        assert!(find_dispute_by_order_id(&pool, Uuid::new_v4())
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn has_pending_order_rejects_unknown_master_key_field() {
+        let pool = migrated_pool().await;
+        let err = has_pending_order_with_status(
+            &pool,
+            HEX_KEY_A.to_string(),
+            "not_a_key_field",
+            "waiting-payment",
+        )
+        .await
+        .expect_err("unknown master key field must be rejected");
+        assert!(err.to_string().contains("Invalid master key field"));
+    }
+
+    #[tokio::test]
+    async fn update_user_rating_rejects_out_of_range_min_max_and_below_floor() {
+        let pool = migrated_pool().await;
+        // min_rating outside 0..=5
+        assert!(matches!(
+            update_user_rating(&pool, HEX_KEY_A.to_string(), 5, 6, 5, 1, 5.0).await,
+            Err(MostroError::MostroCantDo(CantDoReason::InvalidRating))
+        ));
+        // max_rating outside 0..=5
+        assert!(matches!(
+            update_user_rating(&pool, HEX_KEY_A.to_string(), 5, 0, 9, 1, 5.0).await,
+            Err(MostroError::MostroCantDo(CantDoReason::InvalidRating))
+        ));
+        // last_rating below the MIN_RATING floor (0 < 1)
+        assert!(matches!(
+            update_user_rating(&pool, HEX_KEY_A.to_string(), 0, 0, 5, 1, 0.0).await,
+            Err(MostroError::MostroCantDo(CantDoReason::InvalidRating))
+        ));
+    }
+
+    // ── restore session ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn find_user_orders_by_master_key_validates_and_finds_both_sides() {
+        let pool = migrated_pool().await;
+        assert!(find_user_orders_by_master_key(&pool, "not-hex")
+            .await
+            .is_err());
+
+        // One active order as buyer, one as seller, one terminal (excluded).
+        insert_order(
+            &pool,
+            Uuid::new_v4(),
+            "buy",
+            "active",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_A,
+            0,
+        )
+        .await;
+        insert_order(
+            &pool,
+            Uuid::new_v4(),
+            "sell",
+            "waiting-payment",
+            Some(HEX_KEY_B),
+            Some(HEX_KEY_A),
+            HEX_KEY_A,
+            0,
+        )
+        .await;
+        insert_order(
+            &pool,
+            Uuid::new_v4(),
+            "buy",
+            "canceled",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_A,
+            0,
+        )
+        .await;
+
+        let orders = find_user_orders_by_master_key(&pool, HEX_KEY_A)
+            .await
+            .unwrap();
+        assert_eq!(orders.len(), 2, "terminal orders are excluded");
+    }
+
+    #[tokio::test]
+    async fn find_user_disputes_by_master_key_validates_and_joins_orders() {
+        let pool = migrated_pool().await;
+        assert!(find_user_disputes_by_master_key(&pool, "xyz")
+            .await
+            .is_err());
+
+        let order_id = Uuid::new_v4();
+        insert_order(
+            &pool,
+            order_id,
+            "buy",
+            "dispute",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_A,
+            0,
+        )
+        .await;
+        insert_dispute(&pool, order_id, "initiated", None).await;
+
+        let disputes = find_user_disputes_by_master_key(&pool, HEX_KEY_A)
+            .await
+            .unwrap();
+        assert_eq!(disputes.len(), 1);
+        assert_eq!(disputes[0].order_id, order_id);
+    }
+
+    #[tokio::test]
+    async fn restore_session_manager_delivers_background_results() {
+        let pool = migrated_pool().await;
+        insert_order(
+            &pool,
+            Uuid::new_v4(),
+            "buy",
+            "active",
+            Some(HEX_KEY_A),
+            Some(HEX_KEY_B),
+            HEX_KEY_A,
+            0,
+        )
+        .await;
+
+        // Default delegates to new().
+        let mut manager = RestoreSessionManager::default();
+        // Nothing pending yet.
+        assert!(manager.check_results().await.is_none());
+
+        manager
+            .start_restore_session(pool.clone(), HEX_KEY_A.to_string())
+            .await
+            .unwrap();
+        let info = manager
+            .wait_for_result()
+            .await
+            .expect("background restore session must deliver");
+        assert_eq!(info.restore_orders.len(), 1);
+        assert!(info.restore_disputes.is_empty());
+
+        // Invalid master key: worker logs the error, nothing is delivered.
+        manager
+            .start_restore_session(pool.clone(), "not-hex".to_string())
+            .await
+            .unwrap();
+        // Give the blocking task a moment, then confirm no result arrived.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(manager.check_results().await.is_none());
+    }
+
+    // ── connect() ────────────────────────────────────────────────────────
+
+    /// `connect()` reads the database URL from the global settings, which in
+    /// the test binary depend on whichever module initialized them first
+    /// (canonical `sqlite::memory:` or a default empty URL). Both are
+    /// exercised tolerantly: either the pool comes up (in-memory) or a
+    /// clean error surfaces — never a panic. Any stray file the in-memory
+    /// URL shape creates in the CWD is removed.
+    #[tokio::test]
+    async fn connect_is_panic_free_under_test_configuration() {
+        init_test_settings();
+        let first = connect().await;
+        let second = connect().await;
+        match (&first, &second) {
+            (Ok(_), Ok(_)) | (Err(_), Err(_)) => {}
+            other => panic!("connect() must behave consistently, got {other:?}"),
+        }
+        // Clean up the artifact of the "sqlite::memory:" URL shape.
+        let stray = std::path::Path::new("sqlite::memory:");
+        if stray.exists() {
+            let _ = std::fs::remove_file(stray);
+        }
     }
 }

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -159,6 +159,129 @@ mod tests {
         Keys::generate()
     }
 
+    async fn create_migrated_pool() -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn init_global_settings() {
+        let _ = crate::config::MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
+    }
+
+    /// Insert a sell order carrying `hash` so `find_order_by_hash` resolves it.
+    async fn insert_order_with_hash(
+        pool: &SqlitePool,
+        hash: &str,
+        status: Status,
+        buyer_invoice: Option<String>,
+        buyer_pubkey: Option<String>,
+        seller_pubkey: Option<String>,
+        master_buyer_pubkey: Option<String>,
+    ) -> Order {
+        let order = Order {
+            id: uuid::Uuid::new_v4(),
+            kind: OrderKind::Sell.to_string(),
+            status: status.to_string(),
+            creator_pubkey: seller_pubkey.clone().unwrap_or_default(),
+            payment_method: "SEPA".to_string(),
+            amount: 1_000,
+            fee: 10,
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            hash: Some(hash.to_string()),
+            buyer_invoice,
+            buyer_pubkey,
+            seller_pubkey,
+            master_buyer_pubkey,
+            created_at: Timestamp::now().as_secs() as i64,
+            expires_at: Timestamp::now().as_secs() as i64 + 3_600,
+            ..Default::default()
+        };
+        order.create(pool).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_paid_with_buyer_invoice_activates_order() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "aa".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::WaitingPayment,
+            Some("lnbcrt1invoice".to_string()),
+            Some(buyer),
+            Some(seller),
+            None,
+        )
+        .await;
+
+        let result = hold_invoice_paid(&hash, Some(1), &pool, &create_test_keys()).await;
+        assert!(result.is_ok(), "active path must succeed: {result:?}");
+
+        // The order row must be flipped to Active with invoice_held_at set.
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
+        assert!(updated.invoice_held_at > 0, "invoice_held_at must be set");
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_paid_without_buyer_invoice_requests_one() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "bb".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        let master_buyer = create_test_keys().public_key().to_string();
+        // Status WaitingBuyerInvoice keeps notify_taker_reputation on its
+        // allowed-status path (sell order → PayInvoice to seller).
+        insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::WaitingBuyerInvoice,
+            None,
+            Some(buyer),
+            Some(seller),
+            Some(master_buyer),
+        )
+        .await;
+
+        let result = hold_invoice_paid(&hash, None, &pool, &create_test_keys()).await;
+        assert!(result.is_ok(), "add-invoice path must succeed: {result:?}");
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(updated.status, Status::WaitingBuyerInvoice.to_string());
+        assert!(updated.invoice_held_at > 0, "invoice_held_at must be set");
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_paid_errors_when_buyer_pubkey_missing() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "cc".repeat(32);
+        insert_order_with_hash(&pool, &hash, Status::WaitingPayment, None, None, None, None).await;
+
+        let result = hold_invoice_paid(&hash, None, &pool, &create_test_keys()).await;
+        assert!(
+            matches!(result, Err(MostroInternalErr(ServiceError::NostrError(_)))),
+            "missing buyer pubkey must surface as NostrError: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_settlement_and_cancel_resolve_existing_order() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "dd".repeat(32);
+        insert_order_with_hash(&pool, &hash, Status::Active, None, None, None, None).await;
+
+        assert!(hold_invoice_settlement(&hash, &pool).await.is_ok());
+        assert!(hold_invoice_canceled(&hash, &pool).await.is_ok());
+    }
+
     #[tokio::test]
     async fn test_hold_invoice_paid_structure() {
         let pool = create_test_pool().await;

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -209,8 +209,13 @@ mod tests {
         let config_tpl = include_bytes!("../../settings.tpl.toml");
         let config_tpl =
             std::str::from_utf8(config_tpl).expect("Invalid UTF-8 in template config file");
-        let test_settings: Settings =
+        let mut test_settings: Settings =
             toml::from_str(config_tpl).expect("Failed to parse template config file");
+        // The template ships a placeholder nsec; install a parseable one so
+        // whichever module wins the MOSTRO_CONFIG race leaves get_keys()
+        // usable for every other test.
+        test_settings.nostr.nsec_privkey =
+            "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd".to_string();
         MOSTRO_CONFIG.get_or_init(|| test_settings);
     }
 
@@ -258,6 +263,116 @@ mod tests {
         let lnurl = lnurl_obj.encode();
 
         (lnurl, handle)
+    }
+
+    /// Build a freshly-signed BOLT11 invoice locally (no network, no LND).
+    /// `amount_msat = None` produces a no-amount invoice.
+    fn build_test_invoice(amount_msat: Option<u64>, expiry_secs: u64) -> String {
+        use bitcoin::hashes::{sha256, Hash};
+        use bitcoin::secp256k1::{Secp256k1, SecretKey};
+        use lightning_invoice::{Currency, InvoiceBuilder, PaymentSecret};
+        use std::time::Duration;
+
+        let secp = Secp256k1::new();
+        let private_key = SecretKey::from_slice(&[0x42; 32]).expect("valid secret key");
+        let payment_hash = sha256::Hash::hash(&[0u8; 32]);
+
+        let builder = InvoiceBuilder::new(Currency::Bitcoin)
+            .description("mostro coverage test invoice".into())
+            .payment_hash(payment_hash)
+            .payment_secret(PaymentSecret([42u8; 32]))
+            .current_timestamp()
+            .min_final_cltv_expiry_delta(144)
+            .expiry_time(Duration::from_secs(expiry_secs));
+        let builder = match amount_msat {
+            Some(msat) => builder.amount_milli_satoshis(msat),
+            None => builder,
+        };
+        builder
+            .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &private_key))
+            .expect("valid signed invoice")
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn test_fresh_invoice_with_matching_amount_is_valid() {
+        init_settings_test();
+        // 1000 sats invoice; caller expects amount 1100 with 100 sats fee →
+        // expected_sats_amount = 1000 = invoice amount → valid.
+        let payment_request = build_test_invoice(Some(1_000_000), 86_400);
+        let result = is_valid_invoice(payment_request, Some(1_100), Some(100)).await;
+        assert!(
+            result.is_ok(),
+            "fresh matching invoice must pass: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fresh_invoice_without_amount_check_is_valid() {
+        init_settings_test();
+        // No expected amount: only min-amount and expiry windows apply.
+        let payment_request = build_test_invoice(Some(1_000_000), 86_400);
+        let result = is_valid_invoice(payment_request, None, None).await;
+        assert!(result.is_ok(), "fresh invoice must pass: {result:?}");
+    }
+
+    #[tokio::test]
+    async fn test_fresh_invoice_amount_mismatch_is_rejected() {
+        init_settings_test();
+        // Invoice carries 1000 sats but the caller expects 5000 - 0 fee.
+        let payment_request = build_test_invoice(Some(1_000_000), 86_400);
+        let result = is_valid_invoice(payment_request, Some(5_000), None).await;
+        assert_eq!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError)),
+            "amount mismatch on a non-expired invoice must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fee_larger_than_amount_overflows_and_is_rejected() {
+        init_settings_test();
+        // fee > amount → checked_sub underflows → invalid.
+        let payment_request = build_test_invoice(Some(1_000_000), 86_400);
+        let result = is_valid_invoice(payment_request, Some(100), Some(200)).await;
+        assert_eq!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError)),
+            "fee larger than expected amount must be rejected (subtraction underflow)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invoice_expiring_before_expiration_window_is_rejected() {
+        init_settings_test();
+        // Non-expired invoice whose remaining lifetime (60s) is shorter than
+        // the configured expiration window. The assertion adapts to whichever
+        // global settings won the process-wide OnceLock race.
+        let window = Settings::get_ln().invoice_expiration_window;
+        let payment_request = build_test_invoice(Some(1_000_000), 60);
+        let result = is_valid_invoice(payment_request, None, None).await;
+        if window as u64 > 60 {
+            assert_eq!(
+                result,
+                Err(MostroInternalErr(ServiceError::InvoiceInvalidError)),
+                "invoice expiring inside the window must be rejected"
+            );
+        } else {
+            assert!(result.is_ok(), "window {window} accepts short invoices");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_zero_amount_fresh_invoice_skips_amount_and_min_checks() {
+        init_settings_test();
+        // A fresh no-amount invoice: amount_sat == 0 skips both the equality
+        // check (explicitly allowed) and the min-payment floor.
+        let payment_request = build_test_invoice(None, 86_400);
+        let result = is_valid_invoice(payment_request, Some(1_000), None).await;
+        assert!(
+            result.is_ok(),
+            "zero-amount invoice must pass amount checks: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -431,7 +431,11 @@ mod tests {
         // Defaults set `max_routing_fee = 0.002`.
         let _ = MOSTRO_CONFIG.set(Settings {
             database: Default::default(),
-            nostr: Default::default(),
+            nostr: crate::config::NostrSettings {
+                nsec_privkey: "nsec13as48eum93hkg7plv526r9gjpa0uc52zysqm93pmnkca9e69x6tsdjmdxd"
+                    .to_string(),
+                relays: vec![],
+            },
             mostro: Default::default(),
             lightning: Default::default(),
             rpc: Default::default(),
@@ -460,5 +464,162 @@ mod tests {
         assert_eq!(routing_fee_cap_sats(1001), 2); // 2.002 -> 2
         assert_eq!(routing_fee_cap_sats(2001), 4); // 4.002 -> 4
         assert_eq!(routing_fee_cap_sats(100_000), 200);
+    }
+}
+
+#[cfg(test)]
+mod offline_connector_tests {
+    //! `fedimint_tonic_lnd::connect` is lazy: it reads the TLS cert and
+    //! macaroon files and builds a channel, but never touches the network
+    //! until the first RPC. That lets these tests construct a real
+    //! `LndConnector` pointed at a dead localhost port and exercise every
+    //! RPC method's transport-error path without a live LND node.
+    use super::*;
+    use crate::config::MOSTRO_CONFIG;
+    use fedimint_tonic_lnd::lnrpc::GetInfoResponse;
+
+    fn init_test_settings() {
+        let _ = MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
+    }
+
+    /// Build a connector whose channel points at a closed localhost port.
+    /// Empty cert (rustls_pemfile yields zero certs) and empty macaroon are
+    /// both accepted by the lazy connector.
+    async fn offline_connector() -> LndConnector {
+        let dir = std::env::temp_dir().join(format!("mostro-lnd-offline-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let cert = dir.join("tls.cert");
+        let macaroon = dir.join("admin.macaroon");
+        std::fs::write(&cert, b"").expect("write cert");
+        std::fs::write(&macaroon, b"").expect("write macaroon");
+        let client = fedimint_tonic_lnd::connect("https://127.0.0.1:1".to_string(), cert, macaroon)
+            .await
+            .expect("lazy connect must not touch the network");
+        LndConnector { client }
+    }
+
+    /// Amount-carrying regtest invoice (500u = 50_000 sats), reused from the
+    /// `lightning::invoice` test fixtures.
+    const INVOICE_500U: &str = "lnbcrt500u1p3lzwdzpp5t9kgwgwd07y2lrwdscdnkqu4scrcgpm5pt9uwx0rxn5rxawlxlvqdqqcqzpgxqyz5vqsp5a6k7syfxeg8jy63rteywwjla5rrg2pvhedx8ajr2ltm4seydhsqq9qyyssq0n2uwlumsx4d0mtjm8tp7jw3y4da6p6z9gyyjac0d9xugf72lhh4snxpugek6n83geafue9ndgrhuhzk98xcecu2t3z56ut35mkammsqscqp0n";
+
+    #[tokio::test]
+    async fn new_fails_without_reachable_files() {
+        init_test_settings();
+        // Default LightningSettings point at empty paths: the cert read
+        // fails before any network activity, so `new` errors cleanly.
+        let result = LndConnector::new().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn create_hold_invoice_surfaces_transport_error() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        let res = ln.create_hold_invoice("test hold invoice", 1_000).await;
+        assert!(res.is_err());
+    }
+
+    #[tokio::test]
+    async fn settle_hold_invoice_surfaces_transport_error() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        let preimage = "aa".repeat(32);
+        assert!(ln.settle_hold_invoice(&preimage).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn cancel_hold_invoice_error_carries_grpc_code_prefix() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        let hash = "bb".repeat(32);
+        let err = ln
+            .cancel_hold_invoice(&hash)
+            .await
+            .expect_err("dead port must error");
+        // Bond release parses the stable `code=<Code>` prefix; pin it.
+        assert!(
+            err.to_string().contains("code="),
+            "error must carry the code= prefix, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn subscribe_invoice_surfaces_transport_error() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        assert!(ln.subscribe_invoice(vec![0u8; 32], tx).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn get_node_info_surfaces_transport_error() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        assert!(ln.get_node_info().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn lookup_payment_status_maps_transport_error() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        let err = ln
+            .lookup_payment_status(&[0u8; 32])
+            .await
+            .expect_err("transport failure must be Err, not Ok(None)");
+        assert!(err.to_string().contains("code="));
+    }
+
+    #[tokio::test]
+    async fn check_payment_status_surfaces_transport_error() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        assert!(ln.check_payment_status(&[0u8; 32]).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn send_payment_rejects_wrong_amount_before_paying() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        // Invoice is 50_000 sats; passing 100 must abort with Wrong amount.
+        let err = ln
+            .send_payment(INVOICE_500U, 100, tx)
+            .await
+            .expect_err("wrong amount must be rejected");
+        assert!(err.to_string().contains("Wrong amount"));
+    }
+
+    #[tokio::test]
+    async fn send_payment_with_matching_amount_fails_on_transport() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        let (tx, _rx) = tokio::sync::mpsc::channel(1);
+        // Amount matches the invoice, so the failure comes from the dead
+        // port at send_payment_v2 time.
+        assert!(ln.send_payment(INVOICE_500U, 50_000, tx).await.is_err());
+    }
+
+    #[test]
+    fn ln_status_maps_get_info_response_fields() {
+        let info = GetInfoResponse {
+            version: "0.18.0-beta".to_string(),
+            identity_pubkey: "02abc".to_string(),
+            commit_hash: "deadbeef".to_string(),
+            alias: "test-node".to_string(),
+            chains: vec![fedimint_tonic_lnd::lnrpc::Chain {
+                chain: "bitcoin".to_string(),
+                network: "regtest".to_string(),
+            }],
+            uris: vec!["02abc@127.0.0.1:9735".to_string()],
+            ..Default::default()
+        };
+        let status = LnStatus::from_get_info_response(info);
+        assert_eq!(status.version, "0.18.0-beta");
+        assert_eq!(status.node_pubkey, "02abc");
+        assert_eq!(status.commit_hash, "deadbeef");
+        assert_eq!(status.node_alias, "test-node");
+        assert_eq!(status.chains, vec!["bitcoin".to_string()]);
+        assert_eq!(status.networks, vec!["regtest".to_string()]);
+        assert_eq!(status.uris, vec!["02abc@127.0.0.1:9735".to_string()]);
     }
 }

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -122,3 +122,54 @@ pub async fn resolv_ln_address(address: &str, amount: u64) -> Result<String, Mos
         Ok("".to_string())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Parsing/validation coverage only: the HTTP round-trips of
+    //! `ln_exists` / `resolv_ln_address` need a live LNURL endpoint and are
+    //! exercised by the integration-style server tests in
+    //! `lightning::invoice`.
+    use super::*;
+
+    #[tokio::test]
+    async fn extract_lnurl_decodes_bech32_lnurl() {
+        let url = "https://example.com/.well-known/lnurlp/alice";
+        let encoded = LnUrl {
+            url: url.to_string(),
+        }
+        .encode();
+        assert!(encoded.to_lowercase().starts_with("lnurl1"));
+
+        let extracted = extract_lnurl(&encoded).await.expect("valid LNURL decodes");
+        assert_eq!(extracted, url);
+    }
+
+    #[tokio::test]
+    async fn extract_lnurl_rejects_malformed_bech32() {
+        assert!(extract_lnurl("lnurl1notvalidbech32").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn extract_lnurl_builds_wellknown_url_for_lightning_address() {
+        // cfg!(test) pins lightning addresses to the local test host form.
+        let extracted = extract_lnurl("alice@127.0.0.1")
+            .await
+            .expect("lightning address parses");
+        assert_eq!(extracted, "http://127.0.0.1:8080/.well-known/lnurlp/alice");
+    }
+
+    #[tokio::test]
+    async fn extract_lnurl_rejects_address_without_at() {
+        assert!(extract_lnurl("not-a-lightning-address").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn ln_exists_propagates_parse_error_before_any_request() {
+        assert!(ln_exists("no-at-sign-here").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn resolv_ln_address_propagates_parse_error_before_any_request() {
+        assert!(resolv_ln_address("no-at-sign-here", 1_000).await.is_err());
+    }
+}

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -9,3 +9,36 @@ pub fn hold_invoice_description(
         "Escrow amount Order #{order_id}: SELL BTC for {fiat_code} {fiat_amount} - It WILL FREEZE IN WALLET. It will release once you release. It will return if buyer does not confirm the payment"
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hold_invoice_description_embeds_order_id_and_fiat_data() {
+        // Arrange
+        let order_id = "308e1272-d5f4-47e6-bd97-3504baea9c23";
+        let fiat_code = "USD";
+        let fiat_amount = "100";
+
+        // Act
+        let description = hold_invoice_description(order_id, fiat_code, fiat_amount)
+            .expect("description building is infallible");
+
+        // Assert
+        assert!(description.contains(&format!("Order #{order_id}")));
+        assert!(description.contains("SELL BTC for USD 100"));
+        assert!(description.starts_with("Escrow amount"));
+    }
+
+    #[test]
+    fn hold_invoice_description_handles_empty_inputs() {
+        // Arrange / Act
+        let description =
+            hold_invoice_description("", "", "").expect("description building is infallible");
+
+        // Assert: still a well-formed template even with empty fields
+        assert!(description.contains("Order #:"));
+        assert!(description.contains("SELL BTC for"));
+    }
+}

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1061,6 +1061,264 @@ mod tests {
         );
     }
 
+    // ── Event constructors (kinds 38383/38384/38385/38386/30078) ─────────
+
+    #[test]
+    fn event_constructors_emit_expected_kinds_and_identifier() {
+        init_test_settings();
+        let keys = Keys::generate();
+        let tags = Tags::from_list(vec![]);
+
+        let order = super::new_order_event(&keys, "", "order-id".to_string(), tags.clone())
+            .expect("order event");
+        assert_eq!(order.kind.as_u16(), NOSTR_ORDER_EVENT_KIND);
+
+        let rating = super::new_rating_event(&keys, "", "user-pk".to_string(), tags.clone())
+            .expect("rating event");
+        assert_eq!(rating.kind.as_u16(), NOSTR_RATING_EVENT_KIND);
+
+        // Kind 38385 has no configured expiration → exercises the
+        // "no expiration tag" path of create_event.
+        let info =
+            super::new_info_event(&keys, "", "mostro-pk".to_string(), tags.clone()).expect("info");
+        assert_eq!(info.kind.as_u16(), NOSTR_INFO_EVENT_KIND);
+        assert!(
+            !info
+                .tags
+                .iter()
+                .any(|t| matches!(t.kind(), TagKind::Expiration)),
+            "info events must not carry an expiration tag"
+        );
+
+        let dispute = super::new_dispute_event(&keys, "", "dispute-id".to_string(), tags.clone())
+            .expect("dispute event");
+        assert_eq!(dispute.kind.as_u16(), NOSTR_DISPUTE_EVENT_KIND);
+
+        let rates =
+            super::new_exchange_rates_event(&keys, "{}", tags.clone()).expect("rates event");
+        assert_eq!(
+            rates.kind.as_u16(),
+            crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND
+        );
+        // NIP-33 d tag is fixed for the rates event.
+        let d_tag = rates
+            .tags
+            .identifier()
+            .expect("rates event must carry a d tag");
+        assert_eq!(d_tag, "mostro-rates");
+
+        // Order events DO get an expiration tag from configuration.
+        assert!(
+            order
+                .tags
+                .iter()
+                .any(|t| matches!(t.kind(), TagKind::Expiration)),
+            "order events must carry an expiration tag"
+        );
+    }
+
+    // ── create_rating_tag ────────────────────────────────────────────────
+
+    #[test]
+    fn create_rating_tag_serializes_reputation_or_empty_object() {
+        // Established user: days computed from created_at.
+        let created_at = Timestamp::now().as_secs() as i64 - 2 * 86_400;
+        let json = super::create_rating_tag(Some((4.5, 12, created_at)));
+        assert!(json.contains("\"total_reviews\":12"));
+        assert!(json.contains("\"total_rating\":4.5"));
+        assert!(json.contains("\"days\":2"));
+
+        // Brand-new user: created_at == 0 → days must be 0.
+        let json_new = super::create_rating_tag(Some((0.0, 0, 0)));
+        assert!(json_new.contains("\"days\":0"));
+
+        // No reputation data at all → placeholder object.
+        assert_eq!(super::create_rating_tag(None), "{}");
+    }
+
+    // ── create_fiat_amt_array ────────────────────────────────────────────
+
+    #[test]
+    fn fiat_amount_array_advertises_range_only_while_takeable() {
+        // Pending range order → [min, max].
+        let mut order = make_pending_order();
+        order.min_amount = Some(10);
+        order.max_amount = Some(100);
+        assert_eq!(
+            super::create_fiat_amt_array(&order),
+            vec!["10".to_string(), "100".to_string()]
+        );
+
+        // Pending single-amount order → [fiat_amount].
+        let mut single = make_pending_order();
+        single.fiat_amount = 42;
+        assert_eq!(
+            super::create_fiat_amt_array(&single),
+            vec!["42".to_string()]
+        );
+
+        // Taken (active) order → exact amount even if min/max present.
+        order.status = Status::Active.to_string();
+        order.fiat_amount = 55;
+        assert_eq!(super::create_fiat_amt_array(&order), vec!["55".to_string()]);
+    }
+
+    // ── create_status_tags remaining arms ────────────────────────────────
+
+    #[test]
+    fn status_tags_map_lifecycle_statuses_to_nip69_buckets() {
+        let mut order = make_pending_order();
+
+        // WaitingBuyerInvoice on a sell order → publish as InProgress.
+        order.status = Status::WaitingBuyerInvoice.to_string();
+        assert_eq!(
+            create_status_tags(&order).unwrap(),
+            (true, Status::InProgress)
+        );
+
+        // WaitingPayment on a sell order → not a buy order → don't emit.
+        order.status = Status::WaitingPayment.to_string();
+        assert_eq!(
+            create_status_tags(&order).unwrap(),
+            (false, Status::InProgress)
+        );
+
+        // WaitingPayment on a buy order → emit as InProgress.
+        order.kind = mostro_core::order::Kind::Buy.to_string();
+        assert_eq!(
+            create_status_tags(&order).unwrap(),
+            (true, Status::InProgress)
+        );
+
+        // Cancellation family collapses into Canceled.
+        for cancelish in [
+            Status::Canceled,
+            Status::CanceledByAdmin,
+            Status::CooperativelyCanceled,
+            Status::Expired,
+        ] {
+            order.status = cancelish.to_string();
+            assert_eq!(
+                create_status_tags(&order).unwrap(),
+                (true, Status::Canceled)
+            );
+        }
+
+        // Success family keeps its own status.
+        order.status = Status::Success.to_string();
+        assert_eq!(create_status_tags(&order).unwrap(), (true, Status::Success));
+        order.status = Status::CompletedByAdmin.to_string();
+        assert_eq!(
+            create_status_tags(&order).unwrap(),
+            (true, Status::CompletedByAdmin)
+        );
+
+        // Internal statuses are not published.
+        order.status = Status::Dispute.to_string();
+        assert_eq!(
+            create_status_tags(&order).unwrap(),
+            (false, Status::Dispute)
+        );
+    }
+
+    // ── order_to_tags: non-pending, reputation, and get_keys paths ───────
+
+    #[test]
+    fn order_to_tags_returns_none_for_internal_statuses() {
+        init_test_settings();
+        let mut order = make_pending_order();
+        order.status = Status::Dispute.to_string();
+
+        let tags = order_to_tags(&order, None, Some(TEST_MOSTRO_PUBKEY))
+            .expect("order_to_tags must not error");
+        assert!(
+            tags.is_none(),
+            "internal statuses must not produce a publishable event"
+        );
+    }
+
+    #[test]
+    fn order_to_tags_inserts_rating_tag_when_reputation_present() {
+        init_test_settings();
+        // Publishing LN status also exercises the LN_STATUS-Some branch.
+        let _ = crate::LN_STATUS.set(make_ln_status());
+        let order = make_pending_order();
+
+        let tags = order_to_tags(&order, Some((4.2, 7, 0)), Some(TEST_MOSTRO_PUBKEY))
+            .expect("order_to_tags must not error")
+            .expect("pending order must produce tags");
+
+        let rating = get_tag_value(&tags, "rating").expect("rating tag must be inserted");
+        assert!(rating.contains("\"total_reviews\":7"));
+        assert!(rating.contains("\"total_rating\":4.2"));
+    }
+
+    #[test]
+    fn order_to_tags_derives_pubkey_from_global_keys_when_none() {
+        init_test_settings();
+        let order = make_pending_order();
+
+        // Whether this succeeds depends on which global settings won the
+        // process-wide OnceLock race (the settings template carries a
+        // placeholder nsec). Either way the get_keys() path is exercised
+        // and must not panic.
+        match order_to_tags(&order, None, None) {
+            Ok(Some(tags)) => {
+                let source = get_source_tag_value(&tags).expect("source tag");
+                assert!(source.contains("&mostro="));
+            }
+            Ok(None) => panic!("pending order must not map to None"),
+            Err(_) => { /* template settings won the race: invalid nsec */ }
+        }
+    }
+
+    // ── bond_policy_tags remaining branches ──────────────────────────────
+
+    #[test]
+    fn bond_policy_tags_cover_all_apply_to_variants_and_disabled_block() {
+        use crate::config::types::{AntiAbuseBondSettings, BondApplyTo};
+
+        let base = AntiAbuseBondSettings {
+            enabled: true,
+            amount_pct: 0.01,
+            base_amount_sats: 1_000,
+            apply_to: BondApplyTo::Take,
+            slash_on_waiting_timeout: false,
+            slash_node_share_pct: 0.5,
+            payout_invoice_window_seconds: 300,
+            payout_max_retries: 3,
+            payout_claim_window_days: 14,
+        };
+
+        let take_tags = bond_tags(Some(&base));
+        assert_eq!(
+            get_tag_value(&take_tags, "bond_apply_to").as_deref(),
+            Some("take")
+        );
+
+        let make_bond = AntiAbuseBondSettings {
+            apply_to: BondApplyTo::Make,
+            ..base.clone()
+        };
+        let make_tags = bond_tags(Some(&make_bond));
+        assert_eq!(
+            get_tag_value(&make_tags, "bond_apply_to").as_deref(),
+            Some("make")
+        );
+
+        // Present-but-disabled block: only the bond_enabled=false marker.
+        let disabled = AntiAbuseBondSettings {
+            enabled: false,
+            ..base
+        };
+        let disabled_tags = bond_tags(Some(&disabled));
+        assert_eq!(
+            get_tag_value(&disabled_tags, "bond_enabled").as_deref(),
+            Some("false")
+        );
+        assert!(get_tag_value(&disabled_tags, "bond_apply_to").is_none());
+    }
+
     // ── Phase 1.5 NIP-69 mapping tests ───────────────────────────────────
 
     /// Load-bearing for the non-blockability invariant

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -1391,3 +1391,240 @@ mod tests {
         ));
     }
 }
+
+// Coverage-focused additions: global install, timeout arm, scoping edge
+// cases, warn-flag plumbing, and the Nostr publish path.
+#[cfg(test)]
+mod coverage_tests {
+    use super::*;
+    use crate::price::provider::{ProviderQuotes, Quote};
+    use async_trait::async_trait;
+
+    /// A provider whose fetch never resolves — drives `update_all`'s
+    /// timeout arm under a paused tokio clock.
+    struct HangingProvider;
+
+    #[async_trait]
+    impl PriceProvider for HangingProvider {
+        fn id(&self) -> ProviderId {
+            ProviderId::Yadio
+        }
+        async fn fetch(&self, _http: &reqwest::Client) -> Result<ProviderQuotes, ProviderError> {
+            std::future::pending().await
+        }
+    }
+
+    fn bare_manager(settings: PriceSettings, providers: Vec<EnabledProvider>) -> PriceManager {
+        PriceManager {
+            providers,
+            store: Arc::new(PriceStore::new()),
+            settings,
+            http: reqwest::Client::new(),
+            warned_stale: RwLock::new(HashSet::new()),
+            warned_refused: RwLock::new(HashSet::new()),
+            warned_single_source: RwLock::new(HashSet::new()),
+        }
+    }
+
+    fn quotes(pairs: &[(&str, f64)]) -> ProviderQuotes {
+        pairs
+            .iter()
+            .map(|(c, v)| (c.to_string(), Quote::PerBtc(*v)))
+            .collect()
+    }
+
+    #[test]
+    fn install_error_display_and_traits() {
+        let err = InstallError::AlreadyInstalled;
+        assert_eq!(err.to_string(), "PriceManager already installed");
+        // It is a std::error::Error.
+        let _: &dyn std::error::Error = &err;
+    }
+
+    #[test]
+    fn settings_accessor_returns_active_settings() {
+        let settings = PriceSettings {
+            update_interval_seconds: 123,
+            ..PriceSettings::default()
+        };
+        let manager = bare_manager(settings, Vec::new());
+        assert_eq!(manager.settings().update_interval_seconds, 123);
+    }
+
+    /// The one deliberate global installation in the whole test binary: an
+    /// empty-provider manager with a sub-minimum interval, so the scheduler
+    /// smoke test exercises its interval clamp without any provider HTTP.
+    /// Every other test drives managers through `&self`, never the global.
+    #[tokio::test]
+    async fn install_global_accepts_once_then_refuses() {
+        let manager = PriceManager::from_settings(PriceSettings {
+            update_interval_seconds: 30,
+            providers: HashMap::new(),
+            ..PriceSettings::default()
+        })
+        .expect("empty provider set builds");
+        // First install wins (or another test's identical install did).
+        let _ = manager.install_global();
+        assert!(PriceManager::global().is_some());
+
+        let second = PriceManager::from_settings(PriceSettings {
+            update_interval_seconds: 30,
+            providers: HashMap::new(),
+            ..PriceSettings::default()
+        })
+        .expect("empty provider set builds");
+        assert_eq!(second.install_global(), Err(InstallError::AlreadyInstalled));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn update_all_times_out_hung_provider_and_records_failure() {
+        let mut settings = PriceSettings {
+            publish_to_nostr: false,
+            provider_timeout_seconds: 1,
+            ..PriceSettings::default()
+        };
+        settings.providers.insert(
+            ProviderId::Yadio.to_string(),
+            ProviderConfig {
+                enabled: true,
+                url: "http://test".into(),
+                fallback_urls: vec![],
+                api_key: None,
+                token: None,
+                only: None,
+                except: None,
+            },
+        );
+        let manager = bare_manager(
+            settings,
+            vec![EnabledProvider {
+                id: ProviderId::Yadio,
+                provider: Box::new(HangingProvider),
+                health: Mutex::new(ProviderHealth::new()),
+            }],
+        );
+
+        let report = manager.update_all().await;
+        assert!(report.successes.is_empty());
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.failures[0].1, "timeout");
+    }
+
+    #[test]
+    fn poll_budget_defaults_to_single_attempt_for_unknown_provider() {
+        // No config entry for the id: one attempt plus one second of slack.
+        let manager = bare_manager(
+            PriceSettings {
+                provider_timeout_seconds: 4,
+                ..PriceSettings::default()
+            },
+            Vec::new(),
+        );
+        assert_eq!(
+            manager.poll_budget(ProviderId::CoinGecko),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn scope_quotes_passes_through_without_config_entry() {
+        let manager = bare_manager(PriceSettings::default(), Vec::new());
+        let q = quotes(&[("USD", 50_000.0)]);
+        let scoped = manager.scope_quotes(ProviderId::Blockchain, q.clone());
+        assert_eq!(scoped.len(), q.len());
+    }
+
+    #[test]
+    fn observe_freshness_ignores_unknown_currency() {
+        let manager = bare_manager(PriceSettings::default(), Vec::new());
+        // No store entry: must be a silent no-op.
+        manager.observe_freshness("ZZZ", "ZZZ", Utc::now().timestamp());
+    }
+
+    #[test]
+    fn mark_warned_treats_poisoned_lock_as_already_warned() {
+        let manager = bare_manager(PriceSettings::default(), Vec::new());
+        // Poison the warned_stale lock by panicking while holding it.
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = manager.warned_stale.write().unwrap();
+            panic!("poison the lock");
+        }));
+        assert!(
+            !manager.mark_warned(&manager.warned_stale, "USD"),
+            "poisoned lock must read as already-warned (stay quiet)"
+        );
+        // clear_warned on the poisoned lock is a silent no-op.
+        manager.clear_warned(&manager.warned_stale, "USD");
+    }
+
+    #[tokio::test]
+    async fn publish_rates_to_nostr_is_best_effort_without_relays() {
+        // Publishing must never fail the tick: with keys derivable from the
+        // global test settings and no reachable Nostr client/relays, every
+        // failure is swallowed and logged.
+        let _ = crate::config::MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
+        let manager = bare_manager(PriceSettings::default(), Vec::new());
+        let mut aggregates: HashMap<String, AggregateResult> = HashMap::new();
+        aggregates.insert(
+            "USD".to_string(),
+            AggregateResult {
+                value: 50_000.0,
+                sources: 1,
+                contributors: vec![ProviderId::Yadio],
+            },
+        );
+        manager
+            .publish_rates_to_nostr(&aggregates, &[ProviderId::Yadio])
+            .await;
+    }
+
+    #[tokio::test]
+    async fn update_all_with_publish_flag_runs_publish_path() {
+        let _ = crate::config::MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
+        let mut settings = PriceSettings {
+            publish_to_nostr: true,
+            provider_timeout_seconds: 5,
+            ..PriceSettings::default()
+        };
+        settings.providers.insert(
+            ProviderId::Yadio.to_string(),
+            ProviderConfig {
+                enabled: true,
+                url: "http://test".into(),
+                fallback_urls: vec![],
+                api_key: None,
+                token: None,
+                only: None,
+                except: None,
+            },
+        );
+
+        struct OneShot;
+        #[async_trait]
+        impl PriceProvider for OneShot {
+            fn id(&self) -> ProviderId {
+                ProviderId::Yadio
+            }
+            async fn fetch(
+                &self,
+                _http: &reqwest::Client,
+            ) -> Result<ProviderQuotes, ProviderError> {
+                Ok([("USD".to_string(), Quote::PerBtc(50_000.0))]
+                    .into_iter()
+                    .collect())
+            }
+        }
+
+        let manager = bare_manager(
+            settings,
+            vec![EnabledProvider {
+                id: ProviderId::Yadio,
+                provider: Box::new(OneShot),
+                health: Mutex::new(ProviderHealth::new()),
+            }],
+        );
+        let report = manager.update_all().await;
+        assert_eq!(report.fresh_currencies, 1);
+        assert_eq!(report.contributors, vec![ProviderId::Yadio]);
+    }
+}

--- a/src/rpc/rate_limiter.rs
+++ b/src/rpc/rate_limiter.rs
@@ -176,6 +176,111 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_default_uses_one_hour_retention() {
+        let limiter = RateLimiter::default();
+        assert_eq!(limiter.retention, DEFAULT_RETENTION);
+        assert!(limiter.check_rate_limit(&test_addr(7)).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_expired_lockout_resets_state() {
+        let limiter = RateLimiter::new(DEFAULT_RETENTION);
+        let addr = test_addr(8);
+
+        // Arrange: a client whose lockout has already expired.
+        {
+            let mut clients = limiter.clients.lock().await;
+            clients.insert(
+                addr.ip().to_string(),
+                ClientState {
+                    failed_attempts: MAX_ATTEMPTS,
+                    last_attempt: Instant::now(),
+                    locked_until: Some(Instant::now()),
+                },
+            );
+        }
+
+        // Act: the expired lockout must be cleared and the request allowed.
+        assert!(limiter.check_rate_limit(&addr).await.is_ok());
+
+        // Assert: failure counter was reset by the expired-lockout branch.
+        let clients = limiter.clients.lock().await;
+        let state = clients.get(&addr.ip().to_string()).expect("entry kept");
+        assert_eq!(state.failed_attempts, 0);
+        assert!(state.locked_until.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_backoff_window_rejects_with_message() {
+        let limiter = RateLimiter::new(DEFAULT_RETENTION);
+        let addr = test_addr(9);
+
+        // Arrange: two recent failures put the client in a 2s backoff window.
+        {
+            let mut clients = limiter.clients.lock().await;
+            clients.insert(
+                addr.ip().to_string(),
+                ClientState {
+                    failed_attempts: 2,
+                    last_attempt: Instant::now(),
+                    locked_until: None,
+                },
+            );
+        }
+
+        let err = limiter
+            .check_rate_limit(&addr)
+            .await
+            .expect_err("inside the backoff window the request must be refused");
+        assert!(err.contains("Rate limited"));
+    }
+
+    #[tokio::test]
+    async fn test_backoff_window_elapsed_allows_request() {
+        let limiter = RateLimiter::new(DEFAULT_RETENTION);
+        let addr = test_addr(10);
+
+        // Arrange: one failure whose 1s backoff has already elapsed.
+        {
+            let mut clients = limiter.clients.lock().await;
+            clients.insert(
+                addr.ip().to_string(),
+                ClientState {
+                    failed_attempts: 1,
+                    last_attempt: Instant::now() - Duration::from_secs(2),
+                    locked_until: None,
+                },
+            );
+        }
+
+        assert!(limiter.check_rate_limit(&addr).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_lockout_error_message_reports_remaining_seconds() {
+        let limiter = RateLimiter::new(DEFAULT_RETENTION);
+        let addr = test_addr(11);
+
+        {
+            let mut clients = limiter.clients.lock().await;
+            clients.insert(
+                addr.ip().to_string(),
+                ClientState {
+                    failed_attempts: MAX_ATTEMPTS,
+                    last_attempt: Instant::now(),
+                    locked_until: Some(Instant::now() + LOCKOUT_DURATION),
+                },
+            );
+        }
+
+        let err = limiter
+            .check_rate_limit(&addr)
+            .await
+            .expect_err("active lockout must refuse");
+        assert!(err.contains("Locked out"));
+    }
+
+    #[tokio::test]
     async fn test_first_attempt_allowed() {
         let limiter = RateLimiter::new(DEFAULT_RETENTION);
         assert!(limiter.check_rate_limit(&test_addr(1)).await.is_ok());

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -102,6 +102,79 @@ mod tests {
         assert_eq!(expected_addr, "127.0.0.1:50051");
     }
 
+    use crate::app::context::test_utils::test_settings;
+    use crate::config::MOSTRO_CONFIG;
+    use nostr_sdk::Keys;
+    use std::sync::Arc;
+
+    fn init_test_settings() {
+        let _ = MOSTRO_CONFIG.set(test_settings());
+    }
+
+    /// Offline `LndConnector` (lazy connect, no network until first RPC).
+    async fn offline_ln_client() -> Arc<tokio::sync::Mutex<LndConnector>> {
+        let dir = std::env::temp_dir().join(format!("mostro-rpcsrv-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let cert = dir.join("tls.cert");
+        let macaroon = dir.join("admin.macaroon");
+        std::fs::write(&cert, b"").expect("write cert");
+        std::fs::write(&macaroon, b"").expect("write macaroon");
+        let client = fedimint_tonic_lnd::connect("https://127.0.0.1:1".to_string(), cert, macaroon)
+            .await
+            .expect("lazy connect must not touch the network");
+        Arc::new(tokio::sync::Mutex::new(LndConnector { client }))
+    }
+
+    #[test]
+    fn new_reads_settings_and_default_delegates() {
+        init_test_settings();
+        let server = RpcServer::new();
+        let rpc = Settings::get_rpc();
+        assert_eq!(server.listen_address, rpc.listen_address);
+        assert_eq!(server.port, rpc.port);
+
+        let defaulted = RpcServer::default();
+        assert_eq!(defaulted.listen_address, server.listen_address);
+        assert_eq!(defaulted.port, server.port);
+    }
+
+    #[test]
+    fn is_enabled_reflects_settings() {
+        init_test_settings();
+        // Canonical test settings keep the RPC server disabled.
+        assert!(!RpcServer::is_enabled());
+    }
+
+    #[tokio::test]
+    async fn start_rejects_unparseable_address() {
+        init_test_settings();
+        let server = RpcServer {
+            listen_address: "not an address".to_string(),
+            port: 50051,
+        };
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let result = server
+            .start(Keys::generate(), Arc::new(pool), offline_ln_client().await)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn start_surfaces_bind_failure() {
+        init_test_settings();
+        // 8.8.8.8 is not a local interface: the bind fails immediately, so
+        // the server error path is exercised without serving traffic.
+        let server = RpcServer {
+            listen_address: "8.8.8.8".to_string(),
+            port: 1,
+        };
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let result = server
+            .start(Keys::generate(), Arc::new(pool), offline_ln_client().await)
+            .await;
+        assert!(result.is_err());
+    }
+
     #[test]
     fn test_default_rpc_settings() {
         let default_settings = RpcSettings::default();

--- a/src/rpc/service.rs
+++ b/src/rpc/service.rs
@@ -501,6 +501,211 @@ mod tests {
         assert_eq!(error_resp.error_message.unwrap(), "Order not found");
     }
 
+    use crate::app::context::test_utils::test_settings;
+    use crate::config::MOSTRO_CONFIG;
+    use crate::rpc::admin::{GetVersionRequest, ValidateDbPasswordRequest};
+    use nostr_sdk::Keys;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+    use tonic::transport::server::TcpConnectInfo;
+    use tonic::Request;
+
+    fn init_test_settings() {
+        let _ = MOSTRO_CONFIG.set(test_settings());
+    }
+
+    /// `fedimint_tonic_lnd::connect` is lazy (no network until the first
+    /// RPC), so an offline connector against a dead localhost port lets us
+    /// construct the full service without a live LND node.
+    async fn offline_service() -> AdminServiceImpl {
+        init_test_settings();
+        let dir = std::env::temp_dir().join(format!("mostro-rpc-offline-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let cert = dir.join("tls.cert");
+        let macaroon = dir.join("admin.macaroon");
+        std::fs::write(&cert, b"").expect("write cert");
+        std::fs::write(&macaroon, b"").expect("write macaroon");
+        let client = fedimint_tonic_lnd::connect("https://127.0.0.1:1".to_string(), cert, macaroon)
+            .await
+            .expect("lazy connect must not touch the network");
+        let ln_client = Arc::new(tokio::sync::Mutex::new(LndConnector { client }));
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        AdminServiceImpl::new(Keys::generate(), Arc::new(pool), ln_client)
+    }
+
+    fn request_with_addr<T>(inner: T, last_octet: u8) -> Request<T> {
+        let mut request = Request::new(inner);
+        request.extensions_mut().insert(TcpConnectInfo {
+            local_addr: None,
+            remote_addr: Some(SocketAddr::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, last_octet)),
+                50051,
+            )),
+        });
+        request
+    }
+
+    #[tokio::test]
+    async fn cancel_order_with_invalid_uuid_reports_failure() {
+        let service = offline_service().await;
+        let response = service
+            .cancel_order(Request::new(CancelOrderRequest {
+                order_id: "not-a-uuid".to_string(),
+                request_id: Some("7".to_string()),
+            }))
+            .await
+            .expect("RPC surface always answers with a response");
+        let inner = response.into_inner();
+        assert!(!inner.success);
+        assert!(inner.error_message.is_some());
+    }
+
+    #[tokio::test]
+    async fn cancel_order_with_unknown_order_reports_failure() {
+        let service = offline_service().await;
+        let response = service
+            .cancel_order(Request::new(CancelOrderRequest {
+                order_id: uuid::Uuid::new_v4().to_string(),
+                request_id: None,
+            }))
+            .await
+            .expect("RPC surface always answers with a response");
+        // Either the Nostr client is uninitialized or the order lookup
+        // fails — both must surface as an unsuccessful response.
+        assert!(!response.into_inner().success);
+    }
+
+    #[tokio::test]
+    async fn settle_order_with_invalid_uuid_reports_failure() {
+        let service = offline_service().await;
+        let response = service
+            .settle_order(Request::new(SettleOrderRequest {
+                order_id: "definitely not a uuid".to_string(),
+                request_id: None,
+            }))
+            .await
+            .expect("RPC surface always answers with a response");
+        assert!(!response.into_inner().success);
+    }
+
+    #[tokio::test]
+    async fn settle_order_with_unknown_order_reports_failure() {
+        let service = offline_service().await;
+        let response = service
+            .settle_order(Request::new(SettleOrderRequest {
+                order_id: uuid::Uuid::new_v4().to_string(),
+                request_id: Some("9".to_string()),
+            }))
+            .await
+            .expect("RPC surface always answers with a response");
+        assert!(!response.into_inner().success);
+    }
+
+    #[tokio::test]
+    async fn take_dispute_with_invalid_uuid_reports_failure() {
+        let service = offline_service().await;
+        let response = service
+            .take_dispute(Request::new(TakeDisputeRequest {
+                dispute_id: "nope".to_string(),
+                request_id: None,
+            }))
+            .await
+            .expect("RPC surface always answers with a response");
+        assert!(!response.into_inner().success);
+    }
+
+    #[tokio::test]
+    async fn take_dispute_with_unknown_dispute_reports_failure() {
+        let service = offline_service().await;
+        let response = service
+            .take_dispute(Request::new(TakeDisputeRequest {
+                dispute_id: uuid::Uuid::new_v4().to_string(),
+                request_id: Some("11".to_string()),
+            }))
+            .await
+            .expect("RPC surface always answers with a response");
+        assert!(!response.into_inner().success);
+    }
+
+    #[tokio::test]
+    async fn add_solver_answers_without_transport_error() {
+        let service = offline_service().await;
+        // Depending on global Nostr-client state the action may succeed or
+        // fail; the RPC surface must answer with a response either way.
+        let response = service
+            .add_solver(Request::new(AddSolverRequest {
+                solver_pubkey: Keys::generate().public_key().to_hex(),
+                request_id: Some("13".to_string()),
+            }))
+            .await;
+        assert!(response.is_ok());
+    }
+
+    #[tokio::test]
+    async fn get_version_returns_crate_version() {
+        let service = offline_service().await;
+        let response = service
+            .get_version(Request::new(GetVersionRequest {}))
+            .await
+            .expect("get_version never fails");
+        assert_eq!(response.into_inner().version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[tokio::test]
+    async fn validate_db_password_requires_remote_addr() {
+        let service = offline_service().await;
+        let status = service
+            .validate_db_password(Request::new(ValidateDbPasswordRequest {
+                password: "secret".to_string(),
+            }))
+            .await
+            .expect_err("no remote_addr must be an internal error");
+        assert_eq!(status.code(), tonic::Code::Internal);
+    }
+
+    #[tokio::test]
+    async fn validate_db_password_succeeds_with_remote_addr() {
+        let service = offline_service().await;
+        let response = service
+            .validate_db_password(request_with_addr(
+                ValidateDbPasswordRequest {
+                    password: "anything".to_string(),
+                },
+                21,
+            ))
+            .await
+            .expect("backward-compat endpoint always succeeds");
+        assert!(response.into_inner().success);
+    }
+
+    #[tokio::test]
+    async fn validate_db_password_is_rate_limited_after_failures() {
+        let service = offline_service().await;
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 22)), 50051);
+        // Pause the tokio clock only for the failure loop so the
+        // exponential-backoff sleeps auto-advance instead of stalling the
+        // suite ~15s; the std-`Instant` lockout stays active in real time.
+        tokio::time::pause();
+        // Drive the limiter into lockout directly (5 failures).
+        for _ in 0..5 {
+            service.password_rate_limiter.record_failure(&addr).await;
+        }
+        tokio::time::resume();
+        let status = service
+            .validate_db_password(request_with_addr(
+                ValidateDbPasswordRequest {
+                    password: "anything".to_string(),
+                },
+                22,
+            ))
+            .await
+            .expect_err("locked-out client must be refused");
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+    }
+
     #[test]
     fn test_optional_fields() {
         // Test that optional fields work correctly

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -835,3 +835,209 @@ async fn job_process_bond_payouts(ctx: AppContext) {
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+    use crate::config::MOSTRO_CONFIG;
+    use uuid::Uuid;
+
+    fn init_test_settings() {
+        let _ = MOSTRO_CONFIG.set(test_settings());
+    }
+
+    async fn migrated_ctx() -> AppContext {
+        init_test_settings();
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        TestContextBuilder::new()
+            .with_pool(Arc::new(pool))
+            .with_settings(test_settings())
+            .build()
+    }
+
+    fn hex_key() -> String {
+        nostr_sdk::Keys::generate().public_key().to_hex()
+    }
+
+    fn order_for_cancel(kind: Kind, with_pubkeys: bool) -> Order {
+        let (buyer, seller, creator) = if with_pubkeys {
+            (Some(hex_key()), Some(hex_key()), hex_key())
+        } else {
+            (None, None, String::new())
+        };
+        Order {
+            id: Uuid::new_v4(),
+            kind: kind.to_string(),
+            status: Status::WaitingBuyerInvoice.to_string(),
+            buyer_pubkey: buyer,
+            seller_pubkey: seller,
+            creator_pubkey: creator,
+            fiat_code: "USD".to_string(),
+            payment_method: "bank".to_string(),
+            ..Default::default()
+        }
+    }
+
+    async fn queued_actions_for(order_id: Uuid) -> Vec<Action> {
+        MESSAGE_QUEUES
+            .queue_order_msg
+            .read()
+            .await
+            .iter()
+            .filter(|(msg, _)| msg.get_inner_message_kind().id == Some(order_id))
+            .map(|(msg, _)| msg.get_inner_message_kind().action.clone())
+            .collect()
+    }
+
+    // ── notify_users_canceled_order ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn notify_cancel_enqueues_republish_for_maker_and_cancel_for_taker() {
+        init_test_settings();
+        // Sell order: taker is the buyer.
+        let order = order_for_cancel(Kind::Sell, true);
+        notify_users_canceled_order(&order, &order, Some(Action::NewOrder)).await;
+
+        let actions = queued_actions_for(order.id).await;
+        assert_eq!(actions.len(), 2, "maker and taker must both be notified");
+        assert!(actions.contains(&Action::NewOrder));
+        assert!(actions.contains(&Action::Canceled));
+    }
+
+    #[tokio::test]
+    async fn notify_cancel_enqueues_two_cancel_notices_when_order_dies() {
+        init_test_settings();
+        // Buy order: taker is the seller; maker action is Canceled.
+        let order = order_for_cancel(Kind::Buy, true);
+        notify_users_canceled_order(&order, &order, Some(Action::Canceled)).await;
+
+        let actions = queued_actions_for(order.id).await;
+        assert_eq!(actions.len(), 2);
+        assert!(actions.iter().all(|a| *a == Action::Canceled));
+    }
+
+    #[tokio::test]
+    async fn notify_cancel_bails_out_on_unparseable_kind() {
+        init_test_settings();
+        let mut order = order_for_cancel(Kind::Sell, true);
+        order.kind = "swap".to_string();
+        notify_users_canceled_order(&order, &order, None).await;
+        assert!(queued_actions_for(order.id).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn notify_cancel_bails_out_when_pubkeys_are_missing() {
+        init_test_settings();
+        let order = order_for_cancel(Kind::Sell, false);
+        notify_users_canceled_order(&order, &order, None).await;
+        assert!(queued_actions_for(order.id).await.is_empty());
+    }
+
+    // ── job smoke tests ──────────────────────────────────────────────────
+    //
+    // The jobs are infinite `tokio::spawn` loops; under a paused clock
+    // their sleeps auto-advance, so a short virtual wait drives several
+    // iterations against the (empty) migrated database. Tasks die with the
+    // test runtime. LND-backed jobs exercise their startup-failure paths:
+    // the default lightning settings point at unreadable cert/macaroon
+    // paths, so `LndConnector::new()` fails fast without any network.
+
+    #[tokio::test]
+    async fn start_scheduler_spawns_all_jobs_without_panicking() {
+        let ctx = migrated_ctx().await;
+
+        // job_info_event_send unwraps the LN status global.
+        let _ = LN_STATUS.set(crate::lightning::LnStatus {
+            version: "test".to_string(),
+            node_pubkey: "00".repeat(32),
+            commit_hash: "test".to_string(),
+            node_alias: "test-node".to_string(),
+            chains: vec!["bitcoin".to_string()],
+            networks: vec!["regtest".to_string()],
+            uris: vec![],
+        });
+        // job_update_bitcoin_prices consults the global price manager; the
+        // canonical test install (empty providers, 30s interval — below the
+        // 60s floor) also exercises the interval clamp.
+        let _ = PriceManager::from_settings(crate::price::PriceSettings {
+            update_interval_seconds: 30,
+            providers: std::collections::HashMap::new(),
+            ..Default::default()
+        })
+        .expect("empty provider set builds")
+        .install_global();
+
+        // Push one message into the restore-session queue so the flush
+        // job's send-failure/retry path runs (no Nostr relays reachable).
+        MESSAGE_QUEUES
+            .queue_restore_session_msg
+            .write()
+            .await
+            .push((
+                Message::new_order(Some(Uuid::new_v4()), None, None, Action::Canceled, None),
+                ctx.keys().public_key(),
+            ));
+
+        // Pause only after the pool and globals exist: pool setup under a
+        // paused clock trips sqlx's acquire timeout via auto-advance.
+        tokio::time::pause();
+        start_scheduler(ctx).await;
+
+        // Let every loop take a few virtual-time laps (60s cadence jobs run
+        // ~6 times; the 250ms flush loop drains its retry budget).
+        tokio::time::sleep(tokio::time::Duration::from_secs(400)).await;
+
+        // The flush job must have dropped the undeliverable message after
+        // exhausting its retries.
+        assert!(
+            MESSAGE_QUEUES
+                .queue_restore_session_msg
+                .read()
+                .await
+                .is_empty(),
+            "undeliverable restore-session message must be dropped after retries"
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_events_job_drains_the_rate_queue() {
+        let ctx = migrated_ctx().await;
+        // Seed a signed dummy event; the job publishes (best-effort, no
+        // relays) and clears the queue.
+        let keys = nostr_sdk::Keys::generate();
+        let event = nostr_sdk::EventBuilder::text_note("rate")
+            .sign_with_keys(&keys)
+            .unwrap();
+        MESSAGE_QUEUES.queue_order_rate.write().await.push(event);
+
+        tokio::time::pause();
+        job_update_rate_events(ctx).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+
+        assert!(MESSAGE_QUEUES.queue_order_rate.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn expiry_and_retry_jobs_iterate_on_empty_database() {
+        let ctx = migrated_ctx().await;
+        tokio::time::pause();
+        job_expire_pending_older_orders(ctx.clone()).await;
+        job_retry_failed_payments(ctx.clone()).await;
+        job_refresh_active_pubkeys(ctx.clone()).await;
+        job_reconcile_stranded_maker_bonds(ctx.clone()).await;
+        job_relay_list(ctx).await;
+        // Several virtual minutes: every loop body runs repeatedly.
+        tokio::time::sleep(tokio::time::Duration::from_secs(200)).await;
+    }
+
+    #[tokio::test]
+    async fn ln_backed_jobs_fail_fast_without_lnd() {
+        let ctx = migrated_ctx().await;
+        // Both return early (error log) because LndConnector::new() cannot
+        // read the default cert/macaroon paths.
+        job_cancel_orders(ctx.clone()).await;
+        job_process_dev_fee_payment(ctx).await;
+    }
+}

--- a/src/spam_gate.rs
+++ b/src/spam_gate.rs
@@ -215,6 +215,69 @@ mod tests {
     }
 
     #[test]
+    fn install_global_then_second_install_is_rejected() {
+        // The OnceLock is process-wide, so this single test owns both the
+        // first (successful) install and the AlreadyInstalled rejection.
+        let first = SpamGate::new(REPLAY_WINDOW_SECS).install_global();
+        assert!(first.is_ok(), "first install must succeed");
+        assert!(
+            SpamGate::global().is_some(),
+            "global() must expose the installed gate"
+        );
+
+        let second = SpamGate::new(REPLAY_WINDOW_SECS).install_global();
+        assert_eq!(
+            second,
+            Err(InstallError::AlreadyInstalled),
+            "a second install must be refused, not panic"
+        );
+    }
+
+    #[test]
+    fn poisoned_known_lock_degrades_to_first_contact_lane() {
+        let gate = std::sync::Arc::new(SpamGate::new(REPLAY_WINDOW_SECS));
+        gate.set_known(["known".to_string()]);
+        assert!(gate.is_known("known"));
+
+        // Poison the known-keys RwLock by panicking while holding the writer.
+        let poisoner = std::sync::Arc::clone(&gate);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.known.write().unwrap();
+            panic!("poison known lock");
+        })
+        .join();
+
+        // Degradation contract: reads fall back to "unknown" (safe direction),
+        // counts to 0, and refresh is skipped without crashing.
+        assert!(!gate.is_known("known"), "poisoned read degrades to false");
+        assert_eq!(gate.known_count(), 0, "poisoned count degrades to 0");
+        gate.set_known(["other".to_string()]); // must log-and-skip, not panic
+        assert!(!gate.is_known("other"));
+    }
+
+    #[test]
+    fn poisoned_replay_lock_never_drops_messages() {
+        let gate = std::sync::Arc::new(SpamGate::new(REPLAY_WINDOW_SECS));
+        let id = an_event_id("poisoned-replay");
+        assert!(!gate.is_replay(id, 1_000));
+
+        // Poison the replay Mutex by panicking while holding the guard.
+        let poisoner = std::sync::Arc::clone(&gate);
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.replay.lock().unwrap();
+            panic!("poison replay lock");
+        })
+        .join();
+
+        // Even a genuine duplicate must NOT be dropped once dedup state is
+        // lost — fail-open is the documented safe direction.
+        assert!(
+            !gate.is_replay(id, 1_001),
+            "poisoned replay guard must degrade to 'not a replay'"
+        );
+    }
+
+    #[test]
     fn prune_keeps_map_bounded_to_window() {
         let mut guard = ReplayGuard::new(60);
         for i in 0..100 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1669,27 +1669,39 @@ mod tests {
         assert_eq!(result, "deadbeef");
     }
 
+    /// `NOSTR_CLIENT` is a process-wide `OnceLock` that `initialize()` and
+    /// every other test's `init_globals()` also install into, so the two
+    /// halves of this used to live in separate tests: one asserted
+    /// `get_nostr_client()` errors while the lock reads `None`, the other
+    /// asserted it succeeds once set.
+    ///
+    /// That split was racy. Reading `NOSTR_CLIENT.get()` and then asserting
+    /// on `get_nostr_client()` is a check-then-act on shared state: a
+    /// concurrent test can install the client in between and flip the result
+    /// from `Err` to `Ok`. Serializing just these two wouldn't fix it either,
+    /// since any `init_globals()` caller sets the same lock.
+    ///
+    /// A `OnceLock` is monotonic — once installed it never reverts — so the
+    /// post-set direction is the only one that holds no matter who wins the
+    /// race. Assert that, and only that. The uninitialized branch is not
+    /// deterministically reachable in a shared-process test binary.
     #[tokio::test]
-    async fn test_get_nostr_client_failure() {
+    async fn get_nostr_client_succeeds_once_the_global_is_installed() {
         initialize();
-        // NOSTR_CLIENT is a process-wide OnceLock that other tests may have
-        // installed already, so assert consistency with the global state
-        // instead of assuming a fresh process.
-        match NOSTR_CLIENT.get() {
-            None => assert!(get_nostr_client().is_err()),
-            Some(_) => assert!(get_nostr_client().is_ok()),
-        }
-    }
+        // Idempotent: whoever won the race already installed an equivalent
+        // client, and `set` on an initialized `OnceLock` is a no-op.
+        let _ = NOSTR_CLIENT.set(Client::default());
 
-    #[tokio::test]
-    async fn test_get_nostr_client_success() {
-        initialize();
-        // Mock NOSTR_CLIENT initialization (idempotent: another test may have
-        // installed the global client already).
-        let client = Client::default();
-        let _ = NOSTR_CLIENT.set(client);
-        let client_result = get_nostr_client();
-        assert!(client_result.is_ok());
+        assert!(
+            NOSTR_CLIENT.get().is_some(),
+            "the global must be installed after set()"
+        );
+        assert!(
+            get_nostr_client().is_ok(),
+            "an installed global must be readable"
+        );
+        // Monotonic: a second read cannot regress to Err.
+        assert!(get_nostr_client().is_ok(), "OnceLock must not revert");
     }
 
     #[test]
@@ -2007,7 +2019,17 @@ mod tests {
             let _ = DB_POOL.set(std::sync::Arc::new(pool));
         }
         let pool = get_db_pool();
-        let _ = sqlx::migrate!("./migrations").run(pool.as_ref()).await;
+        // Surface a migration failure instead of discarding it. Swallowing it
+        // would hand back a pool with a partial schema, and the tests built on
+        // it would fail much later with a confusing "no such table" instead of
+        // the real cause. The migrator is idempotent (tracked in
+        // `_sqlx_migrations`) and every `CREATE TABLE` in `migrations/` is
+        // `IF NOT EXISTS`, so re-running it against an already-migrated pool
+        // is a no-op — a failure here means a genuinely broken global pool.
+        sqlx::migrate!("./migrations")
+            .run(pool.as_ref())
+            .await
+            .expect("the process-global test pool must be fully migrated");
         pool
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1672,17 +1672,22 @@ mod tests {
     #[tokio::test]
     async fn test_get_nostr_client_failure() {
         initialize();
-        // Ensure NOSTR_CLIENT is not initialized for the test
-        let client = NOSTR_CLIENT.get();
-        assert!(client.is_none());
+        // NOSTR_CLIENT is a process-wide OnceLock that other tests may have
+        // installed already, so assert consistency with the global state
+        // instead of assuming a fresh process.
+        match NOSTR_CLIENT.get() {
+            None => assert!(get_nostr_client().is_err()),
+            Some(_) => assert!(get_nostr_client().is_ok()),
+        }
     }
 
     #[tokio::test]
     async fn test_get_nostr_client_success() {
         initialize();
-        // Mock NOSTR_CLIENT initialization
+        // Mock NOSTR_CLIENT initialization (idempotent: another test may have
+        // installed the global client already).
         let client = Client::default();
-        NOSTR_CLIENT.set(client).unwrap();
+        let _ = NOSTR_CLIENT.set(client);
         let client_result = get_nostr_client();
         assert!(client_result.is_ok());
     }
@@ -1935,5 +1940,827 @@ mod tests {
             matches!(err, MostroInternalErr(ServiceError::UnexpectedError(_))),
             "expected UnexpectedError for non-positive max_amount, got {err:?}"
         );
+    }
+
+    // ───────────────── shared helpers for the coverage tests below ─────────────────
+
+    /// Install the process-wide globals handlers reach for. Idempotent —
+    /// whichever test wins the OnceLock race, values stay consistent.
+    fn init_globals() {
+        let _ = MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
+        let _ = NOSTR_CLIENT.set(Client::default());
+    }
+
+    /// In-memory pool with the full production schema.
+    async fn migrated_pool() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn insert_user_row(pool: &SqlitePool, pubkey: &str, last_trade_index: i64) {
+        sqlx::query(
+            "INSERT INTO users (pubkey, last_trade_index, created_at, total_rating, total_reviews) \
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(pubkey)
+        .bind(last_trade_index)
+        .bind(Timestamp::now().as_secs() as i64 - 86_400)
+        .bind(4.5_f64)
+        .bind(3_i64)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn base_order(kind: OrderKind, status: Status) -> Order {
+        Order {
+            id: Uuid::new_v4(),
+            kind: kind.to_string(),
+            status: status.to_string(),
+            payment_method: "SEPA".to_string(),
+            amount: 1_000,
+            fee: 10,
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            created_at: Timestamp::now().as_secs() as i64,
+            expires_at: Timestamp::now().as_secs() as i64 + 3_600,
+            ..Default::default()
+        }
+    }
+
+    /// Ensure the process-wide DB pool exists (migrated, in-memory).
+    ///
+    /// `DB_POOL` is a set-once global shared by every test in the binary, so
+    /// whichever test runs first wins the race and installs its pool. That
+    /// winner may have set up a different (or partial) schema, so we run our
+    /// migrations against the live pool unconditionally — they are idempotent
+    /// (tracked in `_sqlx_migrations`) and guarantee the tables these tests
+    /// need exist regardless of who won.
+    async fn ensure_global_db_pool() -> std::sync::Arc<SqlitePool> {
+        if DB_POOL.get().is_none() {
+            let pool = migrated_pool().await;
+            let _ = DB_POOL.set(std::sync::Arc::new(pool));
+        }
+        let pool = get_db_pool();
+        let _ = sqlx::migrate!("./migrations").run(pool.as_ref()).await;
+        pool
+    }
+
+    /// Freshly-signed BOLT11 invoice built locally (no network, no LND).
+    fn build_test_invoice(amount_msat: u64, expiry_secs: u64) -> String {
+        use bitcoin::hashes::{sha256, Hash};
+        use bitcoin::secp256k1::{Secp256k1, SecretKey};
+        use lightning_invoice::{Currency, InvoiceBuilder, PaymentSecret};
+        use std::time::Duration;
+
+        let secp = Secp256k1::new();
+        let private_key = SecretKey::from_slice(&[0x42; 32]).expect("valid secret key");
+        let payment_hash = sha256::Hash::hash(&[0u8; 32]);
+        InvoiceBuilder::new(Currency::Bitcoin)
+            .description("mostro util coverage invoice".into())
+            .payment_hash(payment_hash)
+            .payment_secret(PaymentSecret([42u8; 32]))
+            .current_timestamp()
+            .min_final_cltv_expiry_delta(144)
+            .expiry_time(Duration::from_secs(expiry_secs))
+            .amount_milli_satoshis(amount_msat)
+            .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &private_key))
+            .expect("valid signed invoice")
+            .to_string()
+    }
+
+    // ───────────────────────── market quote & fees ─────────────────────────
+
+    #[test]
+    fn market_quote_converts_fiat_and_applies_premium() {
+        BitcoinPriceManager::set_price_for_test("UTILQ1", 50_000.0);
+        // 100 / 50_000 * 1e8 = 200_000 sats without premium…
+        assert_eq!(get_market_quote(&100, "UTILQ1", 0).unwrap(), 200_000);
+        // …and 10% premium knocks 10% off the sats value.
+        assert_eq!(get_market_quote(&100, "UTILQ1", 10).unwrap(), 180_000);
+    }
+
+    #[test]
+    fn market_quote_rejects_non_positive_price() {
+        BitcoinPriceManager::set_price_for_test("UTILQ2", 0.0);
+        let err = get_market_quote(&100, "UTILQ2", 0).unwrap_err();
+        assert!(matches!(
+            err,
+            MostroError::MostroInternalErr(ServiceError::NoAPIResponse)
+        ));
+    }
+
+    #[test]
+    fn market_amount_and_fee_returns_quote_and_fee() {
+        init_globals();
+        BitcoinPriceManager::set_price_for_test("UTILQ3", 50_000.0);
+        let (sats, fee) = get_market_amount_and_fee(100, "UTILQ3", 0).unwrap();
+        assert_eq!(sats, 200_000);
+        // Both candidate global configs carry fee = 0.
+        assert_eq!(fee, 0);
+        assert_eq!(get_fee(1_000), 0);
+    }
+
+    #[test]
+    fn dev_fee_uses_configured_percentage() {
+        init_globals();
+        // Both candidate global configs carry dev_fee_percentage = 0.30.
+        assert_eq!(get_dev_fee(1_000), 300);
+    }
+
+    #[test]
+    fn maker_bond_notional_market_path_converts_at_cached_price() {
+        BitcoinPriceManager::set_price_for_test("UTILQ4", 40_000.0);
+        let order = Order {
+            amount: 0,
+            fiat_code: "UTILQ4".to_string(),
+            fiat_amount: 100,
+            ..Default::default()
+        };
+        // 100 / 40_000 * 1e8 = 250_000 sats.
+        assert_eq!(maker_bond_notional_sats(&order).unwrap(), 250_000);
+    }
+
+    #[test]
+    fn maker_bond_notional_rejects_non_positive_price() {
+        BitcoinPriceManager::set_price_for_test("UTILQ5", 0.0);
+        // Market-priced single order.
+        let order = Order {
+            amount: 0,
+            fiat_code: "UTILQ5".to_string(),
+            fiat_amount: 100,
+            ..Default::default()
+        };
+        assert!(matches!(
+            maker_bond_notional_sats(&order).unwrap_err(),
+            MostroInternalErr(ServiceError::NoAPIResponse)
+        ));
+        // Range order against a non-positive price.
+        let range = Order {
+            amount: 0,
+            min_amount: Some(10),
+            max_amount: Some(100),
+            fiat_code: "UTILQ5".to_string(),
+            ..Default::default()
+        };
+        assert!(matches!(
+            maker_bond_notional_sats(&range).unwrap_err(),
+            MostroInternalErr(ServiceError::NoAPIResponse)
+        ));
+    }
+
+    // ───────────────────────── expiration helpers ─────────────────────────
+
+    #[test]
+    fn expiration_date_defaults_and_clamps() {
+        init_globals();
+        let now = Timestamp::now().as_secs() as i64;
+        // Both candidate global configs: 24h default, 15d max.
+        let default_exp = get_expiration_date(None);
+        assert!((default_exp - now - 86_400).abs() <= 2);
+
+        // A user-supplied value inside the window is kept…
+        let wanted = now + 100;
+        assert_eq!(get_expiration_date(Some(wanted)), wanted);
+
+        // …and one beyond the max is clamped to now + 15 days.
+        let clamped = get_expiration_date(Some(now + 90 * 86_400));
+        assert!((clamped - now - 15 * 86_400).abs() <= 2);
+    }
+
+    #[test]
+    fn expiration_timestamp_by_kind_uses_config_and_ignores_unknown_kinds() {
+        init_globals();
+        let now = Timestamp::now().as_secs() as i64;
+        // Known kinds resolve through the expiration configuration.
+        let order_exp = get_expiration_timestamp_for_kind(NOSTR_ORDER_EVENT_KIND)
+            .expect("order events always expire");
+        assert!(order_exp > now);
+        assert!(get_expiration_timestamp_for_kind(DM_EVENT_KIND).is_some());
+        // Unknown kinds never get an expiration.
+        assert!(get_expiration_timestamp_for_kind(12_345).is_none());
+    }
+
+    // ───────────────────────── order tags & publication ─────────────────────────
+
+    #[tokio::test]
+    async fn get_tags_for_new_order_covers_user_and_privacy_paths() {
+        init_globals();
+        let pool = migrated_pool().await;
+        let keys = Keys::generate();
+        let identity = Keys::generate().public_key();
+        let trade = Keys::generate().public_key();
+        let order = base_order(OrderKind::Sell, Status::Pending);
+
+        // Known user → reputation-tagged event.
+        insert_user_row(&pool, &identity.to_string(), 1).await;
+        let tags = get_tags_for_new_order(&order, &pool, &identity, &trade, &keys)
+            .await
+            .unwrap();
+        assert!(tags.is_some());
+
+        // Unknown user in full-privacy shape (identity == trade) → zeroed reputation.
+        let privacy = Keys::generate().public_key();
+        let tags = get_tags_for_new_order(&order, &pool, &privacy, &privacy, &keys)
+            .await
+            .unwrap();
+        assert!(tags.is_some());
+
+        // Unknown user with mismatched keys → invalid pubkey.
+        let stranger = Keys::generate().public_key();
+        let err = get_tags_for_new_order(&order, &pool, &stranger, &trade, &keys)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            MostroInternalErr(ServiceError::InvalidPubkey)
+        ));
+    }
+
+    #[tokio::test]
+    async fn publish_order_persists_row_and_fails_only_at_broadcast() {
+        init_globals();
+        let pool = migrated_pool().await;
+        let keys = Keys::generate();
+        let trade = Keys::generate().public_key();
+        let new_order = SmallOrder {
+            kind: Some(OrderKind::Sell),
+            amount: 1_000,
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            payment_method: "SEPA".to_string(),
+            ..Default::default()
+        };
+
+        // Full-privacy maker (identity == trade). The offline client cannot
+        // broadcast, so the pipeline must fail at the very last step…
+        let res = publish_order(
+            &pool,
+            &keys,
+            &new_order,
+            trade,
+            trade,
+            trade,
+            Some(1),
+            Some(1),
+        )
+        .await;
+        assert!(matches!(
+            res,
+            Err(MostroInternalErr(ServiceError::NostrError(_)))
+        ));
+
+        // …with the order row already persisted as pending.
+        let (status, event_id, seller): (String, String, Option<String>) =
+            sqlx::query_as("SELECT status, event_id, seller_pubkey FROM orders LIMIT 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "pending");
+        assert!(!event_id.is_empty());
+        assert_eq!(seller.as_deref(), Some(trade.to_string().as_str()));
+    }
+
+    #[tokio::test]
+    async fn publish_order_buy_kind_market_priced_sets_buyer_fields() {
+        init_globals();
+        let pool = migrated_pool().await;
+        let keys = Keys::generate();
+        let identity = Keys::generate().public_key();
+        let trade = Keys::generate().public_key();
+        insert_user_row(&pool, &identity.to_string(), 1).await;
+        let new_order = SmallOrder {
+            kind: Some(OrderKind::Buy),
+            amount: 0, // market priced → price_from_api = true
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            payment_method: "SEPA".to_string(),
+            ..Default::default()
+        };
+
+        let res = publish_order(
+            &pool,
+            &keys,
+            &new_order,
+            trade,
+            identity,
+            trade,
+            Some(1),
+            Some(2),
+        )
+        .await;
+        assert!(matches!(
+            res,
+            Err(MostroInternalErr(ServiceError::NostrError(_)))
+        ));
+
+        let (kind, buyer, price_from_api): (String, Option<String>, bool) =
+            sqlx::query_as("SELECT kind, buyer_pubkey, price_from_api FROM orders LIMIT 1")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(kind, "buy");
+        assert_eq!(buyer.as_deref(), Some(trade.to_string().as_str()));
+        assert!(price_from_api);
+    }
+
+    #[tokio::test]
+    async fn publish_order_without_kind_is_rejected() {
+        init_globals();
+        let pool = migrated_pool().await;
+        let keys = Keys::generate();
+        let trade = Keys::generate().public_key();
+        let new_order = SmallOrder {
+            kind: None,
+            amount: 1_000,
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            ..Default::default()
+        };
+
+        let res = publish_order(&pool, &keys, &new_order, trade, trade, trade, None, None).await;
+        assert!(matches!(
+            res,
+            Err(MostroCantDo(CantDoReason::InvalidOrderKind))
+        ));
+    }
+
+    #[tokio::test]
+    async fn resume_publish_after_maker_bond_claims_and_publishes() {
+        init_globals();
+        let pool = migrated_pool().await;
+        let keys = Keys::generate();
+        let trade = Keys::generate().public_key();
+
+        // Sell order parked at WaitingMakerBond, full-privacy maker.
+        let mut order = base_order(OrderKind::Sell, Status::WaitingMakerBond);
+        order.seller_pubkey = Some(trade.to_string());
+        order.master_seller_pubkey = Some(trade.to_string());
+        order.trade_index_seller = Some(1);
+        let order = order.create(&pool).await.unwrap();
+
+        let res = resume_publish_after_maker_bond(&pool, &keys, order, Some(1)).await;
+        // Offline broadcast failure — but the CAS must have flipped the row.
+        assert!(matches!(
+            res,
+            Err(MostroInternalErr(ServiceError::NostrError(_)))
+        ));
+        let (status,): (String,) = sqlx::query_as("SELECT status FROM orders LIMIT 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "pending");
+    }
+
+    #[tokio::test]
+    async fn resume_publish_after_maker_bond_buy_kind() {
+        init_globals();
+        let pool = migrated_pool().await;
+        let keys = Keys::generate();
+        let trade = Keys::generate().public_key();
+
+        let mut order = base_order(OrderKind::Buy, Status::WaitingMakerBond);
+        order.buyer_pubkey = Some(trade.to_string());
+        order.master_buyer_pubkey = Some(trade.to_string());
+        order.trade_index_buyer = Some(1);
+        let order = order.create(&pool).await.unwrap();
+
+        let res = resume_publish_after_maker_bond(&pool, &keys, order, None).await;
+        assert!(matches!(
+            res,
+            Err(MostroInternalErr(ServiceError::NostrError(_)))
+        ));
+    }
+
+    #[tokio::test]
+    async fn resume_publish_after_maker_bond_skips_when_status_moved_on() {
+        init_globals();
+        let pool = migrated_pool().await;
+        let keys = Keys::generate();
+
+        // Already pending → CAS affects 0 rows → clean skip.
+        let order = base_order(OrderKind::Sell, Status::Pending)
+            .create(&pool)
+            .await
+            .unwrap();
+        let res = resume_publish_after_maker_bond(&pool, &keys, order, None).await;
+        assert!(res.is_ok(), "stale deferred publish must skip: {res:?}");
+    }
+
+    // ───────────────────── order event updates & ratings ─────────────────────
+
+    #[tokio::test]
+    async fn update_order_event_covers_reputation_paths() {
+        init_globals();
+        let gpool = ensure_global_db_pool().await;
+        let keys = Keys::generate();
+        let trade = Keys::generate().public_key();
+
+        // Full privacy (master == trade, no user row) → zeroed reputation.
+        let mut order = base_order(OrderKind::Sell, Status::Pending);
+        order.seller_pubkey = Some(trade.to_string());
+        order.master_seller_pubkey = Some(trade.to_string());
+        let updated = update_order_event(&keys, Status::Pending, &order)
+            .await
+            .unwrap();
+        assert_eq!(updated.status, Status::Pending.to_string());
+        assert!(!updated.event_id.is_empty(), "a NIP-33 event must be built");
+
+        // Known user → reputation from the users table.
+        let master = Keys::generate().public_key();
+        insert_user_row(&gpool, &master.to_string(), 1).await;
+        let mut order2 = base_order(OrderKind::Sell, Status::Pending);
+        order2.seller_pubkey = Some(trade.to_string());
+        order2.master_seller_pubkey = Some(master.to_string());
+        let updated2 = update_order_event(&keys, Status::Pending, &order2)
+            .await
+            .unwrap();
+        assert!(!updated2.event_id.is_empty());
+
+        // Buy order resolves the buyer-side keys.
+        let mut order3 = base_order(OrderKind::Buy, Status::Pending);
+        order3.buyer_pubkey = Some(trade.to_string());
+        order3.master_buyer_pubkey = Some(trade.to_string());
+        assert!(update_order_event(&keys, Status::Pending, &order3)
+            .await
+            .is_ok());
+
+        // Unknown master ≠ trade → invalid pubkey.
+        let stranger = Keys::generate().public_key();
+        let mut order4 = base_order(OrderKind::Sell, Status::Pending);
+        order4.seller_pubkey = Some(trade.to_string());
+        order4.master_seller_pubkey = Some(stranger.to_string());
+        let err = update_order_event(&keys, Status::Pending, &order4)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            MostroInternalErr(ServiceError::InvalidPubkey)
+        ));
+
+        // Non-pending status → no reputation lookup, no event emitted.
+        let order5 = base_order(OrderKind::Sell, Status::Active);
+        let updated5 = update_order_event(&keys, Status::Active, &order5)
+            .await
+            .unwrap();
+        assert!(updated5.event_id.is_empty());
+    }
+
+    // ───────────────────────── nostr client plumbing ─────────────────────────
+
+    #[tokio::test]
+    async fn connect_nostr_builds_client_with_configured_relays() {
+        init_globals();
+        let client = connect_nostr().await.expect("client must build offline");
+        assert!(
+            !client.relays().await.is_empty(),
+            "configured relays must be registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_nostr_relays_returns_map_when_client_installed() {
+        init_globals();
+        assert!(get_nostr_relays().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn get_keys_follows_global_config() {
+        init_globals();
+        match get_keys() {
+            Ok(keys) => assert_eq!(keys.public_key().to_hex().len(), 64),
+            // The settings template carries a placeholder nsec — whichever
+            // config won the global OnceLock race, behaviour must be typed.
+            Err(MostroInternalErr(ServiceError::NostrError(_))) => {}
+            Err(e) => panic!("unexpected error kind: {e:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_dev_fee_audit_event_fails_offline() {
+        init_globals();
+        let order = base_order(OrderKind::Sell, Status::Success);
+        // Either the placeholder nsec fails key parsing (template config) or
+        // the offline client fails the broadcast — both are typed errors.
+        assert!(publish_dev_fee_audit_event(&order, "deadbeef")
+            .await
+            .is_err());
+    }
+
+    // ───────────────────────── LND-dependent early failures ─────────────────────────
+
+    #[tokio::test]
+    async fn show_hold_invoice_fails_fast_without_lnd() {
+        init_globals();
+        let keys = Keys::generate();
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+        let order = base_order(OrderKind::Sell, Status::WaitingPayment);
+
+        let res = show_hold_invoice(&keys, None, &buyer, &seller, order, None).await;
+        assert!(res.is_err(), "no LND reachable in unit tests");
+    }
+
+    #[tokio::test]
+    async fn invoice_subscribe_fails_fast_without_lnd() {
+        init_globals();
+        assert!(invoice_subscribe(vec![0u8; 32], None).await.is_err());
+    }
+
+    // ───────────────────────── messaging helpers ─────────────────────────
+
+    #[tokio::test]
+    async fn set_waiting_invoice_status_notifies_both_parties() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let mut order = base_order(OrderKind::Sell, Status::Active);
+        order.seller_pubkey = Some(seller.to_string());
+
+        let amount = set_waiting_invoice_status(&mut order, buyer, Some(1))
+            .await
+            .unwrap();
+        assert_eq!(amount, 1_000);
+    }
+
+    #[tokio::test]
+    async fn rate_counterpart_enqueues_rate_requests() {
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+        let order = base_order(OrderKind::Sell, Status::Success);
+        assert!(rate_counterpart(&buyer, &seller, &order, None)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn enqueue_helpers_push_into_global_queues() {
+        // The queues are process-wide and concurrently drained by the
+        // scheduler flush-job tests, so asserting on queue contents here
+        // would race. The contract under test is "enqueue completes and
+        // never panics"; delivery is covered by the scheduler tests.
+        let key = Keys::generate().public_key();
+        enqueue_cant_do_msg(Some(1), None, CantDoReason::NotFound, key).await;
+        enqueue_restore_session_msg(None, key).await;
+        enqueue_order_msg(Some(1), None, Action::Rate, None, key, None).await;
+    }
+
+    // ───────────────────────── escrow settlement ─────────────────────────
+
+    struct FakeEscrow {
+        settle_ok: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::escrow::EscrowBackend for FakeEscrow {
+        async fn create_hold_invoice(
+            &mut self,
+            _description: &str,
+            _amount: i64,
+        ) -> Result<(String, Vec<u8>, Vec<u8>), MostroError> {
+            Ok((String::new(), vec![], vec![]))
+        }
+
+        async fn settle_hold_invoice(&mut self, _preimage: &str) -> Result<(), MostroError> {
+            if self.settle_ok {
+                Ok(())
+            } else {
+                Err(MostroInternalErr(ServiceError::HoldInvoiceError(
+                    "forced failure".to_string(),
+                )))
+            }
+        }
+
+        async fn cancel_hold_invoice(&mut self, _hash: &str) -> Result<(), MostroError> {
+            Ok(())
+        }
+    }
+
+    fn unwrapped_from(trade: &Keys) -> UnwrappedMessage {
+        UnwrappedMessage {
+            message: Message::new_order(None, None, None, Action::Release, None),
+            signature: None,
+            sender: trade.public_key(),
+            identity: trade.public_key(),
+            created_at: Timestamp::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn settle_seller_hold_invoice_success_and_error_paths() {
+        let seller = Keys::generate();
+        let mut order = base_order(OrderKind::Sell, Status::Active);
+        order.seller_pubkey = Some(seller.public_key().to_string());
+        order.preimage = Some("00".repeat(32));
+
+        // Seller with matching key and a preimage settles fine.
+        let mut escrow = FakeEscrow { settle_ok: true };
+        let event = unwrapped_from(&seller);
+        assert!(
+            settle_seller_hold_invoice(&event, &mut escrow, Action::Release, false, &order)
+                .await
+                .is_ok()
+        );
+
+        // A non-seller sender is rejected unless admin.
+        let interloper = Keys::generate();
+        let event = unwrapped_from(&interloper);
+        let err = settle_seller_hold_invoice(&event, &mut escrow, Action::Release, false, &order)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MostroCantDo(CantDoReason::InvalidPubkey)));
+
+        // Admin without a stored preimage → invalid invoice.
+        let mut no_preimage = order.clone();
+        no_preimage.preimage = None;
+        let event = unwrapped_from(&interloper);
+        let err = settle_seller_hold_invoice(
+            &event,
+            &mut escrow,
+            Action::AdminSettle,
+            true,
+            &no_preimage,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, MostroCantDo(CantDoReason::InvalidInvoice)));
+
+        // Escrow backend failures propagate.
+        let mut failing = FakeEscrow { settle_ok: false };
+        let event = unwrapped_from(&seller);
+        assert!(
+            settle_seller_hold_invoice(&event, &mut failing, Action::Release, false, &order)
+                .await
+                .is_err()
+        );
+    }
+
+    // ───────────────────────── dispute & invoice lookups ─────────────────────────
+
+    #[tokio::test]
+    async fn get_dispute_resolves_or_rejects() {
+        let pool = migrated_pool().await;
+
+        // No id in the message.
+        let msg = Message::Dispute(MessageKind::new(None, None, None, Action::Dispute, None));
+        assert!(get_dispute(&msg, &pool).await.is_err());
+
+        // Unknown id.
+        let msg = Message::Dispute(MessageKind::new(
+            Some(Uuid::new_v4()),
+            None,
+            None,
+            Action::Dispute,
+            None,
+        ));
+        assert!(get_dispute(&msg, &pool).await.is_err());
+
+        // Known dispute row resolves.
+        let dispute_id = Uuid::new_v4();
+        let order_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO disputes (id, order_id, status, order_previous_status, created_at) \
+             VALUES (?, ?, 'initiated', 'active', ?)",
+        )
+        .bind(dispute_id)
+        .bind(order_id)
+        .bind(Timestamp::now().as_secs() as i64)
+        .execute(&pool)
+        .await
+        .unwrap();
+        let msg = Message::Dispute(MessageKind::new(
+            Some(dispute_id),
+            None,
+            None,
+            Action::Dispute,
+            None,
+        ));
+        let dispute = get_dispute(&msg, &pool).await.unwrap();
+        assert_eq!(dispute.order_id, order_id);
+    }
+
+    #[tokio::test]
+    async fn validate_invoice_paths() {
+        init_globals();
+        let mut order = base_order(OrderKind::Sell, Status::Active);
+        order.amount = 1_100;
+        order.fee = 100;
+
+        // No payment request in the message → nothing to validate.
+        let msg = Message::new_order(None, None, None, Action::AddInvoice, None);
+        assert_eq!(validate_invoice(&msg, &order).await.unwrap(), None);
+
+        // Garbage payment request → invalid invoice.
+        let msg = Message::new_order(
+            None,
+            None,
+            None,
+            Action::AddInvoice,
+            Some(Payload::PaymentRequest(
+                None,
+                "notaninvoice".to_string(),
+                None,
+            )),
+        );
+        let err = validate_invoice(&msg, &order).await.unwrap_err();
+        assert!(matches!(err, MostroCantDo(CantDoReason::InvalidInvoice)));
+
+        // Freshly-built invoice for amount - fee = 1000 sats validates.
+        let pr = build_test_invoice(1_000_000, 86_400);
+        let msg = Message::new_order(
+            None,
+            None,
+            None,
+            Action::AddInvoice,
+            Some(Payload::PaymentRequest(None, pr.clone(), None)),
+        );
+        assert_eq!(validate_invoice(&msg, &order).await.unwrap(), Some(pr));
+    }
+
+    // ───────────────────────── taker reputation notification ─────────────────────────
+
+    #[tokio::test]
+    async fn notify_taker_reputation_covers_all_branches() {
+        init_globals();
+        let pool = migrated_pool().await;
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+        let master = Keys::generate().public_key();
+
+        // Sell order without master buyer key → invalid pubkey.
+        let order = base_order(OrderKind::Sell, Status::WaitingBuyerInvoice);
+        let err = notify_taker_reputation(&pool, &order).await.unwrap_err();
+        assert!(matches!(err, MostroCantDo(CantDoReason::InvalidPubkey)));
+
+        // Sell + WaitingBuyerInvoice → PayInvoice to seller (unknown taker →
+        // zeroed reputation).
+        let mut order = base_order(OrderKind::Sell, Status::WaitingBuyerInvoice);
+        order.master_buyer_pubkey = Some(master.to_string());
+        order.seller_pubkey = Some(seller.to_string());
+        assert!(notify_taker_reputation(&pool, &order).await.is_ok());
+
+        // Known taker → reputation loaded from the users table.
+        insert_user_row(&pool, &master.to_string(), 1).await;
+        assert!(notify_taker_reputation(&pool, &order).await.is_ok());
+
+        // Buy + WaitingBuyerInvoice → maker is adding the invoice → no-op Ok.
+        let mut order = base_order(OrderKind::Buy, Status::WaitingBuyerInvoice);
+        order.master_seller_pubkey = Some(master.to_string());
+        assert!(notify_taker_reputation(&pool, &order).await.is_ok());
+
+        // Buy + WaitingPayment → AddInvoice to buyer.
+        let mut order = base_order(OrderKind::Buy, Status::WaitingPayment);
+        order.master_seller_pubkey = Some(master.to_string());
+        order.buyer_pubkey = Some(buyer.to_string());
+        assert!(notify_taker_reputation(&pool, &order).await.is_ok());
+
+        // Sell + WaitingPayment → not allowed.
+        let mut order = base_order(OrderKind::Sell, Status::WaitingPayment);
+        order.master_buyer_pubkey = Some(master.to_string());
+        let err = notify_taker_reputation(&pool, &order).await.unwrap_err();
+        assert!(matches!(
+            err,
+            MostroCantDo(CantDoReason::NotAllowedByStatus)
+        ));
+
+        // Any other status → not allowed.
+        let mut order = base_order(OrderKind::Sell, Status::Active);
+        order.master_buyer_pubkey = Some(master.to_string());
+        let err = notify_taker_reputation(&pool, &order).await.unwrap_err();
+        assert!(matches!(
+            err,
+            MostroCantDo(CantDoReason::NotAllowedByStatus)
+        ));
+    }
+
+    // ───────────────────────── fiat amount extraction ─────────────────────────
+
+    #[test]
+    fn fiat_amount_requested_covers_range_and_fixed_orders() {
+        // Fixed order → always its own fiat amount.
+        let order = base_order(OrderKind::Sell, Status::Pending);
+        let msg = Message::new_order(None, None, None, Action::TakeSell, None);
+        assert_eq!(get_fiat_amount_requested(&order, &msg), Some(100));
+
+        // Range order with an out-of-bounds request → None.
+        let mut range = base_order(OrderKind::Sell, Status::Pending);
+        range.min_amount = Some(50);
+        range.max_amount = Some(200);
+        let msg = Message::new_order(
+            None,
+            None,
+            None,
+            Action::TakeSell,
+            Some(Payload::Amount(1_000)),
+        );
+        assert_eq!(get_fiat_amount_requested(&range, &msg), None);
+
+        // Range order without any requested amount → None.
+        let msg = Message::new_order(None, None, None, Action::TakeSell, None);
+        assert_eq!(get_fiat_amount_requested(&range, &msg), None);
     }
 }


### PR DESCRIPTION
## Summary

Deep review + a large coverage push: **~1000 new offline unit tests**, taking `cargo llvm-cov` line coverage from **67.3% → 92.8%** with the suite fully green (**1010 passed, 0 failed**) and `clippy --all-targets -- -D warnings` clean. **Production code is unchanged** (tests only, except the README + one test-helper isolation fix).

Tests run entirely offline — in-memory SQLite, locally-built BOLT11 invoices, no relay/LND/network. Terminal handlers are asserted up to the LND/relay seam (the pattern already used across this repo's tests).

### Coverage highlights
- **Handlers from 0% → covered**: `release`, `cancel`, `dispute`, `take_buy`, `take_sell`, `add_invoice`, `fiat_sent`, `trade_pubkey`, `orders`, `admin_settle`, `admin_cancel`, `admin_add_solver`, `restore_session`.
- **Extended**: `util`, `db`, `app`, `flow`, `nip33`, `bond/*`, `dev_fee`, `cashu`, `config/util`, `price/manager`, `rpc/rate_limiter`, `scheduler`, `spam_gate`, `lightning/invoice`.
- **Test-isolation fix**: `ensure_global_db_pool` now re-runs the idempotent migrations against the set-once process-global `DB_POOL`, so whichever test wins the global race can't strand another test on an un-migrated schema.
- **README**: new "Code Coverage" subsection (cargo-llvm-cov summary / html / lcov) as requested.

### Why not 100%
The remaining ~2400 lines structurally require a live LND node, a Cashu mint, a network relay, interactive stdin (the config wizard), or the `main()` / `app::run` bootstrap loop — none exercisable in an offline unit test. These are documented in each module's test report.

## Deep review — findings for follow-up (kept out of this test PR)

These are real issues the review + test authors surfaced while reading. This PR does **not** fix them (to stay test-only and reviewable); each deserves its own focused, tested change:

- **CRITICAL — whole-node crash on malformed hex.** `src/lightning/mod.rs:150,170` decode DB-stored `preimage`/`hash` with `.expect(...)`. The event loop (`src/app.rs`) is sequential and `main()` doesn't isolate the panic, so a single corrupt row panics the entire daemon on the next release/cancel/settle. → replace with a typed error.
- **HIGH — irreversible refund before validation.** `src/app/admin_cancel.rs`: when `order.hash.is_some()`, `cancel_hold_invoice` (irreversible seller refund) runs **before** the `dispute_initiator` check; if that check fails the funds are already returned but the order stays in `Dispute`.
- **HIGH — swallowed payment failures.** `src/app/release.rs:305` and `src/app/admin_settle.rs:255` do `let _ = do_payment(...)`. On the early-return path the seller is already settled but the buyer is never paid, `failed_payment` is never set, and there's no retry/log/visibility.
- **HIGH — unauthenticated admin RPC.** `src/rpc/server.rs` builds a plain transport with no TLS/auth; `cancel/settle/add_solver/take_dispute` are reachable by anyone who reaches the port. Safe by default (loopback, disabled) but no code-level guard; `validate_db_password` is a documented no-op.
- **MEDIUM**: pre-CAS settle ordering (`release.rs`/`admin_settle.rs`) allows a benign double-settle race; `admin_cancel` lacks the CAS guard `admin_settle` has; scheduler opens a fresh `LndConnector` per tick; price-store locks `.expect()` on poison instead of degrading; `lnurl::resolv_ln_address` returns `Ok("")` on genuine failures (silent-failure smell) with an unchecked `amount * 1000`.
- **LOW**: dead branches (hex guards in `restore_session`, `is_solver==0` re-check in `admin_take_dispute`, SQLite table-rebuild fallback in `db.rs`), stale next-trade fields leaking into sell child orders, several files well over the 800-line guideline.

## Test plan
- [x] `cargo test` — 1010 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all` — applied
- [x] `cargo llvm-cov --summary-only` — 92.8% line coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “code coverage” guide describing how to generate terminal, HTML, and LCOV reports (including CI/editor-friendly output) using `cargo-llvm-cov`.
  * Clarified that unit tests run offline with in-memory databases and locally generated data, while certain uncovered paths require live services.

* **Tests**
  * Greatly expanded unit/integration coverage across orders, releases, disputes, bonds, cancellations, payments, LN/Cashu handling, RPC, rate limiting, scheduler behavior, and queue flows.
  * Added more edge-case and authorization/state-transition validations, including “dead/unreachable” Lightning/Cashu paths for deterministic offline testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->