### PR TITLE
feat(nip33): advertise pow_first_contact in the info event

### DIFF
--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -133,7 +133,9 @@ Configuration is loaded from `~/.mostro/settings.toml` (template: `settings.tpl.
 - `publish_mostro_info_interval` (u32): Mostro info publish interval in seconds (default: 300)
 
 *Network/API:*
-- `pow` (u8): Proof-of-work difficulty requirement (default: 0)
+- `pow` (u8): Proof-of-work difficulty (leading-zero bits, NIP-13) required of every incoming event, checked on the outer event before anything else (default: 0, i.e. no requirement)
+- `pow_first_contact` (Option\<u8\>): Stiffer PoW demanded of a *first-contact* event — one whose visible sender is not in the active-trade cache — checked before the NIP-44 decrypt. Only enforced on the `nip44` transport; `None` falls back to `pow` (default: None). Setting it *below* `pow` has no effect, since the base check runs first. See [TRANSPORT_V2_SPEC.md](TRANSPORT_V2_SPEC.md) §6 Phase 2
+- `active_pubkeys_refresh_interval` (u64): How often, in seconds, to rebuild the active-trade-pubkey cache that the first-contact gate consults (default: 60)
 - `bitcoin_price_api_url` (String): Bitcoin price API base URL (default: [`https://api.yadio.io`](https://api.yadio.io))
 
 *Market Support:*

--- a/docs/TRANSPORT_V2_SPEC.md
+++ b/docs/TRANSPORT_V2_SPEC.md
@@ -227,12 +227,35 @@ transport, whose outer key is a throwaway with no pre-validatable signal.
 - **Discoverability** (`src/nip33.rs`): the kind-38385 info event carries a
   `pow_first_contact` tag next to `pow`. A dropped event gets no `cant-do`
   reply — it never reaches a handler — so the info event is the only way a
-  client can learn what a first event costs. The published value is the
-  *enforced* difficulty (`advertised_first_contact_pow`): on `nip44`
+  client can learn what the first-contact lane costs. The published value is
+  the *enforced* difficulty (`advertised_first_contact_pow`): on `nip44`
   `max(pow, effective_pow_first_contact())` — a max because the two checks run
   in sequence, so a `pow_first_contact` below `pow` still enforces `pow` — and
   on `gift-wrap` just `pow`, since the gate never runs there and advertising the
   stiffer number would make clients grind work nobody checks.
+- **Recognition is eventually consistent — the lane is not "the first event
+  only".** Accepting a create or take does *not* insert that trade key into the
+  cache synchronously; `job_refresh_active_pubkeys` is the only writer after
+  startup and rebuilds the whole set on its interval. A trade key whose event
+  was just accepted therefore keeps being classified as first contact until the
+  next rebuild lands — up to one full `active_pubkeys_refresh_interval`
+  (default 60 s), and longer if a reload fails and the previous snapshot is
+  retained. A client that mined `pow_first_contact` once and then dropped back
+  to `pow` for an immediate follow-up (the `take-sell` right after a
+  `new-order`, or the invoice message that follows a take) would have that
+  follow-up silently discarded.
+
+  The client-side rule is therefore: **mine `pow_first_contact` for every event
+  sent from a trade key, not just for its first one.** Recognition is not
+  observable from the client side — the daemon publishes no per-key signal and
+  does not advertise the refresh interval — so there is no bound a client can
+  safely wait out; it must keep using the higher difficulty for the lifetime of
+  the trade key. On nodes where `pow_first_contact` resolves to `pow` (the
+  default) the rule costs nothing; on nodes that set it higher it is the
+  difference between working and failing silently. Making recognition
+  synchronous at accept time, so the rule can be relaxed to a bounded window,
+  is follow-up work — the advertised value is correct either way, because it
+  always reports the difficulty the gate enforces on an unrecognized sender.
 
 New config (`[mostro]`): `pow_first_contact` (`Option<u8>`, default = `pow`)
 and `active_pubkeys_refresh_interval` (default 60). Both `#[serde(default)]`,

--- a/docs/TRANSPORT_V2_SPEC.md
+++ b/docs/TRANSPORT_V2_SPEC.md
@@ -224,6 +224,15 @@ transport, whose outer key is a throwaway with no pre-validatable signal.
   re-sent identical event id before decryption. The existing 10-second
   freshness window (post-decrypt, on the inner `created_at`) still applies as
   the precise stale-event check.
+- **Discoverability** (`src/nip33.rs`): the kind-38385 info event carries a
+  `pow_first_contact` tag next to `pow`. A dropped event gets no `cant-do`
+  reply — it never reaches a handler — so the info event is the only way a
+  client can learn what a first event costs. The published value is the
+  *enforced* difficulty (`advertised_first_contact_pow`): on `nip44`
+  `max(pow, effective_pow_first_contact())` — a max because the two checks run
+  in sequence, so a `pow_first_contact` below `pow` still enforces `pow` — and
+  on `gift-wrap` just `pow`, since the gate never runs there and advertising the
+  stiffer number would make clients grind work nobody checks.
 
 New config (`[mostro]`): `pow_first_contact` (`Option<u8>`, default = `pow`)
 and `active_pubkeys_refresh_interval` (default 60). Both `#[serde(default)]`,

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -567,13 +567,18 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
             TagKind::Custom(Cow::Borrowed("pow")),
             vec![mostro_settings.pow.to_string()],
         ),
