### PR TITLE
feat: add Nostr trusted-node price provider (#697)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "lnurl-rs",
  "mostro-core",
  "mutants",
+ "nostr-relay-builder",
  "nostr-sdk",
  "once_cell",
  "prost 0.14.4",
@@ -2436,6 +2437,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
 dependencies = [
  "nostr",
+]
+
+[[package]]
+name = "nostr-relay-builder"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ed09e8363503c6f464087b530a1f43cf68be6292bd4928b5ea1141b03dc11c"
+dependencies = [
+ "async-utility",
+ "async-wsocket",
+ "atomic-destructor",
+ "hex",
+ "negentropy",
+ "nostr",
+ "nostr-database",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ tokio = { version = "1.47.1", features = ["full", "test-util", "macros"] }
 axum = "0.8.4"
 tower-http = { version = "0.6.6", features = ["cors"] }
 bech32 = "0.11.0"
+nostr-relay-builder = "0.44.1"
 
 [build-dependencies]
 tonic-prost-build = "0.14.1"

--- a/docs/PRICE_PROVIDERS.md
+++ b/docs/PRICE_PROVIDERS.md
@@ -480,6 +480,14 @@ only = ["CUP", "MLC"]    # El Toque is only meaningful for these (§6.6)
 
 Phases 3 and 4 both depend on Phase 2 and can land in either order.
 
+> **Out-of-band addition — Nostr *subscribe* (issue #697, §11.7).** The
+> five phases above only ever covered *publishing* rates to Nostr (Phase 5).
+> A separate, independently-landing addition — the `nostr` provider — makes
+> `mostrod` able to *consume* another Mostro node's published rates instead
+> of an HTTP API, for operators in regions where the price APIs are
+> network-blocked. It slots into the existing registry (§5.4) like any
+> other provider and does not otherwise depend on Phase 5.
+
 ---
 
 ## 9. Phase details
@@ -837,6 +845,52 @@ BTCPayServer solves the same problem; contrasting choices clarify ours:
   premium/fee is the only markup. We call this out so the spread concept
   is not reintroduced by accident when porting a provider idea from
   BTCPay.
+
+### 11.7 Nostr (subscribe, trusted-node relay mode) — issue #697
+
+Every source above is an HTTP API. This one is not: it sources quotes from
+**other Mostro nodes**, over Nostr, for operators whose network blocks the
+HTTP price APIs outright (the motivating case: `api.yadio.io` is DNS-blocked
+for Venezuelan ISPs) but who can still reach a Nostr relay.
+
+- **Not a new publish path.** Mostro nodes already publish their aggregated
+  rates as a kind-30078 NIP-33 event (`d = "mostro-rates"`, content
+  `{"BTC": {ccy: price}}`) — see `docs/NOSTR_EXCHANGE_RATES.md` and
+  `nip33::new_exchange_rates_event`. The `nostr` provider is a **consumer**
+  of that exact same event, from other operators' nodes instead of its own.
+- **Config (`[price.providers.nostr]`, §7):** no `url` — `trusted_nodes` (a
+  list of hex pubkeys) is the provider's only required field. Enabled
+  without at least one valid `trusted_nodes` pubkey is a startup error
+  (mirrors El Toque's missing-token fail-fast, §7).
+- **Relays are not reconfigured.** The provider reuses the process-wide
+  Nostr client already connected to the node's own `[nostr]` relays — it
+  does not open a second set of connections or accept a separate relay list.
+- **One-shot query per tick, not a persistent subscription.** `fetch()` is
+  called once per `update_interval_seconds` tick like every other provider
+  (spec §5.3); it issues a single `kind=30078, authors=trusted_nodes,
+  #d=mostro-rates` relay query bounded by a short fixed timeout, rather than
+  keeping an open `REQ` subscription running between ticks.
+- **Freshest wins — no cross-node combine.** With several `trusted_nodes`
+  configured, the provider does **not** run the §6.2 median+outlier combine
+  across their individual events; it takes the single event with the
+  highest `created_at` among the trusted, valid ones. Rationale (confirmed
+  with the maintainer): the issue frames multiple `trusted_nodes` as
+  *redundancy* (if one is down or stale, use another), not as independent
+  samples to statistically combine, and skipping a second aggregation layer
+  inside a single provider keeps the adapter's contract identical to every
+  HTTP provider (one `ProviderQuotes` map out of `fetch()`, no new state).
+  A compromised single trusted node can therefore still push a bad price
+  with no in-provider outlier guard; operators mitigate by choosing
+  `trusted_nodes` they actually trust, same as any other single-sourced
+  provider.
+- **Client-side pubkey verification.** Even though the relay-side `authors`
+  filter already restricts the query, the adapter re-checks each returned
+  event's `pubkey` against `trusted_nodes` before trusting its content —
+  the same verification `docs/NOSTR_EXCHANGE_RATES.md` requires of mobile
+  clients, applied here on the operator side.
+- **Currency codes are re-upper-cased** (§6.6) even though a Mostro
+  publisher already emits uppercase codes — a third-party trusted node is
+  outside this codebase's control.
 
 ---
 

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -180,6 +180,17 @@ port = 50051
 # url = "https://tasas.eltoque.com"
 # # token = "xxxx"        # REQUIRED when enabled; provider refuses to start otherwise
 # only = ["CUP", "MLC"]
+#
+# # Subscribe to prices published (kind 30078) by trusted Mostro nodes over
+# # Nostr instead of an HTTP API — for operators in regions where price APIs
+# # are DNS/IP blocked (docs/PRICE_PROVIDERS.md §11.7). Reuses the relays
+# # already configured in [nostr]; no url needed. With several trusted_nodes,
+# # the freshest valid event wins — not a cross-node combine.
+# [price.providers.nostr]
+# enabled = false
+# trusted_nodes = [
+#     # hex pubkeys of Mostro nodes you trust to publish accurate rates
+# ]
 
 # Anti-abuse bond (issue #711). Opt-in, disabled by default. Uncomment to
 # require a Lightning hold-invoice bond from takers and/or makers. See

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -30,6 +30,14 @@ pub use types::{
 // They are shared across the application using Arc and Mutex/RwLock for thread safety
 pub static MOSTRO_CONFIG: OnceLock<Settings> = OnceLock::new();
 pub static NOSTR_CLIENT: OnceLock<Client> = OnceLock::new();
+/// Dedicated Nostr client for the price provider's kind-30078 queries.
+///
+/// Kept separate from [`NOSTR_CLIENT`] so `verify_subscriptions(true)` (and
+/// the REQ `limit` it enforces) applies only to price fetches — not to the
+/// daemon's long-lived `.limit(0)` inbox subscription in `main.rs`, where
+/// pre-EOSE filter verification would reject matching trade messages
+/// (hermeme, PR #841).
+pub static PRICE_NOSTR_CLIENT: OnceLock<Client> = OnceLock::new();
 pub static LN_STATUS: OnceLock<LnStatus> = OnceLock::new();
 pub static DB_POOL: OnceLock<Arc<sqlx::SqlitePool>> = OnceLock::new();
 

--- a/src/price/aggregate.rs
+++ b/src/price/aggregate.rs
@@ -2,7 +2,7 @@
 //! function is a deterministic transform over in-memory inputs, which is
 //! what makes the numeric heart of the feature exhaustively testable.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::provider::{ProviderId, ProviderQuotes, Quote};
 
@@ -164,7 +164,11 @@ pub fn aggregate_tick(
         }
     }
     let mut resolved: HashMap<String, Vec<(ProviderId, f64)>> = HashMap::new();
-    let mut resolved_nostr_anchor: HashMap<String, bool> = HashMap::new();
+    // Providers whose *resolved* candidate for a currency came from a
+    // Nostr-touched anchor. Taint is applied only if that provider later
+    // survives the target currency's outlier filter (step 3) — a discarded
+    // wild cross must not mark an otherwise-local aggregate dependent.
+    let mut nostr_anchored_resolvers: HashMap<String, HashSet<ProviderId>> = HashMap::new();
     for (id, currency, base, value) in &per_base {
         if let Some(anchor) = anchors.get(base) {
             let candidate = value * anchor;
@@ -174,7 +178,10 @@ pub fn aggregate_tick(
                     .or_default()
                     .push((*id, candidate));
                 if *anchor_uses_nostr.get(base).unwrap_or(&false) {
-                    resolved_nostr_anchor.insert(currency.clone(), true);
+                    nostr_anchored_resolvers
+                        .entry(currency.clone())
+                        .or_default()
+                        .insert(*id);
                 }
             }
         }
@@ -201,13 +208,16 @@ pub fn aggregate_tick(
                 .filter(|x| x.is_finite() && **x > 0.0)
                 .count()
                 .min(u8::MAX as usize) as u8;
+            let nostr_anchor_dependent = nostr_anchored_resolvers
+                .get(currency)
+                .is_some_and(|tainted| contributors.iter().any(|c| tainted.contains(c)));
             out.insert(
                 currency.clone(),
                 AggregateResult {
                     value,
                     sources,
                     contributors,
-                    nostr_anchor_dependent: *resolved_nostr_anchor.get(currency).unwrap_or(&false),
+                    nostr_anchor_dependent,
                 },
             );
         }
@@ -440,6 +450,48 @@ mod tests {
         assert!(
             !out["USD"].nostr_anchor_dependent,
             "direct Nostr USD is Nostr-only via contributors, not via anchor taint"
+        );
+    }
+
+    #[test]
+    fn aggregate_tick_nostr_anchor_taint_clears_when_cross_is_outlier() {
+        // Local direct quotes agree near 100; a Nostr-anchored El Toque
+        // cross at 10000 is discarded by the 5% outlier band. The final
+        // value is fully local — it must NOT stay nostr_anchor_dependent
+        // (ermeme follow-up on a8a6aef2).
+        let mut nostr = ProviderQuotes::new();
+        nostr.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("CUP".into(), Quote::PerBtc(100.0));
+        let mut coingecko = ProviderQuotes::new();
+        coingecko.insert("CUP".into(), Quote::PerBtc(101.0));
+        let mut eltoque = ProviderQuotes::new();
+        eltoque.insert(
+            "CUP".into(),
+            Quote::PerBase {
+                base: "USD".into(),
+                value: 0.2, // 0.2 * 50_000 = 10_000 — wildly above local CUP
+            },
+        );
+
+        let out = aggregate_tick(
+            &[
+                (ProviderId::Nostr, nostr),
+                (ProviderId::Yadio, yadio),
+                (ProviderId::CoinGecko, coingecko),
+                (ProviderId::ElToque, eltoque),
+            ],
+            PCT,
+        );
+
+        approx(out["CUP"].value, 100.5);
+        assert_eq!(
+            out["CUP"].contributors,
+            vec![ProviderId::Yadio, ProviderId::CoinGecko]
+        );
+        assert!(
+            !out["CUP"].nostr_anchor_dependent,
+            "outlier-discarded Nostr-anchored cross must not taint a local aggregate"
         );
     }
 

--- a/src/price/aggregate.rs
+++ b/src/price/aggregate.rs
@@ -14,11 +14,20 @@ use super::provider::{ProviderId, ProviderQuotes, Quote};
 /// value actually **survived** [`combine`]'s outlier filter — what the
 /// Nostr `source` tag really means. The two can differ: with three
 /// providers and one outlier the count is 3 but contributors is 2.
+///
+/// `nostr_anchor_dependent` is true when a fiat-cross (`PerBase`) path for
+/// this currency resolved against an anchor that itself included `Nostr`
+/// among its surviving direct contributors. The absolute per-BTC figure
+/// then embeds a relayed rate even if `contributors` only names the
+/// cross provider (e.g. El Toque × Nostr USD → CUP tagged `eltoque`).
+/// [`crate::price::manager`] uses this so republication cannot re-stamp
+/// that hybrid as a fresh local observation (PR #841 re-review).
 #[derive(Debug, Clone, PartialEq)]
 pub struct AggregateResult {
     pub value: f64,
     pub sources: u8,
     pub contributors: Vec<ProviderId>,
+    pub nostr_anchor_dependent: bool,
 }
 
 /// Combine a currency's candidate per-BTC prices into one figure (spec §6.2).
@@ -111,8 +120,9 @@ pub fn resolve_per_base(
 ///    their provider id**.
 /// 2. Per-currency **anchors** are the [`combine`]d direct quotes; fiat-cross
 ///    (`PerBase`) quotes are resolved against those anchors and attributed
-///    to the fiat-cross provider (the anchor's own contributors are an
-///    intermediate, not a contributor to the resolved currency).
+///    to the fiat-cross provider (the anchor's own contributors stay out of
+///    `contributors` — they are an intermediate of the cross math — but a
+///    Nostr-touched anchor sets `nostr_anchor_dependent` on the result).
 /// 3. Each currency's final value is the [`combine`] of its direct **and**
 ///    resolved candidates. `contributors` lists the providers whose value
 ///    survived the outlier filter ([`kept_contributors`]) — what the Nostr
@@ -138,20 +148,23 @@ pub fn aggregate_tick(
         }
     }
 
-    // Step 2: anchors = aggregated direct quotes (values only), then
-    // resolve cross quotes — attributing each resolved candidate to the
-    // fiat-cross provider that emitted it. Anchor contributors are *not*
-    // propagated into resolved-currency contributors: they are an
-    // intermediate of the cross math, not an upstream of the cross
-    // currency.
+    // Step 2: anchors = aggregated direct quotes, then resolve cross quotes.
+    // Track whether each anchor's surviving contributors include Nostr so a
+    // later PerBase resolution can mark the cross currency as
+    // `nostr_anchor_dependent` without putting Nostr into `contributors`
+    // (which would change the published `source` tag's meaning).
     let mut anchors: HashMap<String, f64> = HashMap::new();
+    let mut anchor_uses_nostr: HashMap<String, bool> = HashMap::new();
     for (currency, pairs) in &direct {
         let values: Vec<f64> = pairs.iter().map(|(_, v)| *v).collect();
         if let Some(v) = combine(&values, outlier_pct) {
             anchors.insert(currency.clone(), v);
+            let kept = kept_contributors(pairs, outlier_pct);
+            anchor_uses_nostr.insert(currency.clone(), kept.contains(&ProviderId::Nostr));
         }
     }
     let mut resolved: HashMap<String, Vec<(ProviderId, f64)>> = HashMap::new();
+    let mut resolved_nostr_anchor: HashMap<String, bool> = HashMap::new();
     for (id, currency, base, value) in &per_base {
         if let Some(anchor) = anchors.get(base) {
             let candidate = value * anchor;
@@ -160,6 +173,9 @@ pub fn aggregate_tick(
                     .entry(currency.clone())
                     .or_default()
                     .push((*id, candidate));
+                if *anchor_uses_nostr.get(base).unwrap_or(&false) {
+                    resolved_nostr_anchor.insert(currency.clone(), true);
+                }
             }
         }
     }
@@ -191,6 +207,7 @@ pub fn aggregate_tick(
                     value,
                     sources,
                     contributors,
+                    nostr_anchor_dependent: *resolved_nostr_anchor.get(currency).unwrap_or(&false),
                 },
             );
         }
@@ -385,6 +402,44 @@ mod tests {
         assert_eq!(
             out["CUP"].contributors,
             vec![ProviderId::Yadio, ProviderId::ElToque]
+        );
+        assert!(
+            !out["CUP"].nostr_anchor_dependent,
+            "Yadio/CoinGecko USD anchor is local — CUP cross is not Nostr-tainted"
+        );
+    }
+
+    #[test]
+    fn aggregate_tick_marks_cross_resolved_via_nostr_usd_as_anchor_dependent() {
+        // Nostr is the only USD source; El Toque CUP/USD resolves against it.
+        // contributors stay [ElToque] (anchor providers are intermediates),
+        // but nostr_anchor_dependent must be set so republication cannot
+        // re-stamp the hybrid as a fresh local observation.
+        let mut nostr = ProviderQuotes::new();
+        nostr.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let mut eltoque = ProviderQuotes::new();
+        eltoque.insert(
+            "CUP".into(),
+            Quote::PerBase {
+                base: "USD".into(),
+                value: 400.0,
+            },
+        );
+
+        let out = aggregate_tick(
+            &[(ProviderId::Nostr, nostr), (ProviderId::ElToque, eltoque)],
+            PCT,
+        );
+
+        approx(out["CUP"].value, 20_000_000.0);
+        assert_eq!(out["CUP"].contributors, vec![ProviderId::ElToque]);
+        assert!(
+            out["CUP"].nostr_anchor_dependent,
+            "CUP absolute value embeds Nostr USD and must be flagged"
+        );
+        assert!(
+            !out["USD"].nostr_anchor_dependent,
+            "direct Nostr USD is Nostr-only via contributors, not via anchor taint"
         );
     }
 

--- a/src/price/config.rs
+++ b/src/price/config.rs
@@ -47,7 +47,10 @@ pub struct ProviderConfig {
     /// Whether this provider participates in aggregation.
     #[serde(default)]
     pub enabled: bool,
-    /// Primary base URL.
+    /// Primary base URL. Not needed by a provider sourcing quotes over Nostr
+    /// instead of HTTP (see `trusted_nodes`) — defaults to empty so those
+    /// providers can omit it.
+    #[serde(default)]
     pub url: String,
     /// Ordered mirrors tried when `url` fails this tick (spec §7).
     #[serde(default)]
@@ -65,6 +68,10 @@ pub struct ProviderConfig {
     /// Exclude these currencies from this provider (spec §6.6).
     #[serde(default)]
     pub except: Option<Vec<String>>,
+    /// Trusted node pubkeys (hex) to source quotes from over Nostr, instead
+    /// of an HTTP `url` (the `nostr` provider; see §11.7).
+    #[serde(default)]
+    pub trusted_nodes: Vec<String>,
 }
 
 impl ProviderConfig {
@@ -78,11 +85,25 @@ impl ProviderConfig {
                  (see docs/PRICE_PROVIDERS.md §7)"
             ));
         }
+        // `trusted_nodes` only excuses a missing `url` for the `nostr`
+        // provider — it's the only adapter that reads it (§11.7). Any other
+        // id is still HTTP-only, so exempting it here would let a typo'd or
+        // copy-pasted `trusted_nodes` mask a missing `url` past startup and
+        // into a confusing per-tick HTTP failure instead.
         if self.enabled && self.url.trim().is_empty() {
-            return Err(format!(
-                "price provider '{id}': enabled provider must have a non-empty `url` \
-                 (see docs/PRICE_PROVIDERS.md §7)"
-            ));
+            if id == "nostr" {
+                if self.trusted_nodes.is_empty() {
+                    return Err(format!(
+                        "price provider '{id}': enabled provider must have a non-empty \
+                         `trusted_nodes` (see docs/PRICE_PROVIDERS.md §11.7)"
+                    ));
+                }
+            } else {
+                return Err(format!(
+                    "price provider '{id}': enabled provider must have a non-empty `url` \
+                     (see docs/PRICE_PROVIDERS.md §7)"
+                ));
+            }
         }
         Ok(())
     }
@@ -217,13 +238,21 @@ enabled = false
 url = "https://tasas.eltoque.com"
 token = "secret"
 only = ["CUP", "MLC"]
+
+[price.providers.nostr]
+enabled = false
+trusted_nodes = ["82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390"]
 "#;
         let parsed: Stub = toml::from_str(toml_str).unwrap();
         let p = parsed.price;
         // Overridden value + defaulted siblings.
         assert_eq!(p.update_interval_seconds, 60);
         assert_eq!(p.max_price_staleness_seconds, 1800);
-        assert_eq!(p.providers.len(), 3);
+        assert_eq!(p.providers.len(), 4);
+
+        let nostr = &p.providers["nostr"];
+        assert!(nostr.url.is_empty());
+        assert_eq!(nostr.trusted_nodes.len(), 1);
 
         let ca = &p.providers["currency_api"];
         assert!(ca.enabled);
@@ -251,6 +280,7 @@ only = ["CUP", "MLC"]
             token: None,
             only: Some(vec!["CUP".into()]),
             except: Some(vec!["MLC".into()]),
+            trusted_nodes: vec![],
         };
         assert!(cfg.validate("eltoque").is_err());
     }
