### PR TITLE
fix: validate the dispute initiator before refunding the escrow (#805)

### DIFF
--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -115,6 +115,18 @@ pub async fn admin_cancel_action(
     let bond_resolution = bond::extract_bond_resolution(&msg);
     bond::validate_bond_resolution(pool, &order, &bond_resolution).await?;
 
+    // Resolve the dispute initiator *before* the escrow is touched (#805).
+    // This match rejects orders whose initiator flags are unset or ambiguous,
+    // and `cancel_hold_invoice` below is irreversible: running it first meant
+    // a rejected request could still refund the seller while leaving the order
+    // in `Dispute`, so the LN side and the DB disagreed with no way back.
+    // Every check that can reject the call now precedes the refund.
+    let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
+        (true, false) => "seller",
+        (false, true) => "buyer",
+        (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
+    };
+
     if order.hash.is_some() {
         // We return funds to seller
         if let Some(hash) = order.hash.as_ref() {
@@ -125,13 +137,6 @@ pub async fn admin_cancel_action(
 
     // we check if there is a dispute
     let dispute = find_dispute_by_order_id(pool, order.id).await;
-
-    // Get the creator of the dispute
-    let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
-        (true, false) => "seller",
-        (false, true) => "buyer",
-        (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
-    };
 
     if let Ok(mut d) = dispute {
         let dispute_id = d.id;
@@ -559,6 +564,49 @@ mod tests {
             result,
             Err(MostroInternalErr(ServiceError::DisputeEventError))
         ));
+    }
+
+    /// Regression for #805: an order carrying a hold-invoice `hash` whose
+    /// dispute-initiator flags are unset must fail validation *before* the
+    /// irreversible `cancel_hold_invoice`. Reaching the LND seam here would
+    /// surface as `LnNodeError` and would mean the seller was already
+    /// refunded on a request that goes on to be rejected.
+    #[tokio::test]
+    async fn dispute_without_initiator_flag_errors_before_refunding() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        // Hold invoice present, but neither side is flagged as the dispute
+        // initiator, so `dispute_initiator` resolution must reject the call.
+        order.hash = Some("11".repeat(32));
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::DisputeEventError))
+            ),
+            "expected the initiator check to reject before the LND cancel, got {result:?}"
+        );
+
+        // The order must be left untouched so the solver can retry.
+        let stored = get_order(&cancel_msg(order.id), ctx.pool()).await.unwrap();
+        assert_eq!(stored.status, Status::Dispute.to_string());
     }
 
     /// A dispute order carrying a hold-invoice `hash` returns funds to the

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -42,9 +42,16 @@ use tracing::{error, info};
 /// Returns `MostroError` if:
 /// - Solver is not assigned to the dispute
 /// - Order/dispute not found
+/// - The dispute initiator flags are unset or ambiguous, or a counterparty
+///   pubkey is missing/unparseable — both are checked before the refund, so
+///   they leave the escrow and the order untouched (#805)
 /// - Lightning invoice cancellation fails
 /// - Database update fails
 /// - Nostr publish fails