-        // Companion of `pow` for the Phase 2 anti-spam gate: the difficulty a
-        // *first-contact* event must clear (sender not in the active-trade
-        // cache). Advertised as an already-resolved absolute difficulty so a
-        // client can grind the right amount of work for a brand-new order or
-        // take without replicating the fallback rules. Under-powered events are
-        // dropped before decryption with no reply, so discovery has to come
-        // from here. See docs/TRANSPORT_V2_SPEC.md §6 Phase 2.
+        // Companion of `pow` for the Phase 2 anti-spam gate: the difficulty an
+        // event from a sender that is *not* in the active-trade cache must
+        // clear. Advertised as an already-resolved absolute difficulty so a
+        // client can grind the right amount of work without replicating the
+        // fallback rules. Under-powered events are dropped before decryption
+        // with no reply, so discovery has to come from here.
+        //
+        // This is a per-*event* requirement, not a one-off toll on the first
+        // one: the cache is rebuilt periodically, so a trade key stays
+        // unrecognized for up to one `active_pubkeys_refresh_interval` after
+        // its first accepted event and its follow-ups must carry the same
+        // work. See docs/TRANSPORT_V2_SPEC.md §6 Phase 2.
         Tag::custom(
             TagKind::Custom(Cow::Borrowed("pow_first_contact")),
             vec![advertised_first_contact_pow(mostro_settings).to_string()],
@@ -913,26 +918,35 @@ mod tests {
 
         let tags = info_to_tags(&ln_status);
 
-        // Asserted against literals, not against a second call to the helper:
-        // deriving `expected` from the code under test would pass under any
-        // wrong implementation. `test_settings()` is the shipped default —
-        // `pow = 0`, `pow_first_contact` unset, gift-wrap transport — so both
-        // tags must read "0". The per-transport resolution matrix is pinned
-        // separately in `advertised_first_contact_pow_is_transport_dependent`.
-        let settings = test_settings();
-        assert_eq!(
-            settings.mostro.pow, 0,
-            "default settings assumed by this test"
-        );
+        // Expectations come from the settings actually installed in
+        // `MOSTRO_CONFIG`, never from this module's `test_settings()` copy:
+        // the OnceLock is process-wide and first-set-wins, so whichever test
+        // module runs first in the binary decides what `info_to_tags` reads.
+        // Pinning literals here would make this test depend on that ordering.
+        // Both values compared below are plain config data, not something the
+        // code under test derives — the resolution rules, including what the
+        // shipped defaults advertise, are pinned against literals in
+        // `advertised_first_contact_pow_is_transport_dependent`.
+        let live = &MOSTRO_CONFIG
+            .get()
+            .expect("init_test_settings installs a config")
+            .mostro;
         assert_eq!(
             get_tag_value(&tags, "pow").as_deref(),
-            Some("0"),
+            Some(live.pow.to_string().as_str()),
             "info_to_tags must advertise the base PoW difficulty"
         );
-        assert_eq!(
-            get_tag_value(&tags, "pow_first_contact").as_deref(),
-            Some("0"),
-            "info_to_tags must advertise the first-contact PoW difficulty"
+        let first_contact: u8 = get_tag_value(&tags, "pow_first_contact")
+            .expect("info_to_tags must advertise the first-contact PoW difficulty")
+            .parse()
+            .expect("the pow_first_contact tag must carry a NIP-13 difficulty");
+        // The one relation that must hold for *any* configuration: the base
+        // check runs first, so advertising below `pow` would tell a client to
+        // mine less work than the node accepts and have its event dropped.
+        assert!(
+            first_contact >= live.pow,
+            "advertised first-contact difficulty {first_contact} is below the enforced base pow {}",
+            live.pow
         );
     }
 
@@ -984,6 +998,16 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(super::advertised_first_contact_pow(&v1), 4);
+
+        // The shipped defaults (`pow = 0`, `pow_first_contact` unset) must
+        // advertise "0" — identical in meaning to the pre-tag behaviour, so a
+        // node that changes nothing keeps demanding nothing. Pinned here, on
+        // an explicit value, rather than in the `info_to_tags` test, whose
+        // config depends on which module wins the OnceLock race.
+        assert_eq!(
+            super::advertised_first_contact_pow(&MostroSettings::default()),
+            0
+        );
     }
 
     /// Look up a single-value tag in a Tags collection, returning its

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -940,13 +940,20 @@ mod tests {
             .expect("info_to_tags must advertise the first-contact PoW difficulty")
             .parse()
             .expect("the pow_first_contact tag must carry a NIP-13 difficulty");
-        // The one relation that must hold for *any* configuration: the base
-        // check runs first, so advertising below `pow` would tell a client to
-        // mine less work than the node accepts and have its event dropped.
-        assert!(
-            first_contact >= live.pow,
-            "advertised first-contact difficulty {first_contact} is below the enforced base pow {}",
-            live.pow
+        // Compared against the resolver rather than against a lower bound like
+        // `>= live.pow`: this assertion is about *wiring* — that the resolved
+        // difficulty is what reaches the `pow_first_contact` tag, and not, say,
+        // the base `pow`, which a bound would happily accept. What the resolver
+        // must itself return per transport, shipped defaults included, is
+        // pinned against literals in
+        // `advertised_first_contact_pow_is_transport_dependent`.
+        let expected = super::advertised_first_contact_pow(live);
+        assert_eq!(
+            first_contact, expected,
+            "info_to_tags advertised first-contact difficulty {first_contact}, \
+             but the gate enforces {expected} under the installed settings \
+             (pow = {}, pow_first_contact = {:?})",
+            live.pow, live.pow_first_contact
         );
     }
 

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1,6 +1,6 @@
 use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
 use crate::config::settings::Settings;
-use crate::config::types::BondApplyTo;
+use crate::config::types::{BondApplyTo, MostroSettings};
 use crate::lightning::LnStatus;
 use crate::util::{get_expiration_timestamp_for_kind, get_keys};
 use crate::LN_STATUS;
@@ -480,6 +480,35 @@ pub fn order_to_tags(
     }
 }
 
+/// PoW difficulty (leading-zero bits, NIP-13) a *first-contact* event must
+/// clear on this node — the value published in the `pow_first_contact` tag of
+/// the kind-38385 info event.
+///
+/// Transport-dependent because the Phase 2 gate is v2-only: on `nip44` an
+/// unknown sender must clear `pow_first_contact` before the daemon decrypts,
+/// while on `gift-wrap` that gate is skipped entirely (the throwaway outer key
+/// carries no pre-validatable signal), so a first event only has to clear the
+/// base `pow`. Advertising the v2 number on a v1 node would make clients grind
+/// work nobody checks.
+///
+/// The v2 arm takes the **maximum** of the two knobs because the event loop
+/// applies them in sequence — the base `pow` check runs first, then the
+/// first-contact one — so a config with `pow_first_contact` *below* `pow` still
+/// enforces `pow`. Publishing the lower number would tell clients to mine less
+/// work than the node accepts, and their first event would be dropped silently.
+///
+/// DEPRECATED(v0.19.0, #786): with the v1 path gone this collapses to
+/// `max(pow, effective_pow_first_contact())`.
+#[allow(deprecated)]
+fn advertised_first_contact_pow(mostro_settings: &MostroSettings) -> u8 {
+    match mostro_settings.transport {
+        Transport::Nip44Direct => mostro_settings
+            .pow
+            .max(mostro_settings.effective_pow_first_contact()),
+        _ => mostro_settings.pow,
+    }
+}
+
 /// Transform mostro info fields to tags
 ///
 /// # Arguments
@@ -534,6 +563,17 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
         Tag::custom(
             TagKind::Custom(Cow::Borrowed("pow")),
             vec![mostro_settings.pow.to_string()],
+        ),
+        // Companion of `pow` for the Phase 2 anti-spam gate: the difficulty a
+        // *first-contact* event must clear (sender not in the active-trade
+        // cache). Advertised as an already-resolved absolute difficulty so a
+        // client can grind the right amount of work for a brand-new order or
+        // take without replicating the fallback rules. Under-powered events are
+        // dropped before decryption with no reply, so discovery has to come
+        // from here. See docs/TRANSPORT_V2_SPEC.md §6 Phase 2.
+        Tag::custom(
+            TagKind::Custom(Cow::Borrowed("pow_first_contact")),
+            vec![advertised_first_contact_pow(mostro_settings).to_string()],
         ),
         // Capability advertisement: which Mostro protocol version this node
         // speaks ("1" = gift wrap, "2" = NIP-44 direct), derived from the
@@ -854,6 +894,85 @@ mod tests {
             y_values, expected,
             "info_to_tags must wire create_platform_tag_values correctly into the y tag"
         );
+    }
+
+    #[test]
+    fn info_to_tags_advertises_both_pow_difficulties() {
+        // The `pow` tag only tells a client what the known-keys lane costs.
+        // Without a companion tag a brand-new trade key cannot know how much
+        // work its *first* event needs, and an under-powered event is dropped
+        // silently (no cant-do reply). Both tags must travel together, each
+        // carrying an absolute difficulty the client can mine against
+        // directly (see `advertised_first_contact_pow` for how the
+        // first-contact one is resolved).
+        init_test_settings();
+        let ln_status = make_ln_status();
+
+        let tags = info_to_tags(&ln_status);
+
+        let settings = test_settings();
+        assert_eq!(
+            get_tag_value(&tags, "pow").as_deref(),
+            Some(settings.mostro.pow.to_string().as_str()),
+            "info_to_tags must advertise the base PoW difficulty"
+        );
+
+        let expected = super::advertised_first_contact_pow(&settings.mostro).to_string();
+        assert_eq!(
+            get_tag_value(&tags, "pow_first_contact").as_deref(),
+            Some(expected.as_str()),
+            "info_to_tags must advertise the first-contact PoW difficulty"
+        );
+    }
+
+    /// Per-transport branches of the advertised first-contact difficulty.
+    /// Exercised through the pure helper because `info_to_tags` reads settings
+    /// from the process-wide `MOSTRO_CONFIG` OnceLock, which cannot be mutated
+    /// mid-run (same reason as `bond_tags` below).
+    #[test]
+    #[allow(deprecated)]
+    fn advertised_first_contact_pow_is_transport_dependent() {
+        use crate::config::types::MostroSettings;
+
+        // v2: the gate runs, so the stiffer explicit value is what a
+        // first-contact sender must actually clear.
+        let v2 = MostroSettings {
+            pow: 4,
+            pow_first_contact: Some(16),
+            transport: Transport::Nip44Direct,
+            ..Default::default()
+        };
+        assert_eq!(super::advertised_first_contact_pow(&v2), 16);
+
+        // v2 without an explicit override falls back to the base `pow`.
+        let v2_default = MostroSettings {
+            pow: 4,
+            pow_first_contact: None,
+            transport: Transport::Nip44Direct,
+            ..Default::default()
+        };
+        assert_eq!(super::advertised_first_contact_pow(&v2_default), 4);
+
+        // v2 with an override BELOW the base `pow`: the base check runs first
+        // and still rejects, so the enforced difficulty is `pow`. Advertising
+        // the lower number would make clients under-mine and be dropped.
+        let v2_below = MostroSettings {
+            pow: 8,
+            pow_first_contact: Some(2),
+            transport: Transport::Nip44Direct,
+            ..Default::default()
+        };
+        assert_eq!(super::advertised_first_contact_pow(&v2_below), 8);
+
+        // v1: the gate is skipped, so a configured `pow_first_contact` is not
+        // enforced and must NOT be advertised — only the base `pow` is real.
+        let v1 = MostroSettings {
+            pow: 4,
+            pow_first_contact: Some(16),
+            transport: Transport::GiftWrap,
+            ..Default::default()
+        };
+        assert_eq!(super::advertised_first_contact_pow(&v1), 4);
     }
 
     /// Look up a single-value tag in a Tags collection, returning its

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -505,7 +505,10 @@ fn advertised_first_contact_pow(mostro_settings: &MostroSettings) -> u8 {
         Transport::Nip44Direct => mostro_settings
             .pow
             .max(mostro_settings.effective_pow_first_contact()),
-        _ => mostro_settings.pow,
+        // Matched explicitly rather than with a catch-all: a future transport
+        // variant must fail the build here instead of silently advertising the
+        // base `pow` for a gate whose behaviour nobody has considered yet.
+        Transport::GiftWrap => mostro_settings.pow,
     }
 }
 
