### PR TITLE
Fix hold invoice resubscribe after restart

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -919,12 +919,26 @@ pub async fn find_locked_cashu_orders(pool: &SqlitePool) -> Result<Vec<Order>, M
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
 }
 
+/// Orders whose Lightning hold invoice still needs an LND subscription after
+/// a daemon restart.
+///
+/// Includes:
+/// - `waiting-payment` — seller has not paid yet; `Accepted` advances the trade
+/// - `waiting-buyer-invoice` / `active` — hold already accepted; keep watching
+///   `Settled` / `Canceled`
+///
+/// Selection is by a non-empty `hash`, not `invoice_held_at`: that timestamp is
+/// only written in `hold_invoice_paid` *after* `Accepted`, so filtering on it
+/// would permanently skip the `WaitingPayment` phase where resubscription
+/// matters most.
 pub async fn find_held_invoices(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
     let order = sqlx::query_as::<_, Order>(
         r#"
           SELECT *
           FROM orders
-          WHERE invoice_held_at !=0 AND  status == 'active'
+          WHERE hash IS NOT NULL
+            AND hash != ''
+            AND status IN ('waiting-payment', 'waiting-buyer-invoice', 'active')
         "#,
     )
     .fetch_all(pool)
@@ -1948,17 +1962,18 @@ mod tests {
         let pool = setup_orders_db().await.unwrap();
         let id = uuid::Uuid::new_v4();
 
-        // Insert order with invoice_held_at != 0 and status = 'active'
+        // Insert order with a payment hash and status = 'active'
         sqlx::query(
             r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
                     amount, fiat_code, fiat_amount, created_at, expires_at,
                     failed_payment, payment_attempts, dev_fee, dev_fee_paid,
-                    invoice_held_at)
+                    invoice_held_at, hash)
             VALUES (?1, 'buy', 'ev1', 'active', 0, 'lightning',
                     100000, 'USD', 100, 1700000000, 1700086400,
-                    0, 0, 0, 0, 1700001000)"#,
+                    0, 0, 0, 0, 1700001000, ?2)"#,
         )
         .bind(id)
+        .bind("aa".repeat(32))
         .execute(&pool)
         .await
         .unwrap();
@@ -1972,18 +1987,78 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_find_held_invoices_ignores_non_active() {
+    async fn test_find_held_invoices_returns_waiting_payment_with_hash() {
+        let pool = setup_orders_db().await.unwrap();
+        let id = uuid::Uuid::new_v4();
+
+        // WaitingPayment: hold invoice created, seller not yet paid.
+        // `invoice_held_at` is still 0 — that field is only set on Accepted.
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    invoice_held_at, hash)
+            VALUES (?1, 'buy', 'ev1', 'waiting-payment', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0, 0, ?2)"#,
+        )
+        .bind(id)
+        .bind("bb".repeat(32))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = super::find_held_invoices(&pool).await.unwrap();
+        assert_eq!(
+            result.len(),
+            1,
+            "WaitingPayment orders with a hash must be resubscribed on restart"
+        );
+        assert_eq!(result[0].id, id);
+    }
+
+    #[tokio::test]
+    async fn test_find_held_invoices_returns_waiting_buyer_invoice_with_hash() {
+        let pool = setup_orders_db().await.unwrap();
+        let id = uuid::Uuid::new_v4();
+
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    invoice_held_at, hash)
+            VALUES (?1, 'sell', 'ev1', 'waiting-buyer-invoice', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0, 1700001000, ?2)"#,
+        )
+        .bind(id)
+        .bind("cc".repeat(32))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = super::find_held_invoices(&pool).await.unwrap();
+        assert_eq!(
+            result.len(),
+            1,
+            "WaitingBuyerInvoice orders with a hash must be resubscribed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_held_invoices_ignores_waiting_payment_without_hash() {
         let pool = setup_orders_db().await.unwrap();
 
-        // Insert order with invoice_held_at != 0 but wrong status
+        // Pre-hold WaitingBuyerInvoice / empty-hash waiting states have
+        // nothing for LND to subscribe to.
         sqlx::query(
             r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
                     amount, fiat_code, fiat_amount, created_at, expires_at,
                     failed_payment, payment_attempts, dev_fee, dev_fee_paid,
                     invoice_held_at)
-            VALUES (?1, 'buy', 'ev1', 'pending', 0, 'lightning',
+            VALUES (?1, 'sell', 'ev1', 'waiting-buyer-invoice', 0, 'lightning',
                     100000, 'USD', 100, 1700000000, 1700086400,
-                    0, 0, 0, 0, 1700001000)"#,
+                    0, 0, 0, 0, 0)"#,
         )
         .bind(uuid::Uuid::new_v4())
         .execute(&pool)
