### PR TITLE
fix: resubscribe hold invoices correctly across a restart

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -919,12 +919,25 @@ pub async fn find_locked_cashu_orders(pool: &SqlitePool) -> Result<Vec<Order>, M
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
 }
 
+/// Orders whose hold invoice still needs an LND subscription attached.
+///
+/// Two disjoint cases, and the second is the one that matters after a restart:
+///
+/// - `active` with `invoice_held_at != 0` — the seller already paid, so the
+///   subscription is there to observe settle/cancel.
+/// - `waiting-payment` / `waiting-buyer-invoice` with a hash — the invoice
+///   exists but nobody has paid it yet. `invoice_held_at` is still 0 here
+///   (only [`crate::flow::hold_invoice_paid`] ever writes it), which is why
+///   that column cannot gate this branch: these rows would never match.
+///   Missing this window is what makes a seller who paid during a restart
+///   look like a seller who never paid.
 pub async fn find_held_invoices(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
     let order = sqlx::query_as::<_, Order>(
         r#"
           SELECT *
           FROM orders
-          WHERE invoice_held_at !=0 AND  status == 'active'
+          WHERE (invoice_held_at != 0 AND status == 'active')
+             OR (status IN ('waiting-payment', 'waiting-buyer-invoice') AND hash IS NOT NULL)
         "#,
     )
     .fetch_all(pool)
@@ -1992,6 +2005,64 @@ mod tests {
 
         let result = super::find_held_invoices(&pool).await.unwrap();
         assert!(result.is_empty(), "Should not find non-active orders");
+    }
+
+    #[tokio::test]
+    async fn test_find_held_invoices_includes_orders_awaiting_seller_payment() {
+        let pool = setup_orders_db().await.unwrap();
+
+        // The hold invoice exists (hash set) but the seller has not paid it yet,
+        // so invoice_held_at is still 0 — it is only written by hold_invoice_paid.
+        // This is precisely the window a restart must not drop: the Accepted
+        // event has not arrived, so the subscription is what is load-bearing.
+        for status in ["waiting-payment", "waiting-buyer-invoice"] {
+            sqlx::query(
+                r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                        amount, fiat_code, fiat_amount, created_at, expires_at,
+                        failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                        invoice_held_at, hash)
+                VALUES (?1, 'buy', 'ev1', ?2, 0, 'lightning',
+                        100000, 'USD', 100, 1700000000, 1700086400,
+                        0, 0, 0, 0, 0, ?3)"#,
+            )
+            .bind(uuid::Uuid::new_v4())
+            .bind(status)
+            .bind("aa".repeat(32))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let result = super::find_held_invoices(&pool).await.unwrap();
+        assert_eq!(
+            result.len(),
+            2,
+            "both pre-payment statuses must be resubscribed on restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_held_invoices_ignores_orders_without_hash() {
+        let pool = setup_orders_db().await.unwrap();
+
+        // Nothing to subscribe to without an r_hash, so such a row must not be
+        // returned — the caller would have no bytes to hand LND.
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    invoice_held_at)
+            VALUES (?1, 'buy', 'ev1', 'waiting-payment', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0, 0)"#,
+        )
+        .bind(uuid::Uuid::new_v4())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = super::find_held_invoices(&pool).await.unwrap();
+        assert!(result.is_empty(), "rows without a hash must be skipped");
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -2042,6 +2042,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_find_held_invoices_includes_waiting_buyer_invoice_after_payment() {
+        let pool = setup_orders_db().await.unwrap();
+
+        // The state hold_invoice_paid leaves behind on its no-buyer-invoice
+        // branch: still waiting-buyer-invoice, but the invoice was already
+        // observed. It must keep being resubscribed so later settle/cancel
+        // events are seen; hold_invoice_paid itself no-ops on the replay.
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    invoice_held_at, hash)
+            VALUES (?1, 'buy', 'ev1', 'waiting-buyer-invoice', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0, 1700001000, ?2)"#,
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind("bb".repeat(32))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = super::find_held_invoices(&pool).await.unwrap();
+        assert_eq!(result.len(), 1, "post-payment rows stay subscribed");
+    }
+
+    #[tokio::test]
     async fn test_find_held_invoices_ignores_orders_without_hash() {
         let pool = setup_orders_db().await.unwrap();
 

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -27,6 +27,27 @@ pub async fn hold_invoice_paid(
         order.id
     );
 
+    // Only an order still waiting on the seller's payment may be advanced by
+    // this event. Without the check, a redelivered or late `Accepted` — after a
+    // restart reattaches the subscription, or after the row was canceled while
+    // the hold invoice lived on in LND — would flip a settled or canceled order
+    // back into a live trade.
+    let current_status = order.get_order_status().map_err(MostroInternalErr)?;
+    if !matches!(
+        current_status,
+        Status::WaitingPayment | Status::WaitingBuyerInvoice
+    ) {
+        // Loud on purpose: the HTLC is real and locked, but this order is past
+        // the point where we can credit it, so an operator has to look.
+        tracing::warn!(
+            order_id = %order.id,
+            status = %current_status,
+            "Ignoring hold-invoice payment for an order outside the pre-payment \
+             window; the invoice with hash {hash} may still be locked in LND"
+        );
+        return Ok(());
+    }
+
     // Check if the order kind is valid
     let order_kind = order.get_order_kind().map_err(MostroInternalErr)?;
 
@@ -255,6 +276,40 @@ mod tests {
         let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
         assert_eq!(updated.status, Status::WaitingBuyerInvoice.to_string());
         assert!(updated.invoice_held_at > 0, "invoice_held_at must be set");
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_paid_does_not_revive_a_settled_order() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "cc".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        // A redelivered or late Accepted event for an order that has already
+        // left the pre-payment window must not drag it back into a live trade.
+        insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::Canceled,
+            Some("lnbcrt1invoice".to_string()),
+            Some(buyer),
+            Some(seller),
+            None,
+        )
+        .await;
+
+        let result = hold_invoice_paid(&hash, None, &pool, &create_test_keys()).await;
+        assert!(
+            result.is_ok(),
+            "a stale Accepted is a no-op, not a failure: {result:?}"
+        );
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(updated.status, Status::Canceled.to_string());
+        assert_eq!(
+            updated.invoice_held_at, 0,
+            "no side effects on an order outside the pre-payment window"
+        );
     }
 
     #[tokio::test]

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -15,6 +15,40 @@ pub async fn hold_invoice_paid(
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
+    // Decide whether this event may advance the order before touching anything
+    // else, so a replay costs one status read and cannot surface a spurious
+    // error from a degraded row.
+    //
+    // Two conditions, and both are load-bearing:
+    //
+    // - Status must still be pre-payment. Otherwise a late `Accepted` — the row
+    //   was canceled while the hold invoice lived on in LND — would drag a dead
+    //   order back into a live trade.
+    // - `invoice_held_at` must still be unset. This is the idempotency marker:
+    //   it is written at the end of this function and read nowhere else, and
+    //   `WaitingBuyerInvoice` is both an entry *and* an exit state of the flow
+    //   below. Without it, every restart resubscribes such a row, LND replays
+    //   the held invoice's `Accepted`, and the buyer gets another `AddInvoice`
+    //   while the maker gets another reputation notification.
+    let current_status = order.get_order_status().map_err(MostroInternalErr)?;
+    let is_pre_payment = matches!(
+        current_status,
+        Status::WaitingPayment | Status::WaitingBuyerInvoice
+    );
+    if !is_pre_payment || order.invoice_held_at != 0 {
+        // Loud on purpose: the HTLC is real and locked, but this order is past
+        // the point where we can credit it, so an operator has to look.
+        tracing::warn!(
+            order_id = %order.id,
+            status = %current_status,
+            invoice_held_at = order.invoice_held_at,
+            "Ignoring hold-invoice payment for an order already past the \
+             pre-payment window; the invoice with hash {hash} may still be \
+             locked in LND"
+        );
+        return Ok(());
+    }
+
     let buyer_pubkey = order
         .get_buyer_pubkey()
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
@@ -26,27 +60,6 @@ pub async fn hold_invoice_paid(
         "Order Id: {} - Seller paid invoice with hash: {hash}",
         order.id
     );
-
-    // Only an order still waiting on the seller's payment may be advanced by
-    // this event. Without the check, a redelivered or late `Accepted` — after a
-    // restart reattaches the subscription, or after the row was canceled while
-    // the hold invoice lived on in LND — would flip a settled or canceled order
-    // back into a live trade.
-    let current_status = order.get_order_status().map_err(MostroInternalErr)?;
-    if !matches!(
-        current_status,
-        Status::WaitingPayment | Status::WaitingBuyerInvoice
-    ) {
-        // Loud on purpose: the HTLC is real and locked, but this order is past
-        // the point where we can credit it, so an operator has to look.
-        tracing::warn!(
-            order_id = %order.id,
-            status = %current_status,
-            "Ignoring hold-invoice payment for an order outside the pre-payment \
-             window; the invoice with hash {hash} may still be locked in LND"
-        );
-        return Ok(());
-    }
 
     // Check if the order kind is valid
     let order_kind = order.get_order_kind().map_err(MostroInternalErr)?;
@@ -309,6 +322,46 @@ mod tests {
         assert_eq!(
             updated.invoice_held_at, 0,
             "no side effects on an order outside the pre-payment window"
+        );
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_paid_is_a_noop_on_redelivery() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "ee".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        let master_buyer = create_test_keys().public_key().to_string();
+        // This is the else-branch's *own* output state: WaitingBuyerInvoice with
+        // the hold invoice already observed. Such a row is resubscribed on every
+        // restart, and LND replays the current Accepted state on resubscribe, so
+        // the flow must not run a second time — it would re-send AddInvoice to
+        // the buyer and re-notify the maker on each restart.
+        let order = insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::WaitingBuyerInvoice,
+            None,
+            Some(buyer),
+            Some(seller),
+            Some(master_buyer),
+        )
+        .await;
+        crate::db::update_order_invoice_held_at_time(&pool, order.id, 1_700_000_000)
+            .await
+            .unwrap();
+
+        let result = hold_invoice_paid(&hash, None, &pool, &create_test_keys()).await;
+        assert!(
+            result.is_ok(),
+            "a replayed Accepted is a no-op, not a failure: {result:?}"
+        );
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(
+            updated.invoice_held_at, 1_700_000_000,
+            "a replayed Accepted must not re-run the flow"
         );
     }
 

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -5,6 +5,21 @@ use nostr_sdk::prelude::*;
 use sqlx::SqlitePool;
 use tracing::info;
 
