### PR TITLE
docs: state the English-language convention explicitly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 - Run `cargo test` locally after schema or query changes.
 
 ## Commit & Pull Request Guidelines
+- **Write in English.** Commit messages, PR titles and bodies, issue and review comments, documentation, and code comments are all English, regardless of the language a contributor or maintainer is speaking in elsewhere. Mostro has contributors who do not read Spanish, and a repository that mixes languages is one they cannot review.
 - Base work on `main`; keep topics scoped.
 - Commit subject: imperative, ≤50 chars; sign with `git commit -S`.
 - Squash fixups before review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ All Mostro contributors submit changes via pull requests. The workflow is as fol
 
 Pull requests should be focused on a single change. Do not mix, for example, refactorings with a bug fix or implementation of a new feature. This practice makes it easier for fellow contributors to review each pull request.
 
+Contributions are written in **English** — commit messages, pull request titles and bodies, issue and review comments, documentation, and code comments. Discussion in other languages is welcome on Telegram, but anything that lands in the repository should be readable by every contributor.
+
 ### Protocol / Tag Changes
 
 Changes that affect Nostr event tags (e.g. `y` tags, `z` tags) or event kinds are **protocol changes** and deserve extra care:


### PR DESCRIPTION
## Problem

Every artifact in this repository is already in English, but the convention is nowhere written down. Grepping `AGENTS.md`, `CONTRIBUTING.md` and `docs/` for "language" turns up only two unrelated things: the `ACK`/`NACK`/`utACK` review vocabulary in `CONTRIBUTING.md`, and markdownlint's MD040 code-block specifiers in `AGENTS.md`.

That gap is easy to fall into for contributors and AI agents whose working conversation happens in another language. The leap from "we are discussing this in Spanish" to "I will write the PR body in Spanish" is a short one, and it produces artifacts a good part of the project cannot review. It happened on #821, which is what prompted this.

## Change

Two sentences, one in each file, because the two audiences read different documents:

- `AGENTS.md` → under **Commit & Pull Request Guidelines**, where agents look for commit and PR rules.
- `CONTRIBUTING.md` → under **Contributor Workflow**, next to the existing "PRs should be focused on a single change" guidance, where human contributors look.

Both spell out the same scope — commit messages, PR titles and bodies, issue and review comments, documentation, and code comments — and both make clear the rule is about what lands *in the repository*, not about what language people speak in Telegram.

## Test plan

- [x] Docs only. No code, no behaviour change, nothing to run.
- [x] Diff is 3 added lines across 2 files.
- [x] No markdownlint config in the repo; the added lines are plain prose with no fenced blocks, so MD040 does not apply.

If you would rather keep this in one place only, drop whichever of the two you consider redundant — the split is a judgement call, not a requirement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified contribution guidelines requiring repository content—including commits, pull requests, issues, reviews, documentation, and code comments—to be written in English.
  * Noted that discussions in other languages are welcome outside the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->