@@ -1991,14 +2066,44 @@ mod tests {
         .unwrap();
 
         let result = super::find_held_invoices(&pool).await.unwrap();
-        assert!(result.is_empty(), "Should not find non-active orders");
+        assert!(
+            result.is_empty(),
+            "Orders without a payment hash must not be selected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_held_invoices_ignores_non_active() {
+        let pool = setup_orders_db().await.unwrap();
+
+        // Insert order with a hash but a terminal / unrelated status
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    invoice_held_at, hash)
+            VALUES (?1, 'buy', 'ev1', 'pending', 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0, 1700001000, ?2)"#,
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind("dd".repeat(32))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let result = super::find_held_invoices(&pool).await.unwrap();
+        assert!(
+            result.is_empty(),
+            "Should not find orders outside waiting/active hold-invoice statuses"
+        );
     }
 
     #[tokio::test]
     async fn test_find_held_invoices_ignores_zero_held_at() {
         let pool = setup_orders_db().await.unwrap();
 
-        // Insert active order but invoice_held_at = 0
+        // Active without a hash: nothing to resubscribe (e.g. Cashu trades).
         sqlx::query(
             r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
                     amount, fiat_code, fiat_amount, created_at, expires_at,
@@ -2014,7 +2119,10 @@ mod tests {
         .unwrap();
 
         let result = super::find_held_invoices(&pool).await.unwrap();
-        assert!(result.is_empty(), "Should not find orders with held_at = 0");
+        assert!(
+            result.is_empty(),
+            "Should not find active orders without a payment hash"
+        );
     }
 
     // -- Tests for find_failed_payment --

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -306,7 +306,10 @@ mod tests {
 
         let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
         assert_eq!(updated.status, Status::Active.to_string());
-        assert_eq!(updated.invoice_held_at, 0, "invoice_held_at must stay untouched");
+        assert_eq!(
+            updated.invoice_held_at, 0,
+            "invoice_held_at must stay untouched"
+        );
     }
 
     #[tokio::test]

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -15,6 +15,19 @@ pub async fn hold_invoice_paid(
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
+    // `Accepted` only advances a trade still waiting for the seller's hold
+    // payment. After a restart LND may redeliver the current invoice state;
+    // without this guard a redelivered `Accepted` on an already-advanced
+    // order would regress status / re-enqueue party messages.
+    let current_status = order.get_order_status().map_err(MostroInternalErr)?;
+    if current_status != Status::WaitingPayment {
+        info!(
+            "Order Id: {} - Ignoring hold-invoice Accepted in status {current_status} (hash {hash})",
+            order.id
+        );
+        return Ok(());
+    }
+
     let buyer_pubkey = order
         .get_buyer_pubkey()
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
@@ -235,19 +248,30 @@ mod tests {
         let hash = "bb".repeat(32);
         let buyer = create_test_keys().public_key().to_string();
         let seller = create_test_keys().public_key().to_string();
-        let master_buyer = create_test_keys().public_key().to_string();
-        // Status WaitingBuyerInvoice keeps notify_taker_reputation on its
-        // allowed-status path (sell order → PayInvoice to seller).
-        insert_order_with_hash(
-            &pool,
-            &hash,
-            Status::WaitingBuyerInvoice,
-            None,
-            Some(buyer),
-            Some(seller),
-            Some(master_buyer),
-        )
-        .await;
+        let master_seller = create_test_keys().public_key().to_string();
+        // Buy order still WaitingPayment: seller just paid the hold invoice
+        // and the maker (buyer) has not supplied a settlement invoice yet.
+        // `notify_taker_reputation` accepts WaitingPayment on buy orders.
+        let order = Order {
+            id: uuid::Uuid::new_v4(),
+            kind: OrderKind::Buy.to_string(),
+            status: Status::WaitingPayment.to_string(),
+            creator_pubkey: buyer.clone(),
+            payment_method: "SEPA".to_string(),
+            amount: 1_000,
+            fee: 10,
+            fiat_code: "USD".to_string(),
+            fiat_amount: 100,
+            hash: Some(hash.clone()),
+            buyer_invoice: None,
+            buyer_pubkey: Some(buyer),
+            seller_pubkey: Some(seller),
+            master_seller_pubkey: Some(master_seller),
+            created_at: Timestamp::now().as_secs() as i64,
+            expires_at: Timestamp::now().as_secs() as i64 + 3_600,
+            ..Default::default()
+        };
+        order.create(&pool).await.unwrap();
 
         let result = hold_invoice_paid(&hash, None, &pool, &create_test_keys()).await;
         assert!(result.is_ok(), "add-invoice path must succeed: {result:?}");
@@ -255,6 +279,34 @@ mod tests {
         let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
         assert_eq!(updated.status, Status::WaitingBuyerInvoice.to_string());
         assert!(updated.invoice_held_at > 0, "invoice_held_at must be set");
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_paid_ignores_accepted_when_not_waiting_payment() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "ee".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        // Already Active: a redelivered Accepted after restart must not
+        // regress the order or re-enqueue party messages.
+        insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::Active,
+            Some("lnbcrt1invoice".to_string()),
+            Some(buyer),
+            Some(seller),
+            None,
+        )
+        .await;
+
+        let result = hold_invoice_paid(&hash, Some(1), &pool, &create_test_keys()).await;
+        assert!(result.is_ok(), "stale Accepted must be a no-op: {result:?}");
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
+        assert_eq!(updated.invoice_held_at, 0, "invoice_held_at must stay untouched");
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use crate::db::find_held_invoices;
 use crate::lightning::LnStatus;
 use crate::lightning::LndConnector;
 use crate::rpc::RpcServer;
+use nostr_sdk::nostr::hashes::hex::FromHex;
 use nostr_sdk::prelude::*;
 use scheduler::start_scheduler;
 use std::env;
@@ -224,9 +225,24 @@ async fn main() -> Result<()> {
     if let Ok(held_invoices) = find_held_invoices(get_db_pool().as_ref()).await {
         for invoice in held_invoices.iter() {
             if let Some(hash) = &invoice.hash {
-                tracing::info!("Resubscribing order id - {}", invoice.id);
-                if let Err(e) = invoice_subscribe(hash.as_bytes().to_vec(), None).await {
-                    tracing::error!("Ln node error {e}")
+                // `orders.hash` is lowercase hex from `util::bytes_to_string`.
+                // LND's `SubscribeSingleInvoiceRequest.r_hash` wants the raw
+                // 32 bytes — mirror `bond::resubscribe_active_bonds`. Passing
+                // `hash.as_bytes()` would hand LND 64 ASCII hex digits and
+                // every restart resubscribe would fail instantly.
+                match Vec::<u8>::from_hex(hash) {
+                    Ok(bytes) => {
+                        tracing::info!("Resubscribing order id - {}", invoice.id);
+                        if let Err(e) = invoice_subscribe(bytes, None).await {
+                            tracing::error!("Ln node error {e}")
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Order {} has malformed payment hash, skipping resubscribe: {e}",
+                            invoice.id
+                        )
+                    }
                 }
             }
         }
@@ -364,7 +380,28 @@ fn install_price_manager() -> std::result::Result<(), Box<dyn std::error::Error>
 #[cfg(test)]
 mod tests {
     use mostro_core::message::Message;
+    use nostr_sdk::nostr::hashes::hex::FromHex;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[test]
+    fn restart_resubscribe_hex_decodes_payment_hash() {
+        // Regression for the ASCII-hex-as-r_hash bug: `orders.hash` is a
+        // 64-char lowercase hex string from `util::bytes_to_string`, and
+        // LND expects the raw 32-byte payment hash.
+        let raw_hash: [u8; 32] = [0xab; 32];
+        let hex_string = crate::util::bytes_to_string(&raw_hash);
+        assert_eq!(hex_string.len(), 64);
+
+        // The broken form previously used in `main`:
+        let ascii_bytes = hex_string.as_bytes().to_vec();
+        assert_eq!(ascii_bytes.len(), 64);
+        assert_ne!(ascii_bytes, raw_hash.to_vec());
+
+        // The fixed form (same as `bond::resubscribe_active_bonds`):
+        let decoded = Vec::<u8>::from_hex(&hex_string).unwrap();
+        assert_eq!(decoded.len(), 32);
+        assert_eq!(decoded, raw_hash.to_vec());
+    }
 
     #[test]
     fn test_message_deserialize_serialize() {


### PR DESCRIPTION
## Summary

Two restart bugs could skip seller hold-invoice payments and, with `slash_on_waiting_timeout`, wrongfully slash the seller's anti-abuse bond.

## Changes

- Hex-decode `orders.hash` before `invoice_subscribe` on restart (LND expects 32 raw bytes, not 64 ASCII hex digits), matching `bond::resubscribe_active_bonds`
- Select resubscribe candidates by non-empty `hash` in `waiting-payment` / `waiting-buyer-invoice` / `active` — `invoice_held_at` is only set *after* `Accepted`, so the old filter permanently skipped `WaitingPayment`
- Gate `hold_invoice_paid` on `WaitingPayment` so a redelivered `Accepted` cannot regress an already-advanced order

## How to test

```bash
cargo test --bin mostrod find_held_invoices
cargo test --bin mostrod hold_invoice_paid
cargo test --bin mostrod restart_resubscribe
```

All three groups passed locally (12 tests).

## Notes for reviewers

- No schema/migration or config changes
- End-to-end slash path was code-traced, not exercised against a live LND
- Query change is in `find_held_invoices` only (no `.sqlx` offline cache in this repo)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of held invoices after restart, including orders awaiting payment or buyer invoices.
  * Prevented unrelated, hashless, or stale orders from being incorrectly resumed.
  * Ignored outdated payment events without changing active orders or invoice timestamps.
  * Added validation for saved payment hashes, safely skipping malformed values.
* **Reliability**
  * Improved invoice processing consistency across payment and order status transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->