@@ -910,17 +913,25 @@ mod tests {
 
         let tags = info_to_tags(&ln_status);
 
+        // Asserted against literals, not against a second call to the helper:
+        // deriving `expected` from the code under test would pass under any
+        // wrong implementation. `test_settings()` is the shipped default —
+        // `pow = 0`, `pow_first_contact` unset, gift-wrap transport — so both
+        // tags must read "0". The per-transport resolution matrix is pinned
+        // separately in `advertised_first_contact_pow_is_transport_dependent`.
         let settings = test_settings();
         assert_eq!(
+            settings.mostro.pow, 0,
+            "default settings assumed by this test"
+        );
+        assert_eq!(
             get_tag_value(&tags, "pow").as_deref(),
-            Some(settings.mostro.pow.to_string().as_str()),
+            Some("0"),
             "info_to_tags must advertise the base PoW difficulty"
         );
-
-        let expected = super::advertised_first_contact_pow(&settings.mostro).to_string();
         assert_eq!(
             get_tag_value(&tags, "pow_first_contact").as_deref(),
-            Some(expected.as_str()),
+            Some("0"),
             "info_to_tags must advertise the first-contact PoW difficulty"
         );
     }


### PR DESCRIPTION
## Why

The Phase 2 anti-spam gate (`docs/TRANSPORT_V2_SPEC.md` §6) charges a *first-contact* sender — one whose visible trade key is not in the active-trade cache, i.e. anyone creating or taking an order — a stiffer PoW than the base `pow`. That difficulty was enforceable but not discoverable: the kind-38385 info event published only `pow`.

