### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Policy
 
-Mostro is a non-custodial Lightning Network peer-to-peer exchange. Although the daemon never takes ownership of user funds, it coordinates hold invoices, escrow settlement, disputes and reputation, so defects in those paths can put real money and user privacy at risk. Security reports are treated as a priority.
+Mostro is a Lightning Network peer-to-peer exchange built on Nostr. The daemon coordinates hold invoices, escrow settlement, disputes and reputation, so defects in those paths can put real money and user privacy at risk. Security reports are treated as a priority.
 
 ## Supported Versions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Report suspected vulnerabilities privately by email to:
 
 **security@mostro.network**
 
-Do not open a public GitHub issue, pull request, or discussion for a security report, and do not post details in the public Telegram groups. Public disclosure before a fix is available exposes every operator and their users.
+Do not open a public GitHub issue, pull request, or discussion for a security report, and do not post details in the public Telegram groups. Premature public disclosure exposes every operator and their users; see [Coordinated Disclosure](#coordinated-disclosure) below for the timeline we ask you to follow.
 
 Include as much of the following as you can:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,65 @@
+# Security Policy
+
+Mostro is a non-custodial Lightning Network peer-to-peer exchange. Although the daemon never takes ownership of user funds, it coordinates hold invoices, escrow settlement, disputes and reputation, so defects in those paths can put real money and user privacy at risk. Security reports are treated as a priority.
+
+## Supported Versions
+
+Security fixes are developed against the `main` branch and released in the next published version. Only the latest release on [crates.io](https://crates.io/crates/mostro) and the current `main` branch receive security updates; older releases are not patched or backported.
+
+Operators running a Mostro instance are expected to upgrade to the latest release to receive fixes.
+
+## Reporting a Vulnerability
+
+Report suspected vulnerabilities privately by email to:
+
+**security@mostro.network**
+
+Do not open a public GitHub issue, pull request, or discussion for a security report, and do not post details in the public Telegram groups. Public disclosure before a fix is available exposes every operator and their users.
+
+Include as much of the following as you can:
+
+- A description of the issue and the impact you believe it has.
+- The affected version, tag, or commit hash.
+- Step-by-step reproduction instructions, ideally against a regtest or testnet setup.
+- Any proof-of-concept code, logs, or Nostr events that demonstrate the problem.
+- Whether the issue has been disclosed or reported anywhere else.
+
+Reports in English or Spanish are both fine.
+
+## What to Expect
+
+- **Acknowledgement:** within 72 hours of your report.
+- **Initial assessment:** within 7 days, including our severity evaluation and whether we accept the report.
+- **Status updates:** at least every 14 days while the issue remains open.
+- **Resolution:** we aim to ship a fix within 90 days of triage; complex protocol-level issues may take longer, and we will tell you if that is the case.
+
+If you do not receive an acknowledgement within 72 hours, resend your message — mail delivery failures happen.
+
+## Coordinated Disclosure
+
+We ask that you give us a reasonable window to develop and ship a fix before disclosing publicly. Our target is coordinated disclosure once a patched release is available, or 90 days after triage, whichever comes first.
+
+When a fix is released we publish an advisory describing the issue, the affected versions, and the upgrade path. Reporters are credited by name or handle unless they ask to remain anonymous.
+
+## Scope
+
+In scope: the Mostro daemon in this repository, including order and escrow handling, Lightning hold invoice and settlement logic, Cashu escrow, dispute and admin flows, the RPC interface, Nostr event construction and validation, key handling, and the development fee system.
+
+Out of scope for this policy:
+
+- Vulnerabilities in third-party dependencies. Report those upstream, but tell us if Mostro is exploitable through them.
+- Infrastructure operated by third parties, such as public Nostr relays or Lightning nodes you do not control.
+- Client applications maintained in other repositories under the [MostroP2P organization](https://github.com/MostroP2P). Report those to the corresponding repository.
+- Issues that require an already-compromised operator host, database, or private keys.
+- Social engineering, physical attacks, and volumetric denial of service against public infrastructure.
+
+Reports about the Mostro protocol specification itself can also be sent to the same address.
+
+## Safe Harbor
+
+We consider security research conducted in good faith and in accordance with this policy to be authorized, and we will not pursue legal action over it. In return, we ask that you:
+
+- Test against regtest, testnet, or an instance you operate — never against production instances or other users' trades.
+- Avoid accessing, modifying, or destroying data that is not yours.
+- Avoid degrading the service for other users.
+- Give us a reasonable time to respond before disclosing.


### PR DESCRIPTION
Adds a `SECURITY.md` at the repository root. The project had no security policy and no documented channel for reporting vulnerabilities privately.

- Private reporting via security@mostro.network
- Supported versions: latest published release and `main`, no backports
- Response targets: 72h acknowledgement, 7-day initial assessment, 14-day status updates, 90-day fix target
- Coordinated disclosure window and reporter credit
- Scope boundaries and a safe harbor statement for good-faith research

The response timelines are a proposal — they are a public commitment, so they should be confirmed by whoever owns the mailbox before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy covering supported versions, vulnerability reporting, response timelines, coordinated disclosure, scope, and safe-harbor terms.
  * Provided guidance on the information to include when reporting security issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->