+///
+/// Failures *after* the refund are logged and swallowed rather than
+/// returned (DM fan-out, bond resolution), so the handler always runs to
+/// the end once the escrow has moved. Making that tail atomic is #810.
 pub async fn admin_cancel_action(
     ctx: &AppContext,
     msg: Message,
@@ -120,13 +127,44 @@ pub async fn admin_cancel_action(
     // and `cancel_hold_invoice` below is irreversible: running it first meant
     // a rejected request could still refund the seller while leaving the order
     // in `Dispute`, so the LN side and the DB disagreed with no way back.
-    // This initiator check now precedes the refund. Operations after the
-    // refund can still fail (dispute/order events, DB updates, DM delivery);
-    // making that path atomic is tracked separately in #810.
+    // This initiator check now precedes the refund, as does the counterparty
+    // resolution below. What remains after the refund either can't reject the
+    // call (the DM fan-out is best effort) or is a DB/event write whose
+    // atomicity is tracked separately in #810.
     let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
         (true, false) => "seller",
         (false, true) => "buyer",
-        (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
+        (seller_dispute, buyer_dispute) => {
+            // A bare `DisputeEventError` doesn't tell the operator why the
+            // cancel bounces. The pair is only reachable through a corrupted
+            // row — `dispute_action` gates on `Active`/`FiatSent`, so exactly
+            // one flag is set by the time an order reaches `Dispute`.
+            error!(
+                order_id = %order.id,
+                seller_dispute,
+                buyer_dispute,
+                "admin_cancel: ambiguous dispute initiator flags; refusing before the escrow is touched"
+            );
+            return Err(MostroInternalErr(ServiceError::DisputeEventError));
+        }
+    };
+
+    // Same reasoning as the initiator check above: resolving the
+    // counterparties is pure validation over the `order` snapshot, so it
+    // belongs before the irreversible refund rather than after it. Left
+    // where it was, an unparseable or missing pubkey aborted the handler
+    // once the escrow was already refunded and the order already
+    // `CanceledByAdmin` — past the point where a solver retry is possible
+    // (the `Dispute` guard above rejects it) and before the bond resolution
+    // below, stranding every `Locked` bond with no reconciler.
+    let (seller_pubkey, buyer_pubkey) = match (&order.seller_pubkey, &order.buyer_pubkey) {
+        (Some(seller), Some(buyer)) => (
+            PublicKey::from_str(seller.as_str())
+                .map_err(|_| MostroInternalErr(ServiceError::InvalidPubkey))?,
+            PublicKey::from_str(buyer.as_str())
+                .map_err(|_| MostroInternalErr(ServiceError::InvalidPubkey))?,
+        ),
+        (None, _) | (_, None) => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
     };
 
     if order.hash.is_some() {
@@ -201,27 +239,24 @@ pub async fn admin_cancel_action(
     let message = message
         .as_json()
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-    // Message to admin
-    send_dm(event.sender, my_keys, &message, None)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-
-    let (seller_pubkey, buyer_pubkey) = match (&order.seller_pubkey, &order.buyer_pubkey) {
-        (Some(seller), Some(buyer)) => (
-            PublicKey::from_str(seller.as_str())
-                .map_err(|_| MostroInternalErr(ServiceError::InvalidPubkey))?,
-            PublicKey::from_str(buyer.as_str())
-                .map_err(|_| MostroInternalErr(ServiceError::InvalidPubkey))?,
-        ),
-        (None, _) => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
-        (_, None) => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
-    };
-    send_dm(seller_pubkey, my_keys, &message, None)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
-    send_dm(buyer_pubkey, my_keys, &message, None)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+    // The escrow is already refunded and the order already `CanceledByAdmin`
+    // by this point, so a relay hiccup on a notification must not abort the
+    // handler: an early return here skips the bond resolution below and
+    // strands every `Locked` bond with no retry path (a second admin cancel
+    // is rejected by the `Dispute` guard, and only range maker bonds have a
+    // reconciler). Delivery is best effort, mirroring `notify_bond_slashed`.
+    for (role, destination) in [
+        ("admin", event.sender),
+        ("seller", seller_pubkey),
+        ("buyer", buyer_pubkey),
+    ] {
+        if let Err(e) = send_dm(destination, my_keys, &message, None).await {
+            error!(
+                order_id = %order.id,
+                "admin_cancel: failed to notify the {role} of the cancellation: {e}"
+            );
+        }
+    }
 
     // Phase 2: apply the solver's `BondResolution` to the bond rows
     // (release-by-default when absent). The buyer/seller pubkeys on
@@ -534,9 +569,11 @@ mod tests {
         ));
     }
 
-    /// A dispute order with no `hash` skips the LND cancel and, when
-    /// neither `seller_dispute` nor `buyer_dispute` is set, fails the
-    /// dispute-initiator resolution with `DisputeEventError`.
+    /// With neither `seller_dispute` nor `buyer_dispute` set, the
+    /// dispute-initiator resolution fails with `DisputeEventError`. The
+    /// order carries no `hash`, so this covers the resolution itself
+    /// independently of the escrow; the pre-refund ordering is pinned by
+    /// `dispute_without_initiator_flag_errors_before_refunding` below.
     #[tokio::test]
     async fn dispute_without_initiator_flag_errors() {
         let pool = setup_pool().await;
@@ -573,6 +610,12 @@ mod tests {
     /// irreversible `cancel_hold_invoice`. Reaching the LND seam here would
     /// surface as `LnNodeError` and would mean the seller was already
     /// refunded on a request that goes on to be rejected.
+    ///
+    /// The discriminator is the error *type*, which depends on `dead_lnd`
+    /// making every RPC fail: if the LND seam is ever replaced by a mock
+    /// that returns `Ok`, the pre-fix ordering would also end in
+    /// `DisputeEventError` and this test would stop guarding the invariant.
+    /// Assert on a cancel-call spy instead if that day comes.
     #[tokio::test]
     async fn dispute_without_initiator_flag_errors_before_refunding() {
         let pool = setup_pool().await;
@@ -608,6 +651,84 @@ mod tests {
 
         // The order must be left untouched so the solver can retry.
         let stored = get_order(&cancel_msg(order.id), ctx.pool()).await.unwrap();
+        assert_eq!(stored.status, Status::Dispute.to_string());
+    }
+
+    /// Both initiator flags set is as ambiguous as neither: the same arm
+    /// rejects it before the escrow is touched, so a corrupted row can't
+    /// pick an arbitrary side for the kind-38386 `initiator` tag.
+    #[tokio::test]
+    async fn dispute_with_both_initiator_flags_errors_before_refunding() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.seller_dispute = true;
+        order.buyer_dispute = true;
+        order.hash = Some("11".repeat(32));
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::DisputeEventError))
+            ),
+            "expected the initiator check to reject before the LND cancel, got {result:?}"
+        );
+    }
+
+    /// Counterparty resolution is validation too, so a missing pubkey must
+    /// be rejected before the refund (#805). Pre-fix this parsed only after
+    /// `cancel_hold_invoice`, the dispute row and the order status had all
+    /// been written — a rejection that had already moved the money and left
+    /// the bonds `Locked` past any retry.
+    #[tokio::test]
+    async fn missing_counterparty_pubkey_errors_before_refunding() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.seller_dispute = true;
+        order.buyer_pubkey = None;
+        order.hash = Some("11".repeat(32));
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(MostroInternalErr(ServiceError::InvalidPubkey))),
+            "expected the pubkey check to reject before the LND cancel, got {result:?}"
+        );
+
+        // Untouched: no refund, no status change, so the row is still
+        // recoverable once the pubkey is repaired.
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
         assert_eq!(stored.status, Status::Dispute.to_string());
     }
 
