### PR TITLE
fix(privacy): drop the log lines that pair two user keys (#836)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -416,10 +416,14 @@ async fn accept_event(
     // signature — unwrap_message already verified it, so if identity
     // and sender differ here without a signature we bail out.
     if unwrapped.identity != unwrapped.sender && unwrapped.signature.is_none() {
+        // Identity beside trade key is the linkage the two-key design keeps to
+        // Mostro alone; `sender` alone is unpaired, and is what tells one
+        // misbehaving client from many. No `event.id`: on the v1 path this is
+        // the gift wrap, signed by a throwaway key with a tweaked timestamp
+        // precisely so it cannot be attributed to the rumor's author.
         tracing::warn!(
-            "Missing inner signature: identity {} differs from trade key {}",
-            unwrapped.identity,
-            unwrapped.sender
+            trade_key = %unwrapped.sender,
+            "missing inner signature: identity differs from trade key"
         );
         return None;
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -416,11 +416,11 @@ pub(crate) async fn notify_users_canceled_order(
     // Neutral wording on purpose: this helper serves several closure paths
     // (waiting-state timeout, hold-invoice cancel, actual cancels), so the
     // specific cause is logged by each caller, not here.
+    // No party keys here: maker and taker in one line pairs the two
+    // counterparties, and the published order event carries neither.
     tracing::info!(
-        "Notifying maker {} and taker {} that order {} was not completed",
-        maker_pubkey.to_string(),
-        taker_pubkey.to_string(),
-        old_order.id
+        order_id = %old_order.id,
+        "notifying maker and taker that the order was not completed"
     );
 
     // get payload
@@ -707,10 +707,7 @@ async fn job_cancel_orders(ctx: AppContext) {
                             };
 
                         // Get edited order to use for update_order_event
-                        let edited_order = if let Ok(edited_order) = edited_order {
-                            println!("Edited order: {:?}", edited_order);
-                            edited_order
-                        } else {
+                        let Ok(edited_order) = edited_order else {
                             tracing::warn!("Error editing pubkeys in order {} cancel", order.id);
                             continue;
                         };

--- a/src/util.rs
+++ b/src/util.rs
@@ -694,11 +694,6 @@ pub async fn send_dm(
     payload: &str,
     expiration: Option<Timestamp>,
 ) -> Result<(), MostroError> {
-    info!(
-        "sender key {} - receiver key {}",
-        sender_keys.public_key().to_hex(),
-        receiver_pubkey.to_hex()
-    );
     let mut message = Message::from_json(payload)
         .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
 
@@ -727,6 +722,10 @@ pub async fn send_dm(
     // Mostro node holds a single keypair: it doubles as identity and trade key.
     // Server-originated messages are unsigned because clients don't track a
     // trade_index for the node.
+    // No party keys on this path: `receiver_pubkey` can be an identity key, and
+    // `payload` carries `Payload::Peer { pubkey }`. Routing fields only, on both
+    // outcomes of the wrap, so a failure is never silent.
+    let inner = message.get_inner_message_kind();
     let event = wrap_message_with(
         transport,
         &message,
@@ -739,13 +738,27 @@ pub async fn send_dm(
             ..WrapOptions::default()
         },
     )
-    .await?;
+    .await
+    .inspect_err(|e| {
+        tracing::warn!(
+            action = %inner.action,
+            order_id = ?inner.id,
+            request_id = ?inner.request_id,
+            error = %e,
+            "wrapping DM failed"
+        )
+    })?;
 
+    // `event_id` is the only join key to the relay copy. On v2 it links nothing
+    // the timestamp doesn't: the kind-14 is Mostro-signed, p-tagged to the
+    // receiver, with an untweaked `created_at`. On v1 it resolves the receiver
+    // through the wrap's `p` tag — a residual that goes with that transport.
     info!(
-        "Sending message, Event ID: {} to {} with payload: {:#?}",
-        event.id,
-        receiver_pubkey.to_hex(),
-        payload
+        event_id = %event.id,
+        action = %inner.action,
+        order_id = ?inner.id,
+        request_id = ?inner.request_id,
+        "sending DM"
     );
 
     if let Ok(client) = get_nostr_client() {


### PR DESCRIPTION
## Summary

`Refs #836` — deliberately not `Closes`. The issue asks for a *structural* fix:
a CI gate, or a `tracing_subscriber` layer redacting at runtime. This PR is
neither. It is the narrow fix for the five log lines that actually leak, so the
structural half stays open, and the negative result on the regex-gate approach
is written up on #836 so nobody rebuilds it.

**History, since the diff no longer matches the title's origin:** this branch
started as a 16-file change — a `scripts/check_log_redaction.py` CI gate plus 14
redacted call sites. @Catrya's review established the right criterion and the
branch was rewritten around it: **one commit, 3 files, +35/−21, no script, no CI
job.**

## The criterion

Not "a pubkey appears in the line" but **what linkage does the line reveal**. A
key beside an order id is Mostro-only data. **Two *user* keys in one record** —
one person's identity and trade key, or two counterparties — is the association
the two-key design exists to keep to Mostro alone. Mostro's own key is public,
which is why `pubkey_event_can_solve` keeps two keys in one line and stays as it
is. Five lines meet the test:

| Line | Linkage |
|---|---|
| `job_cancel_orders` — `println!("Edited order: {:?}")` | identity ↔ trade key, **this order ↔ the maker's next one**, and `buyer_invoice` — on stdout |
| `accept_event` missing-inner-signature | identity ↔ trade key |
| `notify_users_canceled_order` | maker ↔ taker ↔ order |
| `send_dm` sender / receiver | identity key, on the hot path |
| `send_dm` receiver + payload | receiver's trade key ↔ the key inside `Payload::Peer` |

**The first is the widest, and an earlier revision filed it as an unrelated
chore.** It dumps a whole `Order`. `edit_pubkeys_order` nulls only the
counterparty pair, so on the side it keeps the dump carries the maker's trade
key beside their identity key; `next_trade_pubkey`, which links this order to
the same maker's next one — the only one of the five that breaks unlinkability
*across* orders; and `buyer_invoice` where populated, which AGENTS.md names
explicitly ("Scrub logs that might leak invoices or Nostr keys"). It went to
stdout, so neither `RUST_LOG` nor the redaction layer #836 stays open for would
ever touch it. It now lives in the same commit as the other four, so the fix
cannot be cherry-picked without it.

The last is the ordinary trade flow, not an admin path: on every `FiatSent`,
`fiat_sent.rs` sends `Payload::Peer { pubkey: event.sender }` to the seller and
`Peer { pubkey: seller_pubkey }` to the buyer. That line printed receiver **and**
payload, so it wrote the seller's trade key next to the buyer's on every trade.

## What changed

- **`src/scheduler.rs`** — the `println!` is gone, which collapses the rebind it
  sat in to the `let-else` `job_cancel_orders` already uses. In
  `notify_users_canceled_order`, both trade keys are dropped and the order id is
  kept.

- **`src/app.rs`** — drop `unwrapped.identity`, keep `unwrapped.sender`, which
  is unpaired and is the half that tells one misbehaving client from many.

  **Deliberately without `event.id`.** This warning fires mostly on the v1
  gift-wrap path — `identity != sender` is the *normal* dual-key layout there —
  and on that path the outer event is signed by a throwaway key with a tweaked
  timestamp (`gift_wrap_from_seal_with_pow`) precisely so it cannot be
  attributed to the rumor's author. Logging the wrap id beside the trade key
  inside it would undo that. On v2 the kind-14 is signed by the trade key
  (`wrap_message_nip44`), so `sender == event.pubkey` and the id adds nothing.

- **`src/util.rs`** — `send_dm` logs **once per send**, after the wrap:

  ```rust
  let event = wrap_message_with(/* … */)
      .await
      .inspect_err(|e| {
          tracing::warn!(
              action = %inner.action,
              order_id = ?inner.id,
              request_id = ?inner.request_id,
              error = %e,
              "wrapping DM failed"
          )
      })?;

  info!(
      event_id = %event.id,
      action = %inner.action,
      order_id = ?inner.id,
      request_id = ?inner.request_id,
      "sending DM"
  );
  ```

  *With `event_id`*, because it is the only join key between the log and the
  relay copy. `request_id` does not carry it: it is client-supplied, and **23 of
  the 65 `enqueue_order_msg` call sites pass `None`**, including *both* sends in
  `notify_users_canceled_order`.

  *After the wrap, with the failure logged separately*, because this is the only
  log on that path. The queue drainer reports a failed send as
  `Failed to send message: {e}` — no order, no action — and drops it after four
  retries, so a wrap failure with no line of its own would be invisible. Either
  outcome of the wrap now leaves exactly one line with the routing fields.

- **Structured `tracing` fields** on every touched line rather than interpolated
  strings, per AGENTS.md's "prefer `tracing` spans over ad-hoc logging". It also
  matters for the half of #836 left open: a `tracing_subscriber` redaction layer
  can only act on *named* fields, so a redaction PR emitting opaque message
  strings would be writing the one shape that mechanism could never touch.

## The limits of this change, stated rather than hidden

**1. What a relay archive still reveals.** On v2, the default transport,
`wrap_message_nip44` publishes every DM Mostro sends as a kind-14 signed by
Mostro, p-tagged to the receiver, with an untweaked `created_at`. So anyone
holding these logs *and* a relay archive can match the log's timestamp to the
event and resolve `order_id → receiver`, with or without `event_id`. Joining the
two sends of one cancellation on `order_id` then rebuilds the maker↔taker
pairing removed from `notify_users_canceled_order`. `event_id` adds a join key,
not a linkage. On v1, `gift_wrap_from_seal_with_pow` signs with an ephemeral key
and tweaks `created_at` by up to two days, so timestamps don't match — but there
`event_id` itself resolves the receiver through the wrap's `p` tag. That residual
goes away with the deprecated transport (#786).

This PR removes the linkages that are readable **from the logs alone**. It does
not make logs plus a relay archive safe, and it should not be read as settling
that.

**2. The invariant is per-line, not repo-wide.** `bond/payout.rs` logs
`recipient = %recipient_pubkey` beside `order_id = %bond.order_id` by design, and
that is one of the lines this PR deliberately puts back — for several of the
reverted sites the key *is* the log's content, and dropping it leaves "someone
asked, the answer was 7". Making the guarantee mechanical is the structural work
#836 stays open for, and the repo already has a precedent worth reusing there:
the `<redacted>` `Debug` impls in `price/providers/coingecko.rs` and
`price/providers/eltoque.rs`, each with a test.

## Everything else stays

The surviving `{event:#?}` dumps are NIP-33 replaceable events published to
relays a moment later. A key next to an order or dispute id links nothing. And
`add solver request`, `pubkey_event_can_solve`, `last_trade_index` and
`is_assigned_solver` are back exactly as they were.

## Test plan

Based on `main` @ `afc39a2` (v0.18.7).

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --bin mostrod` — **1323 passed**, 0 failed, 2 ignored
