### PR TITLE
fix(lightning): don't panic the daemon on malformed preimage/hash (#804)

### DIFF
--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -55,6 +55,41 @@ pub fn routing_fee_cap_sats(amount: i64) -> i64 {
     max_fee as i64
 }
 
+/// Length in bytes of a Lightning payment preimage and of the payment
+/// hash derived from it (both are SHA-256 sized).
+const HASH_LEN: usize = 32;
+
+/// Decode a hex-encoded 32-byte preimage or payment hash — as stored in
+/// the `orders` / `bonds` tables — into the raw bytes LND expects.
+///
+/// This must never panic. The main event loop in `src/app.rs` processes
+/// messages sequentially on a single task with no panic boundary, so an
+/// `.expect()` here would turn a single malformed row (corruption, a
+/// partial write, a manual DB edit) into a full-daemon outage for every
+/// user of the instance. Returning a typed error keeps the blast radius
+/// at the one operation that touched the bad row.
+///
+/// `field` names the column for the log line. The value itself is never
+/// included in the error: the preimage is the secret that claims the
+/// HTLC, and errors end up in logs.
+fn decode_hash32(field: &str, value: &str) -> Result<Vec<u8>, MostroError> {
+    let bytes = Vec::<u8>::from_hex(value).map_err(|e| {
+        MostroInternalErr(ServiceError::HoldInvoiceError(format!(
+            "invalid {field}: not valid hex ({e})"
+        )))
+    })?;
+
+    if bytes.len() != HASH_LEN {
+        return Err(MostroInternalErr(ServiceError::HoldInvoiceError(format!(
+            "invalid {field}: expected {} bytes, got {}",
+            HASH_LEN,
+            bytes.len()
+        ))));
+    }
+
+    Ok(bytes)
+}
+
 impl LndConnector {
     pub async fn new() -> Result<Self, MostroError> {
         let ln_settings = Settings::get_ln();
@@ -147,7 +182,7 @@ impl LndConnector {
         &mut self,
         preimage: &str,
     ) -> Result<SettleInvoiceResp, MostroError> {
-        let preimage = FromHex::from_hex(preimage).expect("Wrong preimage");
+        let preimage = decode_hash32("preimage", preimage)?;
 
         let preimage_message = SettleInvoiceMsg { preimage };
         let settle = self
@@ -167,7 +202,7 @@ impl LndConnector {
         &mut self,
         hash: &str,
     ) -> Result<CancelInvoiceResp, MostroError> {
-        let payment_hash = FromHex::from_hex(hash).expect("Wrong payment hash");
+        let payment_hash = decode_hash32("payment hash", hash)?;
 
         let cancel_message = CancelInvoiceMsg { payment_hash };
         let cancel = self.client.invoices().cancel_invoice(cancel_message).await;
@@ -423,9 +458,10 @@ impl LnStatus {
 
 #[cfg(test)]
 mod tests {
-    use super::routing_fee_cap_sats;
+    use super::{decode_hash32, routing_fee_cap_sats};
     use crate::config::settings::Settings;
     use crate::config::MOSTRO_CONFIG;
+    use mostro_core::prelude::*;
 
     fn init_test_settings() {
         // Defaults set `max_routing_fee = 0.002`.
@@ -460,5 +496,106 @@ mod tests {
         assert_eq!(routing_fee_cap_sats(1001), 2); // 2.002 -> 2
         assert_eq!(routing_fee_cap_sats(2001), 4); // 4.002 -> 4
         assert_eq!(routing_fee_cap_sats(100_000), 200);
+    }
+
+    // --- decode_hash32 -----------------------------------------------
+    //
+    // These guard the CRITICAL fix for #804: a malformed `preimage` /
+    // `hash` column must fail *that* operation, never panic the daemon.
+
+    /// Assert the error is the typed hold-invoice error naming `field`,
+    /// and that it never echoes the raw value back into logs.
+    fn assert_hold_invoice_err(err: MostroError, field: &str, value: &str) {
+        match err {
+            MostroInternalErr(ServiceError::HoldInvoiceError(msg)) => {
+                assert!(
+                    msg.contains(field),
+                    "error should name the offending column, got: {msg}"
+                );
+                assert!(
+                    !msg.contains(value),
+                    "error must not leak the secret value, got: {msg}"
+                );
+            }
+            other => panic!("expected HoldInvoiceError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decodes_valid_32_byte_hex() {
+        // Arrange
+        let value = "ab".repeat(32);
+
+        // Act
+        let bytes = decode_hash32("preimage", &value).expect("valid hex must decode");
+
+        // Assert
+        assert_eq!(bytes, vec![0xab; 32]);
+    }
+
+    #[test]
+    fn accepts_uppercase_hex() {
+        // Arrange: LND and some tooling emit uppercase hex; rejecting it
+        // would strand otherwise-valid rows.
+        let value = "AB".repeat(32);
+
+        // Act
+        let bytes = decode_hash32("preimage", &value).expect("uppercase hex must decode");
+
+        // Assert
+        assert_eq!(bytes, vec![0xab; 32]);
+    }
+
+    #[test]
+    fn returns_error_instead_of_panicking_on_non_hex() {
+        // Arrange: `bonds` fixtures and hand-edited rows have produced
+        // values like this; before #804 they panicked the process.
+        let value = "p".repeat(64);
+
+        // Act
+        let err = decode_hash32("preimage", &value).expect_err("non-hex must be rejected");
+
+        // Assert
+        assert_hold_invoice_err(err, "preimage", &value);
+    }
+
+    #[test]
+    fn returns_error_on_odd_length_hex() {
+        // Arrange: a truncated / partially written column.
+        let value = "abc";
+
+        // Act
+        let err = decode_hash32("payment hash", value).expect_err("odd length must be rejected");
+
+        // Assert
+        assert_hold_invoice_err(err, "payment hash", value);
+    }
+
+    #[test]
+    fn returns_error_on_empty_string() {
+        // Arrange / Act
+        let err = decode_hash32("preimage", "").expect_err("empty must be rejected");
+
+        // Assert: empty is valid hex for a zero-length Vec, so it is the
+        // length check that has to catch it.
+        match err {
+            MostroInternalErr(ServiceError::HoldInvoiceError(msg)) => {
+                assert!(msg.contains("expected 32 bytes, got 0"), "got: {msg}")
+            }
+            other => panic!("expected HoldInvoiceError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn returns_error_on_wrong_length_hex() {
+        // Arrange: well-formed hex, wrong size — LND would reject it
+        // anyway, but we want a clear error at the boundary.
+        for value in ["00".repeat(31), "00".repeat(33)] {
+            // Act
+            let err = decode_hash32("preimage", &value).expect_err("wrong length must be rejected");
+
+            // Assert
+            assert_hold_invoice_err(err, "preimage", &value);
+        }
     }
 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -349,8 +349,21 @@ async fn job_cancel_orders(ctx: AppContext) {
                         // If hold invoice is paid return funds to seller
                         // We return funds to seller
                         if let Some(hash) = order.hash.as_ref() {
+                            // The cancel must succeed before we clear the
+                            // order. Falling through on error would take the
+                            // order out of `find_order_by_seconds`'s
+                            // waiting-state eligibility window — and log
+                            // "funds returned" — while the hold invoice is
+                            // still encumbered, with no later tick to fix it.
+                            // Same reasoning as the bond slash/release below:
+                            // stay eligible and retry rather than persist a
+                            // state that doesn't match the HTLC.
                             if let Err(e) = ln_client.cancel_hold_invoice(hash).await {
-                                error!("{e}");
+                                error!(
+                                    "scheduler_timeout: cancel_hold_invoice failed for order {} ({e}); skipping cancel/republish so next tick retries",
+                                    order.id
+                                );
+                                continue;
                             }
                             info!("Order Id {}: Funds returned to seller - buyer did not sent regular invoice in time", &order.id);
                         };


### PR DESCRIPTION
Closes #804.

## Problem

`settle_hold_invoice` and `cancel_hold_invoice` decoded the stored `preimage` / `hash` columns with `hex::from_hex(..).expect(..)`.

The main event loop in `src/app.rs` processes messages sequentially on a single task, and `main()` does not wrap message handling in a panic boundary. So **a single malformed row** — corruption, a partial write, a bad migration, a manual DB edit — would take down the **entire daemon** the next time that order or bond was settled/cancelled. A one-row data problem became a full denial of service for every user of the instance.

## Fix

Both call sites now go through a `decode_hash32` helper that returns `ServiceError::HoldInvoiceError`. The bad row fails **that** operation and is logged; the process survives.

Additionally:

- **Validation at the boundary**: the helper enforces the 32-byte invariant, so a wrong-length column produces a clear error here instead of an opaque gRPC rejection from LND.
- **No secret leakage**: the error names the offending column but never includes the value — the preimage is what claims the HTLC, and errors end up in logs.

**No signature changes**: both functions already returned `Result<_, MostroError>`, and all 11 call sites (`util.rs`, `app/cancel.rs`, `admin_cancel.rs`, `scheduler.rs`, `bond/flow.rs`, `bond/slash.rs`) already propagated with `?` or logged the error.

## Follow-up included after review

Codex flagged (P2) that `job_cancel_orders` only logged a `cancel_hold_invoice` failure and then fell through to mark the funds as returned and republish/cancel the order — persisting the order out of `find_order_by_seconds`'s waiting-state eligibility window, so no later tick re-evaluates it. The order gets cleared while the hold invoice is still encumbered.

That swallow predates this PR (any transient LND error already hit it); the `.expect()` merely masked the malformed-hash trigger by killing the process instead. Since a bad `hash` column now returns an error, the path is reachable, so it is fixed here: on failure we `continue`, leaving the order eligible for the next tick — the same trade-off the bond slash/release branch below already makes. The "funds returned" log now only fires on success.

## Audited scope

Grep over all of `src/`: no other `.expect()` / `.unwrap()` on hex decoding remains in production code (the only one left, in `cashu/mod.rs`, is under `#[cfg(test)]`). All other `cancel_hold_invoice` / `settle_hold_invoice` call sites were checked for the same log-and-proceed shape: `app/cancel.rs`, `admin_cancel.rs` and `util.rs` propagate with `?`; `bond/flow.rs` and `bond/slash.rs` classify the error and leave the bond `Locked` / unmarked for retry. `scheduler.rs` was the only offender.

## Test plan

- [x] 6 new unit tests: valid lowercase and uppercase hex, non-hex, odd length, empty string, wrong length (31 and 33 bytes).
- [x] An assert helper verifies the error names the column and **never** contains the value.
- [x] Full suite: 535 passed, 0 failed.
- [x] `cargo fmt --all` + `cargo clippy --all-targets -- -D warnings` clean.

Caveat on coverage: `job_cancel_orders` has no tests (it builds a real `LndConnector`), so the scheduler change is verified by inspection and compilation, not by a test exercising it.