### PR TITLE
test: mutation testing for Nostr event handling

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -60,15 +60,27 @@ jobs:
             exit 0
           fi
 
-          # Build --file flags for each changed file
-          file_args=""
-          for f in $changed_rs; do
-            file_args="$file_args --file $f"
-          done
-
           echo "Running mutation testing for changed files:"
           echo "$changed_rs"
-          cargo mutants $file_args
+
+          # These filenames come from a PR diff, so they are
+          # attacker-controlled. Built as a bash array (never joined into a
+          # string) and passed with "${file_args[@]}" so a crafted filename
+          # can only ever be one --file value, never extra argv tokens — an
+          # unquoted string of them is word-split by the shell, which turns
+          # a crafted filename into extra flags for cargo-mutants/cargo/rustc.
+          # This deliberately bypasses `make mutation-test`, whose $(ARGS) is
+          # a plain string splice safe only for hand-typed input, so it
+          # repeats that target's environment here (see the Makefile for why
+          # each variable is set).
+          file_args=()
+          while IFS= read -r f; do
+            file_args+=(--file "$f")
+          done <<< "$changed_rs"
+
+          # Keep these two in sync with the mutation-test target in Makefile.
+          CARGO_MUTANTS_JOBS=1 MOSTRO_TEST_LN_PORT=18080 \
+            cargo mutants "${file_args[@]}"
 
       - name: Upload mutation report
         uses: actions/upload-artifact@v4
@@ -195,7 +207,7 @@ jobs:
           tool: cargo-mutants
 
       - name: Run full mutation testing
-        run: cargo mutants
+        run: make mutation-test
         # Note: Do NOT fail on low score initially (report only mode)
         continue-on-error: true
 

--- a/Makefile
+++ b/Makefile
@@ -66,3 +66,42 @@ docker-build-startos:
 	cd docker && \
 	docker compose build mostro-startos
 
+# The run is serial at the worker level only. One test binds a fixed host
+# port — `test_lnurl_validation_with_test_server` in src/lightning/invoice.rs
+# — and every lookup it makes, LNURL and lightning address alike, goes to its
+# own listener; every other listener in the suite binds :0. So two test
+# threads in one run cannot collide on that port, but two concurrent runs
+# can, and a test that fails because it lost that race is scored as a killed
+# mutant, silently inflating the number this target measures.
+#
+# CARGO_MUTANTS_JOBS=1 serialises the mutant workers. cargo-mutants already
+# does this by default (verified against 27.1.0: one scratch dir on a
+# 16-CPU host with no -j); it is set explicitly so the guarantee is stated
+# rather than inherited.
+#
+# Test threads inside each run stay parallel on purpose. Serialising them
+# (RUST_TEST_THREADS=1, or `--test-threads=1`) protects nothing, and
+# roughly doubles the time per mutant — enough to push the PR job for a few
+# changed files past GitHub's 6h job limit. If a test ever flakes under
+# parallel threads, name it here as the reason before serialising.
+#
+# MOSTRO_TEST_LN_PORT moves that test off 8080 in case something on the
+# host already holds it. It does NOT make the suite hermetic: two concurrent
+# runs would still collide on 18080. Serialising is what makes the run
+# trustworthy; the port override only dodges a pre-existing listener.
+#
+# The 18080 here deliberately differs from the code's own 8080 default, so
+# `cargo test` and `make mutation-test` do bind different ports. That is the
+# point: plain `cargo test` keeps exercising the default path, and only this
+# target — which runs the suite hundreds of times over — steps aside from a
+# port a developer machine is likely to have in use.
+#
+# ARGS is spliced into the shell command as plain text — only pass
+# hand-typed, trusted values (e.g. `make mutation-test ARGS="--file
+# src/foo.rs"`). Never build ARGS from PR-diff filenames or other
+# attacker-controlled input; that class of data must be turned into a bash
+# array and passed to `cargo mutants` directly (see the PR job in
+# .github/workflows/mutation.yml).
+mutation-test:
+	CARGO_MUTANTS_JOBS=1 \
+	MOSTRO_TEST_LN_PORT=$${MOSTRO_TEST_LN_PORT:-18080} cargo mutants $(ARGS)

