### PR TITLE
fix(restore-session): scrub Nostr keys from log lines

### DIFF
--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -26,10 +26,10 @@ pub async fn restore_session_action(
         return Err(MostroCantDo(CantDoReason::InvalidPubkey));
     }
 
-    tracing::info!(
-        "Starting background restore session for master key: {}",
-        master_key
-    );
+    // No key in the log line — master_key is the user's persistent Nostr
+    // identity, not a per-trade ephemeral one (AGENTS.md: scrub Nostr keys
+    // from logs).
+    tracing::info!("Starting background restore session");
 
     // Create a new manager for this specific restore session
     let manager = RestoreSessionManager::new();
@@ -99,7 +99,8 @@ async fn send_restore_session_response(
     )
     .await;
 
-    tracing::info!("Restore session response sent to user {}", trade_key,);
+    // No key in the log line (AGENTS.md: scrub Nostr keys from logs).
+    tracing::info!("Restore session response sent to user");
 
     Ok(())
 }
@@ -112,7 +113,8 @@ async fn send_restore_session_timeout(trade_key: &str) -> Result<(), MostroError
     // Send timeout message without payload since Text doesn't exist
     enqueue_restore_session_msg(None, trade_pubkey).await;
 
-    tracing::warn!("Restore session timed out for user: {}", trade_key);
+    // No key in the log line (AGENTS.md: scrub Nostr keys from logs).
+    tracing::warn!("Restore session timed out for user");
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

`AGENTS.md:48` says: *"Scrub logs that might leak invoices or Nostr keys; rotate secrets promptly if exposed."*

`src/app/restore_session.rs` logged `master_key`/`trade_key` verbatim in 3 places (`tracing::info!`/`tracing::warn!`). `master_key` in particular is the user's persistent Nostr identity, not a per-trade ephemeral key — every successful restore-session request hits this path in production (the hex-format validation guards always pass for real `PublicKey` values, so this isn't a rare branch). If these logs reach an external aggregator, anyone with log access can correlate "this identity restored a session at this timestamp" in cleartext.

## Solution

Dropped the key from all 3 log lines. The surrounding message (action + outcome) is still useful for debugging without the identifying value.

## Tests

No test asserted on log content before or after — the fix only removes an interpolated value from 3 `tracing` macro calls, no behavior change. Full suite still green: `cargo test` 1019/1020 passing (the 1 failure is a pre-existing, unrelated local-environment issue — a fixed-port test server colliding with something already bound to :8080, same as on other recent PRs).

`cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` both clean.

Closes #834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed sensitive key information from restore-session logs.
  * Restore-session processing and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->