@@ -648,9 +769,10 @@ mod tests {
 
     /// Full no-LND cancel path: a seller-initiated dispute with no hold
     /// invoice hash. The dispute row is moved to `SellerRefunded` and the
-    /// order to `CanceledByAdmin` before the DM fan-out. Those DB writes are
-    /// deterministic; the terminal `send_dm` depends on the process-global
-    /// Nostr client, so the top-level result is not asserted.
+    /// order to `CanceledByAdmin`, and the handler runs to completion even
+    /// though the DM fan-out fails here (no process-global Nostr client) —
+    /// notifications are best effort precisely so a relay failure can't skip
+    /// the bond resolution that follows them.
     #[tokio::test]
     async fn seller_dispute_without_hash_refunds_and_cancels() {
         let pool = setup_pool().await;
@@ -669,7 +791,7 @@ mod tests {
             .unwrap()
             .id;
 
-        let _ = admin_cancel_action(
+        let result = admin_cancel_action(
             &ctx,
             cancel_msg(order.id),
             &admin_event(admin.public_key()),
@@ -677,6 +799,11 @@ mod tests {
             &mut ln,
         )
         .await;
+
+        assert!(
+            result.is_ok(),
+            "a failed DM must not abort the handler before bond resolution: {result:?}"
+        );
 
         let stored_order = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
         assert_eq!(stored_order.status, Status::CanceledByAdmin.to_string());

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -120,7 +120,9 @@ pub async fn admin_cancel_action(
     // and `cancel_hold_invoice` below is irreversible: running it first meant
     // a rejected request could still refund the seller while leaving the order
     // in `Dispute`, so the LN side and the DB disagreed with no way back.
-    // Every check that can reject the call now precedes the refund.
+    // This initiator check now precedes the refund. Operations after the
+    // refund can still fail (dispute/order events, DB updates, DM delivery);
+    // making that path atomic is tracked separately in #810.
     let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
         (true, false) => "seller",
         (false, true) => "buyer",

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -46,9 +46,16 @@ use tracing::{error, info, warn};
 /// - A pre-trade (`Pending` / `WaitingTakerBond`) order is cancelled by
 ///   anything but the daemon key
 /// - Order/dispute not found
+/// - The dispute initiator flags are unset or ambiguous, or a counterparty
+///   pubkey is missing/unparseable — both are checked before the refund, so
+///   they leave the escrow and the order untouched (#805)
 /// - Lightning invoice cancellation fails
 /// - Database update fails
 /// - Nostr publish fails
+///
+/// Failures *after* the refund are logged and swallowed rather than
+/// returned (DM fan-out, bond resolution), so the handler always runs to
+/// the end once the escrow has moved. Making that tail atomic is #810.
 pub async fn admin_cancel_action(
     ctx: &AppContext,
     msg: Message,
@@ -144,13 +151,44 @@ pub async fn admin_cancel_action(
     // and `cancel_hold_invoice` below is irreversible: running it first meant
     // a rejected request could still refund the seller while leaving the order
     // in `Dispute`, so the LN side and the DB disagreed with no way back.
-    // This initiator check now precedes the refund. Operations after the
-    // refund can still fail (dispute/order events, DB updates, DM delivery);
-    // making that path atomic is tracked separately in #810.
+    // This initiator check now precedes the refund, as does the counterparty
+    // resolution below. What remains after the refund either can't reject the
+    // call (the DM fan-out is best effort) or is a DB/event write whose
+    // atomicity is tracked separately in #810.
     let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
         (true, false) => "seller",
         (false, true) => "buyer",
-        (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
+        (seller_dispute, buyer_dispute) => {
+            // A bare `DisputeEventError` doesn't tell the operator why the
+            // cancel bounces. The pair is only reachable through a corrupted
+            // row — `dispute_action` gates on `Active`/`FiatSent`, so exactly
+            // one flag is set by the time an order reaches `Dispute`.
+            error!(
+                order_id = %order.id,
+                seller_dispute,
+                buyer_dispute,
+                "admin_cancel: ambiguous dispute initiator flags; refusing before the escrow is touched"
+            );
+            return Err(MostroInternalErr(ServiceError::DisputeEventError));
+        }
+    };
+
+    // Same reasoning as the initiator check above: resolving the
+    // counterparties is pure validation over the `order` snapshot, so it
+    // belongs before the irreversible refund rather than after it. Left
+    // where it was, an unparseable or missing pubkey aborted the handler
+    // once the escrow was already refunded and the order already
+    // `CanceledByAdmin` — past the point where a solver retry is possible
+    // (the `Dispute` guard above rejects it) and before the bond resolution
+    // below, stranding every `Locked` bond with no reconciler.
+    let (seller_pubkey, buyer_pubkey) = match (&order.seller_pubkey, &order.buyer_pubkey) {
+        (Some(seller), Some(buyer)) => (
+            PublicKey::from_str(seller.as_str())
+                .map_err(|_| MostroInternalErr(ServiceError::InvalidPubkey))?,
+            PublicKey::from_str(buyer.as_str())
+                .map_err(|_| MostroInternalErr(ServiceError::InvalidPubkey))?,
+        ),
+        (None, _) | (_, None) => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
     };
 
     if let Some(hash) = order.hash.as_ref() {
@@ -216,27 +254,24 @@ pub async fn admin_cancel_action(
     let message = message
         .as_json()
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-    // Message to admin
-    send_dm(event.sender, my_keys, &message, None)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-
-    let (seller_pubkey, buyer_pubkey) = match (&order.seller_pubkey, &order.buyer_pubkey) {
-        (Some(seller), Some(buyer)) => (
-            PublicKey::from_str(seller.as_str())
-                .map_err(|_| MostroInternalErr(ServiceError::InvalidPubkey))?,
-            PublicKey::from_str(buyer.as_str())
-                .map_err(|_| MostroInternalErr(ServiceError::InvalidPubkey))?,
-        ),
-        (None, _) => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
-        (_, None) => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
-    };
-    send_dm(seller_pubkey, my_keys, &message, None)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
-    send_dm(buyer_pubkey, my_keys, &message, None)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+    // The escrow is already refunded and the order already `CanceledByAdmin`
+    // by this point, so a relay hiccup on a notification must not abort the
+    // handler: an early return here skips the bond resolution below and
+    // strands every `Locked` bond with no retry path (a second admin cancel
+    // is rejected by the `Dispute` guard, and only range maker bonds have a
+    // reconciler). Delivery is best effort, mirroring `notify_bond_slashed`.
+    for (role, destination) in [
+        ("admin", event.sender),
+        ("seller", seller_pubkey),
+        ("buyer", buyer_pubkey),
+    ] {
+        if let Err(e) = send_dm(destination, my_keys, &message, None).await {
+            error!(
+                order_id = %order.id,
+                "admin_cancel: failed to notify the {role} of the cancellation: {e}"
+            );
+        }
+    }
 
     // Phase 2: apply the solver's `BondResolution` to the bond rows
     // (release-by-default when absent). The buyer/seller pubkeys on
@@ -665,9 +700,11 @@ mod tests {
         ));
     }
 
-    /// A dispute order with no `hash` skips the LND cancel and, when
-    /// neither `seller_dispute` nor `buyer_dispute` is set, fails the
-    /// dispute-initiator resolution with `DisputeEventError`.
+    /// With neither `seller_dispute` nor `buyer_dispute` set, the
+    /// dispute-initiator resolution fails with `DisputeEventError`. The
+    /// order carries no `hash`, so this covers the resolution itself
+    /// independently of the escrow; the pre-refund ordering is pinned by
+    /// `dispute_without_initiator_flag_errors_before_refunding` below.
     #[tokio::test]
     async fn dispute_without_initiator_flag_errors() {
         let pool = setup_pool().await;
@@ -704,6 +741,12 @@ mod tests {
     /// irreversible `cancel_hold_invoice`. Reaching the LND seam here would
     /// surface as `LnNodeError` and would mean the seller was already
     /// refunded on a request that goes on to be rejected.
+    ///
+    /// The discriminator is the error *type*, which depends on `dead_lnd`
+    /// making every RPC fail: if the LND seam is ever replaced by a mock
+    /// that returns `Ok`, the pre-fix ordering would also end in
+    /// `DisputeEventError` and this test would stop guarding the invariant.
+    /// Assert on a cancel-call spy instead if that day comes.
     #[tokio::test]
     async fn dispute_without_initiator_flag_errors_before_refunding() {
         let pool = setup_pool().await;
@@ -739,6 +782,84 @@ mod tests {
 
         // The order must be left untouched so the solver can retry.
         let stored = get_order(&cancel_msg(order.id), ctx.pool()).await.unwrap();
+        assert_eq!(stored.status, Status::Dispute.to_string());
+    }
+
+    /// Both initiator flags set is as ambiguous as neither: the same arm
+    /// rejects it before the escrow is touched, so a corrupted row can't
+    /// pick an arbitrary side for the kind-38386 `initiator` tag.
+    #[tokio::test]
+    async fn dispute_with_both_initiator_flags_errors_before_refunding() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.seller_dispute = true;
+        order.buyer_dispute = true;
+        order.hash = Some("11".repeat(32));
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::DisputeEventError))
+            ),
+            "expected the initiator check to reject before the LND cancel, got {result:?}"
+        );
+    }
+
+    /// Counterparty resolution is validation too, so a missing pubkey must
+    /// be rejected before the refund (#805). Pre-fix this parsed only after
+    /// `cancel_hold_invoice`, the dispute row and the order status had all
+    /// been written — a rejection that had already moved the money and left
+    /// the bonds `Locked` past any retry.
+    #[tokio::test]
+    async fn missing_counterparty_pubkey_errors_before_refunding() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.seller_dispute = true;
+        order.buyer_pubkey = None;
+        order.hash = Some("11".repeat(32));
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(MostroInternalErr(ServiceError::InvalidPubkey))),
+            "expected the pubkey check to reject before the LND cancel, got {result:?}"
+        );
+
+        // Untouched: no refund, no status change, so the row is still
+        // recoverable once the pubkey is repaired.
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
         assert_eq!(stored.status, Status::Dispute.to_string());
     }
 
@@ -779,9 +900,10 @@ mod tests {
 
     /// Full no-LND cancel path: a seller-initiated dispute with no hold
     /// invoice hash. The dispute row is moved to `SellerRefunded` and the
-    /// order to `CanceledByAdmin` before the DM fan-out. Those DB writes are
-    /// deterministic; the terminal `send_dm` depends on the process-global
-    /// Nostr client, so the top-level result is not asserted.
+    /// order to `CanceledByAdmin`, and the handler runs to completion even
+    /// though the DM fan-out fails here (no process-global Nostr client) —
+    /// notifications are best effort precisely so a relay failure can't skip
+    /// the bond resolution that follows them.
     #[tokio::test]
     async fn seller_dispute_without_hash_refunds_and_cancels() {
         let pool = setup_pool().await;
@@ -800,7 +922,7 @@ mod tests {
             .unwrap()
             .id;
 
-        let _ = admin_cancel_action(
+        let result = admin_cancel_action(
             &ctx,
             cancel_msg(order.id),
             &admin_event(admin.public_key()),
@@ -808,6 +930,11 @@ mod tests {
             &mut ln,
         )
         .await;
+
+        assert!(
+            result.is_ok(),
+            "a failed DM must not abort the handler before bond resolution: {result:?}"
+        );
 
         let stored_order = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
         assert_eq!(stored_order.status, Status::CanceledByAdmin.to_string());

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -139,6 +139,18 @@ pub async fn admin_cancel_action(
     let bond_resolution = bond::extract_bond_resolution(&msg);
     bond::validate_bond_resolution(pool, &order, &bond_resolution).await?;
 
+    // Resolve the dispute initiator *before* the escrow is touched (#805).
+    // This match rejects orders whose initiator flags are unset or ambiguous,
+    // and `cancel_hold_invoice` below is irreversible: running it first meant
+    // a rejected request could still refund the seller while leaving the order
+    // in `Dispute`, so the LN side and the DB disagreed with no way back.
+    // Every check that can reject the call now precedes the refund.
+    let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
+        (true, false) => "seller",
+        (false, true) => "buyer",
+        (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
+    };
+
     if let Some(hash) = order.hash.as_ref() {
         // We return funds to seller. A hold invoice that LND already
         // canceled (CLTV expiry refunded the seller long ago) or does not
@@ -152,13 +164,6 @@ pub async fn admin_cancel_action(
 
     // we check if there is a dispute
     let dispute = find_dispute_by_order_id(pool, order.id).await;
-
-    // Get the creator of the dispute
-    let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
-        (true, false) => "seller",
-        (false, true) => "buyer",
-        (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
-    };
 
     if let Ok(mut d) = dispute {
         let dispute_id = d.id;
@@ -690,6 +695,49 @@ mod tests {
             result,
             Err(MostroInternalErr(ServiceError::DisputeEventError))
         ));
+    }
+
+    /// Regression for #805: an order carrying a hold-invoice `hash` whose
+    /// dispute-initiator flags are unset must fail validation *before* the
+    /// irreversible `cancel_hold_invoice`. Reaching the LND seam here would
+    /// surface as `LnNodeError` and would mean the seller was already
+    /// refunded on a request that goes on to be rejected.
+    #[tokio::test]
+    async fn dispute_without_initiator_flag_errors_before_refunding() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        // Hold invoice present, but neither side is flagged as the dispute
+        // initiator, so `dispute_initiator` resolution must reject the call.
+        order.hash = Some("11".repeat(32));
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_cancel_action(
+            &ctx,
+            cancel_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::DisputeEventError))
+            ),
+            "expected the initiator check to reject before the LND cancel, got {result:?}"
+        );
+
+        // The order must be left untouched so the solver can retry.
+        let stored = get_order(&cancel_msg(order.id), ctx.pool()).await.unwrap();
+        assert_eq!(stored.status, Status::Dispute.to_string());
     }
 
     /// A dispute order carrying a hold-invoice `hash` returns funds to the

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -144,7 +144,9 @@ pub async fn admin_cancel_action(
     // and `cancel_hold_invoice` below is irreversible: running it first meant
     // a rejected request could still refund the seller while leaving the order
     // in `Dispute`, so the LN side and the DB disagreed with no way back.
-    // Every check that can reject the call now precedes the refund.
+    // This initiator check now precedes the refund. Operations after the
+    // refund can still fail (dispute/order events, DB updates, DM delivery);
+    // making that path atomic is tracked separately in #810.
     let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
         (true, false) => "seller",
         (false, true) => "buyer",

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -91,6 +91,28 @@ pub async fn admin_settle_action(
     let bond_resolution = bond::extract_bond_resolution(&msg);
     bond::validate_bond_resolution(pool, &order, &bond_resolution).await?;
 
+    // Resolve the dispute initiator *before* the settle (#805, same class as
+    // the fix applied to `admin_cancel`). `settle_seller_hold_invoice` is
+    // irreversible: resolving the initiator afterwards meant a rejected
+    // request had already moved the escrow, and the early return then also
+    // skipped the `AdminSettled` fan-out and the bond resolution below.
+    let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
+        (true, false) => "seller",
+        (false, true) => "buyer",
+        (seller_dispute, buyer_dispute) => {
+            // Only reachable through a corrupted row — `dispute_action`
+            // gates on `Active`/`FiatSent`, so exactly one flag is set by
+            // the time an order reaches `Dispute`.
+            error!(
+                order_id = %order.id,
+                seller_dispute,
+                buyer_dispute,
+                "admin_settle: ambiguous dispute initiator flags; refusing before the escrow is settled"
+            );
+            return Err(MostroInternalErr(ServiceError::DisputeEventError));
+        }
+    };
+
     // Settle seller hold invoice
     settle_seller_hold_invoice(event, ln_client, Action::AdminSettled, true, &order)
         .await
@@ -130,13 +152,6 @@ pub async fn admin_settle_action(
         d.update(pool)
             .await
             .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-
-        // Get the creator of the dispute
-        let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
-            (true, false) => "seller",
-            (false, true) => "buyer",
-            (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
-        };
 
         // We create a tag to show status of the dispute
         let tags = create_dispute_event_tags(
@@ -524,6 +539,50 @@ mod handler_tests {
             result,
             Err(MostroCantDo(CantDoReason::InvalidOrderStatus))
         ));
+    }
+
+    /// Same invariant as `admin_cancel` (#805): with the initiator flags
+    /// unset, the request must be rejected *before* the irreversible
+    /// `settle_seller_hold_invoice`. Pre-fix the initiator was resolved
+    /// after the settle, so this order reached the settle seam and returned
+    /// `LnNodeError` — the escrow moved on a request that was then rejected,
+    /// skipping the `AdminSettled` fan-out and the bond resolution.
+    #[tokio::test]
+    async fn dispute_without_initiator_flag_errors_before_settling() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        // Neither side flagged as initiator; `preimage` is left as the
+        // dispute-order default so the settle seam is genuinely reachable.
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::DisputeEventError))
+            ),
+            "expected the initiator check to reject before the settle, got {result:?}"
+        );
+
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, Status::Dispute.to_string());
     }
 
     /// A genuine dispute settle reaches `settle_seller_hold_invoice`, which

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -91,6 +91,28 @@ pub async fn admin_settle_action(
     let bond_resolution = bond::extract_bond_resolution(&msg);
     bond::validate_bond_resolution(pool, &order, &bond_resolution).await?;
 
+    // Resolve the dispute initiator *before* the settle (#805, same class as
+    // the fix applied to `admin_cancel`). `settle_seller_hold_invoice` is
+    // irreversible: resolving the initiator afterwards meant a rejected
+    // request had already moved the escrow, and the early return then also
+    // skipped the `AdminSettled` fan-out and the bond resolution below.
+    let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
+        (true, false) => "seller",
+        (false, true) => "buyer",
+        (seller_dispute, buyer_dispute) => {
+            // Only reachable through a corrupted row — `dispute_action`
+            // gates on `Active`/`FiatSent`, so exactly one flag is set by
+            // the time an order reaches `Dispute`.
+            error!(
+                order_id = %order.id,
+                seller_dispute,
+                buyer_dispute,
+                "admin_settle: ambiguous dispute initiator flags; refusing before the escrow is settled"
+            );
+            return Err(MostroInternalErr(ServiceError::DisputeEventError));
+        }
+    };
+
     // Settle seller hold invoice
     settle_seller_hold_invoice(event, ln_client, Action::AdminSettled, true, &order)
         .await
@@ -129,13 +151,6 @@ pub async fn admin_settle_action(
         d.update(pool)
             .await
             .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-
-        // Get the creator of the dispute
-        let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
-            (true, false) => "seller",
-            (false, true) => "buyer",
-            (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
-        };
 
         // We create a tag to show status of the dispute
         let tags: Tags = Tags::from_list(vec![
@@ -536,6 +551,50 @@ mod handler_tests {
             result,
             Err(MostroCantDo(CantDoReason::InvalidOrderStatus))
         ));
+    }
+
+    /// Same invariant as `admin_cancel` (#805): with the initiator flags
+    /// unset, the request must be rejected *before* the irreversible
+    /// `settle_seller_hold_invoice`. Pre-fix the initiator was resolved
+    /// after the settle, so this order reached the settle seam and returned
+    /// `LnNodeError` — the escrow moved on a request that was then rejected,
+    /// skipping the `AdminSettled` fan-out and the bond resolution.
+    #[tokio::test]
+    async fn dispute_without_initiator_flag_errors_before_settling() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        // Neither side flagged as initiator; `preimage` is left as the
+        // dispute-order default so the settle seam is genuinely reachable.
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::DisputeEventError))
+            ),
+            "expected the initiator check to reject before the settle, got {result:?}"
+        );
+
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, Status::Dispute.to_string());
     }
 
     /// A genuine dispute settle reaches `settle_seller_hold_invoice`, which