+/// Advance an order whose seller has just paid the hold invoice.
+///
+/// Called from the LND invoice subscriber on `InvoiceState::Accepted`, which
+/// means it can fire more than once for the same invoice: LND replays the
+/// current state whenever a subscription is (re)attached, and every restart
+/// reattaches one for each row `crate::db::find_held_invoices` returns.
+///
+/// It therefore only acts on an order that is still in `WaitingPayment` or
+/// `WaitingBuyerInvoice` *and* still has `invoice_held_at == 0`. Anything else
+/// — a replay, or a late event for an order canceled while its hold invoice
+/// lived on in LND — is a no-op that returns `Ok` after a warning, never an
+/// error, since there is nothing for the caller to retry.
+///
+/// Not atomic: the check and the write are separate statements, so a cancel
+/// running concurrently on the main loop can still interleave. See #855.
 pub async fn hold_invoice_paid(
     hash: &str,
     request_id: Option<u64>,

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -72,7 +72,7 @@ const HASH_LEN: usize = 32;
 /// `field` names the column for the log line. The value itself is never
 /// included in the error: the preimage is the secret that claims the
 /// HTLC, and errors end up in logs.
-fn decode_hash32(field: &str, value: &str) -> Result<Vec<u8>, MostroError> {
+pub(crate) fn decode_hash32(field: &str, value: &str) -> Result<Vec<u8>, MostroError> {
     let bytes = Vec::<u8>::from_hex(value).map_err(|e| {
         MostroInternalErr(ServiceError::HoldInvoiceError(format!(
             "invalid {field}: not valid hex ({e})"

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,24 +221,33 @@ async fn main() -> Result<()> {
         panic!("No connection to LND node - shutting down Mostro!");
     };
 
-    if let Ok(held_invoices) = find_held_invoices(get_db_pool().as_ref()).await {
-        for invoice in held_invoices.iter() {
-            if let Some(hash) = &invoice.hash {
-                // `orders.hash` is hex text; LND's SubscribeSingleInvoiceRequest
-                // wants the 32 raw bytes. Passing the 64 ASCII characters makes
-                // every resubscribe fail, which is silent here because the error
-                // is only logged — and a missed subscription looks exactly like
-                // a seller who never paid.
-                let r_hash = match crate::lightning::decode_hash32("order hash", hash) {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        tracing::error!("Order {} has an undecodable hash: {e}", invoice.id);
-                        continue;
+    // A failure here means no in-flight hold invoice is resubscribed for the
+    // whole run, which is indistinguishable from "there were none" unless it is
+    // said out loud — the same silent-failure shape this path already had.
+    match find_held_invoices(get_db_pool().as_ref()).await {
+        Err(e) => tracing::error!(
+            "Could not load held invoices to resubscribe; in-flight trades will \
+             not be observed until the next restart: {e}"
+        ),
+        Ok(held_invoices) => {
+            for invoice in held_invoices.iter() {
+                if let Some(hash) = &invoice.hash {
+                    // `orders.hash` is hex text; LND's SubscribeSingleInvoiceRequest
+                    // wants the 32 raw bytes. Passing the 64 ASCII characters makes
+                    // every resubscribe fail, which is silent here because the error
+                    // is only logged — and a missed subscription looks exactly like
+                    // a seller who never paid.
+                    let r_hash = match crate::lightning::decode_hash32("order hash", hash) {
+                        Ok(bytes) => bytes,
+                        Err(e) => {
+                            tracing::error!("Order {} has an undecodable hash: {e}", invoice.id);
+                            continue;
+                        }
+                    };
+                    tracing::info!("Resubscribing order id - {}", invoice.id);
+                    if let Err(e) = invoice_subscribe(r_hash, None).await {
+                        tracing::error!("Ln node error {e}")
                     }
-                };
-                tracing::info!("Resubscribing order id - {}", invoice.id);
-                if let Err(e) = invoice_subscribe(r_hash, None).await {
-                    tracing::error!("Ln node error {e}")
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,8 +224,20 @@ async fn main() -> Result<()> {
     if let Ok(held_invoices) = find_held_invoices(get_db_pool().as_ref()).await {
         for invoice in held_invoices.iter() {
             if let Some(hash) = &invoice.hash {
+                // `orders.hash` is hex text; LND's SubscribeSingleInvoiceRequest
+                // wants the 32 raw bytes. Passing the 64 ASCII characters makes
+                // every resubscribe fail, which is silent here because the error
+                // is only logged — and a missed subscription looks exactly like
+                // a seller who never paid.
+                let r_hash = match crate::lightning::decode_hash32("order hash", hash) {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        tracing::error!("Order {} has an undecodable hash: {e}", invoice.id);
+                        continue;
+                    }
+                };
                 tracing::info!("Resubscribing order id - {}", invoice.id);
-                if let Err(e) = invoice_subscribe(hash.as_bytes().to_vec(), None).await {
+                if let Err(e) = invoice_subscribe(r_hash, None).await {
                     tracing::error!("Ln node error {e}")
                 }
             }


### PR DESCRIPTION
## Summary

Second of the five findings from the security review (the first landed in #851).

Three defects broke hold-invoice resubscription after a daemon restart. Together they mean every in-flight trade across any restart is mishandled, and with `[anti_abuse_bond] slash_on_waiting_timeout = true` a seller who paid the hold invoice **on time** has their bond slashed as the responsible party — a loss of user funds caused by the daemon's own missed observation.

## What was wrong

**1. The r_hash was passed as ASCII hex.** `main.rs` called `invoice_subscribe(hash.as_bytes().to_vec(), ...)`, but `orders.hash` is a 64-character hex string, so `.as_bytes()` yields 64 ASCII characters rather than the 32 raw bytes `SubscribeSingleInvoiceRequest.r_hash` expects. Every resubscribe errored instantly, and the error was only logged (`tracing::error!`), so it was silent in practice. The bond resubscriber already did this correctly with `from_hex` — this now uses the existing `decode_hash32` helper, which also length-checks and keeps the value out of the log line.

**2. The query excluded the window that matters.** `find_held_invoices` selected only `status == 'active'`, skipping `waiting-payment` and `waiting-buyer-invoice` — the phases where the `Accepted` event is load-bearing, because that is when the seller actually pays.

Worth flagging, since it is not obvious and the finding did not mention it: widening the status filter alone would **not** have fixed this. Those rows also have `invoice_held_at = 0`, since that column is only ever written by `hold_invoice_paid` — i.e. after the seller pays. The existing `invoice_held_at != 0` predicate would have kept excluding them. The new branch keys off `hash IS NOT NULL` instead, and is disjoint from the original `active` branch so that path is unchanged.

**3. `hold_invoice_paid` had no current-status guard.** Once resubscription works, a redelivered or late `Accepted` would advance whatever order it resolved to. It now no-ops outside `WaitingPayment` / `WaitingBuyerInvoice`, with a `warn` carrying the order id and status — loud on purpose, because the HTLC is real and locked while the order can no longer be credited, so an operator has to look.

That third change also closes the amplifier in finding #5 (the stale full-row write on `cancel_pending_order_from_maker`), where a canceled order could be revived by the seller paying a hold invoice that outlived the row's escrow columns. The clobber itself is untouched and still open.

## Tests

Written first, confirmed failing against the unfixed code:

- `db::tests::test_find_held_invoices_includes_orders_awaiting_seller_payment` — both pre-payment statuses are selected with `invoice_held_at = 0`.
- `db::tests::test_find_held_invoices_ignores_orders_without_hash` — no hash, nothing to subscribe to.
- `flow::tests::hold_invoice_paid_does_not_revive_a_settled_order` — a stale `Accepted` on a canceled order leaves status and `invoice_held_at` untouched, and returns `Ok`.

Existing coverage for the `active` branch and both happy paths of `hold_invoice_paid` is unchanged and still passes.

## Verification

```bash
cargo test --bin mostrod          # 1095 passed, 0 failed, 2 ignored
cargo clippy --all-targets -- -D warnings
cargo fmt --all -- --check
```

## Not covered here

The wrongful-slash consequence was code-traced through the scheduler and bond slash path, not executed against a live LND. The two enabling defects are test-proven; the fix removes their cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored eligible invoices in “waiting for payment” and “waiting for buyer invoice” states when valid invoice information is available.
  - Prevented duplicate or stale payments from reviving canceled, settled, or already-processed orders.
  - Improved invoice resubscription by validating stored order hashes and safely skipping invalid entries.
  - Added safeguards to exclude incomplete invoice records from recovery and prevent invalid payment notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->