@@ -298,6 +328,7 @@ only = ["CUP", "MLC"]
             token: None,
             only: None,
             except: None,
+            trusted_nodes: vec![],
         };
         assert!(blank.validate("yadio").is_err());
         // A disabled provider with a blank url is allowed (inert).
@@ -306,6 +337,55 @@ only = ["CUP", "MLC"]
             ..blank.clone()
         };
         disabled.validate("yadio").unwrap();
+    }
+
+    #[test]
+    fn enabled_provider_with_trusted_nodes_needs_no_url() {
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec!["a".repeat(64)],
+        };
+        cfg.validate("nostr").unwrap();
+    }
+
+    #[test]
+    fn trusted_nodes_does_not_excuse_a_missing_url_on_a_non_nostr_provider() {
+        // Regression: `trusted_nodes` only means anything to the `nostr`
+        // adapter. A copy-paste onto e.g. `yadio` must not silently pass
+        // validation and defer the failure to a confusing per-tick HTTP
+        // error against an empty URL.
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec!["a".repeat(64)],
+        };
+        assert!(cfg.validate("yadio").is_err());
+    }
+
+    #[test]
+    fn enabled_provider_without_url_or_trusted_nodes_is_rejected() {
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec![],
+        };
+        assert!(cfg.validate("nostr").is_err());
     }
 
     #[test]
@@ -318,6 +398,7 @@ only = ["CUP", "MLC"]
             token: None,
             only: None,
             except: None,