### PR DESCRIPTION
Closes #805.

## The bug

`admin_cancel_action` refunded the seller's escrow **before** it finished validating the request:

```rust
if order.hash.is_some() {
    ln_client.cancel_hold_invoice(hash).await?;   // irreversible
}
...
let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
    (true, false) => "seller",
    (false, true) => "buyer",
    (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),  // rejects — too late
};
```

When neither initiator flag is set (or both are), the handler returns `DisputeEventError` — but `cancel_hold_invoice` has already returned the funds to the seller. The order stays in `Dispute`, the transition to `CanceledByAdmin` never runs, and the dispute row is never moved to `SellerRefunded`. The Lightning side and the DB disagree permanently, and the refund cannot be undone.

## The fix

Move the initiator resolution above the refund, so **every check that can reject the call runs before the escrow is touched**. This is the same ordering discipline already applied to the status guards and the bond-resolution validation just above it (see the existing Phase 2 comment). The valid path — a legitimately flagged initiator — is unchanged.

## Test

New regression test `dispute_without_initiator_flag_errors_before_refunding`: an order with a hold-invoice `hash` and no initiator flag must fail with `DisputeEventError` and be left in `Dispute`.

The test is a genuine before/after discriminator thanks to the existing `dead_lnd()` harness (a real `LndConnector` against a dead endpoint, so any RPC fails fast):