Because the gate drops the event **before** `unwrap_incoming` decrypts, there is no `cant-do` reply either. So a client had neither channel — feedback nor discovery — to learn what a new order costs on a node with `pow_first_contact` set. Its order creation silently did nothing.

Found while auditing the PoW implementation against the protocol docs.

## What changed

`info_to_tags` now emits a `pow_first_contact` tag next to `pow`, carrying the **enforced** difficulty as resolved by the new `advertised_first_contact_pow` helper:

| transport | advertised value | why |
|---|---|---|
| `nip44` | `max(pow, effective_pow_first_contact())` | the event loop applies the two checks in sequence, so a `pow_first_contact` configured *below* `pow` still enforces `pow` — publishing the lower number would tell clients to under-mine and get dropped |
| `gift-wrap` | `pow` | the gate never runs on v1 (throwaway outer key, nothing to pre-validate), so advertising the stiffer number would make clients grind work nobody checks |

Clients get an absolute number they can mine against, with the fallback rules resolved daemon-side rather than duplicated per client.

Docs in this repo:
- `docs/STARTUP_AND_CONFIG.md` — `pow_first_contact` and `active_pubkeys_refresh_interval` were both missing from the config reference; added, and the `pow` entry now says what the number actually is (NIP-13 leading-zero bits on the outer event) instead of "difficulty requirement".
- `docs/TRANSPORT_V2_SPEC.md` — §6 Phase 2 records the advertisement and the `max` reasoning.

