### PR TITLE
Reject non-counterparty senders in cooperative cancel

### DIFF
--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -614,8 +614,11 @@ async fn cancel_active_order<L: CancelLightning + Send>(
     }
 
     // If there is already an initiator recorded, this call becomes the confirmation (step 2).
-    match order.cancel_initiator_pubkey {
-        Some(_) => {
+    match order.cancel_initiator_pubkey.as_deref() {
+        Some(initiator) => {
+            if initiator != counterparty_pubkey {
+                return Err(MostroCantDo(CantDoReason::InvalidPubkey));
+            }
             cancel_cooperative_execution_step_2(
                 ctx,
                 event,
@@ -1480,6 +1483,42 @@ mod tests {
         assert!(queued_actions_for(taker)
             .await
             .contains(&Action::CooperativeCancelAccepted));
+    }
+
+    #[tokio::test]
+    async fn cancel_active_order_rejects_preexisting_stranger_initiator() {
+        set_global_config();
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+        let stranger = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::Active.to_string();
+        order.cancel_initiator_pubkey = Some(stranger.to_string());
+        order.hash = Some("stub-hold-invoice-hash".to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // A real counterparty tries to confirm a cancel that was initiated by a stranger.
+        let event = create_unwrapped_message_with_pubkey(taker);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+        assert_eq!(
+            order_by_id(ctx.pool(), order.id).await.status,
+            Status::Active.to_string()
+        );
     }
 
     #[tokio::test]

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -598,6 +598,12 @@ async fn cancel_active_order<L: CancelLightning + Send>(
     let seller_pubkey = order.get_seller_pubkey().map_err(MostroInternalErr)?;
     let buyer_pubkey = order.get_buyer_pubkey().map_err(MostroInternalErr)?;
 
+    // Only the trade counterparties may drive this flow; without this check a
+    // third party falls into the `else` branch below and is treated as the seller.
+    if event.sender != buyer_pubkey && event.sender != seller_pubkey {
+        return Err(MostroCantDo(CantDoReason::InvalidPubkey));
+    }
+
     let counterparty_pubkey: String;
     if buyer_pubkey == event.sender {
         order.buyer_cooperativecancel = true;
@@ -1295,6 +1301,75 @@ mod tests {
         assert!(queued_actions_for(maker)
             .await
             .contains(&Action::CooperativeCancelInitiatedByPeer));
+    }
+
+    #[tokio::test]
+    async fn cancel_active_order_rejects_stranger_initiate() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::Active.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // Neither buyer nor seller: must not be recorded as initiator.
+        let stranger = Keys::generate().public_key();
+        let event = create_unwrapped_message_with_pubkey(stranger);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert!(after.cancel_initiator_pubkey.is_none());
+        assert!(!after.buyer_cooperativecancel);
+        assert!(!after.seller_cooperativecancel);
+    }
+
+    #[tokio::test]
+    async fn cancel_active_order_rejects_stranger_confirm() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+
+        let mut order = create_pending_order(maker, taker);
+        order.status = Status::Active.to_string();
+        // The buyer already initiated; escrow is still locked.
+        order.cancel_initiator_pubkey = Some(taker.to_string());
+        order.buyer_cooperativecancel = true;
+        order.hash = Some("stub-hold-invoice-hash".to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // Neither buyer nor seller: must not be able to confirm the cancel.
+        let stranger = Keys::generate().public_key();
+        let event = create_unwrapped_message_with_pubkey(stranger);
+        let result = cancel_action_generic(
+            &ctx,
+            cancel_msg(order.id),
+            &event,
+            &Keys::generate(),
+            &mut StubLnClient,
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::InvalidPubkey))
+        ));
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.status, Status::Active.to_string());
+        assert_eq!(after.cancel_initiator_pubkey, Some(taker.to_string()));
     }
 
     #[tokio::test]

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -1337,6 +1337,7 @@ mod tests {
         assert!(after.cancel_initiator_pubkey.is_none());
         assert!(!after.buyer_cooperativecancel);
         assert!(!after.seller_cooperativecancel);
+        assert!(after.status == Status::Active.to_string());
     }
 
     #[tokio::test]
@@ -1373,6 +1374,7 @@ mod tests {
         let after = order_by_id(ctx.pool(), order.id).await;
         assert_eq!(after.status, Status::Active.to_string());
         assert_eq!(after.cancel_initiator_pubkey, Some(taker.to_string()));
+        assert!(after.status == Status::Active.to_string());
     }
 
     #[tokio::test]
@@ -1519,6 +1521,10 @@ mod tests {
             order_by_id(ctx.pool(), order.id).await.status,
             Status::Active.to_string()
         );
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.cancel_initiator_pubkey, Some(stranger.to_string()));
+        assert!(!after.buyer_cooperativecancel);
+        assert!(!after.seller_cooperativecancel);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
`cancel_active_order` routed `Cancel` actions for `Active` / `FiatSent` / `Dispute` orders without verifying the sender was actually the buyer or seller. The side-selection logic only checked `if sender == buyer`, and treated *anyone else* as the seller in the `else` branch. As a result, any Nostr user who knew an order id (public via NIP-69 orderbook events) could:

- **Initiate** a cooperative cancel on an active order, getting recorded as `cancel_initiator_pubkey`, or
- **Confirm** a cooperative cancel already initiated by a real party — cancelling the hold invoice (refunding escrow to the seller), marking the order `CooperativelyCanceled`, and auto-closing any open dispute as `SellerRefunded`.

This let a stranger complete a fund-moving state transition on someone else's trade, with no ability for the actual counterparties to stop it. Worst case: a buyer who already sent fiat loses it, and the dispute path that could have recovered them is closed out from under them.

## Fix
Added an explicit membership check in `cancel_active_order` before the buyer/seller branch:

```rust
if event.sender != buyer_pubkey && event.sender != seller_pubkey {
    return Err(MostroCantDo(CantDoReason::InvalidPubkey));
}
```

This mirrors the check already present in `cancel_not_active_order` for early-stage cancels.

## Tests added
- `cancel_active_order_rejects_stranger_initiate` — a third party can no longer become `cancel_initiator_pubkey` on an `Active` order.
- `cancel_active_order_rejects_stranger_confirm` — with the buyer already recorded as initiator, a third party can no longer "confirm" and drive the order to `CooperativelyCanceled`.

Existing tests confirm legitimate buyer/seller initiate and confirm flows are unaffected. Full `app::cancel::tests` suite: 20 passed, 0 failed.

## Verification
```bash
cargo test --bin mostrod app::cancel::tests -- --nocapture
cargo fmt --all
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cooperative cancellation requests from unauthorized parties are now rejected.
  * Unauthorized cancellation attempts no longer change the order’s cancellation state.
  * Cancellation confirmations must match the party that initiated the request.
  * Preexisting cancellation requests from unauthorized parties are handled safely.
  * Added safeguards to prevent unauthorized cancellations from being confirmed.
  * Added coverage for unauthorized initiation, confirmation, and unchanged order state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->