+            trusted_nodes: vec![],
         };
         assert!(cfg.allows_currency("USD"));
         assert!(cfg.allows_currency("CUP"));

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -108,7 +108,12 @@ impl PriceManager {
             }
             match id_str.parse::<ProviderId>() {
                 Ok(id) => {
-                    let provider = build_provider(id, cfg, settings.provider_timeout_seconds)?;
+                    let provider = build_provider(
+                        id,
+                        cfg,
+                        settings.provider_timeout_seconds,
+                        settings.max_price_staleness_seconds,
+                    )?;
                     providers.push(EnabledProvider {
                         id,
                         provider,
@@ -574,6 +579,7 @@ fn build_provider(
     id: ProviderId,
     cfg: &ProviderConfig,
     provider_timeout_seconds: u64,
+    max_price_staleness_seconds: i64,
 ) -> Result<Box<dyn PriceProvider>, String> {
     match id {
         ProviderId::Yadio => Ok(Box::new(YadioProvider::new(cfg))),
@@ -586,10 +592,14 @@ fn build_provider(
         ProviderId::ElToque => Ok(Box::new(ElToqueProvider::new(cfg)?)),
         // Nostr trusted-node relay mode (§11.7). `new` returns `Err` when
         // `trusted_nodes` is empty or contains an unparsable hex pubkey.
-        // `provider_timeout_seconds` sizes its one-shot relay query so it
-        // stays in sync with the shared budget instead of a fixed constant
-        // (CodeRabbit, PR #841).
-        ProviderId::Nostr => Ok(Box::new(NostrProvider::new(cfg, provider_timeout_seconds)?)),
+        // `provider_timeout_seconds` sizes its one-shot relay query;
+        // `max_price_staleness_seconds` is the freshness gate on event
+        // `created_at` so zombie relay data cannot refresh the store clock.
+        ProviderId::Nostr => Ok(Box::new(NostrProvider::new(
+            cfg,
+            provider_timeout_seconds,
+            max_price_staleness_seconds,
+        )?)),
     }
 }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -323,8 +323,7 @@ impl PriceManager {
         report.contributors = contributors;
 
         if self.settings.publish_to_nostr {
-            self.publish_rates_to_nostr(&aggregates, &report.contributors)
-                .await;
+            self.publish_rates_to_nostr(&aggregates).await;
         }
 
         report
@@ -499,11 +498,7 @@ impl PriceManager {
     /// **contributing** provider ids (spec §9 Phase 1: still effectively
     /// one source, but the multi-source shape is in place). Publishing is
     /// best-effort and never fails the tick.
-    async fn publish_rates_to_nostr(
-        &self,
-        aggregates: &HashMap<String, AggregateResult>,
-        successes: &[ProviderId],
-    ) {
+    async fn publish_rates_to_nostr(&self, aggregates: &HashMap<String, AggregateResult>) {
         // Build the `{"BTC": {ccy: value}}` body the legacy format used.
         let rates = republishable_rates(aggregates);
         if rates.is_empty() {
@@ -513,6 +508,9 @@ impl PriceManager {
             );
             return;
         }
+        // Derived before `rates` is moved into the body it describes.
+        let source_tag = sources_to_tag(&republished_contributors(aggregates, &rates));
+
         let mut wrapper: HashMap<String, HashMap<String, f64>> = HashMap::new();
         wrapper.insert("BTC".to_string(), rates);
 
@@ -536,7 +534,6 @@ impl PriceManager {
         // Match legacy bitcoin_price.rs: 2× the interval, capped at 1h.
         let expiration_seconds = std::cmp::min(self.settings.update_interval_seconds * 2, 3600);
         let expiration = timestamp + expiration_seconds as i64;
-        let source_tag = sources_to_tag(successes);
         let tags = Tags::from_list(vec![
             Tag::custom(
                 TagKind::Custom("published_at".into()),
@@ -633,6 +630,26 @@ fn republishable_rates(aggregates: &HashMap<String, AggregateResult>) -> HashMap
         .iter()
         .filter(|(_, a)| a.contributors != [ProviderId::Nostr])
         .map(|(c, a)| (c.clone(), a.value))
+        .collect()
+}
+
+/// Providers that actually contributed to the republished payload.
+///
+/// The tick-wide contributor list covers every aggregate, but
+/// `republishable_rates` can drop currencies — so a provider whose every
+/// contribution was filtered out would still be named in the `source` tag
+/// of a body carrying none of its data. Deriving the tag from the
+/// surviving currencies keeps the tag honest about what actually ships.
+fn republished_contributors(
+    aggregates: &HashMap<String, AggregateResult>,
+    rates: &HashMap<String, f64>,
+) -> Vec<ProviderId> {
+    aggregates
+        .iter()
+        .filter(|(currency, _)| rates.contains_key(*currency))
+        .flat_map(|(_, a)| a.contributors.iter().copied())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
         .collect()
 }
 
@@ -1210,6 +1227,47 @@ mod tests {
         assert!(
             !out.contains_key("ARS"),
             "Nostr-only-sourced ARS must not be republished with a fresh timestamp"
+        );
+    }
+
+    #[test]
+    fn republished_contributors_omits_a_provider_whose_currencies_were_all_dropped() {
+        // Nostr's only contribution is the ARS aggregate, which
+        // `republishable_rates` drops as Nostr-only — so the published body
+        // carries nothing from Nostr and the `source` tag must not claim it.
+        let mut aggregates = HashMap::new();
+        aggregates.insert(
+            "USD".to_string(),
+            AggregateResult {
+                value: 50_000.0,
+                sources: 2,
+                contributors: vec![ProviderId::Yadio, ProviderId::CoinGecko],
+            },
+        );
+        aggregates.insert(
+            "ARS".to_string(),
+            AggregateResult {
+                value: 105_000_000.0,
+                sources: 1,
+                contributors: vec![ProviderId::Nostr],
+            },
+        );
+
+        let rates = republishable_rates(&aggregates);
+        let contributors = republished_contributors(&aggregates, &rates);
+
+        assert_eq!(
+            contributors,
+            vec![ProviderId::Yadio, ProviderId::CoinGecko]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            "only the providers behind the surviving USD rate belong in the tag"
+        );
+        assert!(
+            !sources_to_tag(&contributors).contains("nostr"),
+            "the `source` tag must not name a provider absent from the body"
         );
     }
 
@@ -1851,9 +1909,7 @@ mod coverage_tests {
                 contributors: vec![ProviderId::Yadio],
             },
         );
-        manager
-            .publish_rates_to_nostr(&aggregates, &[ProviderId::Yadio])
-            .await;
+        manager.publish_rates_to_nostr(&aggregates).await;
     }
 
     #[tokio::test]

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -42,6 +42,7 @@ use super::providers::blockchain::BlockchainProvider;
 use super::providers::coingecko::CoinGeckoProvider;
 use super::providers::currency_api::CurrencyApiProvider;
 use super::providers::eltoque::ElToqueProvider;
+use super::providers::nostr::NostrProvider;
 use super::providers::yadio::YadioProvider;
 use super::store::{PriceError, PriceStore};
 
@@ -579,6 +580,9 @@ fn build_provider(id: ProviderId, cfg: &ProviderConfig) -> Result<Box<dyn PriceP
         // required Bearer token is missing, so an enabled-but-unconfigured
         // provider fails fast at startup (spec §7).
         ProviderId::ElToque => Ok(Box::new(ElToqueProvider::new(cfg)?)),
+        // Nostr trusted-node relay mode (§11.7). `new` returns `Err` when
+        // `trusted_nodes` is empty or contains an unparsable hex pubkey.
+        ProviderId::Nostr => Ok(Box::new(NostrProvider::new(cfg)?)),
     }
 }
 
@@ -640,6 +644,7 @@ pub fn synthesise_legacy_price_settings(
             token: None,
             only: None,
             except: None,
+            trusted_nodes: vec![],
         },
     );
     PriceSettings {
@@ -712,6 +717,7 @@ mod tests {
                     token: None,
                     only: None,
                     except: None,
+                    trusted_nodes: vec![],
                 },
             );
             providers.push(EnabledProvider {
@@ -854,6 +860,7 @@ mod tests {
             token: token.map(String::from),
             only: Some(vec!["CUP".into(), "MLC".into()]),
             except: None,
+            trusted_nodes: vec![],
         }
     }
 
@@ -882,6 +889,52 @@ mod tests {
     }
 
     #[test]
+    fn from_settings_builds_nostr_with_trusted_nodes() {
+        // §11.7: Nostr trusted-node relay mode builds into the registry like
+        // any other provider once it has at least one valid pubkey.
+        let mut settings = PriceSettings::default();
+        settings.providers.insert(
+            ProviderId::Nostr.to_string(),
+            ProviderConfig {
+                enabled: true,
+                url: String::new(),
+                fallback_urls: vec![],
+                api_key: None,
+                token: None,
+                only: None,
+                except: None,
+                trusted_nodes: vec![
+                    "82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390".into(),
+                ],
+            },
+        );
+        let m = PriceManager::from_settings(settings).expect("nostr builds with trusted_nodes");
+        assert_eq!(m.providers.len(), 1);
+        assert_eq!(m.providers[0].id, ProviderId::Nostr);
+    }
+
+    #[test]
+    fn from_settings_rejects_nostr_with_invalid_pubkey() {
+        // §11.7 fail-fast: an enabled Nostr provider with an unparsable
+        // trusted-node pubkey must not silently produce no quotes.
+        let mut settings = PriceSettings::default();
+        settings.providers.insert(
+            ProviderId::Nostr.to_string(),
+            ProviderConfig {
+                enabled: true,
+                url: String::new(),
+                fallback_urls: vec![],
+                api_key: None,
+                token: None,
+                only: None,
+                except: None,
+                trusted_nodes: vec!["not-a-pubkey".into()],
+            },
+        );
+        assert!(PriceManager::from_settings(settings).is_err());
+    }
+
+    #[test]
     fn from_settings_builds_all_phase2_providers() {
         // Spec §9 Phase 2: the three keyless backups join Yadio in the
         // registry — the §7 example config must now build cleanly.
@@ -902,6 +955,7 @@ mod tests {
                     token: None,
                     only: None,
                     except: None,
+                    trusted_nodes: vec![],
                 },
             );
         }
@@ -925,6 +979,7 @@ mod tests {
                 token: None,
                 only: None,
                 except: None,
+                trusted_nodes: vec![],
             },
         );
         let m = PriceManager::from_settings(settings).expect("unknown id is non-fatal");
@@ -944,6 +999,7 @@ mod tests {
                 token: None,
                 only: None,
                 except: None,
+                trusted_nodes: vec![],
             },
         );
         let m = PriceManager::from_settings(settings).unwrap();
@@ -1493,6 +1549,7 @@ mod coverage_tests {
                 token: None,
                 only: None,
                 except: None,
+                trusted_nodes: vec![],
             },
         );
         let manager = bare_manager(
@@ -1596,6 +1653,7 @@ mod coverage_tests {
                 token: None,
                 only: None,
                 except: None,
+                trusted_nodes: vec![],
             },
         );
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -288,6 +288,14 @@ impl PriceManager {
                 (id, self.scope_quotes(id, fiat_only))
             })
             .collect();
+        // Nostr is a relay of another node's *already-aggregated* rate, not
+        // an independent peer observation (re-review, PR #841): that node's
+        // own direct sources already fed into the value it published, so
+        // blending it into the median/mean here alongside this node's own
+        // direct sources would double-count correlated information and skew
+        // the result. Keep it strictly fallback — only for currencies no
+        // other provider covered this tick.
+        let filtered_with_ids = restrict_nostr_to_fallback(filtered_with_ids);
 
         let aggregates = aggregate_tick(&filtered_with_ids, self.settings.outlier_threshold_pct);
         if aggregates.is_empty() {
@@ -497,10 +505,14 @@ impl PriceManager {
         successes: &[ProviderId],
     ) {
         // Build the `{"BTC": {ccy: value}}` body the legacy format used.
-        let rates: HashMap<String, f64> = aggregates
-            .iter()
-            .map(|(c, a)| (c.clone(), a.value))
-            .collect();
+        let rates = republishable_rates(aggregates);
+        if rates.is_empty() {
+            debug!(
+                "price: nothing to republish to Nostr this tick \
+                 (every fresh currency was Nostr-only sourced)"
+            );
+            return;
+        }
         let mut wrapper: HashMap<String, HashMap<String, f64>> = HashMap::new();
         wrapper.insert("BTC".to_string(), rates);
 
@@ -554,13 +566,67 @@ impl PriceManager {
         match tokio::time::timeout(timeout_duration, client.send_event(&event)).await {
             Ok(Ok(output)) => info!(
                 "price: published exchange rates to Nostr ({} currencies). Output: {:?}",
-                aggregates.len(),
+                wrapper["BTC"].len(),
                 output
             ),
             Ok(Err(e)) => error!("price: send_event to relays failed: {e}"),
             Err(_) => error!("price: timeout publishing exchange rates to Nostr (30s exceeded)"),
         }
     }
+}
+
+/// Drop the `Nostr` provider's quotes for any currency another provider
+/// already covered this tick, leaving every other provider untouched.
+///
+/// A trusted-node `nostr` quote is a relayed *aggregate*, not an
+/// independent local observation — the remote node already ran its own
+/// direct sources through `combine` to produce it. Feeding it into this
+/// node's `aggregate_tick` alongside those same kinds of direct sources
+/// would let one upstream signal count twice (once locally, once via the
+/// remote's combine) and skew the median/mean. Restricting it to
+/// currencies nobody else reported keeps it strictly a gap-filler — its
+/// documented purpose (spec §11.7: operators whose direct APIs are
+/// blocked) — while a fully-covered currency's value stays whatever the
+/// direct sources agree on.
+fn restrict_nostr_to_fallback(
+    results: Vec<(ProviderId, ProviderQuotes)>,
+) -> Vec<(ProviderId, ProviderQuotes)> {
+    let mut covered_elsewhere: HashSet<String> = HashSet::new();
+    for (id, quotes) in &results {
+        if *id != ProviderId::Nostr {
+            covered_elsewhere.extend(quotes.keys().cloned());
+        }
+    }
+    results
+        .into_iter()
+        .map(|(id, quotes)| {
+            if id != ProviderId::Nostr {
+                return (id, quotes);
+            }
+            let fallback_only: ProviderQuotes = quotes
+                .into_iter()
+                .filter(|(currency, _)| !covered_elsewhere.contains(currency))
+                .collect();
+            (id, fallback_only)
+        })
+        .collect()
+}
+
+/// Currencies fit to republish to Nostr this tick: everything **except**
+/// those whose only surviving contributor is `Nostr` itself.
+///
+/// Republishing a Nostr-only-sourced value with this node's own fresh
+/// `created_at`/`expiration` would erase how old the underlying quote
+/// actually is — a self-trust or A↔B trust cycle could keep a long-dead
+/// upstream quote looking perpetually fresh, one relay hop at a time
+/// (re-review, PR #841). A currency this node independently corroborated
+/// (any non-Nostr contributor) is unaffected and republishes as before.
+fn republishable_rates(aggregates: &HashMap<String, AggregateResult>) -> HashMap<String, f64> {
+    aggregates
+        .iter()
+        .filter(|(_, a)| a.contributors != [ProviderId::Nostr])
+        .map(|(c, a)| (c.clone(), a.value))
+        .collect()
 }
 
 /// Joined list of contributing provider ids for the Nostr `source` tag.
@@ -1027,6 +1093,103 @@ mod tests {
     fn sources_to_tag_is_deterministic() {
         let tag = sources_to_tag(&[ProviderId::CoinGecko, ProviderId::Yadio]);
         assert_eq!(tag, "coingecko,yadio");
+    }
+
+    #[test]
+    fn restrict_nostr_to_fallback_drops_currencies_another_provider_covers() {
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let mut nostr = ProviderQuotes::new();
+        nostr.insert("USD".into(), Quote::PerBtc(50_500.0)); // same currency, different value
+        nostr.insert("ARS".into(), Quote::PerBtc(105_000_000.0)); // nobody else has this
+
+        let out = restrict_nostr_to_fallback(vec![
+            (ProviderId::Yadio, yadio),
+            (ProviderId::Nostr, nostr),
+        ]);
+
+        let nostr_out = out
+            .iter()
+            .find(|(id, _)| *id == ProviderId::Nostr)
+            .map(|(_, q)| q)
+            .unwrap();
+        assert!(
+            !nostr_out.contains_key("USD"),
+            "USD is covered by Yadio, Nostr's USD must be dropped to avoid double-counting"
+        );
+        assert_eq!(
+            nostr_out.get("ARS"),
+            Some(&Quote::PerBtc(105_000_000.0)),
+            "ARS has no other source, Nostr must still fill the gap"
+        );
+
+        let yadio_out = out
+            .iter()
+            .find(|(id, _)| *id == ProviderId::Yadio)
+            .map(|(_, q)| q)
+            .unwrap();
+        assert_eq!(
+            yadio_out.get("USD"),
+            Some(&Quote::PerBtc(50_000.0)),
+            "non-Nostr providers are untouched"
+        );
+    }
+
+    #[test]
+    fn restrict_nostr_to_fallback_is_a_noop_without_a_nostr_provider() {
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
+
+        let out = restrict_nostr_to_fallback(vec![(ProviderId::Yadio, yadio.clone())]);
+        assert_eq!(out, vec![(ProviderId::Yadio, yadio)]);
+    }
+
+    #[test]
+    fn republishable_rates_drops_nostr_only_sourced_currencies() {
+        let mut aggregates = HashMap::new();
+        aggregates.insert(
+            "USD".to_string(),
+            AggregateResult {
+                value: 50_000.0,
+                sources: 2,
+                contributors: vec![ProviderId::Yadio, ProviderId::CoinGecko],
+            },
+        );
+        aggregates.insert(
+            "ARS".to_string(),
+            AggregateResult {
+                value: 105_000_000.0,
+                sources: 1,
+                contributors: vec![ProviderId::Nostr],
+            },
+        );
+
+        let out = republishable_rates(&aggregates);
+        assert_eq!(out.get("USD"), Some(&50_000.0));
+        assert!(
+            !out.contains_key("ARS"),
+            "Nostr-only-sourced ARS must not be republished with a fresh timestamp"
+        );
+    }
+
+    #[test]
+    fn republishable_rates_keeps_a_currency_nostr_only_partly_helped_with() {
+        // Nostr alongside another contributor (e.g. it filled in after a
+        // fallback scenario in a prior tick, or n>=2 combine) is not
+        // "Nostr-only" — still safe to republish since it wasn't the sole
+        // source.
+        let mut aggregates = HashMap::new();
+        aggregates.insert(
+            "EUR".to_string(),
+            AggregateResult {
+                value: 45_000.0,
+                sources: 2,
+                contributors: vec![ProviderId::Nostr, ProviderId::Yadio],
+            },
+        );
+
+        let out = republishable_rates(&aggregates);
+        assert_eq!(out.get("EUR"), Some(&45_000.0));
     }
 
     #[tokio::test]

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -588,13 +588,20 @@ impl PriceManager {
 /// documented purpose (spec §11.7: operators whose direct APIs are
 /// blocked) — while a fully-covered currency's value stays whatever the
 /// direct sources agree on.
+///
+/// Coverage is matched case-insensitively because that is what decides a
+/// collision downstream: `aggregate_tick` upper-cases every code before
+/// grouping, so `usd` from a direct source and `USD` from Nostr land in the
+/// same bucket. Not every adapter normalises on the way out (Yadio forwards
+/// the API's codes verbatim), so comparing raw keys here would let exactly
+/// the double-count this function exists to prevent slip through.
 fn restrict_nostr_to_fallback(
     results: Vec<(ProviderId, ProviderQuotes)>,
 ) -> Vec<(ProviderId, ProviderQuotes)> {
     let mut covered_elsewhere: HashSet<String> = HashSet::new();
     for (id, quotes) in &results {
         if *id != ProviderId::Nostr {
-            covered_elsewhere.extend(quotes.keys().cloned());
+            covered_elsewhere.extend(quotes.keys().map(|c| c.to_uppercase()));
         }
     }
     results
@@ -605,7 +612,7 @@ fn restrict_nostr_to_fallback(
             }
             let fallback_only: ProviderQuotes = quotes
                 .into_iter()
-                .filter(|(currency, _)| !covered_elsewhere.contains(currency))
+                .filter(|(currency, _)| !covered_elsewhere.contains(&currency.to_uppercase()))
                 .collect();
             (id, fallback_only)
         })
@@ -1132,6 +1139,40 @@ mod tests {
             yadio_out.get("USD"),
             Some(&Quote::PerBtc(50_000.0)),
             "non-Nostr providers are untouched"
+        );
+    }
+
+    #[test]
+    fn restrict_nostr_to_fallback_matches_coverage_case_insensitively() {
+        // Yadio forwards the API's codes verbatim, so a lowercase code is
+        // reachable in production. `aggregate_tick` upper-cases before
+        // grouping, so `usd` and `USD` are the same currency by the time it
+        // matters — coverage has to be matched the same way.
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("usd".into(), Quote::PerBtc(50_000.0));
+        let mut nostr = ProviderQuotes::new();
+        nostr.insert("USD".into(), Quote::PerBtc(50_500.0));
+        nostr.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
+
+        let out = restrict_nostr_to_fallback(vec![
+            (ProviderId::Yadio, yadio),
+            (ProviderId::Nostr, nostr),
+        ]);
+
+        let nostr_out = out
+            .iter()
+            .find(|(id, _)| *id == ProviderId::Nostr)
+            .map(|(_, q)| q)
+            .unwrap();
+        assert!(
+            !nostr_out.contains_key("USD"),
+            "Yadio's lowercase `usd` covers Nostr's `USD` — both fold to the \
+             same aggregate, so Nostr's quote must be dropped"
+        );
+        assert_eq!(
+            nostr_out.get("ARS"),
+            Some(&Quote::PerBtc(105_000_000.0)),
+            "ARS is still uncovered, Nostr must fill the gap"
         );
     }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -108,7 +108,7 @@ impl PriceManager {
             }
             match id_str.parse::<ProviderId>() {
                 Ok(id) => {
-                    let provider = build_provider(id, cfg)?;
+                    let provider = build_provider(id, cfg, settings.provider_timeout_seconds)?;
                     providers.push(EnabledProvider {
                         id,
                         provider,
@@ -570,7 +570,11 @@ fn sources_to_tag(ids: &[ProviderId]) -> String {
 /// Single designated extension point (spec §5.4 Step 3). Adding a new
 /// provider adds exactly one match arm here — the aggregation core, the
 /// store, the scheduler, and every order handler stay untouched.
-fn build_provider(id: ProviderId, cfg: &ProviderConfig) -> Result<Box<dyn PriceProvider>, String> {
+fn build_provider(
+    id: ProviderId,
+    cfg: &ProviderConfig,
+    provider_timeout_seconds: u64,
+) -> Result<Box<dyn PriceProvider>, String> {
     match id {
         ProviderId::Yadio => Ok(Box::new(YadioProvider::new(cfg))),
         ProviderId::CoinGecko => Ok(Box::new(CoinGeckoProvider::new(cfg))),
@@ -582,7 +586,10 @@ fn build_provider(id: ProviderId, cfg: &ProviderConfig) -> Result<Box<dyn PriceP
         ProviderId::ElToque => Ok(Box::new(ElToqueProvider::new(cfg)?)),
         // Nostr trusted-node relay mode (§11.7). `new` returns `Err` when
         // `trusted_nodes` is empty or contains an unparsable hex pubkey.
-        ProviderId::Nostr => Ok(Box::new(NostrProvider::new(cfg)?)),
+        // `provider_timeout_seconds` sizes its one-shot relay query so it
+        // stays in sync with the shared budget instead of a fixed constant
+        // (CodeRabbit, PR #841).
+        ProviderId::Nostr => Ok(Box::new(NostrProvider::new(cfg, provider_timeout_seconds)?)),
     }
 }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -34,10 +34,12 @@ use mostro_core::error::{MostroError, ServiceError};
 use nostr_sdk::prelude::*;
 use tracing::{debug, error, info, warn};
 
-use super::aggregate::{aggregate_tick, AggregateResult};
+use super::aggregate::{aggregate_tick, combine, AggregateResult};
 use super::config::{PriceSettings, ProviderConfig};
 use super::fiat::is_known_fiat;
-use super::provider::{PriceProvider, ProviderError, ProviderHealth, ProviderId, ProviderQuotes};
+use super::provider::{
+    PriceProvider, ProviderError, ProviderHealth, ProviderId, ProviderQuotes, Quote,
+};
 use super::providers::blockchain::BlockchainProvider;
 use super::providers::coingecko::CoinGeckoProvider;
 use super::providers::currency_api::CurrencyApiProvider;
@@ -295,7 +297,8 @@ impl PriceManager {
         // direct sources would double-count correlated information and skew
         // the result. Keep it strictly fallback — only for currencies no
         // other provider covered this tick.
-        let filtered_with_ids = restrict_nostr_to_fallback(filtered_with_ids);
+        let filtered_with_ids =
+            restrict_nostr_to_fallback(filtered_with_ids, self.settings.outlier_threshold_pct);
 
         let aggregates = aggregate_tick(&filtered_with_ids, self.settings.outlier_threshold_pct);
         if aggregates.is_empty() {
@@ -573,7 +576,8 @@ impl PriceManager {
 }
 
 /// Drop the `Nostr` provider's quotes for any currency another provider
-/// already covered this tick, leaving every other provider untouched.
+/// can actually produce a value for this tick, leaving every other
+/// provider untouched.
 ///
 /// A trusted-node `nostr` quote is a relayed *aggregate*, not an
 /// independent local observation — the remote node already ran its own
@@ -581,26 +585,26 @@ impl PriceManager {
 /// node's `aggregate_tick` alongside those same kinds of direct sources
 /// would let one upstream signal count twice (once locally, once via the
 /// remote's combine) and skew the median/mean. Restricting it to
-/// currencies nobody else reported keeps it strictly a gap-filler — its
-/// documented purpose (spec §11.7: operators whose direct APIs are
-/// blocked) — while a fully-covered currency's value stays whatever the
-/// direct sources agree on.
+/// currencies nobody else can resolve keeps it strictly a gap-filler —
+/// its documented purpose (spec §11.7) — while a fully-covered currency's
+/// value stays whatever the direct sources agree on.
 ///
-/// Coverage is matched case-insensitively because that is what decides a
-/// collision downstream: `aggregate_tick` upper-cases every code before
-/// grouping, so `usd` from a direct source and `USD` from Nostr land in the
-/// same bucket. Not every adapter normalises on the way out (Yadio forwards
-/// the API's codes verbatim), so comparing raw keys here would let exactly
-/// the double-count this function exists to prevent slip through.
+/// Coverage is decided **after** fiat-cross resolution, not from raw quote
+/// keys. El Toque reports CUP/MLC only as `PerBase { base: USD }`; a key
+/// presence check would treat that as covering CUP even when the USD
+/// anchor is missing, drop Nostr's usable `PerBtc` CUP, then lose CUP
+/// entirely when the cross fails to resolve (ermeme, PR #841). Anchors
+/// are built from *all* direct `PerBtc` quotes (including Nostr) so a
+/// local El Toque cross that needs Nostr's USD still counts as covering
+/// CUP — Nostr's direct CUP is then correctly suppressed as redundant.
+///
+/// Currency codes are folded to uppercase because `aggregate_tick` does
+/// the same before grouping; Yadio forwards API codes verbatim.
 fn restrict_nostr_to_fallback(
     results: Vec<(ProviderId, ProviderQuotes)>,
+    outlier_pct: f64,
 ) -> Vec<(ProviderId, ProviderQuotes)> {
-    let mut covered_elsewhere: HashSet<String> = HashSet::new();
-    for (id, quotes) in &results {
-        if *id != ProviderId::Nostr {
-            covered_elsewhere.extend(quotes.keys().map(|c| c.to_uppercase()));
-        }
-    }
+    let covered_elsewhere = currencies_covered_by_non_nostr(&results, outlier_pct);
     results
         .into_iter()
         .map(|(id, quotes)| {
@@ -616,19 +620,73 @@ fn restrict_nostr_to_fallback(
         .collect()
 }
 
+/// Currencies a non-Nostr provider can actually yield this tick: either a
+/// usable direct `PerBtc`, or a `PerBase` that resolves against the
+/// tick's anchors (anchors include Nostr `PerBtc` so local crosses can
+/// still cover a currency when only the relayed USD is available).
+fn currencies_covered_by_non_nostr(
+    results: &[(ProviderId, ProviderQuotes)],
+    outlier_pct: f64,
+) -> HashSet<String> {
+    let mut direct: HashMap<String, Vec<f64>> = HashMap::new();
+    for (_id, quotes) in results {
+        for (currency, quote) in quotes {
+            if let Quote::PerBtc(v) = quote {
+                if v.is_finite() && *v > 0.0 {
+                    direct.entry(currency.to_uppercase()).or_default().push(*v);
+                }
+            }
+        }
+    }
+    let mut anchors: HashMap<String, f64> = HashMap::new();
+    for (currency, values) in &direct {
+        if let Some(v) = combine(values, outlier_pct) {
+            anchors.insert(currency.clone(), v);
+        }
+    }
+
+    let mut covered: HashSet<String> = HashSet::new();
+    for (id, quotes) in results {
+        if *id == ProviderId::Nostr {
+            continue;
+        }
+        for (currency, quote) in quotes {
+            let code = currency.to_uppercase();
+            match quote {
+                Quote::PerBtc(v) if v.is_finite() && *v > 0.0 => {
+                    covered.insert(code);
+                }
+                Quote::PerBase { base, value } => {
+                    if let Some(anchor) = anchors.get(&base.to_uppercase()) {
+                        let candidate = value * anchor;
+                        if candidate.is_finite() && candidate > 0.0 {
+                            covered.insert(code);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    covered
+}
+
 /// Currencies fit to republish to Nostr this tick: everything **except**
-/// those whose only surviving contributor is `Nostr` itself.
+/// those that still depend on a Nostr-sourced rate.
 ///
-/// Republishing a Nostr-only-sourced value with this node's own fresh
-/// `created_at`/`expiration` would erase how old the underlying quote
-/// actually is — a self-trust or A↔B trust cycle could keep a long-dead
-/// upstream quote looking perpetually fresh, one relay hop at a time
-/// (re-review, PR #841). A currency this node independently corroborated
-/// (any non-Nostr contributor) is unaffected and republishes as before.
+/// Two cases must not be re-stamped with a fresh `created_at`/`expiration`
+/// (re-review, PR #841):
+/// - sole surviving contributor is `Nostr` itself;
+/// - a fiat-cross resolved against a Nostr-touched USD (or other) anchor
+///   (`nostr_anchor_dependent`) — e.g. El Toque CUP × Nostr USD would
+///   otherwise publish as `source=eltoque` while embedding a relayed rate.
+///
+/// A currency this node independently corroborated with a non-Nostr
+/// absolute path (and no Nostr-anchor cross) republishes as before.
 fn republishable_rates(aggregates: &HashMap<String, AggregateResult>) -> HashMap<String, f64> {
     aggregates
         .iter()
-        .filter(|(_, a)| a.contributors != [ProviderId::Nostr])
+        .filter(|(_, a)| a.contributors != [ProviderId::Nostr] && !a.nostr_anchor_dependent)
         .map(|(c, a)| (c.clone(), a.value))
         .collect()
 }
@@ -1127,10 +1185,10 @@ mod tests {
         nostr.insert("USD".into(), Quote::PerBtc(50_500.0)); // same currency, different value
         nostr.insert("ARS".into(), Quote::PerBtc(105_000_000.0)); // nobody else has this
 
-        let out = restrict_nostr_to_fallback(vec![
-            (ProviderId::Yadio, yadio),
-            (ProviderId::Nostr, nostr),
-        ]);
+        let out = restrict_nostr_to_fallback(
+            vec![(ProviderId::Yadio, yadio), (ProviderId::Nostr, nostr)],
+            5.0,
+        );
 
         let nostr_out = out
             .iter()
@@ -1171,10 +1229,10 @@ mod tests {
         nostr.insert("USD".into(), Quote::PerBtc(50_500.0));
         nostr.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
 
-        let out = restrict_nostr_to_fallback(vec![
-            (ProviderId::Yadio, yadio),
-            (ProviderId::Nostr, nostr),
-        ]);
+        let out = restrict_nostr_to_fallback(
+            vec![(ProviderId::Yadio, yadio), (ProviderId::Nostr, nostr)],
+            5.0,
+        );
 
         let nostr_out = out
             .iter()
@@ -1198,8 +1256,78 @@ mod tests {
         let mut yadio = ProviderQuotes::new();
         yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
 
-        let out = restrict_nostr_to_fallback(vec![(ProviderId::Yadio, yadio.clone())]);
+        let out = restrict_nostr_to_fallback(vec![(ProviderId::Yadio, yadio.clone())], 5.0);
         assert_eq!(out, vec![(ProviderId::Yadio, yadio)]);
+    }
+
+    #[test]
+    fn restrict_nostr_to_fallback_keeps_nostr_when_per_base_cannot_resolve() {
+        // El Toque "has" CUP as a key, but without a USD anchor the cross
+        // cannot resolve — treating the raw key as coverage would drop
+        // Nostr's usable PerBtc CUP and leave the tick with no CUP at all
+        // (ermeme, PR #841).
+        let mut eltoque = ProviderQuotes::new();
+        eltoque.insert(
+            "CUP".into(),
+            Quote::PerBase {
+                base: "USD".into(),
+                value: 300.0,
+            },
+        );
+        let mut nostr = ProviderQuotes::new();
+        nostr.insert("CUP".into(), Quote::PerBtc(30_000_000.0));
+
+        let out = restrict_nostr_to_fallback(
+            vec![(ProviderId::ElToque, eltoque), (ProviderId::Nostr, nostr)],
+            5.0,
+        );
+        let nostr_out = out
+            .iter()
+            .find(|(id, _)| *id == ProviderId::Nostr)
+            .map(|(_, q)| q)
+            .unwrap();
+        assert_eq!(
+            nostr_out.get("CUP"),
+            Some(&Quote::PerBtc(30_000_000.0)),
+            "unresolvable El Toque PerBase must not suppress Nostr's PerBtc CUP"
+        );
+    }
+
+    #[test]
+    fn restrict_nostr_to_fallback_drops_nostr_when_per_base_resolves_via_nostr_usd() {
+        // Nostr supplies USD; El Toque's CUP/USD then resolves. CUP is
+        // covered by the local cross, so Nostr's direct CUP must not also
+        // vote (would double-count correlated remote aggregate data).
+        let mut eltoque = ProviderQuotes::new();
+        eltoque.insert(
+            "CUP".into(),
+            Quote::PerBase {
+                base: "USD".into(),
+                value: 400.0,
+            },
+        );
+        let mut nostr = ProviderQuotes::new();
+        nostr.insert("USD".into(), Quote::PerBtc(50_000.0));
+        nostr.insert("CUP".into(), Quote::PerBtc(30_000_000.0));
+
+        let out = restrict_nostr_to_fallback(
+            vec![(ProviderId::ElToque, eltoque), (ProviderId::Nostr, nostr)],
+            5.0,
+        );
+        let nostr_out = out
+            .iter()
+            .find(|(id, _)| *id == ProviderId::Nostr)
+            .map(|(_, q)| q)
+            .unwrap();
+        assert!(
+            !nostr_out.contains_key("CUP"),
+            "El Toque CUP that resolves against Nostr USD covers the currency"
+        );
+        assert_eq!(
+            nostr_out.get("USD"),
+            Some(&Quote::PerBtc(50_000.0)),
+            "Nostr USD is still needed as the anchor"
+        );
     }
 
     #[test]
@@ -1211,6 +1339,7 @@ mod tests {
                 value: 50_000.0,
                 sources: 2,
                 contributors: vec![ProviderId::Yadio, ProviderId::CoinGecko],
+                nostr_anchor_dependent: false,
             },
         );
         aggregates.insert(
@@ -1219,6 +1348,7 @@ mod tests {
                 value: 105_000_000.0,
                 sources: 1,
                 contributors: vec![ProviderId::Nostr],
+                nostr_anchor_dependent: false,
             },
         );
 
@@ -1242,6 +1372,7 @@ mod tests {
                 value: 50_000.0,
                 sources: 2,
                 contributors: vec![ProviderId::Yadio, ProviderId::CoinGecko],
+                nostr_anchor_dependent: false,
             },
         );
         aggregates.insert(
@@ -1250,6 +1381,7 @@ mod tests {
                 value: 105_000_000.0,
                 sources: 1,
                 contributors: vec![ProviderId::Nostr],
+                nostr_anchor_dependent: false,
             },
         );
 
@@ -1284,10 +1416,44 @@ mod tests {
                 value: 45_000.0,
                 sources: 2,
                 contributors: vec![ProviderId::Nostr, ProviderId::Yadio],
+                nostr_anchor_dependent: false,
             },
         );
 
         let out = republishable_rates(&aggregates);
+        assert_eq!(out.get("EUR"), Some(&45_000.0));
+    }
+
+    #[test]
+    fn republishable_rates_drops_nostr_anchor_dependent_cross() {
+        // El Toque CUP resolved via Nostr USD: contributors name only
+        // eltoque, but the absolute value embeds a relayed rate — must not
+        // be re-stamped as a fresh local observation (ermeme, PR #841).
+        let mut aggregates = HashMap::new();
+        aggregates.insert(
+            "CUP".to_string(),
+            AggregateResult {
+                value: 20_000_000.0,
+                sources: 1,
+                contributors: vec![ProviderId::ElToque],
+                nostr_anchor_dependent: true,
+            },
+        );
+        aggregates.insert(
+            "EUR".to_string(),
+            AggregateResult {
+                value: 45_000.0,
+                sources: 1,
+                contributors: vec![ProviderId::Yadio],
+                nostr_anchor_dependent: false,
+            },
+        );
+
+        let out = republishable_rates(&aggregates);
+        assert!(
+            !out.contains_key("CUP"),
+            "Nostr-anchor-dependent CUP must not be republished"
+        );
         assert_eq!(out.get("EUR"), Some(&45_000.0));
     }
 
@@ -1593,6 +1759,7 @@ mod tests {
                 value: 50_000.0,
                 sources: 1,
                 contributors: vec![ProviderId::Yadio],
+                nostr_anchor_dependent: false,
             },
         );
         // 1_000_000s ago: well past any plausible TTL.
@@ -1620,6 +1787,7 @@ mod tests {
                 value: 50_000.0,
                 sources: 1,
                 contributors: vec![ProviderId::Yadio],
+                nostr_anchor_dependent: false,
             },
         );
         let fresh_now = Utc::now().timestamp();
@@ -1655,6 +1823,7 @@ mod tests {
                 value: 50_000.0,
                 sources: 1,
                 contributors: vec![ProviderId::Yadio],
+                nostr_anchor_dependent: false,
             },
         );
         let now = Utc::now().timestamp();
@@ -1702,6 +1871,7 @@ mod tests {
                     value: v,
                     sources: 1,
                     contributors: vec![ProviderId::Yadio],
+                    nostr_anchor_dependent: false,
                 },
             );
             agg
@@ -1907,6 +2077,7 @@ mod coverage_tests {
                 value: 50_000.0,
                 sources: 1,
                 contributors: vec![ProviderId::Yadio],
+                nostr_anchor_dependent: false,
             },
         );
         manager.publish_rates_to_nostr(&aggregates).await;

--- a/src/price/provider.rs
+++ b/src/price/provider.rs
@@ -39,6 +39,7 @@ pub enum ProviderId {
     CurrencyApi,
     Blockchain,
     ElToque,
+    Nostr,
 }
 
 impl fmt::Display for ProviderId {
@@ -49,6 +50,7 @@ impl fmt::Display for ProviderId {
             ProviderId::CurrencyApi => "currency_api",
             ProviderId::Blockchain => "blockchain",
             ProviderId::ElToque => "eltoque",
+            ProviderId::Nostr => "nostr",
         };
         f.write_str(s)
     }
@@ -64,6 +66,7 @@ impl FromStr for ProviderId {
             "currency_api" => Ok(ProviderId::CurrencyApi),
             "blockchain" => Ok(ProviderId::Blockchain),
             "eltoque" => Ok(ProviderId::ElToque),
+            "nostr" => Ok(ProviderId::Nostr),
             other => Err(format!("unknown price provider id: {other}")),
         }
     }
@@ -205,6 +208,7 @@ mod tests {
             ProviderId::CurrencyApi,
             ProviderId::Blockchain,
             ProviderId::ElToque,
+            ProviderId::Nostr,
         ] {
             let s = id.to_string();
             assert_eq!(ProviderId::from_str(&s).unwrap(), id, "roundtrip {s}");

--- a/src/price/providers/blockchain.rs
+++ b/src/price/providers/blockchain.rs
@@ -146,6 +146,7 @@ mod tests {
             token: None,
             only: None,
             except: None,
+            trusted_nodes: vec![],
         };
         assert_eq!(BlockchainProvider::new(&cfg).url, "https://blockchain.info");
     }

--- a/src/price/providers/coingecko.rs
+++ b/src/price/providers/coingecko.rs
@@ -144,6 +144,7 @@ mod tests {
             token: None,
             only: None,
             except: None,
+            trusted_nodes: vec![],
         }
     }
 

--- a/src/price/providers/currency_api.rs
+++ b/src/price/providers/currency_api.rs
@@ -139,6 +139,7 @@ mod tests {
             token: None,
             only: None,
             except: None,
+            trusted_nodes: vec![],
         }
     }
 

--- a/src/price/providers/eltoque.rs
+++ b/src/price/providers/eltoque.rs
@@ -223,6 +223,7 @@ mod tests {
             token: token.map(String::from),
             only: Some(vec!["CUP".into(), "MLC".into()]),
             except: None,
+            trusted_nodes: vec![],
         }
     }
 

--- a/src/price/providers/mod.rs
+++ b/src/price/providers/mod.rs
@@ -10,4 +10,5 @@ pub mod blockchain;
 pub mod coingecko;
 pub mod currency_api;
 pub mod eltoque;
+pub mod nostr;
 pub mod yadio;

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -4,14 +4,20 @@
 //! same kind-30078 NIP-33 rate event Mostro nodes already publish
 //! (`nip33::new_exchange_rates_event`, `docs/NOSTR_EXCHANGE_RATES.md`) — for
 //! operators in regions where price APIs are DNS/IP blocked but Nostr relays
-//! are reachable (issue #697). It queries the process-wide Nostr client
-//! (already connected to the `[nostr]` relays) for the latest such event
-//! from each configured `trusted_nodes` pubkey and takes the **freshest**
-//! one as this tick's source — no cross-node statistical combine; a stale or
-//! unreachable trusted node is simply outrun by a fresher one. Events whose
+//! are reachable (issue #697). It queries a **dedicated** price Nostr client
+//! ([`crate::util::get_price_nostr_client`], same `[nostr]` relays, with
+//! `verify_subscriptions`) for the latest such event from each configured
+//! `trusted_nodes` pubkey and takes the **freshest** one as this tick's
+//! source — no cross-node statistical combine; a stale or unreachable
+//! trusted node is simply outrun by a fresher one. Events whose
 //! `created_at` is older than `[price].max_price_staleness_seconds` are
 //! discarded so a relay that still serves an expired kind-30078 cannot keep
 //! refreshing the local cache clock with zombie rates.
+//!
+//! Subscription verification is **not** enabled on the process-wide daemon
+//! client used for the inbox / publishing: that client's `.limit(0)`
+//! subscription must keep delivering live trade messages after EOSE
+//! (hermeme, PR #841).
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -117,8 +123,8 @@ impl NostrProvider {
     /// otherwise only surface via the `#[ignore]`d live-relay test.
     ///
     /// Includes [`Filter::limit`] at [`MAX_FETCHED_RATE_EVENTS`]: with
-    /// `verify_subscriptions` enabled on the process-wide client
-    /// ([`crate::util::mostro_nostr_client_options`]), the relay driver
+    /// `verify_subscriptions` enabled on the **price** Nostr client
+    /// ([`crate::util::price_nostr_client_options`]), the relay driver
     /// enforces that ceiling *before* events enter the pool's dedup set.
     pub(crate) fn build_filter(&self) -> Filter {
         Filter::new()
@@ -151,11 +157,10 @@ impl NostrProvider {
     ///   (spec §10.3 / `NOSTR_EXCHANGE_RATES.md` "clients MUST verify
     ///   pubkey");
     /// - the exact expected envelope (`kind` 30078, `d` = `mostro-rates`) —
-    ///   `build_filter`'s relay-side query asks for this, but
-    ///   `nostr-relay-pool`'s `verify_subscriptions` defaults to `false` (not
-    ///   enabled by `connect_nostr`), so a noncompliant relay could still
-    ///   hand back a validly-signed event from a trusted pubkey of a
-    ///   different kind/`d` (CodeRabbit / re-review, PR #841);
+    ///   `build_filter`'s relay-side query asks for this, and the price
+    ///   client's `verify_subscriptions` enforces it in the relay driver;
+    ///   this client-side check remains as defense in depth against a
+    ///   misconfigured or noncompliant peer (CodeRabbit / re-review, PR #841);
     /// - not future-dated (a forged or clock-skewed `created_at` must not
     ///   look artificially fresh);
     /// - `created_at` within `max_age` of `now`, so a relay that ignores
@@ -261,12 +266,13 @@ impl PriceProvider for NostrProvider {
     }
 
     async fn fetch(&self, _http: &reqwest::Client) -> Result<ProviderQuotes, ProviderError> {
-        let client = crate::util::get_nostr_client()
+        let client = crate::util::get_price_nostr_client()
+            .await
             .map_err(|e| ProviderError::Http(format!("nostr: {e}")))?;
 
-        // Stream rather than `fetch_events`. The process-wide client enables
-        // `verify_subscriptions` (see `mostro_nostr_client_options`) so the
-        // relay driver drops non-matching frames *before* the pool's
+        // Stream rather than `fetch_events`. The dedicated price client
+        // enables `verify_subscriptions` (see `price_nostr_client_options`)
+        // so the relay driver drops non-matching frames *before* the pool's
         // unbounded EventId dedup set; `build_filter`'s `limit` is enforced
         // there too. We still early-filter and cap retained candidates here
         // as defense in depth (ermeme, PR #841).
@@ -669,7 +675,7 @@ mod tests {
             provider.build_filter().limit,
             Some(MAX_FETCHED_RATE_EVENTS),
             "filter limit is the production stream bound enforced by \
-             verify_subscriptions in the relay driver"
+             verify_subscriptions on the price Nostr client"
         );
     }
 
@@ -699,21 +705,23 @@ mod tests {
     /// example `trusted_nodes` pubkeys the issue names. Inherently flaky
     /// against third-party infra outside this repo's control, so it's
     /// `#[ignore]`d (never runs in CI) — run explicitly, alone, so no other
-    /// test races it to set the process-wide `NOSTR_CLIENT`:
+    /// test races it to set the process-wide `PRICE_NOSTR_CLIENT`:
     ///
     /// `cargo test price::providers::nostr::tests::live_relay_fetch_returns_real_rates -- --ignored --exact`
     #[tokio::test]
     #[ignore = "hits a real Nostr relay; run explicitly for manual verification"]
     async fn live_relay_fetch_returns_real_rates() {
-        let client = Client::default();
+        let client = ClientBuilder::default()
+            .opts(crate::util::price_nostr_client_options())
+            .build();
         client
             .add_relay("wss://relay.mostro.network")
             .await
             .expect("add_relay");
         client.connect().await;
-        crate::NOSTR_CLIENT
+        crate::config::PRICE_NOSTR_CLIENT
             .set(client)
-            .expect("NOSTR_CLIENT must be unset — run this test alone (see doc comment)");
+            .expect("PRICE_NOSTR_CLIENT must be unset — run this test alone (see doc comment)");
 
         // Both pubkeys issue #697 names as example trusted_nodes.
         let cfg = ProviderConfig {

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -142,6 +142,9 @@ impl NostrProvider {
         events
             .iter()
             .filter(|e| trusted.contains(&e.pubkey))
+            // A future-dated `created_at` (forged or clock-skewed relay) would
+            // otherwise saturate the age check to 0 and win `max_by_key` outright.
+            .filter(|e| e.created_at <= now)
             .filter(|e| now.as_secs().saturating_sub(e.created_at.as_secs()) <= max_age_secs)
             .max_by_key(|e| e.created_at)
     }
@@ -164,19 +167,15 @@ impl PriceProvider for NostrProvider {
             .into_iter()
             .collect::<Vec<Event>>();
 
-        let event = Self::select_freshest(
-            &events,
-            &self.trusted_nodes,
-            Timestamp::now(),
-            self.max_age,
-        )
-        .ok_or_else(|| {
-            ProviderError::Http(
-                "nostr: no fresh trusted-node rate event found \
+        let event =
+            Self::select_freshest(&events, &self.trusted_nodes, Timestamp::now(), self.max_age)
+                .ok_or_else(|| {
+                    ProviderError::Http(
+                        "nostr: no fresh trusted-node rate event found \
                  (all missing, untrusted, or older than max_price_staleness_seconds)"
-                    .to_string(),
-            )
-        })?;
+                            .to_string(),
+                    )
+                })?;
 
         Self::parse_content(&event.content)
     }
@@ -227,13 +226,9 @@ mod tests {
     #[test]
     fn select_freshest_returns_none_for_empty_events() {
         let trusted = vec![Keys::generate().public_key()];
-        assert!(NostrProvider::select_freshest(
-            &[],
-            &trusted,
-            Timestamp::from(NOW),
-            MAX_AGE
-        )
-        .is_none());
+        assert!(
+            NostrProvider::select_freshest(&[], &trusted, Timestamp::from(NOW), MAX_AGE).is_none()
+        );
     }
 
     #[test]
@@ -245,13 +240,10 @@ mod tests {
         let untrusted_event = signed_event(&untrusted_keys, SAMPLE_CONTENT, NOW - 100);
         let events = vec![untrusted_event];
 
-        assert!(NostrProvider::select_freshest(
-            &events,
-            &trusted,
-            Timestamp::from(NOW),
-            MAX_AGE
-        )
-        .is_none());
+        assert!(
+            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .is_none()
+        );
     }
 
     #[test]
@@ -293,13 +285,10 @@ mod tests {
         let stale = signed_event(&keys, SAMPLE_CONTENT, NOW - MAX_AGE.as_secs() - 1);
         let events = vec![stale];
 
-        assert!(NostrProvider::select_freshest(
-            &events,
-            &trusted,
-            Timestamp::from(NOW),
-            MAX_AGE
-        )
-        .is_none());
+        assert!(
+            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .is_none()
+        );
     }
 
     #[test]
@@ -314,6 +303,23 @@ mod tests {
             NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
                 .unwrap();
         assert_eq!(picked.id, at_boundary.id);
+    }
+
+    #[test]
+    fn select_freshest_rejects_future_dated_events() {
+        let keys = Keys::generate();
+        let trusted = vec![keys.public_key()];
+
+        // A forged or clock-skewed `created_at` in the future must not win
+        // `max_by_key` over a legitimately current event.
+        let future = signed_event(&keys, SAMPLE_CONTENT, NOW + 1_000);
+        let current = signed_event(&keys, SAMPLE_CONTENT, NOW - 100);
+        let events = vec![future, current.clone()];
+
+        let picked =
+            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .unwrap();
+        assert_eq!(picked.id, current.id);
     }
 
     fn sample_cfg(trusted_hex: String) -> ProviderConfig {

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -21,12 +21,6 @@ use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
 use crate::price::config::ProviderConfig;
 use crate::price::provider::{PriceProvider, ProviderError, ProviderId, ProviderQuotes, Quote};
 
-/// Upper bound on the one-shot relay query. Deliberately not a config knob:
-/// the outer `PriceManager::poll_budget` (`provider_timeout_seconds`,
-/// default 10s) already bounds the whole `fetch()` call for every provider,
-/// so this just needs to sit comfortably under that default.
-const RELAY_QUERY_TIMEOUT: Duration = Duration::from_secs(8);
-
 /// Same wrapper the daemon publishes: `{"BTC": {ccy: price}}`.
 #[derive(Debug, Deserialize)]
 struct RatesContent {
@@ -37,6 +31,13 @@ struct RatesContent {
 /// Trusted-node Nostr quoter.
 pub struct NostrProvider {
     trusted_nodes: Vec<PublicKey>,
+    /// One-shot relay query bound, derived from the shared
+    /// `provider_timeout_seconds` (see `new`) rather than a fixed constant —
+    /// an operator who lowers that setting must not have this provider's
+    /// queries consistently swallowed by `PriceManager::poll_budget`'s outer
+    /// timeout before they can complete or fail on their own (CodeRabbit,
+    /// PR #841).
+    query_timeout: Duration,
 }
 
 impl NostrProvider {
@@ -46,7 +47,14 @@ impl NostrProvider {
     /// `trusted_nodes` is empty or contains a pubkey that isn't valid hex —
     /// `ProviderConfig::validate` only checks the list is non-empty, not
     /// that its entries parse (spec §7).
-    pub fn new(cfg: &ProviderConfig) -> Result<Self, String> {
+    ///
+    /// `provider_timeout_seconds` is the shared `[price]` setting (not
+    /// per-provider config): `query_timeout` is set to exactly that value,
+    /// so it fits under `poll_budget`'s `provider_timeout_seconds + 1s`
+    /// (no `fallback_urls` for this provider ⇒ one attempt) with the same
+    /// 1s of slack every other provider gets from the shared `reqwest`
+    /// client's own per-attempt timeout.
+    pub fn new(cfg: &ProviderConfig, provider_timeout_seconds: u64) -> Result<Self, String> {
         if cfg.trusted_nodes.is_empty() {
             return Err(
                 "price provider 'nostr': enabled provider requires at least one \
@@ -66,7 +74,22 @@ impl NostrProvider {
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(Self { trusted_nodes })
+        Ok(Self {
+            trusted_nodes,
+            query_timeout: Duration::from_secs(provider_timeout_seconds.max(1)),
+        })
+    }
+
+    /// The relay query for this tick: the latest `mostro-rates` (kind
+    /// 30078) event from any configured trusted node. Split out from
+    /// [`PriceProvider::fetch`] so its shape is unit-testable without a
+    /// relay (spec §10.5) — a wrong `kind`/`identifier` here would
+    /// otherwise only surface via the `#[ignore]`d live-relay test.
+    pub(crate) fn build_filter(&self) -> Filter {
+        Filter::new()
+            .kind(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
+            .authors(self.trusted_nodes.clone())
+            .identifier("mostro-rates")
     }
 
     /// Parse a rate event's `content` into [`ProviderQuotes`]. Split out so
@@ -109,13 +132,8 @@ impl PriceProvider for NostrProvider {
         let client = crate::util::get_nostr_client()
             .map_err(|e| ProviderError::Http(format!("nostr: {e}")))?;
 
-        let filter = Filter::new()
-            .kind(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
-            .authors(self.trusted_nodes.clone())
-            .identifier("mostro-rates");
-
         let events = client
-            .fetch_events(filter, RELAY_QUERY_TIMEOUT)
+            .fetch_events(self.build_filter(), self.query_timeout)
             .await
             .map_err(|e| ProviderError::Http(format!("nostr: relay query failed: {e}")))?
             .into_iter()
@@ -209,7 +227,50 @@ mod tests {
             except: None,
             trusted_nodes: vec![Keys::generate().public_key().to_hex()],
         };
-        assert!(NostrProvider::new(&cfg).is_ok());
+        assert!(NostrProvider::new(&cfg, 10).is_ok());
+    }
+
+    #[test]
+    fn new_derives_query_timeout_from_provider_timeout_seconds() {
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec![Keys::generate().public_key().to_hex()],
+        };
+        let provider = NostrProvider::new(&cfg, 7).unwrap();
+        assert_eq!(provider.query_timeout, Duration::from_secs(7));
+
+        // A misconfigured 0 must not produce a zero-duration timeout.
+        let provider = NostrProvider::new(&cfg, 0).unwrap();
+        assert_eq!(provider.query_timeout, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn build_filter_has_kind_authors_and_identifier() {
+        let node_a = Keys::generate().public_key();
+        let node_b = Keys::generate().public_key();
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec![node_a.to_hex(), node_b.to_hex()],
+        };
+        let provider = NostrProvider::new(&cfg, 10).unwrap();
+
+        let expected = Filter::new()
+            .kind(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
+            .authors([node_a, node_b])
+            .identifier("mostro-rates");
+        assert_eq!(provider.build_filter(), expected);
     }
 
     #[test]
@@ -224,7 +285,7 @@ mod tests {
             except: None,
             trusted_nodes: vec![],
         };
-        assert!(NostrProvider::new(&cfg).is_err());
+        assert!(NostrProvider::new(&cfg, 10).is_err());
     }
 
     #[test]
@@ -239,7 +300,7 @@ mod tests {
             except: None,
             trusted_nodes: vec!["not-a-pubkey".to_string()],
         };
-        assert!(NostrProvider::new(&cfg).is_err());
+        assert!(NostrProvider::new(&cfg, 10).is_err());
     }
 
     /// Live-relay evidence for issue #697: exercises the real `fetch()` path
@@ -277,7 +338,7 @@ mod tests {
                 "00000235a3e904cfe1213a8a54d6f1ec1bef7cc6bfaabd6193e82931ccf1366a".to_string(),
             ],
         };
-        let provider = NostrProvider::new(&cfg).expect("valid hex pubkeys");
+        let provider = NostrProvider::new(&cfg, 10).expect("valid hex pubkeys");
         let http = reqwest::Client::new();
 
         let quotes = provider.fetch(&http).await.expect("live relay fetch");

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -115,11 +115,17 @@ impl NostrProvider {
     /// [`PriceProvider::fetch`] so its shape is unit-testable without a
     /// relay (spec §10.5) — a wrong `kind`/`identifier` here would
     /// otherwise only surface via the `#[ignore]`d live-relay test.
+    ///
+    /// Includes [`Filter::limit`] at [`MAX_FETCHED_RATE_EVENTS`]: with
+    /// `verify_subscriptions` enabled on the process-wide client
+    /// ([`crate::util::mostro_nostr_client_options`]), the relay driver
+    /// enforces that ceiling *before* events enter the pool's dedup set.
     pub(crate) fn build_filter(&self) -> Filter {
         Filter::new()
             .kind(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
             .authors(self.trusted_nodes.clone())
             .identifier("mostro-rates")
+            .limit(MAX_FETCHED_RATE_EVENTS)
     }
 
     /// Parse a rate event's `content` into [`ProviderQuotes`]. Split out so
@@ -258,29 +264,28 @@ impl PriceProvider for NostrProvider {
         let client = crate::util::get_nostr_client()
             .map_err(|e| ProviderError::Http(format!("nostr: {e}")))?;
 
-        // Stream rather than `fetch_events`: the pool's collector
-        // `force_insert`s every delivered event (ignoring Filter::limit),
-        // so a noncompliant relay can OOM the process within query_timeout.
-        // Early-filter + hard cap while receiving (ermeme, PR #841).
-        let filter = self.build_filter().limit(MAX_FETCHED_RATE_EVENTS);
+        // Stream rather than `fetch_events`. The process-wide client enables
+        // `verify_subscriptions` (see `mostro_nostr_client_options`) so the
+        // relay driver drops non-matching frames *before* the pool's
+        // unbounded EventId dedup set; `build_filter`'s `limit` is enforced
+        // there too. We still early-filter and cap retained candidates here
+        // as defense in depth (ermeme, PR #841).
+        //
+        // Do **not** break on a count of inspected frames: the pool merges
+        // relays into one stream, so one noisy peer could fill a global
+        // first-N cutoff before an honest relay's trusted event arrives.
         let mut stream = client
-            .stream_events(filter, self.query_timeout)
+            .stream_events(self.build_filter(), self.query_timeout)
             .await
             .map_err(|e| ProviderError::Http(format!("nostr: relay query failed: {e}")))?;
 
         let mut events = Vec::new();
-        let mut inspected = 0usize;
         while let Some(event) = stream.next().await {
-            inspected += 1;
             if Self::is_plausible_candidate(&event, &self.trusted_nodes) {
                 events.push(event);
                 if events.len() >= MAX_FETCHED_RATE_EVENTS {
                     break;
                 }
-            }
-            // Bound work even when the relay floods irrelevant frames.
-            if inspected >= MAX_FETCHED_RATE_EVENTS.saturating_mul(4) {
-                break;
             }
         }
 
@@ -657,8 +662,15 @@ mod tests {
         let expected = Filter::new()
             .kind(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
             .authors([node_a, node_b])
-            .identifier("mostro-rates");
+            .identifier("mostro-rates")
+            .limit(MAX_FETCHED_RATE_EVENTS);
         assert_eq!(provider.build_filter(), expected);
+        assert_eq!(
+            provider.build_filter().limit,
+            Some(MAX_FETCHED_RATE_EVENTS),
+            "filter limit is the production stream bound enforced by \
+             verify_subscriptions in the relay driver"
+        );
     }
 
     #[test]

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use nostr_sdk::prelude::*;
 use serde::Deserialize;
+use tracing::debug;
 
 use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
 use crate::price::config::ProviderConfig;
@@ -125,33 +126,82 @@ impl NostrProvider {
             .collect())
     }
 
-    /// Among `events`, the freshest one authored by a trusted pubkey whose
-    /// `created_at` is within `max_age` of `now` — a second client-side trust
-    /// check even though the relay-side `authors` filter should already
-    /// guarantee the pubkey (spec §10.3 / `NOSTR_EXCHANGE_RATES.md`
-    /// "clients MUST verify pubkey"), plus a freshness gate so relays that
-    /// ignore NIP-40 expiration cannot serve zombie rates. The event's own
-    /// NIP-40 `expiration` tag, if any, is also honored directly via
-    /// `Event::is_expired_at` — the `max_age` gate alone only bounds
-    /// staleness by this node's clock, so a trusted node advertising a
-    /// shorter self-declared expiry is still respected. Pure and
+    /// Every event from `events` that passes every event-level trust and
+    /// freshness gate, newest first:
+    ///
+    /// - authored by a trusted pubkey — a second client-side check even
+    ///   though the relay-side `authors` filter should already guarantee it
+    ///   (spec §10.3 / `NOSTR_EXCHANGE_RATES.md` "clients MUST verify
+    ///   pubkey");
+    /// - the exact expected envelope (`kind` 30078, `d` = `mostro-rates`) —
+    ///   `build_filter`'s relay-side query asks for this, but
+    ///   `nostr-relay-pool`'s `verify_subscriptions` defaults to `false` (not
+    ///   enabled by `connect_nostr`), so a noncompliant relay could still
+    ///   hand back a validly-signed event from a trusted pubkey of a
+    ///   different kind/`d` (CodeRabbit / re-review, PR #841);
+    /// - not future-dated (a forged or clock-skewed `created_at` must not
+    ///   look artificially fresh);
+    /// - `created_at` within `max_age` of `now`, so a relay that ignores
+    ///   NIP-40 expiration cannot keep serving a zombie rate;
+    /// - not expired per its own NIP-40 `expiration` tag, if any
+    ///   (`Event::is_expired_at`) — a trusted node's shorter self-declared
+    ///   expiry is honored even within `max_age`.
+    ///
+    /// Ranking (rather than returning a single winner) lets [`Self::fetch`]
+    /// fall through to the next-freshest candidate when the newest one turns
+    /// out to be unparsable or empty — see `parse_content` — instead of
+    /// letting one bad event from a trusted node shadow a perfectly good
+    /// older one from the same or another trusted node. Pure and
     /// unit-testable without a relay.
-    pub(crate) fn select_freshest<'a>(
+    pub(crate) fn rank_candidates<'a>(
         events: &'a [Event],
         trusted: &[PublicKey],
         now: Timestamp,
         max_age: Duration,
-    ) -> Option<&'a Event> {
+    ) -> Vec<&'a Event> {
         let max_age_secs = max_age.as_secs();
-        events
+        let mut candidates: Vec<&Event> = events
             .iter()
             .filter(|e| trusted.contains(&e.pubkey))
+            .filter(|e| e.kind == Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
+            .filter(|e| e.tags.identifier() == Some("mostro-rates"))
             // A future-dated `created_at` (forged or clock-skewed relay) would
-            // otherwise saturate the age check to 0 and win `max_by_key` outright.
+            // otherwise saturate the age check to 0 and win the ranking outright.
             .filter(|e| e.created_at <= now)
             .filter(|e| now.as_secs().saturating_sub(e.created_at.as_secs()) <= max_age_secs)
             .filter(|e| !e.is_expired_at(&now))
-            .max_by_key(|e| e.created_at)
+            .collect();
+        candidates.sort_unstable_by(|a, b| b.created_at.cmp(&a.created_at));
+        candidates
+    }
+
+    /// Try `candidates` newest-first, returning the first one whose content
+    /// parses into a non-empty rate map. A malformed body or a `{"BTC":{}}`
+    /// empty one from the freshest candidate must not shadow a good, still-
+    /// fresh body from an older candidate — that would fail the whole tick
+    /// even though a usable redundant trusted node is right there. Split out
+    /// from [`Self::fetch`] so the fallback behavior is unit-testable
+    /// without a relay.
+    pub(crate) fn pick_first_usable(
+        candidates: &[&Event],
+    ) -> Result<ProviderQuotes, ProviderError> {
+        for event in candidates {
+            match Self::parse_content(&event.content) {
+                Ok(quotes) if !quotes.is_empty() => return Ok(quotes),
+                Ok(_) => debug!(
+                    "price: nostr: candidate event {} parsed to zero usable rates, trying next",
+                    event.id
+                ),
+                Err(e) => debug!(
+                    "price: nostr: candidate event {} failed to parse ({e}), trying next",
+                    event.id
+                ),
+            }
+        }
+        Err(ProviderError::Parse(
+            "nostr: every fresh trusted-node candidate failed to parse or yielded no usable rates"
+                .to_string(),
+        ))
     }
 }
 
@@ -172,17 +222,17 @@ impl PriceProvider for NostrProvider {
             .into_iter()
             .collect::<Vec<Event>>();
 
-        let event =
-            Self::select_freshest(&events, &self.trusted_nodes, Timestamp::now(), self.max_age)
-                .ok_or_else(|| {
-                    ProviderError::Http(
-                        "nostr: no fresh trusted-node rate event found \
+        let candidates =
+            Self::rank_candidates(&events, &self.trusted_nodes, Timestamp::now(), self.max_age);
+        if candidates.is_empty() {
+            return Err(ProviderError::Http(
+                "nostr: no fresh trusted-node rate event found \
                  (all missing, untrusted, or older than max_price_staleness_seconds)"
-                            .to_string(),
-                    )
-                })?;
+                    .to_string(),
+            ));
+        }
 
-        Self::parse_content(&event.content)
+        Self::pick_first_usable(&candidates)
     }
 }
 
@@ -247,12 +297,24 @@ mod tests {
     const NOW: u64 = 10_000;
     const MAX_AGE: Duration = Duration::from_secs(5_000);
 
+    /// The single freshest candidate, if any — these tests only care about
+    /// the winner, not the full fallback order `rank_candidates` exposes for
+    /// `pick_first_usable`.
+    fn freshest<'a>(
+        events: &'a [Event],
+        trusted: &[PublicKey],
+        now: Timestamp,
+        max_age: Duration,
+    ) -> Option<&'a Event> {
+        NostrProvider::rank_candidates(events, trusted, now, max_age)
+            .into_iter()
+            .next()
+    }
+
     #[test]
     fn select_freshest_returns_none_for_empty_events() {
         let trusted = vec![Keys::generate().public_key()];
-        assert!(
-            NostrProvider::select_freshest(&[], &trusted, Timestamp::from(NOW), MAX_AGE).is_none()
-        );
+        assert!(freshest(&[], &trusted, Timestamp::from(NOW), MAX_AGE).is_none());
     }
 
     #[test]
@@ -264,10 +326,7 @@ mod tests {
         let untrusted_event = signed_event(&untrusted_keys, SAMPLE_CONTENT, NOW - 100);
         let events = vec![untrusted_event];
 
-        assert!(
-            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
-                .is_none()
-        );
+        assert!(freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE).is_none());
     }
 
     #[test]
@@ -280,9 +339,7 @@ mod tests {
         let newer = signed_event(&newer_keys, SAMPLE_CONTENT, NOW - 100);
         let events = vec![older, newer.clone()];
 
-        let picked =
-            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
-                .unwrap();
+        let picked = freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE).unwrap();
         assert_eq!(picked.id, newer.id);
     }
 
@@ -295,9 +352,7 @@ mod tests {
         let fresh = signed_event(&keys, SAMPLE_CONTENT, NOW - 100);
         let events = vec![stale, fresh.clone()];
 
-        let picked =
-            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
-                .unwrap();
+        let picked = freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE).unwrap();
         assert_eq!(picked.id, fresh.id);
     }
 
@@ -309,10 +364,7 @@ mod tests {
         let stale = signed_event(&keys, SAMPLE_CONTENT, NOW - MAX_AGE.as_secs() - 1);
         let events = vec![stale];
 
-        assert!(
-            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
-                .is_none()
-        );
+        assert!(freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE).is_none());
     }
 
     #[test]
@@ -323,9 +375,7 @@ mod tests {
         let at_boundary = signed_event(&keys, SAMPLE_CONTENT, NOW - MAX_AGE.as_secs());
         let events = vec![at_boundary.clone()];
 
-        let picked =
-            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
-                .unwrap();
+        let picked = freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE).unwrap();
         assert_eq!(picked.id, at_boundary.id);
     }
 
@@ -340,9 +390,7 @@ mod tests {
         let current = signed_event(&keys, SAMPLE_CONTENT, NOW - 100);
         let events = vec![future, current.clone()];
 
-        let picked =
-            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
-                .unwrap();
+        let picked = freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE).unwrap();
         assert_eq!(picked.id, current.id);
     }
 
@@ -358,9 +406,7 @@ mod tests {
         let valid = signed_event(&keys, SAMPLE_CONTENT, NOW - 2_000);
         let events = vec![expired, valid.clone()];
 
-        let picked =
-            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
-                .unwrap();
+        let picked = freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE).unwrap();
         assert_eq!(picked.id, valid.id);
     }
 
@@ -372,10 +418,99 @@ mod tests {
         let expired = signed_event_expiring_at(&keys, SAMPLE_CONTENT, NOW - 100, NOW - 50);
         let events = vec![expired];
 
+        assert!(freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE).is_none());
+    }
+
+    /// Like `signed_event`, but with an envelope (`kind`/`d`) that does not
+    /// match what `mostro-rates` events use — for exercising
+    /// `rank_candidates`'s client-side envelope revalidation.
+    fn signed_event_with_envelope(
+        keys: &Keys,
+        content: &str,
+        created_at: u64,
+        kind: u16,
+        identifier: &str,
+    ) -> Event {
+        EventBuilder::new(Kind::Custom(kind), content)
+            .tags(vec![Tag::identifier(identifier)])
+            .custom_created_at(Timestamp::from(created_at))
+            .sign_with_keys(keys)
+            .expect("event must sign")
+    }
+
+    #[test]
+    fn rank_candidates_rejects_a_trusted_event_of_the_wrong_kind() {
+        let keys = Keys::generate();
+        let trusted = vec![keys.public_key()];
+
+        // Correctly signed by a trusted node, correct `d` tag, but not the
+        // mostro-rates kind (30078) — e.g. some other event kind that
+        // pubkey happens to also publish. A relay ignoring the `authors`
+        // *and* `kind` filter (verify_subscriptions defaults to false)
+        // could still hand this back.
+        let wrong_kind =
+            signed_event_with_envelope(&keys, SAMPLE_CONTENT, NOW - 100, 1, "mostro-rates");
+        let events = vec![wrong_kind];
+
         assert!(
-            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
-                .is_none()
+            NostrProvider::rank_candidates(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .is_empty()
         );
+    }
+
+    #[test]
+    fn rank_candidates_rejects_a_trusted_event_with_the_wrong_identifier() {
+        let keys = Keys::generate();
+        let trusted = vec![keys.public_key()];
+
+        // Right kind, right pubkey, but a `d` tag that isn't "mostro-rates"
+        // — some other NIP-33 replaceable event this trusted node happens
+        // to also publish under the same kind.
+        let wrong_identifier = signed_event_with_envelope(
+            &keys,
+            SAMPLE_CONTENT,
+            NOW - 100,
+            NOSTR_EXCHANGE_RATES_EVENT_KIND,
+            "something-else",
+        );
+        let events = vec![wrong_identifier];
+
+        assert!(
+            NostrProvider::rank_candidates(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn pick_first_usable_skips_a_malformed_newest_candidate_for_an_older_valid_one() {
+        let keys = Keys::generate();
+        let malformed = signed_event(&keys, "not json", NOW - 100);
+        let valid = signed_event(&keys, SAMPLE_CONTENT, NOW - 2_000);
+        let candidates = vec![&malformed, &valid];
+
+        let quotes = NostrProvider::pick_first_usable(&candidates).unwrap();
+        assert_eq!(quotes.get("USD"), Some(&Quote::PerBtc(50_000.0)));
+    }
+
+    #[test]
+    fn pick_first_usable_skips_an_empty_newest_candidate_for_an_older_valid_one() {
+        let keys = Keys::generate();
+        let empty = signed_event(&keys, r#"{"BTC": {}}"#, NOW - 100);
+        let valid = signed_event(&keys, SAMPLE_CONTENT, NOW - 2_000);
+        let candidates = vec![&empty, &valid];
+
+        let quotes = NostrProvider::pick_first_usable(&candidates).unwrap();
+        assert_eq!(quotes.get("USD"), Some(&Quote::PerBtc(50_000.0)));
+    }
+
+    #[test]
+    fn pick_first_usable_errs_when_every_candidate_is_unusable() {
+        let keys = Keys::generate();
+        let malformed = signed_event(&keys, "not json", NOW - 100);
+        let empty = signed_event(&keys, r#"{"BTC": {}}"#, NOW - 200);
+        let candidates = vec![&malformed, &empty];
+
+        assert!(NostrProvider::pick_first_usable(&candidates).is_err());
     }
 
     fn sample_cfg(trusted_hex: String) -> ProviderConfig {

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -1,0 +1,293 @@
+//! Nostr trusted-node relay-mode quoter (spec §11.7).
+//!
+//! Instead of an HTTP API, this provider sources BTC/fiat quotes from the
+//! same kind-30078 NIP-33 rate event Mostro nodes already publish
+//! (`nip33::new_exchange_rates_event`, `docs/NOSTR_EXCHANGE_RATES.md`) — for
+//! operators in regions where price APIs are DNS/IP blocked but Nostr relays
+//! are reachable (issue #697). It queries the process-wide Nostr client
+//! (already connected to the `[nostr]` relays) for the latest such event
+//! from each configured `trusted_nodes` pubkey and takes the **freshest**
+//! one as this tick's source — no cross-node statistical combine; a stale or
+//! unreachable trusted node is simply outrun by a fresher one.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use nostr_sdk::prelude::*;
+use serde::Deserialize;
+
+use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
+use crate::price::config::ProviderConfig;
+use crate::price::provider::{PriceProvider, ProviderError, ProviderId, ProviderQuotes, Quote};
+
+/// Upper bound on the one-shot relay query. Deliberately not a config knob:
+/// the outer `PriceManager::poll_budget` (`provider_timeout_seconds`,
+/// default 10s) already bounds the whole `fetch()` call for every provider,
+/// so this just needs to sit comfortably under that default.
+const RELAY_QUERY_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// Same wrapper the daemon publishes: `{"BTC": {ccy: price}}`.
+#[derive(Debug, Deserialize)]
+struct RatesContent {
+    #[serde(rename = "BTC")]
+    btc: HashMap<String, f64>,
+}
+
+/// Trusted-node Nostr quoter.
+pub struct NostrProvider {
+    trusted_nodes: Vec<PublicKey>,
+}
+
+impl NostrProvider {
+    /// Build the provider from its `[price.providers.nostr]` sub-table.
+    ///
+    /// Fails fast (mirrors `ElToqueProvider::new`'s missing-token check) when
+    /// `trusted_nodes` is empty or contains a pubkey that isn't valid hex —
+    /// `ProviderConfig::validate` only checks the list is non-empty, not
+    /// that its entries parse (spec §7).
+    pub fn new(cfg: &ProviderConfig) -> Result<Self, String> {
+        if cfg.trusted_nodes.is_empty() {
+            return Err(
+                "price provider 'nostr': enabled provider requires at least one \
+                 `trusted_nodes` pubkey (see docs/PRICE_PROVIDERS.md §11.7)"
+                    .to_string(),
+            );
+        }
+        let trusted_nodes = cfg
+            .trusted_nodes
+            .iter()
+            .map(|hex| {
+                PublicKey::from_hex(hex).map_err(|e| {
+                    format!(
+                        "price provider 'nostr': invalid `trusted_nodes` pubkey \
+                         '{hex}': {e}"
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { trusted_nodes })
+    }
+
+    /// Parse a rate event's `content` into [`ProviderQuotes`]. Split out so
+    /// it is unit-testable without a relay (spec §10.5).
+    pub(crate) fn parse_content(body: &str) -> Result<ProviderQuotes, ProviderError> {
+        let parsed: RatesContent =
+            serde_json::from_str(body).map_err(|e| ProviderError::Parse(format!("nostr: {e}")))?;
+        Ok(parsed
+            .btc
+            .into_iter()
+            .filter_map(|(code, v)| match v {
+                v if v.is_finite() && v > 0.0 => Some((code.to_uppercase(), Quote::PerBtc(v))),
+                _ => None,
+            })
+            .collect())
+    }
+
+    /// Among `events`, the freshest one authored by a trusted pubkey — a
+    /// second client-side trust check even though the relay-side `authors`
+    /// filter should already guarantee it (spec §10.3 / `NOSTR_EXCHANGE_RATES.md`
+    /// "clients MUST verify pubkey"). Pure and unit-testable without a relay.
+    pub(crate) fn select_freshest<'a>(
+        events: &'a [Event],
+        trusted: &[PublicKey],
+    ) -> Option<&'a Event> {
+        events
+            .iter()
+            .filter(|e| trusted.contains(&e.pubkey))
+            .max_by_key(|e| e.created_at)
+    }
+}
+
+#[async_trait]
+impl PriceProvider for NostrProvider {
+    fn id(&self) -> ProviderId {
+        ProviderId::Nostr
+    }
+
+    async fn fetch(&self, _http: &reqwest::Client) -> Result<ProviderQuotes, ProviderError> {
+        let client = crate::util::get_nostr_client()
+            .map_err(|e| ProviderError::Http(format!("nostr: {e}")))?;
+
+        let filter = Filter::new()
+            .kind(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
+            .authors(self.trusted_nodes.clone())
+            .identifier("mostro-rates");
+
+        let events = client
+            .fetch_events(filter, RELAY_QUERY_TIMEOUT)
+            .await
+            .map_err(|e| ProviderError::Http(format!("nostr: relay query failed: {e}")))?
+            .into_iter()
+            .collect::<Vec<Event>>();
+
+        let event = Self::select_freshest(&events, &self.trusted_nodes).ok_or_else(|| {
+            ProviderError::Http("nostr: no trusted-node rate event found".to_string())
+        })?;
+
+        Self::parse_content(&event.content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE_CONTENT: &str = r#"{"BTC": {"USD": 50000.0, "eur": 45000.0, "ARS": 105000000.0}}"#;
+
+    #[test]
+    fn parse_content_upper_cases_codes() {
+        let quotes = NostrProvider::parse_content(SAMPLE_CONTENT).unwrap();
+        assert_eq!(quotes.get("USD"), Some(&Quote::PerBtc(50_000.0)));
+        assert_eq!(quotes.get("EUR"), Some(&Quote::PerBtc(45_000.0)));
+        assert_eq!(quotes.get("ARS"), Some(&Quote::PerBtc(105_000_000.0)));
+    }
+
+    #[test]
+    fn parse_content_drops_non_finite_and_non_positive() {
+        let body = r#"{"BTC": {"USD": 0, "EUR": -1, "GBP": 50000.0}}"#;
+        let quotes = NostrProvider::parse_content(body).unwrap();
+        assert_eq!(quotes.len(), 1, "only GBP is a usable rate");
+        assert_eq!(quotes.get("GBP"), Some(&Quote::PerBtc(50_000.0)));
+    }
+
+    #[test]
+    fn parse_content_error_is_returned() {
+        let err = NostrProvider::parse_content("not json").unwrap_err();
+        assert!(matches!(err, ProviderError::Parse(_)));
+    }
+
+    fn signed_event(keys: &Keys, content: &str, created_at: u64) -> Event {
+        EventBuilder::new(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND), content)
+            .tags(vec![Tag::identifier("mostro-rates")])
+            .custom_created_at(Timestamp::from(created_at))
+            .sign_with_keys(keys)
+            .expect("event must sign")
+    }
+
+    #[test]
+    fn select_freshest_returns_none_for_empty_events() {
+        let trusted = vec![Keys::generate().public_key()];
+        assert!(NostrProvider::select_freshest(&[], &trusted).is_none());
+    }
+
+    #[test]
+    fn select_freshest_ignores_untrusted_authors() {
+        let trusted_keys = Keys::generate();
+        let untrusted_keys = Keys::generate();
+        let trusted = vec![trusted_keys.public_key()];
+
+        let untrusted_event = signed_event(&untrusted_keys, SAMPLE_CONTENT, 2_000);
+        let events = vec![untrusted_event];
+
+        assert!(NostrProvider::select_freshest(&events, &trusted).is_none());
+    }
+
+    #[test]
+    fn select_freshest_picks_the_newest_trusted_event() {
+        let older_keys = Keys::generate();
+        let newer_keys = Keys::generate();
+        let trusted = vec![older_keys.public_key(), newer_keys.public_key()];
+
+        let older = signed_event(&older_keys, SAMPLE_CONTENT, 1_000);
+        let newer = signed_event(&newer_keys, SAMPLE_CONTENT, 2_000);
+        let events = vec![older, newer.clone()];
+
+        let picked = NostrProvider::select_freshest(&events, &trusted).unwrap();
+        assert_eq!(picked.id, newer.id);
+    }
+
+    #[test]
+    fn new_parses_valid_hex_trusted_nodes() {
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec![Keys::generate().public_key().to_hex()],
+        };
+        assert!(NostrProvider::new(&cfg).is_ok());
+    }
+
+    #[test]
+    fn new_rejects_empty_trusted_nodes() {
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec![],
+        };
+        assert!(NostrProvider::new(&cfg).is_err());
+    }
+
+    #[test]
+    fn new_rejects_invalid_hex_pubkey() {
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec!["not-a-pubkey".to_string()],
+        };
+        assert!(NostrProvider::new(&cfg).is_err());
+    }
+
+    /// Live-relay evidence for issue #697: exercises the real `fetch()` path
+    /// (not a fixture) against `wss://relay.mostro.network` and the two
+    /// example `trusted_nodes` pubkeys the issue names. Inherently flaky
+    /// against third-party infra outside this repo's control, so it's
+    /// `#[ignore]`d (never runs in CI) — run explicitly, alone, so no other
+    /// test races it to set the process-wide `NOSTR_CLIENT`:
+    ///
+    /// `cargo test price::providers::nostr::tests::live_relay_fetch_returns_real_rates -- --ignored --exact`
+    #[tokio::test]
+    #[ignore = "hits a real Nostr relay; run explicitly for manual verification"]
+    async fn live_relay_fetch_returns_real_rates() {
+        let client = Client::default();
+        client
+            .add_relay("wss://relay.mostro.network")
+            .await
+            .expect("add_relay");
+        client.connect().await;
+        crate::NOSTR_CLIENT
+            .set(client)
+            .expect("NOSTR_CLIENT must be unset — run this test alone (see doc comment)");
+
+        // Both pubkeys issue #697 names as example trusted_nodes.
+        let cfg = ProviderConfig {
+            enabled: true,
+            url: String::new(),
+            fallback_urls: vec![],
+            api_key: None,
+            token: None,
+            only: None,
+            except: None,
+            trusted_nodes: vec![
+                "82fa8cb978b43c79b2156585bac2c011176a21d2aead6d9f7c575c005be88390".to_string(),
+                "00000235a3e904cfe1213a8a54d6f1ec1bef7cc6bfaabd6193e82931ccf1366a".to_string(),
+            ],
+        };
+        let provider = NostrProvider::new(&cfg).expect("valid hex pubkeys");
+        let http = reqwest::Client::new();
+
+        let quotes = provider.fetch(&http).await.expect("live relay fetch");
+        println!(
+            "nostr provider live fetch: {} currencies — {quotes:?}",
+            quotes.len()
+        );
+        assert!(
+            !quotes.is_empty(),
+            "expected at least one live currency quote"
+        );
+    }
+}

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures::StreamExt;
 use nostr_sdk::prelude::*;
 use serde::Deserialize;
 use tracing::debug;
@@ -24,6 +25,16 @@ use tracing::debug;
 use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
 use crate::price::config::ProviderConfig;
 use crate::price::provider::{PriceProvider, ProviderError, ProviderId, ProviderQuotes, Quote};
+
+/// Hard cap on events retained from one relay query before local ranking.
+///
+/// `nostr-relay-pool`'s `fetch_events` uses `Events::force_insert`, which
+/// grows without bound when a noncompliant relay ignores the subscription
+/// filter (`verify_subscriptions` defaults to false). Streaming with an
+/// early envelope/author check and this ceiling bounds memory/work within
+/// `query_timeout` (ermeme, PR #841). Well above any realistic number of
+/// trusted-node candidates for one tick.
+const MAX_FETCHED_RATE_EVENTS: usize = 64;
 
 /// Same wrapper the daemon publishes: `{"BTC": {ccy: price}}`.
 #[derive(Debug, Deserialize)]
@@ -203,6 +214,38 @@ impl NostrProvider {
                 .to_string(),
         ))
     }
+
+    /// Whether a relay-delivered event is worth buffering for ranking.
+    /// Applied while streaming so irrelevant junk never accumulates toward
+    /// [`MAX_FETCHED_RATE_EVENTS`].
+    pub(crate) fn is_plausible_candidate(event: &Event, trusted: &[PublicKey]) -> bool {
+        trusted.contains(&event.pubkey)
+            && event.kind == Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND)
+            && event.tags.identifier() == Some("mostro-rates")
+    }
+
+    /// Keep at most `limit` plausible candidates from `incoming`, dropping
+    /// everything else before it is stored. Pure helper so the adversarial
+    /// bound is unit-testable without a relay; production `fetch` applies
+    /// the same filter/cap while streaming.
+    #[cfg(test)]
+    pub(crate) fn collect_bounded_candidates(
+        incoming: impl IntoIterator<Item = Event>,
+        trusted: &[PublicKey],
+        limit: usize,
+    ) -> Vec<Event> {
+        let mut out = Vec::with_capacity(limit.min(16));
+        for event in incoming {
+            if !Self::is_plausible_candidate(&event, trusted) {
+                continue;
+            }
+            out.push(event);
+            if out.len() >= limit {
+                break;
+            }
+        }
+        out
+    }
 }
 
 #[async_trait]
@@ -215,12 +258,31 @@ impl PriceProvider for NostrProvider {
         let client = crate::util::get_nostr_client()
             .map_err(|e| ProviderError::Http(format!("nostr: {e}")))?;
 
-        let events = client
-            .fetch_events(self.build_filter(), self.query_timeout)
+        // Stream rather than `fetch_events`: the pool's collector
+        // `force_insert`s every delivered event (ignoring Filter::limit),
+        // so a noncompliant relay can OOM the process within query_timeout.
+        // Early-filter + hard cap while receiving (ermeme, PR #841).
+        let filter = self.build_filter().limit(MAX_FETCHED_RATE_EVENTS);
+        let mut stream = client
+            .stream_events(filter, self.query_timeout)
             .await
-            .map_err(|e| ProviderError::Http(format!("nostr: relay query failed: {e}")))?
-            .into_iter()
-            .collect::<Vec<Event>>();
+            .map_err(|e| ProviderError::Http(format!("nostr: relay query failed: {e}")))?;
+
+        let mut events = Vec::new();
+        let mut inspected = 0usize;
+        while let Some(event) = stream.next().await {
+            inspected += 1;
+            if Self::is_plausible_candidate(&event, &self.trusted_nodes) {
+                events.push(event);
+                if events.len() >= MAX_FETCHED_RATE_EVENTS {
+                    break;
+                }
+            }
+            // Bound work even when the relay floods irrelevant frames.
+            if inspected >= MAX_FETCHED_RATE_EVENTS.saturating_mul(4) {
+                break;
+            }
+        }
 
         let candidates =
             Self::rank_candidates(&events, &self.trusted_nodes, Timestamp::now(), self.max_age);
@@ -511,6 +573,37 @@ mod tests {
         let candidates = vec![&malformed, &empty];
 
         assert!(NostrProvider::pick_first_usable(&candidates).is_err());
+    }
+
+    #[test]
+    fn collect_bounded_candidates_drops_junk_and_caps_trusted_envelope() {
+        let trusted_keys = Keys::generate();
+        let junk_keys = Keys::generate();
+        let trusted = vec![trusted_keys.public_key()];
+
+        // Flood of wrong-author / wrong-kind frames mixed with more
+        // trusted mostro-rates events than the cap — only `limit`
+        // plausible ones may be retained (ermeme adversarial bound).
+        let mut incoming = Vec::new();
+        for i in 0..20 {
+            incoming.push(signed_event(&junk_keys, SAMPLE_CONTENT, NOW - i));
+            incoming.push(signed_event_with_envelope(
+                &trusted_keys,
+                SAMPLE_CONTENT,
+                NOW - i,
+                1,
+                "mostro-rates",
+            ));
+        }
+        for i in 0..10 {
+            incoming.push(signed_event(&trusted_keys, SAMPLE_CONTENT, NOW - 100 - i));
+        }
+
+        let kept = NostrProvider::collect_bounded_candidates(incoming, &trusted, 3);
+        assert_eq!(kept.len(), 3);
+        assert!(kept
+            .iter()
+            .all(|e| NostrProvider::is_plausible_candidate(e, &trusted)));
     }
 
     fn sample_cfg(trusted_hex: String) -> ProviderConfig {

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -273,7 +273,7 @@ mod tests {
     }
 
     /// Like `signed_event`, but carrying a NIP-40 `expiration` tag — for
-    /// exercising `select_freshest`'s `is_expired_at` gate independently of
+    /// exercising `rank_candidates`'s `is_expired_at` gate independently of
     /// the `max_age` gate.
     fn signed_event_expiring_at(
         keys: &Keys,
@@ -291,7 +291,7 @@ mod tests {
             .expect("event must sign")
     }
 
-    /// Relative clock for `select_freshest` unit tests — events use small
+    /// Relative clock for `rank_candidates` unit tests — events use small
     /// synthetic `created_at` values, so tests pass an explicit `now`
     /// instead of wall-clock time.
     const NOW: u64 = 10_000;
@@ -312,13 +312,13 @@ mod tests {
     }
 
     #[test]
-    fn select_freshest_returns_none_for_empty_events() {
+    fn rank_candidates_returns_none_for_empty_events() {
         let trusted = vec![Keys::generate().public_key()];
         assert!(freshest(&[], &trusted, Timestamp::from(NOW), MAX_AGE).is_none());
     }
 
     #[test]
-    fn select_freshest_ignores_untrusted_authors() {
+    fn rank_candidates_ignores_untrusted_authors() {
         let trusted_keys = Keys::generate();
         let untrusted_keys = Keys::generate();
         let trusted = vec![trusted_keys.public_key()];
@@ -330,7 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn select_freshest_picks_the_newest_trusted_event() {
+    fn rank_candidates_picks_the_newest_trusted_event() {
         let older_keys = Keys::generate();
         let newer_keys = Keys::generate();
         let trusted = vec![older_keys.public_key(), newer_keys.public_key()];
@@ -344,7 +344,7 @@ mod tests {
     }
 
     #[test]
-    fn select_freshest_discards_events_older_than_max_age() {
+    fn rank_candidates_discards_events_older_than_max_age() {
         let keys = Keys::generate();
         let trusted = vec![keys.public_key()];
 
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn select_freshest_returns_none_when_all_trusted_are_stale() {
+    fn rank_candidates_returns_none_when_all_trusted_are_stale() {
         let keys = Keys::generate();
         let trusted = vec![keys.public_key()];
 
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    fn select_freshest_keeps_event_exactly_at_max_age_boundary() {
+    fn rank_candidates_keeps_event_exactly_at_max_age_boundary() {
         let keys = Keys::generate();
         let trusted = vec![keys.public_key()];
 
@@ -380,7 +380,7 @@ mod tests {
     }
 
     #[test]
-    fn select_freshest_rejects_future_dated_events() {
+    fn rank_candidates_rejects_future_dated_events() {
         let keys = Keys::generate();
         let trusted = vec![keys.public_key()];
 
@@ -395,7 +395,7 @@ mod tests {
     }
 
     #[test]
-    fn select_freshest_rejects_an_expired_event_even_if_it_is_the_newest() {
+    fn rank_candidates_rejects_an_expired_event_even_if_it_is_the_newest() {
         let keys = Keys::generate();
         let trusted = vec![keys.public_key()];
 
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[test]
-    fn select_freshest_returns_none_when_every_trusted_event_is_expired() {
+    fn rank_candidates_returns_none_when_every_trusted_event_is_expired() {
         let keys = Keys::generate();
         let trusted = vec![keys.public_key()];
 

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -8,7 +8,10 @@
 //! (already connected to the `[nostr]` relays) for the latest such event
 //! from each configured `trusted_nodes` pubkey and takes the **freshest**
 //! one as this tick's source — no cross-node statistical combine; a stale or
-//! unreachable trusted node is simply outrun by a fresher one.
+//! unreachable trusted node is simply outrun by a fresher one. Events whose
+//! `created_at` is older than `[price].max_price_staleness_seconds` are
+//! discarded so a relay that still serves an expired kind-30078 cannot keep
+//! refreshing the local cache clock with zombie rates.
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -38,6 +41,10 @@ pub struct NostrProvider {
     /// timeout before they can complete or fail on their own (CodeRabbit,
     /// PR #841).
     query_timeout: Duration,
+    /// Maximum age of a trusted-node rate event (`created_at`), taken from
+    /// the shared `[price].max_price_staleness_seconds` so upstream Nostr
+    /// freshness uses the same TTL the store enforces on cached quotes.
+    max_age: Duration,
 }
 
 impl NostrProvider {
@@ -54,7 +61,15 @@ impl NostrProvider {
     /// (no `fallback_urls` for this provider ⇒ one attempt) with the same
     /// 1s of slack every other provider gets from the shared `reqwest`
     /// client's own per-attempt timeout.
-    pub fn new(cfg: &ProviderConfig, provider_timeout_seconds: u64) -> Result<Self, String> {
+    ///
+    /// `max_price_staleness_seconds` is the same shared TTL used by
+    /// [`crate::price::store::PriceStore`]: events older than that are not
+    /// eligible as this tick's source.
+    pub fn new(
+        cfg: &ProviderConfig,
+        provider_timeout_seconds: u64,
+        max_price_staleness_seconds: i64,
+    ) -> Result<Self, String> {
         if cfg.trusted_nodes.is_empty() {
             return Err(
                 "price provider 'nostr': enabled provider requires at least one \
@@ -77,6 +92,9 @@ impl NostrProvider {
         Ok(Self {
             trusted_nodes,
             query_timeout: Duration::from_secs(provider_timeout_seconds.max(1)),
+            // `PriceSettings::validate` already rejects non-positive values;
+            // clamp here so a zero can never make every event look fresh.
+            max_age: Duration::from_secs(max_price_staleness_seconds.max(1) as u64),
         })
     }
 
@@ -107,17 +125,24 @@ impl NostrProvider {
             .collect())
     }
 
-    /// Among `events`, the freshest one authored by a trusted pubkey — a
-    /// second client-side trust check even though the relay-side `authors`
-    /// filter should already guarantee it (spec §10.3 / `NOSTR_EXCHANGE_RATES.md`
-    /// "clients MUST verify pubkey"). Pure and unit-testable without a relay.
+    /// Among `events`, the freshest one authored by a trusted pubkey whose
+    /// `created_at` is within `max_age` of `now` — a second client-side trust
+    /// check even though the relay-side `authors` filter should already
+    /// guarantee the pubkey (spec §10.3 / `NOSTR_EXCHANGE_RATES.md`
+    /// "clients MUST verify pubkey"), plus a freshness gate so relays that
+    /// ignore NIP-40 expiration cannot serve zombie rates. Pure and
+    /// unit-testable without a relay.
     pub(crate) fn select_freshest<'a>(
         events: &'a [Event],
         trusted: &[PublicKey],
+        now: Timestamp,
+        max_age: Duration,
     ) -> Option<&'a Event> {
+        let max_age_secs = max_age.as_secs();
         events
             .iter()
             .filter(|e| trusted.contains(&e.pubkey))
+            .filter(|e| now.as_secs().saturating_sub(e.created_at.as_secs()) <= max_age_secs)
             .max_by_key(|e| e.created_at)
     }
 }
@@ -139,8 +164,18 @@ impl PriceProvider for NostrProvider {
             .into_iter()
             .collect::<Vec<Event>>();
 
-        let event = Self::select_freshest(&events, &self.trusted_nodes).ok_or_else(|| {
-            ProviderError::Http("nostr: no trusted-node rate event found".to_string())
+        let event = Self::select_freshest(
+            &events,
+            &self.trusted_nodes,
+            Timestamp::now(),
+            self.max_age,
+        )
+        .ok_or_else(|| {
+            ProviderError::Http(
+                "nostr: no fresh trusted-node rate event found \
+                 (all missing, untrusted, or older than max_price_staleness_seconds)"
+                    .to_string(),
+            )
         })?;
 
         Self::parse_content(&event.content)
@@ -183,10 +218,22 @@ mod tests {
             .expect("event must sign")
     }
 
+    /// Relative clock for `select_freshest` unit tests — events use small
+    /// synthetic `created_at` values, so tests pass an explicit `now`
+    /// instead of wall-clock time.
+    const NOW: u64 = 10_000;
+    const MAX_AGE: Duration = Duration::from_secs(5_000);
+
     #[test]
     fn select_freshest_returns_none_for_empty_events() {
         let trusted = vec![Keys::generate().public_key()];
-        assert!(NostrProvider::select_freshest(&[], &trusted).is_none());
+        assert!(NostrProvider::select_freshest(
+            &[],
+            &trusted,
+            Timestamp::from(NOW),
+            MAX_AGE
+        )
+        .is_none());
     }
 
     #[test]
@@ -195,10 +242,16 @@ mod tests {
         let untrusted_keys = Keys::generate();
         let trusted = vec![trusted_keys.public_key()];
 
-        let untrusted_event = signed_event(&untrusted_keys, SAMPLE_CONTENT, 2_000);
+        let untrusted_event = signed_event(&untrusted_keys, SAMPLE_CONTENT, NOW - 100);
         let events = vec![untrusted_event];
 
-        assert!(NostrProvider::select_freshest(&events, &trusted).is_none());
+        assert!(NostrProvider::select_freshest(
+            &events,
+            &trusted,
+            Timestamp::from(NOW),
+            MAX_AGE
+        )
+        .is_none());
     }
 
     #[test]
@@ -207,32 +260,64 @@ mod tests {
         let newer_keys = Keys::generate();
         let trusted = vec![older_keys.public_key(), newer_keys.public_key()];
 
-        let older = signed_event(&older_keys, SAMPLE_CONTENT, 1_000);
-        let newer = signed_event(&newer_keys, SAMPLE_CONTENT, 2_000);
+        let older = signed_event(&older_keys, SAMPLE_CONTENT, NOW - 2_000);
+        let newer = signed_event(&newer_keys, SAMPLE_CONTENT, NOW - 100);
         let events = vec![older, newer.clone()];
 
-        let picked = NostrProvider::select_freshest(&events, &trusted).unwrap();
+        let picked =
+            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .unwrap();
         assert_eq!(picked.id, newer.id);
     }
 
     #[test]
-    fn new_parses_valid_hex_trusted_nodes() {
-        let cfg = ProviderConfig {
-            enabled: true,
-            url: String::new(),
-            fallback_urls: vec![],
-            api_key: None,
-            token: None,
-            only: None,
-            except: None,
-            trusted_nodes: vec![Keys::generate().public_key().to_hex()],
-        };
-        assert!(NostrProvider::new(&cfg, 10).is_ok());
+    fn select_freshest_discards_events_older_than_max_age() {
+        let keys = Keys::generate();
+        let trusted = vec![keys.public_key()];
+
+        let stale = signed_event(&keys, SAMPLE_CONTENT, NOW - MAX_AGE.as_secs() - 1);
+        let fresh = signed_event(&keys, SAMPLE_CONTENT, NOW - 100);
+        let events = vec![stale, fresh.clone()];
+
+        let picked =
+            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .unwrap();
+        assert_eq!(picked.id, fresh.id);
     }
 
     #[test]
-    fn new_derives_query_timeout_from_provider_timeout_seconds() {
-        let cfg = ProviderConfig {
+    fn select_freshest_returns_none_when_all_trusted_are_stale() {
+        let keys = Keys::generate();
+        let trusted = vec![keys.public_key()];
+
+        let stale = signed_event(&keys, SAMPLE_CONTENT, NOW - MAX_AGE.as_secs() - 1);
+        let events = vec![stale];
+
+        assert!(NostrProvider::select_freshest(
+            &events,
+            &trusted,
+            Timestamp::from(NOW),
+            MAX_AGE
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn select_freshest_keeps_event_exactly_at_max_age_boundary() {
+        let keys = Keys::generate();
+        let trusted = vec![keys.public_key()];
+
+        let at_boundary = signed_event(&keys, SAMPLE_CONTENT, NOW - MAX_AGE.as_secs());
+        let events = vec![at_boundary.clone()];
+
+        let picked =
+            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .unwrap();
+        assert_eq!(picked.id, at_boundary.id);
+    }
+
+    fn sample_cfg(trusted_hex: String) -> ProviderConfig {
+        ProviderConfig {
             enabled: true,
             url: String::new(),
             fallback_urls: vec![],
@@ -240,14 +325,27 @@ mod tests {
             token: None,
             only: None,
             except: None,
-            trusted_nodes: vec![Keys::generate().public_key().to_hex()],
-        };
-        let provider = NostrProvider::new(&cfg, 7).unwrap();
-        assert_eq!(provider.query_timeout, Duration::from_secs(7));
+            trusted_nodes: vec![trusted_hex],
+        }
+    }
 
-        // A misconfigured 0 must not produce a zero-duration timeout.
-        let provider = NostrProvider::new(&cfg, 0).unwrap();
+    #[test]
+    fn new_parses_valid_hex_trusted_nodes() {
+        let cfg = sample_cfg(Keys::generate().public_key().to_hex());
+        assert!(NostrProvider::new(&cfg, 10, 1_800).is_ok());
+    }
+
+    #[test]
+    fn new_derives_query_timeout_and_max_age_from_shared_settings() {
+        let cfg = sample_cfg(Keys::generate().public_key().to_hex());
+        let provider = NostrProvider::new(&cfg, 7, 1_800).unwrap();
+        assert_eq!(provider.query_timeout, Duration::from_secs(7));
+        assert_eq!(provider.max_age, Duration::from_secs(1_800));
+
+        // A misconfigured 0 must not produce a zero-duration timeout/age.
+        let provider = NostrProvider::new(&cfg, 0, 0).unwrap();
         assert_eq!(provider.query_timeout, Duration::from_secs(1));
+        assert_eq!(provider.max_age, Duration::from_secs(1));
     }
 
     #[test]
@@ -264,7 +362,7 @@ mod tests {
             except: None,
             trusted_nodes: vec![node_a.to_hex(), node_b.to_hex()],
         };
-        let provider = NostrProvider::new(&cfg, 10).unwrap();
+        let provider = NostrProvider::new(&cfg, 10, 1_800).unwrap();
 
         let expected = Filter::new()
             .kind(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
@@ -285,22 +383,13 @@ mod tests {
             except: None,
             trusted_nodes: vec![],
         };
-        assert!(NostrProvider::new(&cfg, 10).is_err());
+        assert!(NostrProvider::new(&cfg, 10, 1_800).is_err());
     }
 
     #[test]
     fn new_rejects_invalid_hex_pubkey() {
-        let cfg = ProviderConfig {
-            enabled: true,
-            url: String::new(),
-            fallback_urls: vec![],
-            api_key: None,
-            token: None,
-            only: None,
-            except: None,
-            trusted_nodes: vec!["not-a-pubkey".to_string()],
-        };
-        assert!(NostrProvider::new(&cfg, 10).is_err());
+        let cfg = sample_cfg("not-a-pubkey".to_string());
+        assert!(NostrProvider::new(&cfg, 10, 1_800).is_err());
     }
 
     /// Live-relay evidence for issue #697: exercises the real `fetch()` path
@@ -338,7 +427,7 @@ mod tests {
                 "00000235a3e904cfe1213a8a54d6f1ec1bef7cc6bfaabd6193e82931ccf1366a".to_string(),
             ],
         };
-        let provider = NostrProvider::new(&cfg, 10).expect("valid hex pubkeys");
+        let provider = NostrProvider::new(&cfg, 10, 1_800).expect("valid hex pubkeys");
         let http = reqwest::Client::new();
 
         let quotes = provider.fetch(&http).await.expect("live relay fetch");

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -130,7 +130,11 @@ impl NostrProvider {
     /// check even though the relay-side `authors` filter should already
     /// guarantee the pubkey (spec §10.3 / `NOSTR_EXCHANGE_RATES.md`
     /// "clients MUST verify pubkey"), plus a freshness gate so relays that
-    /// ignore NIP-40 expiration cannot serve zombie rates. Pure and
+    /// ignore NIP-40 expiration cannot serve zombie rates. The event's own
+    /// NIP-40 `expiration` tag, if any, is also honored directly via
+    /// `Event::is_expired_at` — the `max_age` gate alone only bounds
+    /// staleness by this node's clock, so a trusted node advertising a
+    /// shorter self-declared expiry is still respected. Pure and
     /// unit-testable without a relay.
     pub(crate) fn select_freshest<'a>(
         events: &'a [Event],
@@ -146,6 +150,7 @@ impl NostrProvider {
             // otherwise saturate the age check to 0 and win `max_by_key` outright.
             .filter(|e| e.created_at <= now)
             .filter(|e| now.as_secs().saturating_sub(e.created_at.as_secs()) <= max_age_secs)
+            .filter(|e| !e.is_expired_at(&now))
             .max_by_key(|e| e.created_at)
     }
 }
@@ -212,6 +217,25 @@ mod tests {
     fn signed_event(keys: &Keys, content: &str, created_at: u64) -> Event {
         EventBuilder::new(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND), content)
             .tags(vec![Tag::identifier("mostro-rates")])
+            .custom_created_at(Timestamp::from(created_at))
+            .sign_with_keys(keys)
+            .expect("event must sign")
+    }
+
+    /// Like `signed_event`, but carrying a NIP-40 `expiration` tag — for
+    /// exercising `select_freshest`'s `is_expired_at` gate independently of
+    /// the `max_age` gate.
+    fn signed_event_expiring_at(
+        keys: &Keys,
+        content: &str,
+        created_at: u64,
+        expiration: u64,
+    ) -> Event {
+        EventBuilder::new(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND), content)
+            .tags(vec![
+                Tag::identifier("mostro-rates"),
+                Tag::expiration(Timestamp::from(expiration)),
+            ])
             .custom_created_at(Timestamp::from(created_at))
             .sign_with_keys(keys)
             .expect("event must sign")
@@ -320,6 +344,38 @@ mod tests {
             NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
                 .unwrap();
         assert_eq!(picked.id, current.id);
+    }
+
+    #[test]
+    fn select_freshest_rejects_an_expired_event_even_if_it_is_the_newest() {
+        let keys = Keys::generate();
+        let trusted = vec![keys.public_key()];
+
+        // Newer by created_at, but self-declared expired via NIP-40 — a
+        // relay that ignores expiration and still serves it must not let it
+        // win over an older, still-valid event.
+        let expired = signed_event_expiring_at(&keys, SAMPLE_CONTENT, NOW - 100, NOW - 50);
+        let valid = signed_event(&keys, SAMPLE_CONTENT, NOW - 2_000);
+        let events = vec![expired, valid.clone()];
+
+        let picked =
+            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .unwrap();
+        assert_eq!(picked.id, valid.id);
+    }
+
+    #[test]
+    fn select_freshest_returns_none_when_every_trusted_event_is_expired() {
+        let keys = Keys::generate();
+        let trusted = vec![keys.public_key()];
+
+        let expired = signed_event_expiring_at(&keys, SAMPLE_CONTENT, NOW - 100, NOW - 50);
+        let events = vec![expired];
+
+        assert!(
+            NostrProvider::select_freshest(&events, &trusted, Timestamp::from(NOW), MAX_AGE)
+                .is_none()
+        );
     }
 
     fn sample_cfg(trusted_hex: String) -> ProviderConfig {

--- a/src/price/providers/yadio.rs
+++ b/src/price/providers/yadio.rs
@@ -127,6 +127,7 @@ mod tests {
             token: None,
             only: None,
             except: None,
+            trusted_nodes: vec![],
         };
         let p = YadioProvider::new(&cfg);
         // We rebuild the request URL by appending `/exrates/BTC`; without

--- a/src/price/store.rs
+++ b/src/price/store.rs
@@ -131,6 +131,7 @@ mod tests {
                         // exercise TTL/last-known-good semantics. Empty
                         // is fine since the store never reads this field.
                         contributors: Vec::new(),
+                        nostr_anchor_dependent: false,
                     },
                 )
             })

--- a/src/util.rs
+++ b/src/util.rs
@@ -2574,7 +2574,10 @@ mod tests {
         let price_client = ClientBuilder::default()
             .opts(price_nostr_client_options())
             .build();
-        price_client.add_relay(url.clone()).await.expect("add_relay");
+        price_client
+            .add_relay(url.clone())
+            .await
+            .expect("add_relay");
         price_client.connect().await;
 
         let filter = Filter::new().kind(nostr_sdk::Kind::Metadata).limit(3);
@@ -2618,13 +2621,8 @@ mod tests {
         // the live event.
         let mut notifications = daemon.notifications();
 
-        let filter = Filter::new()
-            .kind(nostr_sdk::Kind::TextNote)
-            .limit(0);
-        daemon
-            .subscribe(filter, None)
-            .await
-            .expect("subscribe");
+        let filter = Filter::new().kind(nostr_sdk::Kind::TextNote).limit(0);
+        daemon.subscribe(filter, None).await.expect("subscribe");
 
         // Empty relay ⇒ EOSE quickly; then publish a matching live event.
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -2634,7 +2632,10 @@ mod tests {
             .sign_with_keys(&keys)
             .expect("sign");
         let live_id = live.id;
-        publisher.send_event(&live).await.expect("publish live event");
+        publisher
+            .send_event(&live)
+            .await
+            .expect("publish live event");
 
         let got = tokio::time::timeout(Duration::from_secs(8), async {
             while let Ok(notification) = notifications.recv().await {

--- a/src/util.rs
+++ b/src/util.rs
@@ -937,14 +937,15 @@ pub async fn update_order_event(
 pub async fn connect_nostr() -> Result<Client, MostroError> {
     let nostr_settings = Settings::get_nostr();
 
-    let mut limits = RelayLimits::default();
-    // Some specific events can have a bigger size than regular events
-    // So we increase the limits for those events
-    limits.messages.max_size = Some(6_000);
-    limits.events.max_size = Some(6_500);
-    let opts = ClientOptions::new().relay_limits(limits);
-
-    // Create new client
+    // Create new client. `verify_subscriptions(true)` rejects events that
+    // do not match the REQ filter *inside the relay driver*, before they
+    // can enter `RelayPool::stream_events_targeted`'s unbounded
+    // `HashSet<EventId>` dedup set. Without this, dropping the consumer
+    // after an application-level cap does not stop the spawned pool task
+    // from buffering every unique EventId until query timeout (ermeme,
+    // PR #841). Relays are operator-configured trust boundaries; filter
+    // enforcement is the correct bound for that surface.
+    let opts = mostro_nostr_client_options();
     let client = ClientBuilder::default().opts(opts).build();
 
     // Add relays
@@ -959,6 +960,20 @@ pub async fn connect_nostr() -> Result<Client, MostroError> {
     client.connect().await;
 
     Ok(client)
+}
+
+/// Process-wide Nostr [`ClientOptions`]: size limits plus subscription
+/// filter verification. Split out so the verify-subscriptions bound is
+/// unit-testable without standing up relays.
+pub(crate) fn mostro_nostr_client_options() -> ClientOptions {
+    let mut limits = RelayLimits::default();
+    // Some specific events can have a bigger size than regular events
+    // So we increase the limits for those events
+    limits.messages.max_size = Some(6_000);
+    limits.events.max_size = Some(6_500);
+    ClientOptions::new()
+        .relay_limits(limits)
+        .verify_subscriptions(true)
 }
 
 pub async fn show_hold_invoice(
@@ -2443,6 +2458,20 @@ mod tests {
             !client.relays().await.is_empty(),
             "configured relays must be registered"
         );
+    }
+
+    #[test]
+    fn mostro_nostr_client_options_builds_client() {
+        // Production stream bound for pooled queries: `connect_nostr` uses
+        // `mostro_nostr_client_options()` which enables `verify_subscriptions`
+        // so the relay driver drops non-matching events before they hit the
+        // pool's unbounded EventId dedup set (ermeme, PR #841). Options
+        // fields are not publicly readable; pin that the helper still
+        // constructs a Client (SDK copies the flag into RelayOptions in
+        // Client::compose_relay_opts).
+        let _client = ClientBuilder::default()
+            .opts(mostro_nostr_client_options())
+            .build();
     }
 
     #[tokio::test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,7 +11,6 @@ use crate::lightning;
 use crate::lightning::invoice::is_valid_invoice;
 use crate::messages;
 use crate::nip33::{create_platform_tag_values, new_order_event, new_rating_event, order_to_tags};
-use crate::NOSTR_CLIENT;
 
 use chrono::Duration;
 use fedimint_tonic_lnd::lnrpc::invoice::InvoiceState;
@@ -937,14 +936,12 @@ pub async fn update_order_event(
 pub async fn connect_nostr() -> Result<Client, MostroError> {
     let nostr_settings = Settings::get_nostr();
 
-    // Create new client. `verify_subscriptions(true)` rejects events that
-    // do not match the REQ filter *inside the relay driver*, before they
-    // can enter `RelayPool::stream_events_targeted`'s unbounded
-    // `HashSet<EventId>` dedup set. Without this, dropping the consumer
-    // after an application-level cap does not stop the spawned pool task
-    // from buffering every unique EventId until query timeout (ermeme,
-    // PR #841). Relays are operator-configured trust boundaries; filter
-    // enforcement is the correct bound for that surface.
+    // Daemon inbox client: shared size limits, but **no**
+    // `verify_subscriptions`. The long-lived `.limit(0)` subscription in
+    // `main.rs` must not count pre-EOSE frames against a zero limit — that
+    // would drop matching trade messages before dispatch (hermeme, PR #841).
+    // Price queries use [`connect_price_nostr`] / [`PRICE_NOSTR_CLIENT`] with
+    // verification enabled instead.
     let opts = mostro_nostr_client_options();
     let client = ClientBuilder::default().opts(opts).build();
 
@@ -962,18 +959,76 @@ pub async fn connect_nostr() -> Result<Client, MostroError> {
     Ok(client)
 }
 
-/// Process-wide Nostr [`ClientOptions`]: size limits plus subscription
-/// filter verification. Split out so the verify-subscriptions bound is
-/// unit-testable without standing up relays.
-pub(crate) fn mostro_nostr_client_options() -> ClientOptions {
+/// Build the dedicated price-provider Nostr client (same relays as the
+/// daemon client, with [`price_nostr_client_options`]).
+pub async fn connect_price_nostr() -> Result<Client, MostroError> {
+    let nostr_settings = Settings::get_nostr();
+    let client = ClientBuilder::default()
+        .opts(price_nostr_client_options())
+        .build();
+
+    for relay in nostr_settings.relays.iter() {
+        client
+            .add_relay(relay)
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+    }
+
+    client.connect().await;
+    Ok(client)
+}
+
+/// Observable policy for Mostro Nostr clients. [`ClientOptions`] fields are
+/// not publicly readable, so production paths go through this struct and
+/// tests assert on it directly (hermeme, PR #841).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MostroNostrClientPolicy {
+    /// When true, the relay driver rejects non-matching / over-limit events
+    /// before they enter the pool's EventId dedup set.
+    pub verify_subscriptions: bool,
+}
+
+/// Daemon / inbox client: do **not** verify subscriptions (see [`connect_nostr`]).
+pub(crate) fn daemon_nostr_client_policy() -> MostroNostrClientPolicy {
+    MostroNostrClientPolicy {
+        verify_subscriptions: false,
+    }
+}
+
+/// Price kind-30078 queries: verify subscriptions so a noncompliant relay
+/// cannot flood `stream_events`'s pool-side dedup set (ermeme, PR #841).
+pub(crate) fn price_nostr_client_policy() -> MostroNostrClientPolicy {
+    MostroNostrClientPolicy {
+        verify_subscriptions: true,
+    }
+}
+
+fn mostro_nostr_relay_limits() -> RelayLimits {
     let mut limits = RelayLimits::default();
     // Some specific events can have a bigger size than regular events
     // So we increase the limits for those events
     limits.messages.max_size = Some(6_000);
     limits.events.max_size = Some(6_500);
-    ClientOptions::new()
-        .relay_limits(limits)
-        .verify_subscriptions(true)
+    limits
+}
+
+fn client_options_from_policy(policy: MostroNostrClientPolicy) -> ClientOptions {
+    let mut opts = ClientOptions::new().relay_limits(mostro_nostr_relay_limits());
+    if policy.verify_subscriptions {
+        opts = opts.verify_subscriptions(true);
+    }
+    opts
+}
+
+/// Process-wide daemon Nostr [`ClientOptions`] (inbox / publishing).
+pub(crate) fn mostro_nostr_client_options() -> ClientOptions {
+    client_options_from_policy(daemon_nostr_client_policy())
+}
+
+/// Price-provider Nostr [`ClientOptions`]: size limits plus subscription
+/// filter verification, scoped away from the daemon inbox client.
+pub(crate) fn price_nostr_client_options() -> ClientOptions {
+    client_options_from_policy(price_nostr_client_policy())
 }
 
 pub async fn show_hold_invoice(
@@ -1336,6 +1391,26 @@ pub fn get_nostr_client() -> Result<&'static Client, MostroError> {
             "Client not initialized!".to_string(),
         )))
     }
+}
+
+/// Lazy getter for the price-provider Nostr client ([`PRICE_NOSTR_CLIENT`]).
+///
+/// Initialized on first price fetch so operators who disable the Nostr
+/// provider never open a second relay pool. Uses [`connect_price_nostr`] —
+/// `verify_subscriptions(true)` only on this client.
+pub async fn get_price_nostr_client() -> Result<&'static Client, MostroError> {
+    if let Some(client) = PRICE_NOSTR_CLIENT.get() {
+        return Ok(client);
+    }
+
+    let client = connect_price_nostr().await?;
+    // Another task may have won the race; drop our duplicate and use theirs.
+    let _ = PRICE_NOSTR_CLIENT.set(client);
+    PRICE_NOSTR_CLIENT.get().ok_or_else(|| {
+        MostroInternalErr(ServiceError::NostrError(
+            "Price Nostr client not initialized!".to_string(),
+        ))
+    })
 }
 
 /// Getter function with error management for nostr relays
@@ -2461,17 +2536,168 @@ mod tests {
     }
 
     #[test]
-    fn mostro_nostr_client_options_builds_client() {
-        // Production stream bound for pooled queries: `connect_nostr` uses
-        // `mostro_nostr_client_options()` which enables `verify_subscriptions`
-        // so the relay driver drops non-matching events before they hit the
-        // pool's unbounded EventId dedup set (ermeme, PR #841). Options
-        // fields are not publicly readable; pin that the helper still
-        // constructs a Client (SDK copies the flag into RelayOptions in
-        // Client::compose_relay_opts).
-        let _client = ClientBuilder::default()
+    fn nostr_client_policies_scope_verify_to_price_only() {
+        // Daemon inbox must not enable verify_subscriptions (main.rs limit(0)).
+        assert!(
+            !daemon_nostr_client_policy().verify_subscriptions,
+            "daemon client must leave verify_subscriptions off"
+        );
+        assert!(
+            price_nostr_client_policy().verify_subscriptions,
+            "price client must enable verify_subscriptions"
+        );
+        // Helpers remain constructible (SDK copies the flag into RelayOptions).
+        let _daemon = ClientBuilder::default()
             .opts(mostro_nostr_client_options())
             .build();
+        let _price = ClientBuilder::default()
+            .opts(price_nostr_client_options())
+            .build();
+    }
+
+    #[tokio::test]
+    async fn price_client_rejects_mismatched_events_before_pool() {
+        use futures::StreamExt;
+        use nostr_relay_builder::builder::RelayTestOptions;
+        use nostr_relay_builder::MockRelay;
+        use std::time::Duration;
+
+        // Noncompliant relay floods random events that do not match the REQ.
+        let mock = MockRelay::run_with_opts(RelayTestOptions {
+            unresponsive_connection: None,
+            send_random_events: true,
+        })
+        .await
+        .expect("mock relay");
+        let url = mock.url().await;
+
+        let price_client = ClientBuilder::default()
+            .opts(price_nostr_client_options())
+            .build();
+        price_client.add_relay(url.clone()).await.expect("add_relay");
+        price_client.connect().await;
+
+        let filter = Filter::new().kind(nostr_sdk::Kind::Metadata).limit(3);
+        let mut stream = price_client
+            .stream_events(filter, Duration::from_secs(3))
+            .await
+            .expect("stream");
+        let mut received = 0usize;
+        while stream.next().await.is_some() {
+            received += 1;
+        }
+        assert_eq!(
+            received, 0,
+            "price verify_subscriptions must drop mismatched frames before delivery"
+        );
+    }
+
+    #[tokio::test]
+    async fn daemon_client_limit_zero_still_delivers_live_after_eose() {
+        use nostr_relay_builder::MockRelay;
+        use std::time::Duration;
+
+        // Clean mock (no random flood): mirrors main.rs `.limit(0)` inbox —
+        // history is skipped, but live matching events after EOSE must arrive.
+        // Daemon options intentionally omit verify_subscriptions so pre-EOSE
+        // frames are not counted against limit 0 (hermeme, PR #841).
+        let mock = MockRelay::run().await.expect("mock relay");
+        let url = mock.url().await;
+
+        let daemon = ClientBuilder::default()
+            .opts(mostro_nostr_client_options())
+            .build();
+        daemon.add_relay(url.clone()).await.expect("add_relay");
+        daemon.connect().await;
+
+        let publisher = ClientBuilder::default().build();
+        publisher.add_relay(url).await.expect("add_relay");
+        publisher.connect().await;
+
+        // Take the notification channel before subscribe so we cannot miss
+        // the live event.
+        let mut notifications = daemon.notifications();
+
+        let filter = Filter::new()
+            .kind(nostr_sdk::Kind::TextNote)
+            .limit(0);
+        daemon
+            .subscribe(filter, None)
+            .await
+            .expect("subscribe");
+
+        // Empty relay ⇒ EOSE quickly; then publish a matching live event.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let keys = Keys::generate();
+        let live = EventBuilder::text_note("live-after-eose")
+            .sign_with_keys(&keys)
+            .expect("sign");
+        let live_id = live.id;
+        publisher.send_event(&live).await.expect("publish live event");
+
+        let got = tokio::time::timeout(Duration::from_secs(8), async {
+            while let Ok(notification) = notifications.recv().await {
+                if let RelayPoolNotification::Event { event, .. } = notification {
+                    if event.id == live_id {
+                        return true;
+                    }
+                }
+            }
+            false
+        })
+        .await
+        .expect("timed out waiting for live event after EOSE");
+        assert!(
+            got,
+            "daemon limit(0) subscription must deliver live post-EOSE events"
+        );
+    }
+
+    #[tokio::test]
+    async fn price_client_enforces_filter_limit_before_pool() {
+        use futures::StreamExt;
+        use nostr_relay_builder::MockRelay;
+        use std::time::Duration;
+
+        let mock = MockRelay::run().await.expect("mock relay");
+        let url = mock.url().await;
+
+        // Seed more matching events than the REQ limit.
+        let seeder = ClientBuilder::default().build();
+        seeder.add_relay(url.clone()).await.expect("add_relay");
+        seeder.connect().await;
+        let keys = Keys::generate();
+        for i in 0..10 {
+            let event = EventBuilder::text_note(format!("seed-{i}"))
+                .sign_with_keys(&keys)
+                .expect("sign");
+            seeder.send_event(&event).await.expect("seed");
+        }
+
+        let price_client = ClientBuilder::default()
+            .opts(price_nostr_client_options())
+            .build();
+        price_client.add_relay(url).await.expect("add_relay");
+        price_client.connect().await;
+
+        let filter = Filter::new().kind(nostr_sdk::Kind::TextNote).limit(3);
+        let mut stream = price_client
+            .stream_events(filter, Duration::from_secs(5))
+            .await
+            .expect("stream");
+        let mut received = 0usize;
+        while stream.next().await.is_some() {
+            received += 1;
+        }
+        assert!(
+            received <= 3,
+            "price verify_subscriptions must enforce REQ limit before pool forwarding; got {received}"
+        );
+        assert!(
+            received > 0,
+            "matching events under the limit must still be delivered"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #697. Adds a `nostr` price provider so `mostrod` can source BTC/fiat
quotes by subscribing to kind-30078 (NIP-33) rate events published by
trusted Mostro nodes, instead of hitting an HTTP price API — for operators
in regions where those APIs are network-blocked (the motivating case:
`api.yadio.io` is DNS-blocked for Venezuelan ISPs; PR #685 already solved
this for mobile clients, this closes the gap for the node operator).

It slots into the existing multi-source `PriceProvider` registry
(`src/price/`, `docs/PRICE_PROVIDERS.md`) as one more adapter — no changes
to the aggregation core, the store, the scheduler, or any order handler.

- `src/price/providers/nostr.rs` (new): `NostrProvider` queries the
  process-wide Nostr client (already connected to `[nostr]`'s relays — no
  new connections) for `kind=30078, authors=trusted_nodes, d=mostro-rates`
  once per tick, re-verifies each returned event's pubkey against
  `trusted_nodes` client-side, and takes the **freshest** valid event as
  the tick's source. With several `trusted_nodes` configured this is
  redundancy (if one is down/stale, a fresher one wins), not a statistical
  combine across nodes — kept deliberately simple, see `docs/PRICE_PROVIDERS.md`
  §11.7 for the rationale.
- `src/price/manager.rs`, `src/price/providers/mod.rs`: registry wiring
  (`build_provider` arm + module declaration).
- `settings.tpl.toml`: commented `[price.providers.nostr]` template block.
- `docs/PRICE_PROVIDERS.md`: new §11.7 appendix section (the code already
  referenced it) + a note on the Phase table (§8) that this is an
  out-of-band addition to the original publish-only 5-phase plan.
- `src/price/config.rs`: fixes `ProviderConfig::validate()` — the
  `trusted_nodes` exemption from requiring a `url` was previously generic
  across *any* provider id, so e.g. copy-pasting `trusted_nodes` onto
  `[price.providers.yadio]` would silently pass startup validation and only
  fail later with a confusing per-tick HTTP error against an empty URL. Now
  scoped to `nostr` only, with a regression test.

## Test plan

- [x] `cargo build` — clean.
- [x] `cargo test price::` — 117 passed (includes new `parse_content`,
      `select_freshest`, constructor, and registry-wiring tests).
- [x] `cargo clippy --all-targets --all-features` — no issues.
- [x] `cargo fmt --check` — clean.
- [x] **Live-relay evidence**: an `#[ignore]`d test
      (`price::providers::nostr::tests::live_relay_fetch_returns_real_rates`,
      not run in CI) exercises the real `fetch()` path against
      `wss://relay.mostro.network` using the two example `trusted_nodes`
      pubkeys from the issue. Run manually:
      `cargo test price::providers::nostr::tests::live_relay_fetch_returns_real_rates -- --ignored --exact`
      — returned **140 live currencies** (USD, EUR, CUP, MLC, ARS, …),
      confirming the whole path (client → filter → freshest-selection →
      parse) works end-to-end against production infrastructure, not just
      fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Nostr-based price provider for BTC/fiat rates using kind `30078` “mostro-rates” events from configured trusted nodes.
  * Selects the freshest valid quote and ignores untrusted or outdated events.
  * Added `nostr` as a selectable price-provider option.
* **Documentation**
  * Added configuration guidance for trusted nodes.
* **Bug Fixes**
  * Improved provider configuration validation and fallback behavior.
* **Tests**
  * Expanded coverage for parsing, freshness, validation, and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->