### PR TITLE
fix(deps): bump nostr to 0.44.6 for GHSA-hrqp-8w79-gwgw (NIP-44 DoS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.3"
+version = "0.44.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d8f0fe13526800300a36bf3b7c5f752e62e32ab81c74a8e5caa2865708625a"
+checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
 dependencies = [
  "base64 0.22.1",
  "bech32",


### PR DESCRIPTION
## Summary

Bumps the transitive `nostr` crate from **0.44.3 → 0.44.6** to pick up the fix for [GHSA-hrqp-8w79-gwgw](https://github.com/nostrdevkit/nostr/security/advisories/GHSA-hrqp-8w79-gwgw) (CVSS 7.5, High).

### Vulnerability

NIP-44 v2 decryption did not verify that the decrypted buffer contained at least 2 bytes before reading the length prefix. A malformed ciphertext producing a 0/1-byte plaintext triggers an out-of-bounds panic — a remotely-triggerable DoS via relays for any peer holding the conversation key. Since mostrod decrypts NIP-44 payloads from untrusted counterparties, this directly affects daemon availability. Patched upstream in `nostr` 0.44.5.

### Why lockfile-only

`nostr-sdk` has no new stable release (latest is 0.44.1, which we already use); the fix lives in the transitive `nostr` core crate. `nostr-sdk 0.44.1` accepts any `0.44.x`, so `cargo update -p nostr` is the complete fix — `Cargo.toml` is unchanged.

## Test plan

- [x] `cargo build` — OK
- [x] `cargo test` — 1046 passed, 0 failed (2 ignored: env-dependent Cashu mint tests)
- [x] `cargo clippy --all-targets` — no warnings
- [x] `cargo fmt --check` — clean