--- a/src/app.rs
+++ b/src/app.rs
@@ -296,6 +296,24 @@ async fn handle_message_action(
     }
 }
 
+/// True when a rumor's `created_at` falls outside the 10s replay window.
+/// Pulled out of `accept_event` so the boundary can be hit directly instead
+/// of only through a live wrapped event.
+fn is_stale(created_at: Timestamp, since_time: u64) -> bool {
+    created_at.as_secs() < since_time
+}
+
+/// True when the inner rumor is missing a required signature. Full-privacy
+/// clients reuse the trade key as identity and send unsigned rumors; any
+/// other identity/sender split must carry a valid inner signature.
+fn missing_inner_signature(
+    identity: PublicKey,
+    sender: PublicKey,
+    signature: Option<Signature>,
+) -> bool {
+    identity != sender && signature.is_none()
+}
+
 /// Decode and fully validate one relay event into a dispatchable
 /// `(action, message, unwrapped)` triple, or `None` if it must be skipped
 /// (failed PoW, wrong kind, invalid event signature, spam-gate drop, decrypt
@@ -406,7 +424,7 @@ async fn accept_event(
         .checked_sub_signed(chrono::Duration::seconds(10))
         .unwrap()
         .timestamp() as u64;
-    if unwrapped.created_at.as_secs() < since_time {
+    if is_stale(unwrapped.created_at, since_time) {
         return None;
     }
     let message = unwrapped.message.clone();
@@ -415,7 +433,7 @@ async fn accept_event(
     // unsigned rumors. Any other shape must carry a valid inner
     // signature — unwrap_message already verified it, so if identity
     // and sender differ here without a signature we bail out.
-    if unwrapped.identity != unwrapped.sender && unwrapped.signature.is_none() {
+    if missing_inner_signature(unwrapped.identity, unwrapped.sender, unwrapped.signature) {
         tracing::warn!(
             "Missing inner signature: identity {} differs from trade key {}",
             unwrapped.identity,
@@ -703,6 +721,46 @@ mod tests {
     }
 
     #[test]
+    fn is_stale_rejects_events_older_than_the_cutoff() {
+        assert!(is_stale(Timestamp::from(99), 100));
+    }
+
+    #[test]
+    fn is_stale_accepts_events_exactly_at_the_cutoff() {
+        assert!(!is_stale(Timestamp::from(100), 100));
+    }
+
+    #[test]
+    fn is_stale_accepts_events_newer_than_the_cutoff() {
+        assert!(!is_stale(Timestamp::from(101), 100));
+    }
+
+    #[test]
+    fn missing_inner_signature_true_when_identity_and_sender_differ_unsigned() {
+        let identity = create_test_keys().public_key();
+        let sender = create_test_keys().public_key();
+        assert!(missing_inner_signature(identity, sender, None));
+    }
+
+    #[test]
+    fn missing_inner_signature_false_when_identity_equals_sender_unsigned() {
+        let same = create_test_keys().public_key();
+        assert!(!missing_inner_signature(same, same, None));
+    }
+
+    #[test]
+    fn missing_inner_signature_false_when_signed_even_if_identity_differs() {
+        let identity = create_test_keys().public_key();
+        let sender_keys = create_test_keys();
+        let sig = sender_keys.sign_schnorr([7u8; 32]);
+        assert!(!missing_inner_signature(
+            identity,
+            sender_keys.public_key(),
+            Some(sig)
+        ));
+    }
+
+    #[test]
     fn test_warning_msg_all_error_types() {
         let action = Action::NewOrder;
 
@@ -778,7 +836,7 @@ mod tests {
         use super::*;
         use crate::spam_gate::{SpamGate, REPLAY_WINDOW_SECS};
         use mostro_core::nip59::{wrap_message, WrapOptions};
-        use mostro_core::transport::wrap_message_nip44;
+        use mostro_core::transport::{wrap_message_nip44, wrap_message_with, Transport};
 
         /// A protocol-v2 (kind 14) event addressed to `mostro`, in full-privacy
         /// mode (trade key doubles as identity, so no identity proof is needed).
@@ -926,6 +984,48 @@ mod tests {
             );
         }
 
+        /// The first-contact lane: an unseen sender that clears
+        /// `pow_first_contact` is let through to the decrypt.
+        #[tokio::test]
+        async fn unknown_first_contact_sender_clearing_the_pow_bar_is_accepted() {
+            let ctx = create_migrated_ctx().await;
+            let gate = SpamGate::new(REPLAY_WINDOW_SECS);
+            let mostro = create_test_keys();
+
+            // `accept` pins pow_first_contact = 0, trivially cleared, and a
+            // freshly generated trade key is never known to the gate.
+            assert!(
+                accept(&ctx, &v2_event(&mostro), &mostro, &gate)
+                    .await
+                    .is_some(),
+                "an unknown sender over the PoW bar must reach the decrypt"
+            );
+        }
+
+        /// The same lane refusing: only `pow_first_contact` differs, so the
+        /// toll is what decides, not the event or the gate.
+        #[tokio::test]
+        async fn unknown_first_contact_sender_below_the_pow_bar_is_dropped() {
+            let ctx = create_migrated_ctx().await;
+            let gate = SpamGate::new(REPLAY_WINDOW_SECS);
+            let mostro = create_test_keys();
+
+            // u8::MAX demands more leading-zero bits than any real event id
+            // will ever have, so this fails deterministically.
+            let result = accept_event(
+                &ctx,
+                &v2_event(&mostro),
+                &mostro,
+                0,
+                u8::MAX,
+                NostrKind::from(crate::config::constants::DM_EVENT_KIND),
+                Some(&gate),
+            )
+            .await;
+
+            assert!(result.is_none());
+        }
+
         /// The v2-only policy lives in one place now; both event loops read it
         /// from here, so this is where it gets covered.
         #[test]
@@ -934,6 +1034,97 @@ mod tests {
             // `SpamGate::global()` is `None` unless `install_spam_gate` ran, so
             // the v2 arm can only be pinned against the installed state.
             assert_eq!(gate_for(true).is_some(), SpamGate::global().is_some());
+        }
+
+        #[allow(deprecated)] // Transport::GiftWrap: still the tested default; see #786.
+        async fn wrap_test_message(
+            identity_keys: &Keys,
+            trade_keys: &Keys,
+            receiver: PublicKey,
+        ) -> Event {
+            // RestoreSession is the one action whose payload is required to be
+            // None (mostro-core's `verify()`), which keeps this helper free of a
+            // hand-built `Payload::Order`. The trade-index path it short-circuits
+            // is covered directly by `check_trade_index_tests`.
+            wrap_message_with(
+                Transport::GiftWrap,
+                &create_test_message(Action::RestoreSession, None),
+                identity_keys,
+                trade_keys,
+                receiver,
+                WrapOptions::default(),
+            )
+            .await
+            .expect("gift wrap succeeds")
+        }
+
+        #[tokio::test]
+        async fn accepts_a_validly_wrapped_event_and_returns_the_action() {
+            let ctx = create_migrated_ctx().await;
+            let identity_keys = create_test_keys();
+            let trade_keys = create_test_keys();
+            let receiver_keys = create_test_keys();
+            let event =
+                wrap_test_message(&identity_keys, &trade_keys, receiver_keys.public_key()).await;
+
+            let result = accept_event(
+                &ctx,
+                &event,
+                &receiver_keys,
+                0,
+                0,
+                NostrKind::GiftWrap,
+                None,
+            )
+            .await;
+
+            let (action, _message, unwrapped) = result.expect("valid event should be accepted");
+            assert_eq!(action, Action::RestoreSession);
+            assert_eq!(unwrapped.sender, trade_keys.public_key());
+            assert_eq!(unwrapped.identity, identity_keys.public_key());
+        }
+
+        #[tokio::test]
+        async fn rejects_an_event_of_the_wrong_kind() {
+            let ctx = create_migrated_ctx().await;
+            let identity_keys = create_test_keys();
+            let trade_keys = create_test_keys();
+            let receiver_keys = create_test_keys();
+            let event =
+                wrap_test_message(&identity_keys, &trade_keys, receiver_keys.public_key()).await;
+
+            // The event is a real, validly-signed GiftWrap; accepted_kind is
+            // deliberately mismatched to exercise the kind-gate on its own.
+            let result = accept_event(
+                &ctx,
+                &event,
+                &receiver_keys,
+                0,
+                0,
+                NostrKind::TextNote,
+                None,
+            )
+            .await;
+
+            assert!(result.is_none());
+        }
+
+        #[tokio::test]
+        async fn rejects_an_event_not_addressed_to_the_receiver() {
+            let ctx = create_migrated_ctx().await;
+            let identity_keys = create_test_keys();
+            let trade_keys = create_test_keys();
+            let intended_receiver = create_test_keys();
+            let eavesdropper = create_test_keys();
+            let event =
+                wrap_test_message(&identity_keys, &trade_keys, intended_receiver.public_key())
+                    .await;
+
+            // unwrap_incoming can't decrypt a rumor sealed for someone else.
+            let result =
+                accept_event(&ctx, &event, &eavesdropper, 0, 0, NostrKind::GiftWrap, None).await;
+
+            assert!(result.is_none());
         }
     }
 

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -3,6 +3,14 @@ use crate::{db::RestoreSessionManager, util::enqueue_restore_session_msg};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 
+/// How long a restore-session request waits for results before the requester
+/// is told to retry instead of hanging forever.
+///
+/// Named so the timeout and the message reporting it cannot drift apart: they
+/// were two independent literals, and the log said "1 hour" whatever the
+/// duration actually was.
+const RESTORE_SESSION_TIMEOUT_SECS: u64 = 60 * 60;
+
 /// Handle restore session action
 /// This function starts a background task to process the restore session
 /// and immediately returns, avoiding blocking the main application
@@ -41,7 +49,7 @@ pub async fn restore_session_action(
 /// Handle restore session results in the background
 async fn handle_restore_session_results(mut manager: RestoreSessionManager, trade_key: String) {
     // Wait for the result with a timeout
-    let timeout = tokio::time::Duration::from_secs(60 * 60); // 1 hour timeout
+    let timeout = tokio::time::Duration::from_secs(RESTORE_SESSION_TIMEOUT_SECS);
 
     match tokio::time::timeout(timeout, manager.wait_for_result()).await {
         Ok(Some(result)) => {
@@ -60,7 +68,10 @@ async fn handle_restore_session_results(mut manager: RestoreSessionManager, trad
             tracing::error!("Restore session result channel closed unexpectedly");
         }
         Err(_) => {
-            tracing::error!("Restore session timed out after 1 hour");
+            // The `Duration` itself, not a hand-converted unit: it is the value
+            // actually passed to `tokio::time::timeout` above, so the message
+            // cannot disagree with the timeout for any value of the constant.
+            tracing::error!("Restore session timed out after {timeout:?}");
             // Send timeout message to user
             if let Err(e) = send_restore_session_timeout(&trade_key).await {
                 tracing::error!("Failed to send timeout message: {}", e);

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -323,7 +323,10 @@ mod tests {
             )
             .layer(tower_http::cors::CorsLayer::permissive());
 
-        let listener = TcpListener::bind("127.0.0.1:8080").await.unwrap();
+        // Same source of truth as the code that builds the URL.
+        let listener = TcpListener::bind(("127.0.0.1", crate::lnurl::test_ln_port()))
+            .await
+            .unwrap();
         let addr = listener.local_addr().unwrap();
         let port = addr.port();
 

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -239,6 +239,29 @@ async fn lnurl_get(url: Url) -> Result<reqwest::Response, MostroError> {
         .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))
 }
 
+/// Host port the local LNURL test server listens on, and that `cfg!(test)`
+/// lightning addresses are resolved against.
+///
+/// Overridable via `MOSTRO_TEST_LN_PORT` so a run can dodge a port already
+/// taken on the host (`make mutation-test` sets 18080) without disturbing
+/// the 8080 default. One definition on purpose: the prod path, its own
+/// test, and the test server in `lightning::invoice` must agree, and three
+/// hand-copied parses would eventually not.
+///
+/// Not gated on `#[cfg(test)]`: the caller sits behind `cfg!(test)`, which
+/// is a runtime boolean, so both branches are compiled in every profile.
+///
+/// `0` is rejected along with unset and unparseable values: it parses as a
+/// valid `u16` but means "let the OS pick" to a listener, which would bind
+/// an arbitrary port while the URL built here still said `:0`.
+pub(crate) fn test_ln_port() -> u16 {
+    std::env::var("MOSTRO_TEST_LN_PORT")
+        .ok()
+        .and_then(|v| v.parse::<u16>().ok())
+        .filter(|p| *p != 0)
+        .unwrap_or(8080)
+}
+
 /// Parse a Lightning Address or bech32 LNURL into an http(s) [`Url`].
 ///
 /// - Lightning Address (`user@domain`) → well-known LNURL-pay endpoint URL
@@ -263,7 +286,7 @@ async fn extract_lnurl(address: &str) -> Result<Url, MostroError> {
             None => return Err(MostroInternalErr(ServiceError::LnAddressParseError)),
         };
         let base_url = if cfg!(test) {
-            format!("http://{domain}:8080")
+            format!("http://{domain}:{}", test_ln_port())
         } else {
             format!("https://{domain}")
         };
@@ -527,12 +550,15 @@ mod tests {
 
     #[tokio::test]
     async fn extract_lnurl_builds_wellknown_url_for_lightning_address() {
+        // cfg!(test) pins lightning addresses to the local test host form,
+        // so this assertion has to track the same override the code uses.
+        let port = super::test_ln_port();
         let extracted = extract_lnurl("alice@127.0.0.1")
             .await
             .expect("lightning address parses");
         assert_eq!(
             extracted.to_string(),
-            "http://127.0.0.1:8080/.well-known/lnurlp/alice"
+            format!("http://127.0.0.1:{port}/.well-known/lnurlp/alice")
         );
     }
 

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -28,6 +28,13 @@ fn create_event(
     tags.push(Tag::identifier(identifier));
 
     // Add NIP-40 expiration tag if configured and not already provided.
+    // One string comparison covers both construction paths: `Tag::kind()`
+    // returns the tag's serialized name (its first cell, `nostr` 0.45's
+    // `event/tag/mod.rs`), and both `Tag::expiration(..)` and the
+    // `Tag::custom("expiration", ..)` that `order_to_tags` actually builds
+    // put that literal there. No enum matching and no sdk-side name
+    // normalisation is involved, so neither path can slip past this and
+    // double-stamp an order event.
     let has_expiration_tag = tags
         .iter()
         .chain(extra_tags.iter())
@@ -1624,6 +1631,58 @@ mod tests {
         assert!(
             order.tags.iter().any(|t| t.kind() == "expiration"),
             "order events must carry an expiration tag"
+        );
+    }
+
+    #[test]
+    fn create_event_does_not_duplicate_a_caller_supplied_expiration_tag() {
+        // Order events (kind 38383) always get an auto expiration tag from
+        // config when one isn't already present. Pre-supplying a real NIP-40
+        // expiration tag must suppress the auto-add.
+        init_test_settings();
+        let keys = Keys::generate();
+        let extra_tags = Tags::from_list(vec![Tag::expiration(Timestamp::from(123_456_u64))]);
+
+        let order = super::new_order_event(&keys, "", "order-id".to_string(), extra_tags)
+            .expect("order event");
+
+        let expiration_tags = order
+            .tags
+            .iter()
+            .filter(|t| t.kind() == "expiration")
+            .count();
+        assert_eq!(
+            expiration_tags, 1,
+            "caller-supplied expiration tag must not be duplicated"
+        );
+    }
+
+    #[test]
+    fn a_custom_named_expiration_tag_also_suppresses_the_auto_add() {
+        // `order_to_tags` builds the expiration tag by its custom name, so
+        // this is the shape every real order event reaches `create_event`
+        // with. It satisfies the same check as `Tag::expiration` because both
+        // serialise "expiration" into the tag's first cell — this pins that
+        // the custom-named path is covered, alongside the sibling test for
+        // the typed one.
+        init_test_settings();
+        let keys = Keys::generate();
+        let extra_tags =
+            Tags::from_list(vec![Tag::custom("expiration", vec!["123456".to_string()])]);
+
+        let order = super::new_order_event(&keys, "", "order-id".to_string(), extra_tags)
+            .expect("order event");
+
+        let expiration: Vec<&str> = order
+            .tags
+            .iter()
+            .filter(|t| t.kind() == "expiration")
+            .filter_map(|t| t.content())
+            .collect();
+        assert_eq!(
+            expiration,
+            vec!["123456"],
+            "the caller's tag must be the only expiration tag on the event"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #636. Mutation testing for the Nostr event-handling path: `accept_event`
and its gates, `create_event`'s NIP-40 expiration logic, and the
restore-session timeout.

The two functions worth extracting came out of it — `is_stale` and
`missing_inner_signature` are now pure predicates with boundary tests, instead
of conditions reachable only through a live wrapped event.

## Mutation score

Measured on this branch (base `afc39a2`, v0.18.7) with `cargo-mutants 27.1.0`,
via `make mutation-test` — mutant workers serial, test threads parallel (see
[CI and tooling](#ci-and-tooling)).

| Scope | Mutants | Caught | Missed | Unviable |
|---|---|---|---|---|
| `accept_event` (6) + `create_event` (2) + 2 `check_trade_index` struct-field mutants¹ | 10 | 10 | 0 | 0 |
| `is_stale` + `missing_inner_signature` | 9 | 9 | 0 | 0 |
| `restore_session.rs` | 6 | 3 | **3** | 0 |
| **Total** | **25** | **22** | **3** | 0 |

**88% killed**, against #636's >70% target. Reproduce with:

```
make mutation-test ARGS="--file src/app.rs --file src/nip33.rs -F 'in accept_event' -F 'in create_event' -F is_stale -F missing_inner_signature"
make mutation-test ARGS="--file src/app/restore_session.rs"
```

The two predicates are in the count on purpose: they hold the stale check and
the inner-signature check that were inline in `accept_event` before this PR, so
leaving their 9 mutants out would understate the scope.

¹ `delete field pubkey` / `delete field last_trade_index from struct User
expression in check_trade_index` come through the `-F 'in accept_event'` filter
in cargo-mutants 27.1.0. They are counted where the run puts them rather than
dropped.

### The survivors, named

All three are in `restore_session.rs`, and none of them is a coverage gap I can
close honestly.

**`12:46: replace * with +` and `12:46: replace * with /`** — the
`RESTORE_SESSION_TIMEOUT_SECS = 60 * 60` arithmetic. Killing these requires a
test that restates the constant on the line below it, which raises the score
without protecting anything.

An earlier revision of this branch did remove them, by writing the constant
`3_600` so there was no `*` left to mutate. That was the wrong trade and
@Catrya was right to call it: it improves the score by *deleting* a mutant
rather than killing one — the same inflation the rest of this PR exists to
remove — and it shapes production source around the tool measuring it. The
constant is back to `60 * 60`, matching `ORDER_TS_MAX_AGE_SECS` in
`src/util.rs`, and the mutants are reported instead of engineered away.

**`21:5: replace restore_session_action -> Result<(), MostroError> with Ok(())`**
— this one is more interesting, and mutation testing is what surfaced it.

`restore_session_action`'s only fallible call is
`manager.start_restore_session(pool, master_key).await?`. That function
**always returns `Ok(())`**: it spawns a blocking task and the DB error is
handled inside the closure — the `Err` arm of its `spawn_blocking` body in
`src/db.rs` logs it and never propagates it. So
the `?` in `restore_session_action` cannot fire, and the only difference the
mutant makes is skipping the `tokio::spawn`, which is not observable through
the return value.

Killing it would mean asserting on the background task's side effects, which is
timing-dependent and flaky. The survivor is accurate: it is telling us the
error path is already dead, not that the tests are thin.

## What changed

### Tests

- **`src/app.rs`** — what this PR adds:
  - the two first-contact PoW lanes: an unknown sender is accepted when it
    clears `pow_first_contact` and dropped when it does not;
  - the accept/reject basics: a validly wrapped event, the wrong kind, the
    wrong receiver;
  - boundary tests for the two extracted predicates, `is_stale` (3) and
    `missing_inner_signature` (3).

  All of them sit in `accept_event_ordering_tests` on `create_migrated_ctx()`.
  The tampered-signature, replay, and invalid-signature tests in that module
  (`tampered_copy_does_not_censor_the_genuine_event`,
  `genuine_duplicate_is_still_dropped_as_a_replay`,
  `invalid_signature_is_dropped_without_a_gate`,
  `v1_gift_wrap_with_invalid_signature_is_dropped`) came with #892 and are not
  this PR's.

- **`src/nip33.rs`** — `create_event`'s expiration-tag dedup: a caller-supplied
  expiration must not be duplicated by the auto-expiration logic, whichever way
  the tag was built. The tests pin the exact `Tag::custom` shape
  `order_to_tags` emits.

- **`src/lnurl.rs`, `src/lightning/invoice.rs`** — `MOSTRO_TEST_LN_PORT` threaded
  through the test HTTP server and URL builder, so mutation runs don't collide
  with something already bound to 8080. The three copies of the port lookup are
  collapsed into one `test_ln_port()`, which also rejects `0`.

### Production behaviour

- **`src/app/restore_session.rs`** — the only behaviour change in this PR, in
  its own commit. The one-hour timeout was a bare `60 * 60` and the log
  reporting it was the independent literal `"1 hour"`; change one and the other
  silently lies. `RESTORE_SESSION_TIMEOUT_SECS` is now the single source, and
  the log prints the `Duration` actually handed to `tokio::time::timeout` — so
  the message cannot disagree with the timeout for any value of the constant.

- **`src/app.rs`** — `is_stale` and `missing_inner_signature` are extracted from
  `accept_event`. Their bodies are the expressions that were inline, so this is
  a refactor, not a behaviour change.

### CI and tooling

- **`Makefile`** — a `mutation-test` target, serial at the **worker** level
  only:

  - `CARGO_MUTANTS_JOBS=1` runs one mutant at a time (already the default in
    27.1.0; set so the guarantee is stated rather than inherited). This is the
    level that matters: `test_lnurl_validation_with_test_server` binds a fixed
    host port, so two concurrent runs collide on it, and a test that fails
    because it lost that race is scored as a **killed mutant** — inflating the
    number the target exists to measure.
  - Test threads inside each run stay parallel. That test is the only one that
    binds a fixed port, and every lookup it makes goes to its own listener;
    every other listener in the suite binds `:0`, and every test has a private
    in-memory pool. Serialising the threads would protect nothing and roughly
    double the time per mutant (the test run inside each one gets ~3× slower).
  - `MOSTRO_TEST_LN_PORT=18080` steps aside from a port a developer machine is
    likely to have in use.

  `.mutants.toml` is never read by cargo-mutants (#958), so this target is the
  only place the run's environment is actually defined.

- **`.github/workflows/mutation.yml`** — the PR job builds its `--file` args as
  a bash array rather than word-splitting PR-diff filenames, and sets the same
  two variables as the Makefile.

## Acceptance criteria (#636)

- [x] Baseline mutation report for Nostr modules
- [x] Critical mutants in event validation killed (`accept_event`'s
      first-contact PoW lane, and the extracted stale/signature predicates)
- [x] Critical mutants in NIP-33 replaceable-event logic killed (`create_event`)
- [x] Mutation score documented in PR — above, survivors included

## Test plan

Based on `main` @ `afc39a2` (v0.18.7).

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --bin mostrod` — **1336 passed**, 0 failed, 2 ignored