- **Before the fix** it failed with `Err(MostroInternalErr(LnNodeError("code=Unknown message=client error (Connect)")))` — proof the refund RPC had already been dispatched.
- **After the fix** it returns `DisputeEventError` without ever reaching LND.

`dispute_with_hash_reaches_ln_cancel_seam` still passes, confirming the legitimate refund path is untouched.

## Verification
- [x] `cargo test` — **1016 passed, 0 failed**
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all` — clean

## Note
`admin_settle.rs` has related ordering/CAS concerns tracked separately in #809 and #810; this PR deliberately stays scoped to #805.

## Manual testing

The unit tests pin the ordering at the handler seam; this is how to reproduce
the bug and verify the fix end to end against a real LND. **The single
observable that matters throughout: on a request that is going to be
rejected, the hold invoice must still be `ACCEPTED` afterwards.**

### 0. Environment

- LND on regtest (Polar) + a local relay: `cd docker && make docker-up`
  (see `docker/README.md`), or `cargo run` against Polar directly.
- A solver key with `read-write` permission (`admin-add-solver`), plus
  `mostro-cli` for the maker/taker/solver messages.
- Optional but recommended for test E: `[rpc] enabled = true` in
  `settings.toml`, so `CancelOrder` can be driven over gRPC and the error is
  returned to the caller instead of only logged.
- Build the branch: `git checkout fix/admin-cancel-validate-before-refund && cargo run`

Inspection helpers used below (`<ID>` = order id, `<HASH>` = `orders.hash`):

```sh
sqlite3 mostro.db "select status, hash, seller_dispute, buyer_dispute, \
  seller_pubkey is null as no_seller, buyer_pubkey is null as no_buyer \
  from orders where id='<ID>';"
