### PR TITLE
ci: serve the coverage badge from our own Pages, drop Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,11 +39,6 @@ jobs:
   coverage:
     name: Generate and publish report
     runs-on: ubuntu-latest
-    env:
-      # Surfaced as an env var so the upload step can be skipped when Codecov
-      # is not configured: the `secrets` context is not available in a
-      # step-level `if:`.
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -84,24 +79,46 @@ jobs:
       - name: Render HTML report
         run: cargo llvm-cov report --html --output-dir target/llvm-cov
 
+      # Published next to the HTML so editors and external tools can consume
+      # the raw data without re-running the suite.
       - name: Render lcov report
-        run: cargo llvm-cov report --lcov --output-path lcov.info
+        run: cargo llvm-cov report --lcov --output-path target/llvm-cov/html/lcov.info
 
       - name: Coverage summary
         run: cargo llvm-cov report --summary-only >> "$GITHUB_STEP_SUMMARY"
 
-      # Skipped entirely when CODECOV_TOKEN is unset, so an unconfigured
-      # Codecov is visible as a skipped step rather than a silent no-op. When
-      # it does run, a failed upload fails the job: `fail_ci_if_error: false`
-      # would let the workflow stay green while nothing reaches Codecov,
-      # leaving the README badge permanently blank with no signal.
-      - name: Upload to Codecov
-        if: env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+      # Self-hosted badge data, so the README number comes from this repo's
+      # own Pages site instead of a third-party service that would make
+      # readers sign up to see it. shields.io renders it via its `endpoint`
+      # type; the repo already depends on shields for the license, Rust and
+      # version badges, so this adds no new dependency.
+      #
+      # The percentage is read from the machine-readable summary rather than
+      # scraped from the human table: `--json` with `--summary-only` is the
+      # supported combination and its shape is stable
+      # (`.data[0].totals.lines.percent`).
+      - name: Generate badge data
+        run: |
+          set -euo pipefail
+          # Force the C locale: printf's decimal separator follows LC_NUMERIC,
+          # so on a localised machine "%.1f" yields "92,8" and shields.io then
+          # renders a comma in the badge.
+          export LC_ALL=C
+          cargo llvm-cov report --json --summary-only --output-path summary.json
+          pct=$(jq -r '.data[0].totals.lines.percent' summary.json)
+          printf -v rounded '%.1f' "$pct"
+          # Thresholds mirror the usual shields palette so the colour keeps
+          # meaning something if coverage regresses.
+          if   (( $(echo "$pct >= 90" | bc -l) )); then colour=brightgreen
+          elif (( $(echo "$pct >= 75" | bc -l) )); then colour=green
+          elif (( $(echo "$pct >= 60" | bc -l) )); then colour=yellow
+          elif (( $(echo "$pct >= 40" | bc -l) )); then colour=orange
+          else                                          colour=red
+          fi
+          jq -n --arg m "${rounded}%" --arg c "$colour" \
+            '{schemaVersion: 1, label: "coverage", message: $m, color: $c}' \
+            > target/llvm-cov/html/badge.json
+          echo "coverage: ${rounded}% ($colour)"
 
       # Same action and same branch as `mutation.yml`, into a sibling
       # subdirectory. `keep_files` is left at its default: with

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Rust Version](https://img.shields.io/badge/rust-1.94.0%2B-blue.svg)](https://www.rust-lang.org)
 [![Version](https://img.shields.io/crates/v/mostro)](https://crates.io/crates/mostro)
-[![Coverage](https://codecov.io/gh/MostroP2P/mostro/branch/main/graph/badge.svg)](https://codecov.io/gh/MostroP2P/mostro)
+[![Coverage](https://img.shields.io/endpoint?url=https://mostro.network/mostro/coverage/badge.json)](https://mostro.network/mostro/coverage/)
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/MostroP2P/mostro)
 
@@ -1058,13 +1058,15 @@ cd mostro-regtest
 
 **Code Coverage**: Measured with [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov)
 
-The published report lives at **<https://mostrop2p.github.io/mostro/coverage/>**
-— the same browsable HTML `cargo llvm-cov --html` produces locally, regenerated
+The published report lives at **<https://mostro.network/mostro/coverage/>** —
+the same browsable HTML `cargo llvm-cov --html` produces locally, regenerated
 by the `Coverage` workflow every Sunday and on demand from the Actions tab.
+No account or sign-up is needed to read it, and the badge above is served from
+that same page (`coverage/badge.json`), so it always matches the report.
 (It shares the `gh-pages` branch with the mutation-testing report, which keeps
 its own `/mutation-testing/` subdirectory.)
-[Codecov](https://codecov.io/gh/MostroP2P/mostro) tracks the trend over time.
 Note the report reflects the last scheduled run, not the current tip of `main`.
+Raw lcov for editors and external tools: `coverage/lcov.info` on that page.
 
 To reproduce it locally:
 


### PR DESCRIPTION
Follow-up to #823.

## Why

Two problems with the Codecov badge I added in #823:

1. **codecov.io asks visitors to sign up** to view the report. That's poor form generally, and particularly at odds with a project whose premise is not depending on intermediaries.
2. **The badge read `unknown`** at the very top of the README. Codecov was never onboarded, so the upload step skipped itself exactly as designed — the net effect was advertising a broken integration on the front page.

## What changes

The report is already published on our own domain, so the badge data can come from there too:

- The workflow emits `coverage/badge.json` in shields.io's [`endpoint`](https://shields.io/badges/endpoint-badge) schema, next to the HTML.
- The README renders it via shields — already a dependency for the license, Rust and version badges, so nothing new is trusted.
- The number therefore always matches the report sitting beside it, and **no reader has to sign up for anything**.

The percentage is read from `--json --summary-only` (`.data[0].totals.lines.percent`), not scraped out of the human-readable table. Badge colour follows the usual shields thresholds so a regression is visible at a glance.

Also in here:

- `lcov.info` now ships alongside the HTML at `coverage/lcov.info` instead of being rendered and discarded, so editors and external tools can consume the raw data.
- The README points at the canonical `https://mostro.network/mostro/coverage/` rather than the `github.io` URL that redirects to it.
- The Codecov step, its token plumbing and the "Codecov tracks the trend" sentence are all removed.

## What we give up

Codecov's per-PR delta comment and historical trend graph. Neither exists today (nothing was ever uploaded), so nothing is actually lost. If the delta-on-PR feedback turns out to be wanted later, Codecov can be added back alongside this badge — they aren't mutually exclusive.

## Test plan

- [x] YAML parses.
- [x] Ran the badge script locally against real profile data.
- [x] Confirmed shields renders the generated value.

One bug found by actually running it rather than assuming: the script first produced `92,8%` — with a comma — because `printf`'s decimal separator follows `LC_NUMERIC` and my machine is localised. GitHub runners are on the C locale, so **CI would never have caught this**; it would only have surfaced for the next contributor who ran it locally. The step now exports `LC_ALL=C` instead of relying on the runner's locale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project’s coverage badge to use the Mostro-hosted report.
  * Added the new published coverage report URL and clarified coverage generation and badge updates.

* **Chores**
  * Coverage reports now generate badge data and publish directly to the hosted coverage site.
  * Removed automated Codecov uploads from the coverage workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->