## Compatibility

Additive. One extra tag on a kind-38385 replaceable event; clients that ignore unknown tags are unaffected. With default settings (`pow = 0`, `pow_first_contact` unset) the new tag reads `"0"`, identical in meaning to today's behaviour. No config, DB, or handler changes.

## Client-facing spec

MostroP2P/protocol#54 documents the tag, the mining guidance and the silent-drop consequence.

It also spells out why an **absent** tag has to be read as *unknown* rather than as `pow`: a v2 node running 0.18.x with `pow_first_contact` set already enforces that difficulty while publishing no tag, so a client that assumed `pow` would mine too little and have every create/take silently discarded. That is the gap this PR closes for nodes that ship it — and the reason the advertised value is the enforced one rather than the raw setting.

## Test plan

- [x] `cargo test --bin mostrod` — 1049 tests, all green (2 new)
  - `info_to_tags_advertises_both_pow_difficulties` — both tags travel together, each matching settings
  - `advertised_first_contact_pow_is_transport_dependent` — v2 explicit override, v2 fallback to `pow`, v2 override *below* `pow` (must still advertise `pow`), and v1 (must ignore the override)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: run a node with `transport = "nip44"`, `pow = 4`, `pow_first_contact = 16` and confirm the published kind-38385 event carries `["pow_first_contact", "16"]`; flip to `transport = "gift-wrap"` and confirm it drops back to `"4"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transport-aware proof-of-work requirements for first-contact events.
  * Transport information now advertises the effective `pow_first_contact` difficulty, with fallback to the standard `pow` setting where applicable.
  * Clarified that clients should apply first-contact proof-of-work until active-key recognition is confirmed through periodic updates.

* **Documentation**
  * Expanded configuration and Transport V2 guidance, including `active_pubkeys_refresh_interval`.

* **Tests**
  * Added coverage for PoW tags, defaults, and transport-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