sqlite3 mostro.db "select id, status from disputes where order_id='<ID>';"
sqlite3 mostro.db "select role, state from bonds where order_id='<ID>';"   # only if the bond feature is on
lncli --network regtest lookupinvoice <HASH>       # .state: ACCEPTED | CANCELED | SETTLED
```

### 1. Common setup — a disputed order with a live escrow

1. Maker publishes an order, taker takes it.
2. Seller pays the hold invoice → `lncli lookupinvoice <HASH>` shows
   **`ACCEPTED`**; buyer sends the payout invoice; buyer sends `fiat-sent`.
3. Either party sends `dispute`.
4. Solver sends `admin-take-dispute`.

**Checkpoint before every test below:** `orders.status = dispute`, exactly one
of `seller_dispute` / `buyer_dispute` is `1`, `orders.hash` is set,
`disputes.status = in-progress`, invoice state `ACCEPTED`, any bond rows
`locked`.

### 2. Test A — the legitimate path is unchanged (regression guard)

Send `admin-cancel` for the order as the assigned solver.

Must all hold to approve:

- `lookupinvoice <HASH>` → **`CANCELED`** (escrow returned to the seller).
- `orders.status` → **`canceled-by-admin`**.
- `disputes.status` → **`seller-refunded`**.
- A kind-38386 event is published with `s = seller-refunded` and
  `initiator = <the side that actually opened the dispute>` — this tag must
  match the flag set in step 1.3, not an arbitrary side.
- Solver, seller and buyer all receive the `admin-canceled` DM.
- Bond rows (if enabled) leave `locked` → `released` (or `slashed` when a
  `BondResolution` was attached).

### 3. Test B — ambiguous initiator must not touch the escrow (the #805 bug)

The flags are only corruptible out of band, so force the state directly on a
freshly disputed order (repeat §1):

```sh
sqlite3 mostro.db "update orders set seller_dispute=0, buyer_dispute=0 where id='<ID>';"
```

Send `admin-cancel`. Must all hold:

- `lookupinvoice <HASH>` → **still `ACCEPTED`**. *(On `main` this returns
  `CANCELED`: the seller was refunded on a request that was then rejected.)*
- `orders.status` → still **`dispute`**; `disputes.status` still
  `in-progress`; bond rows still `locked`.
- The daemon logs
  `admin_cancel: ambiguous dispute initiator flags; refusing before the escrow is touched`
  with `order_id`, `seller_dispute=false`, `buyer_dispute=false`.
- Over gRPC the call fails with `Admin cancel failed: … DisputeEventError`;
  over Nostr the daemon logs the warning and **no** `admin-canceled` DM is
  emitted to anyone.
- **Retry proof:** restore the correct flag
  (`update orders set seller_dispute=1 …`) and re-send `admin-cancel` → it
  now completes exactly as in Test A. Nothing was stranded by the rejection.

### 4. Test C — both flags set is equally ambiguous

Same as Test B, but `set seller_dispute=1, buyer_dispute=1`. Same expected
result: rejected, invoice `ACCEPTED`, order `dispute`, same log line with
`seller_dispute=true, buyer_dispute=true`. (Pre-fix this arm also refunded
first.)

### 5. Test D — missing counterparty pubkey is rejected before the refund

On a fresh disputed order:

```sh
sqlite3 mostro.db "update orders set buyer_pubkey=NULL where id='<ID>';"
```

Send `admin-cancel`. Must all hold:

- Rejected with `InvalidPubkey`; `lookupinvoice <HASH>` → **still
  `ACCEPTED`**; `orders.status` still `dispute`; `disputes.status`
  unchanged; bond rows still `locked`.
- Restore the pubkey and re-send → completes as in Test A.

*(On `main` this rejection happened after the refund, after the dispute row
was moved to `seller-refunded` and after the order became
`canceled-by-admin` — past the point where a retry is possible, since the
`Dispute` status guard rejects the second attempt, leaving the bonds
`Locked` with no reconciler.)*

### 6. Test E — a failing DM must not abort the bond resolution

Needs `[rpc] enabled = true` so the command does not travel over the relay
that is about to be stopped.

1. Set up a disputed order per §1, with the bond feature enabled so there are
   `locked` bond rows.
2. Stop the relay (`docker compose stop nostr-relay`).
3. Call `CancelOrder` over gRPC.

Must all hold:

- The gRPC call returns **success**.
- The log shows `admin_cancel: failed to notify the admin/seller/buyer of the
  cancellation: …` (one line per undelivered recipient) — and execution
  continues past them.
- `orders.status = canceled-by-admin`, invoice `CANCELED`, and critically the
  bond rows are **no longer `locked`**.
  *(On `main` the first `send_dm` error returned early, so the bonds stayed
  `Locked` with no retry path.)*

### 7. Test F — `admin-settle` got the same treatment

Fresh disputed order per §1 (buyer payout invoice present), then corrupt the
flags as in Test B and send `admin-settle`.

Must all hold:

- Rejected with `DisputeEventError`; log line
  `admin_settle: ambiguous dispute initiator flags; refusing before the escrow is settled`.
- `lookupinvoice <HASH>` → **still `ACCEPTED`**, i.e. **not `SETTLED`** — the
  seller's escrow was not captured. `orders.status` still `dispute`.
- Restore the flag and re-send `admin-settle` → the invoice goes to
  `SETTLED`, the order leaves `dispute` (`settled-hold-invoice`, then the
  payout to the buyer), `disputes.status = settled`, and the `admin-settled`
  DMs go out.

### 8. Approval criteria

Approve only if **every** criterion below is observed:

| # | Criterion |
|---|-----------|
| 1 | Test A: the legitimate cancel behaves exactly as on `main`, with the correct `initiator` tag. |
| 2 | Tests B, C, D, F: on every rejected request, `lookupinvoice` still reports `ACCEPTED` — **no LND state change at all**. |
| 3 | Tests B, C, D, F: on every rejected request the order stays in `dispute` and the dispute row keeps its previous status. |
| 4 | Tests B, C, D, F: after repairing the row, the retry succeeds — no request is left unrecoverable. |
| 5 | Test E: a dead relay yields a successful cancel with per-recipient error logs, and no bond row left `locked`. |
| 6 | Every rejection is diagnosable from the logs alone (order id + both flag values), with no `admin-canceled` DM sent to any party. |

Reject if any rejected request shows a `CANCELED`/`SETTLED` invoice, an order
that left `dispute`, a bond stuck in `locked` after a successful cancel, or a
retry that is refused after the underlying row was repaired.

**Optional before/after:** run tests B and D against `main` first — the
invoice ends `CANCELED` while the order stays in `dispute`, which is the
exact split-brain #805 describes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added authorized daemon cancellation for pending orders, including bond release and maker-bond resolution.
  * Improved dispute cancellation validation and refund handling, including safer retries for already-settled invoices while preserving transient payment errors.
  * Improved dispute settlement by validating the initiator before irreversible settlement.
  * Made post-refund notifications best effort so delivery failures do not block bond resolution.

* **Tests**
  * Added regression coverage for authorization, validation, race conditions, invoice states, payment errors, and settlement safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->