### PR TITLE
Harden LNURL fetches against SSRF and hangs

### DIFF
--- a/docs/LIGHTNING_OPS.md
+++ b/docs/LIGHTNING_OPS.md
@@ -39,17 +39,17 @@ Decodes a BOLT11 invoice string into a structured invoice object.
 **Parameters**:
 - `payment_request`: BOLT11 invoice string
 
-**Returns**: `Bolt11Invoice` or `MostroError::InvalidInvoice`
+**Returns**: `Bolt11Invoice` or `MostroError` (`InvoiceInvalidError` / related)
 
-**Entry**: `src/lightning/invoice.rs:33`
+**Entry**: `src/lightning/invoice.rs` (`fn decode_invoice`)
 
 #### is_valid_invoice
 ```rust
 pub async fn is_valid_invoice(
-    amount: i64,
-    fee: i64,
-    payment_request: &str,
-) -> Result<String, MostroError>
+    payment_request: String,
+    amount: Option<u64>,
+    fee: Option<u64>,
+) -> Result<(), MostroError>
 ```
 Comprehensive validation supporting:
 - BOLT11 Lightning invoices
@@ -62,27 +62,52 @@ Comprehensive validation supporting:
 3. Minimum payment amount enforcement (`mostro_settings.min_payment_amount`)
 4. Expiration validation (`invoice.is_expired()`)
 5. Expiration window compliance: `expires_at > now + invoice_expiration_window`
-6. Lightning Address resolution via LNURL
-7. LNURL callback with amount parameter
+6. Lightning Address / LNURL existence via `ln_exists` (see LNURL host policy below)
+7. LNURL-pay metadata must advertise `tag: payRequest`
 
-**Entry**: `src/lightning/invoice.rs:181`
+**Entry**: `src/lightning/invoice.rs` (`fn is_valid_invoice`)
 
 **Error cases**:
-- `InvalidInvoice`: Decoding fails or format invalid
+- `InvalidInvoice` / `InvoiceInvalidError`: Decoding fails or format invalid
 - `WrongAmountError`: Invoice amount doesn't match expected (after fee deduction)
 - `MinAmountError`: Amount below minimum threshold
 - `InvoiceExpiredError`: Invoice already expired
 - `ExpirationWindowTooShort`: Expires before required window
 
+## LNURL / Lightning Address fetches
+
+Source: `src/lnurl.rs`
+
+Buyer- and operator-supplied Lightning Addresses and LNURL-pay strings are resolved over HTTP. Those URLs are attacker-influenced, so every GET goes through `lnurl_get`:
+
+| Control | Behavior |
+|---------|----------|
+| Scheme | `http` / `https` only; userinfo rejected |
+| Host policy | Rejects link-local, CGNAT (`100.64.0.0/10`), NAT64 (`64:ff9b::/96`), multicast, unspecified, documentation ranges; loopback/RFC1918 forbidden in production (test-only allow guard for local mocks) |
+| DNS | Lookup capped (~2s); result pinned via reqwest `.resolve` (no rebinding) |
+| Redirects | Disabled (`Policy::none()`) |
+| Timeouts | Connect ~2s, full request ~4s (bounds serial message-loop stall) |
+| Errors | LNURL `status: ERROR`, missing `payRequest`, amount out of range, empty `pr` → `Err` (not soft empty success) |
+
+**Public helpers**:
+- `ln_exists` — metadata probe (`payRequest` tag)
+- `resolv_ln_address` — resolve to BOLT11 `pr` (LUD-12 comment when allowed)
+- `extract_lnurl` — parse address/LNURL to a single `Url` (no second parse at callers)
+
+**Payout path** (`src/app/release.rs`, `fn do_payment`):
+- Resolves Lightning Addresses under the policy above
+- Decodes non-empty `pr` as BOLT11 before LND `send_payment`
+- Resolve/decode/`send_payment` failures go through `check_failure_retries` bookkeeping and return `Err` (does not spawn an empty status watcher or report success)
+
 ## Payment Retry System
 
-Source: `src/scheduler.rs:172` (job_retry_failed_payments)
+Source: `src/scheduler.rs` (`fn job_retry_failed_payments`)
 
 Failed outgoing payments are automatically retried via the scheduler.
 
 ### Configuration
 
-**Settings** (`src/config/types.rs:28-46`):
+**Settings** (`src/config/types.rs`, `LightningSettings`):
 ```rust
 pub struct LightningSettings {
     // ... other fields ...
@@ -97,20 +122,20 @@ pub struct LightningSettings {
 - Queries database for failed payments with retry attempts remaining
 - Respects `payment_attempts` limit
 - Scheduled at `payment_retries_interval` frequency
-- Automatically invokes `send_payment()` for each retry
+- Automatically invokes `do_payment()` for each retry
 - Updates payment status and attempt count in database
 
 ### Workflow
 1. Payment fails initially → marked as failed in DB
 2. Scheduler runs retry job every N seconds (payment_retries_interval)
 3. Job finds failed payments with `attempts < payment_attempts`
-4. Invokes send_payment() again
+4. Invokes `do_payment()` again
 5. Increments attempt counter
 6. Continues until success or max attempts reached
 
 ## Payment Error Handling
 
-**Pre-flight Checks** (lines 183-201):
+**Pre-flight Checks** (`LndConnector::send_payment` in `src/lightning/mod.rs`):
 Before attempting payment, `send_payment()` uses `track_payment_v2` to detect duplicate attempts:
 
 ```rust
@@ -126,7 +151,7 @@ match ln_client.router().track_payment_v2(track_req).await {
 }
 ```
 
-**Amount Validation** (lines 210-220):
+**Amount Validation**:
 ```rust
 if let Some(amt_msat) = invoice.amount_milli_satoshis() {
     let invoice_amount_sats = amt_msat / 1000;
@@ -137,7 +162,7 @@ if let Some(amt_msat) = invoice.amount_milli_satoshis() {
 }
 ```
 
-**Zero-Amount Invoice Handling** (lines 222-228):
+**Zero-Amount Invoice Handling**:
 If invoice has no amount, the `amt` field is populated in SendPaymentRequest:
 ```rust
 if invoice.amount_milli_satoshis().is_none() {
@@ -155,7 +180,7 @@ let max_fee = match amount.cmp(&1000) {
 req.fee_limit_sat = max_fee as i64;
 ```
 
-**Timeout**: 60 seconds (line 205)
+**Timeout**: 60 seconds (`SendPaymentRequest::timeout_seconds`)
 
 ## Node Information
 

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -890,11 +890,13 @@ fn dev_fee_comment(order_id: &uuid::Uuid, node: &PublicKey) -> String {
 
 /// Resolve a dev fee LNURL invoice for the given order.
 ///
-/// Contacts the dev fee lightning address, obtains a fresh invoice,
-/// decodes it, and returns the payment request and payment hash.
+/// Contacts the dev fee lightning address via [`resolv_ln_address`] (shared
+/// LNURL host policy, DNS pin, and per-request timeouts in `src/lnurl.rs`),
+/// obtains a fresh invoice, decodes it, and returns the payment request and
+/// payment hash.
 ///
 /// # Timeouts
-/// - LNURL resolution: 15 seconds
+/// - Outer LNURL resolution budget: 15 seconds (inner GETs are shorter)
 pub async fn resolve_dev_fee_invoice(
     order: &Order,
     keys: &Keys,

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -2,6 +2,7 @@ use crate::app::bond;
 use crate::app::context::AppContext;
 use crate::app::dispute::close_dispute_after_user_resolution;
 use crate::escrow::EscrowBackend;
+use crate::lightning::invoice::decode_invoice;
 use crate::lightning::LndConnector;
 use crate::lnurl::resolv_ln_address;
 use crate::nip33::{new_order_event, order_to_tags};
@@ -522,7 +523,17 @@ pub async fn do_payment(
         // `send_payment`. Returning early would leave `failed_payment =
         // false` and hide the order from the retry job.
         match resolv_ln_address(&addr.to_string(), amount, None).await {
-            Ok(pr) if !pr.is_empty() => pr,
+            Ok(pr) if !pr.is_empty() => match decode_invoice(&pr) {
+                Ok(_) => pr,
+                Err(e) => {
+                    warn!(
+                        "Order id {}: payout address returned malformed invoice: {:?}",
+                        order.id, e
+                    );
+                    check_failure_retries_or_log(ctx, &order, request_id).await;
+                    return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+                }
+            },
             outcome => {
                 match outcome {
                     Err(e) => warn!(

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -20,11 +20,7 @@ use tracing::{info, warn};
 
 /// Run [`check_failure_retries`] and surface bookkeeping failures instead of
 /// silently dropping them. On success, preserves the existing retry-count log.
-async fn check_failure_retries_or_log(
-    ctx: &AppContext,
-    order: &Order,
-    request_id: Option<u64>,
-) {
+async fn check_failure_retries_or_log(ctx: &AppContext, order: &Order, request_id: Option<u64>) {
     match check_failure_retries(ctx, order, request_id).await {
         Ok(failed_payment) => {
             info!(

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -496,9 +496,31 @@ pub async fn do_payment(
         return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
     }
     let payment_request = if let Ok(addr) = ln_addr {
-        resolv_ln_address(&addr.to_string(), amount, None)
-            .await
-            .map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?
+        // Resolving a lightning address is a network round-trip to a host the
+        // buyer chose. When it yields no invoice — forbidden host (SSRF
+        // policy), unreachable, or LNURL-level ERROR — that is a payment
+        // failure and must go through the same bookkeeping as a failed
+        // `send_payment`. Returning early would leave `failed_payment =
+        // false` and hide the order from the retry job.
+        match resolv_ln_address(&addr.to_string(), amount, None).await {
+            Ok(pr) if !pr.is_empty() => pr,
+            outcome => {
+                match outcome {
+                    Err(e) => info!(
+                        "Order id {}: could not resolve payout address: {:?}",
+                        order.id, e
+                    ),
+                    _ => info!("Order id {}: payout address returned no invoice", order.id),
+                }
+                if let Ok(failed_payment) = check_failure_retries(ctx, &order, request_id).await {
+                    info!(
+                        "Order id {} has {} failed payments retries",
+                        failed_payment.id, failed_payment.payment_attempts
+                    );
+                }
+                return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+            }
+        }
     } else {
         payment_request
     };

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -553,9 +553,12 @@ pub async fn do_payment(
     let (tx, mut rx) = channel(100);
 
     let payment_task = ln_client_payment.send_payment(&payment_request, amount as i64, tx);
-    if let Err(paymement_result) = payment_task.await {
-        warn!("Error during ln payment : {}", paymement_result);
+    if let Err(payment_result) = payment_task.await {
+        warn!("Error during ln payment : {}", payment_result);
         check_failure_retries_or_log(ctx, &order, request_id).await;
+        // Do not spawn the status watcher or report Ok: nothing was submitted
+        // to LND (or the attempt aborted before a usable status stream).
+        return Err(payment_result);
     }
 
     // Get Mostro keys from context

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -498,6 +498,15 @@ async fn handle_child_order(
     Ok(())
 }
 
+/// Pay the buyer invoice for a settled-hold-invoice order.
+///
+/// Lightning Addresses are resolved via [`resolv_ln_address`] under the LNURL
+/// host policy. A non-empty `pr` must decode as BOLT11 before LND submission;
+/// resolve/decode failures and `send_payment` RPC errors go through
+/// [`check_failure_retries_or_log`] and return `Err` (no empty status-watcher
+/// spawn). Streamed `PaymentStatus::Failed` updates also bump retry
+/// bookkeeping. Callers such as `release_action` typically ignore the error
+/// after hold settlement — retries are driven by the failed-payment job.
 pub async fn do_payment(
     ctx: &AppContext,
     mut order: Order,

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -16,7 +16,30 @@ use sqlx::{Pool, Sqlite};
 use std::cmp::Ordering;
 use std::str::FromStr;
 use tokio::sync::mpsc::channel;
-use tracing::info;
+use tracing::{info, warn};
+
+/// Run [`check_failure_retries`] and surface bookkeeping failures instead of
+/// silently dropping them. On success, preserves the existing retry-count log.
+async fn check_failure_retries_or_log(
+    ctx: &AppContext,
+    order: &Order,
+    request_id: Option<u64>,
+) {
+    match check_failure_retries(ctx, order, request_id).await {
+        Ok(failed_payment) => {
+            info!(
+                "Order id {} has {} failed payments retries",
+                failed_payment.id, failed_payment.payment_attempts
+            );
+        }
+        Err(e) => {
+            warn!(
+                "Order id {}: check_failure_retries failed: {:?}",
+                order.id, e
+            );
+        }
+    }
+}
 
 /// Check if order has failed payment retries
 pub async fn check_failure_retries(
@@ -506,18 +529,13 @@ pub async fn do_payment(
             Ok(pr) if !pr.is_empty() => pr,
             outcome => {
                 match outcome {
-                    Err(e) => info!(
+                    Err(e) => warn!(
                         "Order id {}: could not resolve payout address: {:?}",
                         order.id, e
                     ),
-                    _ => info!("Order id {}: payout address returned no invoice", order.id),
+                    _ => warn!("Order id {}: payout address returned no invoice", order.id),
                 }
-                if let Ok(failed_payment) = check_failure_retries(ctx, &order, request_id).await {
-                    info!(
-                        "Order id {} has {} failed payments retries",
-                        failed_payment.id, failed_payment.payment_attempts
-                    );
-                }
+                check_failure_retries_or_log(ctx, &order, request_id).await;
                 return Err(MostroInternalErr(ServiceError::LnAddressParseError));
             }
         }
@@ -529,13 +547,8 @@ pub async fn do_payment(
 
     let payment_task = ln_client_payment.send_payment(&payment_request, amount as i64, tx);
     if let Err(paymement_result) = payment_task.await {
-        info!("Error during ln payment : {}", paymement_result);
-        if let Ok(failed_payment) = check_failure_retries(ctx, &order, request_id).await {
-            info!(
-                "Order id {} has {} failed payments retries",
-                failed_payment.id, failed_payment.payment_attempts
-            );
-        }
+        warn!("Error during ln payment : {}", paymement_result);
+        check_failure_retries_or_log(ctx, &order, request_id).await;
     }
 
     // Get Mostro keys from context
@@ -569,20 +582,13 @@ pub async fn do_payment(
                             .await;
                         }
                         PaymentStatus::Failed => {
-                            info!(
+                            warn!(
                                 "Order Id {}: Invoice with hash: {} has failed!",
                                 order.id, msg.payment.payment_hash
                             );
 
                             // Mark payment as failed
-                            if let Ok(failed_payment) =
-                                check_failure_retries(&ctx, &order, request_id).await
-                            {
-                                info!(
-                                    "Order id {} has {} failed payments retries",
-                                    failed_payment.id, failed_payment.payment_attempts
-                                );
-                            }
+                            check_failure_retries_or_log(&ctx, &order, request_id).await;
                         }
                         _ => {}
                     }

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -252,9 +252,10 @@ mod tests {
             server.await.unwrap();
         });
 
-        // Build the LNURL for this port and encode it
+        // Build the LNURL for this port and encode it (use 127.0.0.1 so the
+        // pinned address matches the IPv4-only listener).
         let url = format!(
-            "http://localhost:{}/.well-known/lnurlp/MostroP2Ptestlnurl",
+            "http://127.0.0.1:{}/.well-known/lnurlp/MostroP2Ptestlnurl",
             port
         );
 
@@ -420,13 +421,21 @@ mod tests {
     #[tokio::test]
     async fn test_lnurl_validation_with_test_server() {
         init_settings_test();
+        // Local mock LNURL servers bind loopback; production host policy
+        // would refuse them without this test-only escape hatch. Hold the
+        // shared policy lock so parallel lnurl tests cannot flip the flag.
+        let _policy_lock = crate::lnurl::AllowPrivateLnurlHostsGuard::lock_policy();
+        let _allow_private = crate::lnurl::AllowPrivateLnurlHostsGuard::enable();
 
         // Start test server
         let (lnurl, server_handle) = start_test_server().await;
 
         // Test basic LNURL validation
         let result = is_valid_invoice(lnurl.clone(), None, None).await;
-        assert!(result.is_ok(), "Basic LNURL validation should succeed");
+        assert!(
+            result.is_ok(),
+            "Basic LNURL validation should succeed: {result:?}"
+        );
 
         // Test LNURL validation with amount
         let result = is_valid_invoice(lnurl.clone(), Some(5000), None).await;
@@ -435,17 +444,16 @@ mod tests {
             "LNURL validation with valid amount should succeed"
         );
 
-        // Lightning address validation
-        // Test with a valid Lightning address that matches our test server
-        let valid_address = "MostroP2P@localhost".to_string();
+        // Lightning address validation (cfg(test) rewrites to 127.0.0.1:8080)
+        let valid_address = "MostroP2P@127.0.0.1".to_string();
         let result = is_valid_invoice(valid_address, None, None).await;
         assert!(
             result.is_ok(),
-            "Valid Lightning address should pass validation"
+            "Valid Lightning address should pass validation: {result:?}"
         );
 
         // Test with an invalid Lightning address
-        let invalid_address = "nonexistent@localhost".to_string();
+        let invalid_address = "nonexistent@127.0.0.1".to_string();
         let result = is_valid_invoice(invalid_address, None, None).await;
         assert!(
             result.is_err(),

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -424,7 +424,7 @@ mod tests {
         // Local mock LNURL servers bind loopback; production host policy
         // would refuse them without this test-only escape hatch. Hold the
         // shared policy lock so parallel lnurl tests cannot flip the flag.
-        let _policy_lock = crate::lnurl::AllowPrivateLnurlHostsGuard::lock_policy();
+        let _policy_lock = crate::lnurl::AllowPrivateLnurlHostsGuard::lock_policy().await;
         let _allow_private = crate::lnurl::AllowPrivateLnurlHostsGuard::enable();
 
         // Start test server

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -55,7 +55,9 @@ pub fn decode_invoice(payment_request: &str) -> Result<Bolt11Invoice, MostroErro
 /// # Notes
 ///
 /// This function performs a network request to validate the address, so it may
-/// fail due to network issues even if the address format is correct.
+/// fail due to network issues even if the address format is correct. The fetch
+/// goes through [`crate::lnurl::ln_exists`] / LNURL host policy (no private or
+/// link-local destinations in production, DNS pin, short timeouts).
 async fn validate_lightning_address(payment_request: &str) -> Result<(), MostroError> {
     if ln_exists(payment_request).await.is_err() {
         return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
@@ -178,6 +180,8 @@ async fn validate_bolt11_invoice(
 ///
 /// This function is typically used to validate buyer invoices in trading contexts
 /// where the exact payment format may vary depending on user preference.
+/// Lightning Address / LNURL existence checks use the shared LNURL host policy
+/// in `src/lnurl.rs` (SSRF bounds, DNS pin, timeouts).
 pub async fn is_valid_invoice(
     payment_request: String,
     amount: Option<u64>,

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -351,7 +351,9 @@ pub async fn resolv_ln_address(
 ) -> Result<String, MostroError> {
     let url = extract_lnurl(address).await?;
     let url = Url::parse(&url).map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
-    let amount_msat = amount * 1000;
+    let amount_msat = amount
+        .checked_mul(1000)
+        .ok_or(MostroInternalErr(ServiceError::WrongAmountError))?;
 
     let res = lnurl_get(url).await?;
     if !res.status().is_success() {

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -1,17 +1,202 @@
 use lnurl::lnurl::LnUrl;
 use mostro_core::prelude::*;
-use once_cell::sync::Lazy;
-use reqwest::Client;
+use reqwest::redirect::Policy;
+use reqwest::{Client, Url};
 use serde_json::Value;
+use std::net::{IpAddr, SocketAddr};
+use std::time::Duration;
 use tracing::{error, warn};
 
-pub static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
-    Client::builder()
-        .timeout(std::time::Duration::from_secs(10))
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Cap on a single LNURL HTTP round-trip (connect + response).
+/// Kept short so a silent/hanging host cannot stall the serial message
+/// loop for long (DoS bound, not elimination).
+const LNURL_REQUEST_TIMEOUT: Duration = Duration::from_secs(4);
+
+/// Cap on establishing the TCP/TLS connection alone, so an unroutable or
+/// filtered host fails before burning the full request budget.
+const LNURL_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[cfg(test)]
+static ALLOW_PRIVATE_LNURL_HOSTS: AtomicBool = AtomicBool::new(false);
+
+/// Serializes tests that mutate [`ALLOW_PRIVATE_LNURL_HOSTS`] so parallel
+/// tokio tests cannot flip the flag under each other.
+#[cfg(test)]
+static LNURL_HOST_POLICY_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Test-only escape hatch so local mock LNURL servers on loopback / RFC1918
+/// addresses keep working. Link-local (e.g. cloud metadata `169.254.0.0/16`)
+/// stays forbidden even when this is set. Production builds never set this.
+#[cfg(test)]
+pub fn allow_private_lnurl_hosts_for_test(allow: bool) {
+    ALLOW_PRIVATE_LNURL_HOSTS.store(allow, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+fn private_hosts_allowed() -> bool {
+    ALLOW_PRIVATE_LNURL_HOSTS.load(Ordering::SeqCst)
+}
+
+#[cfg(not(test))]
+fn private_hosts_allowed() -> bool {
+    false
+}
+
+/// RAII guard that enables loopback/RFC1918 LNURL hosts for the duration of
+/// a local mock-server test, then restores the previous flag.
+#[cfg(test)]
+pub struct AllowPrivateLnurlHostsGuard {
+    previous: bool,
+}
+
+#[cfg(test)]
+impl AllowPrivateLnurlHostsGuard {
+    pub fn enable() -> Self {
+        let previous = ALLOW_PRIVATE_LNURL_HOSTS.swap(true, Ordering::SeqCst);
+        Self { previous }
+    }
+
+    /// Hold the policy-test lock so concurrent tests cannot flip the flag.
+    pub fn lock_policy() -> std::sync::MutexGuard<'static, ()> {
+        LNURL_HOST_POLICY_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+#[cfg(test)]
+impl Drop for AllowPrivateLnurlHostsGuard {
+    fn drop(&mut self) {
+        ALLOW_PRIVATE_LNURL_HOSTS.store(self.previous, Ordering::SeqCst);
+    }
+}
+
+/// True for destinations the daemon must never fetch for LNURL (SSRF policy).
+///
+/// Always rejects link-local, unspecified, multicast, broadcast, and
+/// documentation ranges. Loopback and RFC1918 private are rejected unless
+/// the test-only allow flag is set (local mock servers).
+fn ip_is_forbidden(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            if v4.is_unspecified()
+                || v4.is_broadcast()
+                || v4.is_multicast()
+                || v4.is_link_local()
+                || v4.is_documentation()
+            {
+                return true;
+            }
+            if private_hosts_allowed() {
+                return false;
+            }
+            v4.is_loopback() || v4.is_private()
+        }
+        IpAddr::V6(v6) => {
+            if v6.is_unspecified()
+                || v6.is_multicast()
+                || v6.is_unicast_link_local()
+                || v6
+                    .to_ipv4_mapped()
+                    .map(|v4| {
+                        v4.is_unspecified()
+                            || v4.is_broadcast()
+                            || v4.is_multicast()
+                            || v4.is_link_local()
+                            || v4.is_documentation()
+                    })
+                    .unwrap_or(false)
+            {
+                return true;
+            }
+            if private_hosts_allowed() {
+                return false;
+            }
+            v6.is_loopback()
+                || v6.is_unique_local()
+                || v6
+                    .to_ipv4_mapped()
+                    .map(|v4| v4.is_loopback() || v4.is_private())
+                    .unwrap_or(false)
+        }
+    }
+}
+
+/// Resolve `url`'s host and reject non-public destinations before any GET.
+///
+/// Returns one checked [`SocketAddr`] suitable for reqwest's `.resolve` pin
+/// so the subsequent request cannot be steered to a different IP via DNS
+/// rebinding.
+async fn assert_url_host_safe(url: &Url) -> Result<SocketAddr, MostroError> {
+    if !crate::util::is_http_or_https(url) {
+        return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+    }
+    let host = url
+        .host_str()
+        .ok_or(MostroInternalErr(ServiceError::LnAddressParseError))?;
+    let port = url
+        .port_or_known_default()
+        .ok_or(MostroInternalErr(ServiceError::LnAddressParseError))?;
+
+    // IP literal: no DNS; check and pin directly.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        if ip_is_forbidden(ip) {
+            warn!("LNURL refused forbidden IP literal destination");
+            return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+        }
+        return Ok(SocketAddr::new(ip, port));
+    }
+
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port))
+        .await
+        .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))?
+        .collect();
+    if addrs.is_empty() {
+        return Err(MostroInternalErr(ServiceError::NoAPIResponse));
+    }
+    if addrs.iter().any(|a| ip_is_forbidden(a.ip())) {
+        warn!("LNURL refused destination that resolves to a forbidden address");
+        return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+    }
+    // Prefer IPv4 when both families are present so a hostname like
+    // `localhost` pins to the address local mock servers typically bind.
+    Ok(addrs
+        .iter()
+        .find(|a| a.is_ipv4())
+        .copied()
+        .unwrap_or(addrs[0]))
+}
+
+/// GET an LNURL URL after host policy checks, with DNS pin and no redirects.
+async fn lnurl_get(url: Url) -> Result<reqwest::Response, MostroError> {
+    let pinned = assert_url_host_safe(&url).await?;
+    let host = url
+        .host_str()
+        .ok_or(MostroInternalErr(ServiceError::LnAddressParseError))?
+        .to_string();
+
+    let client = Client::builder()
+        .timeout(LNURL_REQUEST_TIMEOUT)
+        .connect_timeout(LNURL_CONNECT_TIMEOUT)
         .user_agent(concat!("mostro/", env!("CARGO_PKG_VERSION")))
+        .redirect(Policy::none())
+        .resolve(&host, pinned)
         .build()
-        .expect("valid reqwest Client")
-});
+        .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))?;
+
+    client
+        .get(url)
+        .send()
+        .await
+        .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))
+}
+
 /// Extracts the LNURL from a given address.
 /// The address can be in the form of a Lightning Address (user@domain.com format)
 /// or a LNURL (lnurl1... format).
@@ -25,8 +210,8 @@ pub static HTTP_CLIENT: Lazy<Client> = Lazy::new(|| {
 ///
 /// Validates the scheme is `http`/`https` before returning: a bech32-decoded
 /// LNURL is attacker-controlled input, and every caller of this function
-/// (`ln_exists`, `resolv_ln_address`) does an unguarded GET against the
-/// result, so this is the one place that check has to hold for all of them.
+/// (`ln_exists`, `resolv_ln_address`) does a GET against the result after
+/// host/IP policy checks in [`lnurl_get`].
 async fn extract_lnurl(address: &str) -> Result<String, MostroError> {
     let url = if address.to_lowercase().starts_with("lnurl") {
         let lnurl = LnUrl::decode(address.to_string())
@@ -45,8 +230,8 @@ async fn extract_lnurl(address: &str) -> Result<String, MostroError> {
         };
         format!("{base_url}/.well-known/lnurlp/{user}")
     };
-    let parsed = reqwest::Url::parse(&url)
-        .map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
+    let parsed =
+        Url::parse(&url).map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
     if !crate::util::is_http_or_https(&parsed) {
         return Err(MostroInternalErr(ServiceError::LnAddressParseError));
     }
@@ -54,14 +239,9 @@ async fn extract_lnurl(address: &str) -> Result<String, MostroError> {
 }
 
 pub async fn ln_exists(address: &str) -> Result<(), MostroError> {
-    // Get the url from the str - could be a LNURL or a Lightning Address
     let url = extract_lnurl(address).await?;
-    // Make the request to the LNURL
-    let res = HTTP_CLIENT
-        .get(url)
-        .send()
-        .await
-        .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))?;
+    let url = Url::parse(&url).map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
+    let res = lnurl_get(url).await?;
     let status = res.status();
     if status.is_success() {
         let body = res
@@ -97,21 +277,17 @@ fn fit_comment(comment: Option<&str>, max_len: usize) -> Option<String> {
 /// `amount`/`comment` pair on `callback` is dropped first so the values we
 /// compute here are the ones actually sent, not appended duplicates.
 ///
-/// Only `http`/`https` callbacks are accepted (same check as `extract_lnurl`
-/// applies to the initial address): `callback` comes from a remote LNURL
-/// server's response and, for dev-fee payments, can be reached via a
-/// buyer-supplied lightning address. This blocks scheme confusion
-/// (`javascript:`, `file:`, ...) but not host-based SSRF — a malicious
-/// server can still return an `http(s)` callback pointed at a private or
-/// link-local address; that's a known gap, tracked separately.
+/// Scheme must be `http`/`https`. Host/IP safety (reject private, loopback,
+/// link-local, etc., and DNS-pin the request) is enforced by [`lnurl_get`]
+/// before the callback is fetched.
 fn build_callback_url(
     callback: &str,
     amount_msat: u64,
     comment: Option<&str>,
     comment_allowed: usize,
-) -> Result<reqwest::Url, MostroError> {
-    let mut url = reqwest::Url::parse(callback)
-        .map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
+) -> Result<Url, MostroError> {
+    let mut url =
+        Url::parse(callback).map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
     if !crate::util::is_http_or_https(&url) {
         return Err(MostroInternalErr(ServiceError::LnAddressParseError));
     }
@@ -141,92 +317,122 @@ fn build_callback_url(
 /// `comment` is attached per LUD-12 when the server advertises support for
 /// it (`commentAllowed > 0`); otherwise it's silently dropped, matching the
 /// pre-LUD-12 behavior.
-/// # Arguments
-/// * `address` - A Lightning Address or LNURL to resolve
-/// * `amount` - Payment amount in satoshis (converted to msat internally)
-/// * `comment` - Optional LUD-12 comment, sent only if the server allows it
-/// # Returns
-/// * `Ok(String)` - The resolved bolt11 invoice, or an empty string if the
-///   server rejected the request or doesn't support `payRequest`
-/// * `Err(MostroError)` - If the address/LNURL can't be resolved or the HTTP
-///   exchange fails
+///
+/// Permanent LNURL-level failures (`status: ERROR`, missing `payRequest`,
+/// amount out of range, empty `pr`) return `Err` so callers do not treat
+/// them as soft empty invoices.
 pub async fn resolv_ln_address(
     address: &str,
     amount: u64,
     comment: Option<&str>,
 ) -> Result<String, MostroError> {
-    // Get the url from the str - could be a LNURL or a Lightning Address
     let url = extract_lnurl(address).await?;
-    // Convert the amount to msat
+    let url = Url::parse(&url).map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
     let amount_msat = amount * 1000;
 
-    // Make the request to the LNURL
-    let res = HTTP_CLIENT
-        .get(url)
-        .send()
-        .await
-        .map_err(|_| MostroInternalErr(ServiceError::MalformedAPIRes))?;
-    let status = res.status();
-    if status.is_success() {
-        let body = res
-            .text()
-            .await
-            .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
-        let body: Value = serde_json::from_str(&body)
-            .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
-        if body["status"].as_str() == Some("ERROR") {
-            let reason_len = body["reason"].as_str().map(str::len).unwrap_or(0);
-            error!("LNURL address rejected by server (reason length: {reason_len} bytes)");
-            return Ok("".to_string());
-        }
-        let tag = body["tag"].as_str().unwrap_or("");
-        if tag != "payRequest" {
-            return Ok("".to_string());
-        }
-        let min = body["minSendable"].as_u64().unwrap_or(0);
-        let max = body["maxSendable"].as_u64().unwrap_or(0);
-        if min > amount_msat || max < amount_msat {
-            return Ok("".to_string());
-        }
-        let callback = body["callback"].as_str().unwrap_or("");
-        let comment_allowed = body["commentAllowed"].as_u64().unwrap_or(0) as usize;
-        let callback =
-            build_callback_url(callback, amount_msat, comment, comment_allowed)?.to_string();
-        let res = HTTP_CLIENT
-            .get(callback)
-            .send()
-            .await
-            .map_err(|_| MostroInternalErr(ServiceError::MalformedAPIRes))?;
-        let status = res.status();
-        if status.is_success() {
-            let body = res
-                .text()
-                .await
-                .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
-            let body: Value = serde_json::from_str(&body)
-                .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
-            if body["status"].as_str() == Some("ERROR") {
-                let reason_len = body["reason"].as_str().map(str::len).unwrap_or(0);
-                error!("LNURL callback rejected by server (reason length: {reason_len} bytes)");
-                return Ok("".to_string());
-            }
-            let pr = body["pr"].as_str().unwrap_or("");
-
-            return Ok(pr.to_string());
-        }
-        Ok("".to_string())
-    } else {
-        Ok("".to_string())
+    let res = lnurl_get(url).await?;
+    if !res.status().is_success() {
+        return Err(MostroInternalErr(ServiceError::MalformedAPIRes));
     }
+    let body = res
+        .text()
+        .await
+        .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
+    let body: Value = serde_json::from_str(&body)
+        .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
+    if body["status"].as_str() == Some("ERROR") {
+        let reason_len = body["reason"].as_str().map(str::len).unwrap_or(0);
+        error!("LNURL address rejected by server (reason length: {reason_len} bytes)");
+        return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+    }
+    let tag = body["tag"].as_str().unwrap_or("");
+    if tag != "payRequest" {
+        return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+    }
+    let min = body["minSendable"].as_u64().unwrap_or(0);
+    let max = body["maxSendable"].as_u64().unwrap_or(0);
+    if min > amount_msat || max < amount_msat {
+        return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+    }
+    let callback = body["callback"].as_str().unwrap_or("");
+    let comment_allowed = body["commentAllowed"].as_u64().unwrap_or(0) as usize;
+    let callback = build_callback_url(callback, amount_msat, comment, comment_allowed)?;
+    let res = lnurl_get(callback).await?;
+    if !res.status().is_success() {
+        return Err(MostroInternalErr(ServiceError::MalformedAPIRes));
+    }
+    let body = res
+        .text()
+        .await
+        .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
+    let body: Value = serde_json::from_str(&body)
+        .map_err(|_| MostroInternalErr(ServiceError::MessageSerializationError))?;
+    if body["status"].as_str() == Some("ERROR") {
+        let reason_len = body["reason"].as_str().map(str::len).unwrap_or(0);
+        error!("LNURL callback rejected by server (reason length: {reason_len} bytes)");
+        return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+    }
+    let pr = body["pr"].as_str().unwrap_or("");
+    if pr.is_empty() {
+        return Err(MostroInternalErr(ServiceError::LnAddressParseError));
+    }
+    Ok(pr.to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    //! Parsing/validation coverage only: the HTTP round-trips of
-    //! `ln_exists` / `resolv_ln_address` need a live LNURL endpoint and are
-    //! exercised by the integration-style server tests in
-    //! `lightning::invoice`.
     use super::*;
+    use axum::{http::StatusCode, routing::get, Json, Router};
+    use serde_json::json;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+
+    #[test]
+    fn ip_is_forbidden_rejects_loopback_private_and_link_local() {
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _guard = AllowPrivateLnurlHostsGuard {
+            previous: ALLOW_PRIVATE_LNURL_HOSTS.swap(false, Ordering::SeqCst),
+        };
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1))));
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(
+            169, 254, 169, 254
+        ))));
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::UNSPECIFIED)));
+        assert!(ip_is_forbidden(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+        assert!(!ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
+        assert!(!ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))));
+    }
+
+    #[test]
+    fn ip_is_forbidden_test_guard_allows_loopback_but_not_link_local() {
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _guard = AllowPrivateLnurlHostsGuard::enable();
+        assert!(!ip_is_forbidden(IpAddr::V4(Ipv4Addr::LOCALHOST)));
+        assert!(!ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        // Cloud-metadata style link-local stays forbidden even for local mocks.
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(
+            169, 254, 169, 254
+        ))));
+    }
+
+    #[tokio::test]
+    async fn assert_url_host_safe_rejects_loopback_literal() {
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _guard = AllowPrivateLnurlHostsGuard {
+            previous: ALLOW_PRIVATE_LNURL_HOSTS.swap(false, Ordering::SeqCst),
+        };
+        let url = Url::parse("http://127.0.0.1/cb").unwrap();
+        assert!(assert_url_host_safe(&url).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn assert_url_host_safe_rejects_userinfo() {
+        let url = Url::parse("https://user:pass@example.com/cb").unwrap();
+        assert!(assert_url_host_safe(&url).await.is_err());
+    }
 
     #[tokio::test]
     async fn extract_lnurl_decodes_bech32_lnurl() {
@@ -248,9 +454,6 @@ mod tests {
 
     #[tokio::test]
     async fn extract_lnurl_rejects_non_http_scheme() {
-        // A bech32-decoded LNURL is attacker-controlled: it must not be
-        // able to smuggle a javascript:/file:/ftp: URL past extract_lnurl,
-        // since every caller does an unguarded GET on the result.
         let encoded = LnUrl {
             url: "javascript:alert(1)".to_string(),
         }
@@ -260,7 +463,6 @@ mod tests {
 
     #[tokio::test]
     async fn extract_lnurl_builds_wellknown_url_for_lightning_address() {
-        // cfg!(test) pins lightning addresses to the local test host form.
         let extracted = extract_lnurl("alice@127.0.0.1")
             .await
             .expect("lightning address parses");
@@ -295,11 +497,6 @@ mod tests {
 
     #[test]
     fn build_callback_url_preserves_existing_query_params() {
-        // Regression test: callback already carries its own query string
-        // (common in the wild, e.g. LNbits-style `?id=...`). The old
-        // `format!("{callback}?amount={amount_msat}")` approach produced a
-        // second `?`, which is not a delimiter, so `amount` got swallowed
-        // into the `id` value instead of becoming its own parameter.
         let url =
             build_callback_url("https://pay.example.com/cb?id=abc", 100_000, None, 0).unwrap();
         let pairs = url.query_pairs().collect::<Vec<_>>();
@@ -375,6 +572,207 @@ mod tests {
                 ("amount".into(), "100000".into()),
                 ("comment".into(), "new".into())
             ]
+        );
+    }
+
+    /// Report regression: attacker LNURL (A) is reachable (test guard allows
+    /// loopback), but its `callback` points at link-local metadata
+    /// (`169.254.169.254`). Resolution must fail at the callback host check;
+    /// the internal target must never be contacted.
+    #[tokio::test]
+    async fn resolv_ln_address_refuses_link_local_callback() {
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _guard = AllowPrivateLnurlHostsGuard::enable();
+
+        let hits = Arc::new(Mutex::new(Vec::<String>::new()));
+        // Bind a listener on an unused port only so we can detect accidental
+        // contact if policy ever regresses to allowing link-local by rewriting
+        // — the callback URL itself is the metadata IP literal.
+        let hits_b = hits.clone();
+        let app_b = Router::new().route(
+            "/cb",
+            get(move |method: axum::http::Method, uri: axum::http::Uri| {
+                let hits = hits_b.clone();
+                async move {
+                    hits.lock().unwrap().push(format!(
+                        "{method} {}?{}",
+                        uri.path(),
+                        uri.query().unwrap_or("")
+                    ));
+                    (StatusCode::OK, Json(json!({ "pr": "lnbc1" })))
+                }
+            }),
+        );
+        let listener_b = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener_b, app_b).await.unwrap();
+        });
+
+        let app_a = Router::new().route(
+            "/.well-known/lnurlp/alice",
+            get(|| async {
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "status": "OK",
+                        "tag": "payRequest",
+                        "callback": "http://169.254.169.254/latest/meta-data",
+                        "minSendable": 1000,
+                        "maxSendable": 100000000,
+                        "metadata": "[]"
+                    })),
+                )
+            }),
+        );
+        let listener_a = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port_a = listener_a.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener_a, app_a).await.unwrap();
+        });
+
+        let lnurl_string = LnUrl {
+            url: format!("http://127.0.0.1:{port_a}/.well-known/lnurlp/alice"),
+        }
+        .encode();
+
+        let result = resolv_ln_address(&lnurl_string, 100, None).await;
+        assert!(
+            result.is_err(),
+            "link-local callback must be refused: {result:?}"
+        );
+        assert!(
+            hits.lock().unwrap().is_empty(),
+            "no request must reach any internal listener"
+        );
+    }
+
+    /// Strict policy (no test guard): a bech32 LNURL aimed at loopback is
+    /// refused before the first GET.
+    #[tokio::test]
+    async fn resolv_ln_address_refuses_initial_loopback_lnurl() {
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _policy = AllowPrivateLnurlHostsGuard {
+            previous: ALLOW_PRIVATE_LNURL_HOSTS.swap(false, Ordering::SeqCst),
+        };
+
+        let hits = Arc::new(Mutex::new(0u32));
+        let hits_a = hits.clone();
+        let app_a = Router::new().route(
+            "/.well-known/lnurlp/alice",
+            get(move || {
+                let hits = hits_a.clone();
+                async move {
+                    *hits.lock().unwrap() += 1;
+                    (
+                        StatusCode::OK,
+                        Json(json!({
+                            "status": "OK",
+                            "tag": "payRequest",
+                            "callback": "http://127.0.0.1:9/cb",
+                            "minSendable": 1000,
+                            "maxSendable": 100000000,
+                            "metadata": "[]"
+                        })),
+                    )
+                }
+            }),
+        );
+        let listener_a = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port_a = listener_a.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener_a, app_a).await.unwrap();
+        });
+
+        let lnurl_string = LnUrl {
+            url: format!("http://127.0.0.1:{port_a}/.well-known/lnurlp/alice"),
+        }
+        .encode();
+
+        let result = resolv_ln_address(&lnurl_string, 100, None).await;
+        assert!(
+            result.is_err(),
+            "loopback LNURL must be refused before any GET: {result:?}"
+        );
+        assert_eq!(
+            *hits.lock().unwrap(),
+            0,
+            "daemon must not contact the loopback LNURL host"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolv_ln_address_returns_err_on_lnurl_error_status() {
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _guard = AllowPrivateLnurlHostsGuard::enable();
+
+        let app = Router::new().route(
+            "/.well-known/lnurlp/alice",
+            get(|| async {
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "status": "ERROR",
+                        "reason": "nope"
+                    })),
+                )
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let lnurl_string = LnUrl {
+            url: format!("http://127.0.0.1:{port}/.well-known/lnurlp/alice"),
+        }
+        .encode();
+
+        let result = resolv_ln_address(&lnurl_string, 100, None).await;
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::LnAddressParseError))
+            ),
+            "LNURL ERROR status must be Err, not Ok(\"\"): {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolv_ln_address_returns_err_on_non_payrequest_tag() {
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _guard = AllowPrivateLnurlHostsGuard::enable();
+
+        let app = Router::new().route(
+            "/.well-known/lnurlp/alice",
+            get(|| async {
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "status": "OK",
+                        "tag": "withdrawRequest"
+                    })),
+                )
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let lnurl_string = LnUrl {
+            url: format!("http://127.0.0.1:{port}/.well-known/lnurlp/alice"),
+        }
+        .encode();
+
+        let result = resolv_ln_address(&lnurl_string, 100, None).await;
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::LnAddressParseError))
+            ),
+            "non-payRequest tag must be Err: {result:?}"
         );
     }
 }

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -235,7 +235,7 @@ async fn lnurl_get(url: Url) -> Result<reqwest::Response, MostroError> {
 /// LNURL is attacker-controlled input, and every caller of this function
 /// (`ln_exists`, `resolv_ln_address`) does a GET against the result after
 /// host/IP policy checks in [`lnurl_get`].
-async fn extract_lnurl(address: &str) -> Result<String, MostroError> {
+async fn extract_lnurl(address: &str) -> Result<Url, MostroError> {
     let url = if address.to_lowercase().starts_with("lnurl") {
         let lnurl = LnUrl::decode(address.to_string())
             .map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
@@ -258,7 +258,7 @@ async fn extract_lnurl(address: &str) -> Result<String, MostroError> {
     if !crate::util::is_http_or_https(&parsed) {
         return Err(MostroInternalErr(ServiceError::LnAddressParseError));
     }
-    Ok(url)
+    Ok(parsed)
 }
 
 pub async fn ln_exists(address: &str) -> Result<(), MostroError> {
@@ -481,7 +481,7 @@ mod tests {
         assert!(encoded.to_lowercase().starts_with("lnurl1"));
 
         let extracted = extract_lnurl(&encoded).await.expect("valid LNURL decodes");
-        assert_eq!(extracted, url);
+        assert_eq!(extracted.to_string(), url);
     }
 
     #[tokio::test]
@@ -503,7 +503,10 @@ mod tests {
         let extracted = extract_lnurl("alice@127.0.0.1")
             .await
             .expect("lightning address parses");
-        assert_eq!(extracted, "http://127.0.0.1:8080/.well-known/lnurlp/alice");
+        assert_eq!(
+            extracted.to_string(),
+            "http://127.0.0.1:8080/.well-known/lnurlp/alice"
+        );
     }
 
     #[tokio::test]

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -263,7 +263,6 @@ async fn extract_lnurl(address: &str) -> Result<String, MostroError> {
 
 pub async fn ln_exists(address: &str) -> Result<(), MostroError> {
     let url = extract_lnurl(address).await?;
-    let url = Url::parse(&url).map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
     let res = lnurl_get(url).await?;
     let status = res.status();
     if status.is_success() {
@@ -350,7 +349,6 @@ pub async fn resolv_ln_address(
     comment: Option<&str>,
 ) -> Result<String, MostroError> {
     let url = extract_lnurl(address).await?;
-    let url = Url::parse(&url).map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
     let amount_msat = amount
         .checked_mul(1000)
         .ok_or(MostroInternalErr(ServiceError::WrongAmountError))?;

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -1,3 +1,18 @@
+//! LNURL-pay and Lightning Address resolution for Mostro.
+//!
+//! Every outbound LNURL HTTP fetch goes through [`lnurl_get`], which:
+//! - allows only `http`/`https` (and rejects userinfo)
+//! - resolves DNS under a short timeout and rejects forbidden destinations
+//!   (loopback/private unless the test-only allow flag is set, plus link-local,
+//!   CGNAT `100.64.0.0/10`, NAT64 `64:ff9b::/96`, multicast, etc.)
+//! - pins the request to a checked [`SocketAddr`] (no DNS rebinding) and
+//!   disables redirects
+//! - bounds connect and request duration so a hanging host cannot stall the
+//!   serial message loop for long
+//!
+//! Callers (`ln_exists`, `resolv_ln_address`) map LNURL-level `ERROR` / missing
+//! `payRequest` / empty `pr` to `Err` rather than soft empty success.
+
 use lnurl::lnurl::LnUrl;
 use mostro_core::prelude::*;
 use reqwest::redirect::Policy;
@@ -148,9 +163,9 @@ fn ip_is_forbidden(ip: IpAddr) -> bool {
 
 /// Resolve `url`'s host and reject non-public destinations before any GET.
 ///
-/// Returns one checked [`SocketAddr`] suitable for reqwest's `.resolve` pin
-/// so the subsequent request cannot be steered to a different IP via DNS
-/// rebinding.
+/// DNS lookup is bounded by [`LNURL_DNS_TIMEOUT`]. Returns one checked
+/// [`SocketAddr`] suitable for reqwest's `.resolve` pin so the subsequent
+/// request cannot be steered to a different IP via DNS rebinding.
 async fn assert_url_host_safe(url: &Url) -> Result<SocketAddr, MostroError> {
     if !crate::util::is_http_or_https(url) {
         return Err(MostroInternalErr(ServiceError::LnAddressParseError));
@@ -197,6 +212,10 @@ async fn assert_url_host_safe(url: &Url) -> Result<SocketAddr, MostroError> {
 }
 
 /// GET an LNURL URL after host policy checks, with DNS pin and no redirects.
+///
+/// Applies [`LNURL_CONNECT_TIMEOUT`] and [`LNURL_REQUEST_TIMEOUT`]. Callers
+/// must only pass URLs produced by [`extract_lnurl`] or [`build_callback_url`]
+/// (scheme already constrained to http/https).
 async fn lnurl_get(url: Url) -> Result<reqwest::Response, MostroError> {
     let pinned = assert_url_host_safe(&url).await?;
     let host = url
@@ -220,21 +239,18 @@ async fn lnurl_get(url: Url) -> Result<reqwest::Response, MostroError> {
         .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))
 }
 
-/// Extracts the LNURL from a given address.
-/// The address can be in the form of a Lightning Address (user@domain.com format)
-/// or a LNURL (lnurl1... format).
-/// If the address is a Lightning Address, it is resolved to the corresponding LNURL.
-/// If the address is already a LNURL, it is returned as is.
-/// # Arguments
-/// * `address` - The address to extract the LNURL from
-/// # Returns
-/// * `Ok(String)` - The extracted LNURL
-/// * `Err(MostroError)` - If the address is invalid or cannot be resolved
+/// Parse a Lightning Address or bech32 LNURL into an http(s) [`Url`].
 ///
-/// Validates the scheme is `http`/`https` before returning: a bech32-decoded
-/// LNURL is attacker-controlled input, and every caller of this function
-/// (`ln_exists`, `resolv_ln_address`) does a GET against the result after
-/// host/IP policy checks in [`lnurl_get`].
+/// - Lightning Address (`user@domain`) → well-known LNURL-pay endpoint URL
+/// - Bech32 LNURL (`lnurl1…`) → decoded callback/pay URL
+///
+/// Returns a parsed [`Url`] (not a raw string) so callers can pass it straight
+/// to [`lnurl_get`] without a second parse. Scheme must be `http`/`https`;
+/// host/IP safety is enforced later by [`lnurl_get`].
+///
+/// # Errors
+///
+/// * `LnAddressParseError` — malformed address, bad bech32, or non-http(s) scheme
 async fn extract_lnurl(address: &str) -> Result<Url, MostroError> {
     let url = if address.to_lowercase().starts_with("lnurl") {
         let lnurl = LnUrl::decode(address.to_string())
@@ -261,6 +277,11 @@ async fn extract_lnurl(address: &str) -> Result<Url, MostroError> {
     Ok(parsed)
 }
 
+/// Probe whether a Lightning Address or LNURL-pay endpoint advertises
+/// `tag: payRequest`.
+///
+/// Uses [`lnurl_get`] (host policy, DNS pin, timeouts, no redirects). Does not
+/// request an invoice — only the LNURL-pay metadata document.
 pub async fn ln_exists(address: &str) -> Result<(), MostroError> {
     let url = extract_lnurl(address).await?;
     let res = lnurl_get(url).await?;
@@ -340,9 +361,15 @@ fn build_callback_url(
 /// it (`commentAllowed > 0`); otherwise it's silently dropped, matching the
 /// pre-LUD-12 behavior.
 ///
+/// Both the initial LNURL-pay document and the callback fetch go through
+/// [`lnurl_get`] (SSRF host policy, DNS pin, timeouts, no redirects). The
+/// callback URL is rebuilt with [`build_callback_url`] so `amount`/`comment`
+/// are proper query params.
+///
 /// Permanent LNURL-level failures (`status: ERROR`, missing `payRequest`,
 /// amount out of range, empty `pr`) return `Err` so callers do not treat
-/// them as soft empty invoices.
+/// them as soft empty invoices. Callers that pay the returned `pr` (e.g.
+/// `do_payment`) should still decode it as BOLT11 before submitting to LND.
 pub async fn resolv_ln_address(
     address: &str,
     amount: u64,

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -19,6 +19,11 @@ const LNURL_REQUEST_TIMEOUT: Duration = Duration::from_secs(4);
 /// filtered host fails before burning the full request budget.
 const LNURL_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// Cap on DNS resolution before the HTTP client starts. Without this,
+/// a hanging resolver (slow/malicious NS) can stall the serial message
+/// loop longer than the HTTP timeouts below.
+const LNURL_DNS_TIMEOUT: Duration = Duration::from_secs(2);
+
 #[cfg(test)]
 static ALLOW_PRIVATE_LNURL_HOSTS: AtomicBool = AtomicBool::new(false);
 
@@ -169,10 +174,12 @@ async fn assert_url_host_safe(url: &Url) -> Result<SocketAddr, MostroError> {
         return Ok(SocketAddr::new(ip, port));
     }
 
-    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host, port))
-        .await
-        .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))?
-        .collect();
+    let addrs: Vec<SocketAddr> =
+        tokio::time::timeout(LNURL_DNS_TIMEOUT, tokio::net::lookup_host((host, port)))
+            .await
+            .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))?
+            .map_err(|_| MostroInternalErr(ServiceError::NoAPIResponse))?
+            .collect();
     if addrs.is_empty() {
         return Err(MostroInternalErr(ServiceError::NoAPIResponse));
     }
@@ -418,7 +425,9 @@ mod tests {
         ))));
         // CGNAT / shared address space (RFC 6598).
         assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
-        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(100, 127, 255, 254))));
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(
+            100, 127, 255, 254
+        ))));
         // NAT64 well-known prefix embedding 8.8.8.8 (RFC 6052).
         assert!(ip_is_forbidden(IpAddr::V6(Ipv6Addr::new(
             0x64, 0xff9b, 0, 0, 0, 0, 0x0808, 0x0808

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -77,20 +77,38 @@ impl Drop for AllowPrivateLnurlHostsGuard {
     }
 }
 
+/// True for IPv4 CGNAT / carrier-grade NAT (`100.64.0.0/10`, RFC 6598).
+/// Manual check: `Ipv4Addr::is_shared` is still unstable on stable Rust.
+fn ipv4_is_cgnat(v4: std::net::Ipv4Addr) -> bool {
+    let octets = v4.octets();
+    octets[0] == 100 && (64..=127).contains(&octets[1])
+}
+
+fn ipv4_is_always_forbidden(v4: std::net::Ipv4Addr) -> bool {
+    v4.is_unspecified()
+        || v4.is_broadcast()
+        || v4.is_multicast()
+        || v4.is_link_local()
+        || v4.is_documentation()
+        || ipv4_is_cgnat(v4)
+}
+
+/// RFC 6052 well-known NAT64 prefix `64:ff9b::/96`.
+fn ipv6_is_nat64_well_known(v6: std::net::Ipv6Addr) -> bool {
+    let s = v6.segments();
+    s[0] == 0x0064 && s[1] == 0xff9b && s[2] == 0 && s[3] == 0 && s[4] == 0 && s[5] == 0
+}
+
 /// True for destinations the daemon must never fetch for LNURL (SSRF policy).
 ///
-/// Always rejects link-local, unspecified, multicast, broadcast, and
+/// Always rejects link-local, CGNAT (RFC 6598 `100.64.0.0/10`), NAT64 well-known
+/// prefix (RFC 6052 `64:ff9b::/96`), unspecified, multicast, broadcast, and
 /// documentation ranges. Loopback and RFC1918 private are rejected unless
 /// the test-only allow flag is set (local mock servers).
 fn ip_is_forbidden(ip: IpAddr) -> bool {
     match ip {
         IpAddr::V4(v4) => {
-            if v4.is_unspecified()
-                || v4.is_broadcast()
-                || v4.is_multicast()
-                || v4.is_link_local()
-                || v4.is_documentation()
-            {
+            if ipv4_is_always_forbidden(v4) {
                 return true;
             }
             if private_hosts_allowed() {
@@ -102,15 +120,10 @@ fn ip_is_forbidden(ip: IpAddr) -> bool {
             if v6.is_unspecified()
                 || v6.is_multicast()
                 || v6.is_unicast_link_local()
+                || ipv6_is_nat64_well_known(v6)
                 || v6
                     .to_ipv4_mapped()
-                    .map(|v4| {
-                        v4.is_unspecified()
-                            || v4.is_broadcast()
-                            || v4.is_multicast()
-                            || v4.is_link_local()
-                            || v4.is_documentation()
-                    })
+                    .map(ipv4_is_always_forbidden)
                     .unwrap_or(false)
             {
                 return true;
@@ -403,6 +416,13 @@ mod tests {
         assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(
             169, 254, 169, 254
         ))));
+        // CGNAT / shared address space (RFC 6598).
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(100, 64, 0, 1))));
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(100, 127, 255, 254))));
+        // NAT64 well-known prefix embedding 8.8.8.8 (RFC 6052).
+        assert!(ip_is_forbidden(IpAddr::V6(Ipv6Addr::new(
+            0x64, 0xff9b, 0, 0, 0, 0, 0x0808, 0x0808
+        ))));
         assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::UNSPECIFIED)));
         assert!(ip_is_forbidden(IpAddr::V6(Ipv6Addr::LOCALHOST)));
         assert!(!ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8))));
@@ -418,6 +438,11 @@ mod tests {
         // Cloud-metadata style link-local stays forbidden even for local mocks.
         assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(
             169, 254, 169, 254
+        ))));
+        // CGNAT and NAT64 stay forbidden under the test guard too.
+        assert!(ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(100, 64, 1, 1))));
+        assert!(ip_is_forbidden(IpAddr::V6(Ipv6Addr::new(
+            0x64, 0xff9b, 0, 0, 0, 0, 0xc0a8, 0x0001
         ))));
     }
 

--- a/src/lnurl.rs
+++ b/src/lnurl.rs
@@ -25,7 +25,7 @@ static ALLOW_PRIVATE_LNURL_HOSTS: AtomicBool = AtomicBool::new(false);
 /// Serializes tests that mutate [`ALLOW_PRIVATE_LNURL_HOSTS`] so parallel
 /// tokio tests cannot flip the flag under each other.
 #[cfg(test)]
-static LNURL_HOST_POLICY_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+static LNURL_HOST_POLICY_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Test-only escape hatch so local mock LNURL servers on loopback / RFC1918
 /// addresses keep working. Link-local (e.g. cloud metadata `169.254.0.0/16`)
@@ -60,10 +60,13 @@ impl AllowPrivateLnurlHostsGuard {
     }
 
     /// Hold the policy-test lock so concurrent tests cannot flip the flag.
-    pub fn lock_policy() -> std::sync::MutexGuard<'static, ()> {
-        LNURL_HOST_POLICY_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+    pub async fn lock_policy() -> tokio::sync::MutexGuard<'static, ()> {
+        LNURL_HOST_POLICY_TEST_LOCK.lock().await
+    }
+
+    /// Sync variant for non-async unit tests.
+    pub fn lock_policy_sync() -> tokio::sync::MutexGuard<'static, ()> {
+        LNURL_HOST_POLICY_TEST_LOCK.blocking_lock()
     }
 }
 
@@ -390,7 +393,7 @@ mod tests {
 
     #[test]
     fn ip_is_forbidden_rejects_loopback_private_and_link_local() {
-        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy_sync();
         let _guard = AllowPrivateLnurlHostsGuard {
             previous: ALLOW_PRIVATE_LNURL_HOSTS.swap(false, Ordering::SeqCst),
         };
@@ -408,7 +411,7 @@ mod tests {
 
     #[test]
     fn ip_is_forbidden_test_guard_allows_loopback_but_not_link_local() {
-        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy_sync();
         let _guard = AllowPrivateLnurlHostsGuard::enable();
         assert!(!ip_is_forbidden(IpAddr::V4(Ipv4Addr::LOCALHOST)));
         assert!(!ip_is_forbidden(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
@@ -420,7 +423,7 @@ mod tests {
 
     #[tokio::test]
     async fn assert_url_host_safe_rejects_loopback_literal() {
-        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy().await;
         let _guard = AllowPrivateLnurlHostsGuard {
             previous: ALLOW_PRIVATE_LNURL_HOSTS.swap(false, Ordering::SeqCst),
         };
@@ -581,7 +584,7 @@ mod tests {
     /// the internal target must never be contacted.
     #[tokio::test]
     async fn resolv_ln_address_refuses_link_local_callback() {
-        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy().await;
         let _guard = AllowPrivateLnurlHostsGuard::enable();
 
         let hits = Arc::new(Mutex::new(Vec::<String>::new()));
@@ -650,7 +653,7 @@ mod tests {
     /// refused before the first GET.
     #[tokio::test]
     async fn resolv_ln_address_refuses_initial_loopback_lnurl() {
-        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy().await;
         let _policy = AllowPrivateLnurlHostsGuard {
             previous: ALLOW_PRIVATE_LNURL_HOSTS.swap(false, Ordering::SeqCst),
         };
@@ -702,7 +705,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolv_ln_address_returns_err_on_lnurl_error_status() {
-        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy().await;
         let _guard = AllowPrivateLnurlHostsGuard::enable();
 
         let app = Router::new().route(
@@ -740,7 +743,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolv_ln_address_returns_err_on_non_payrequest_tag() {
-        let _lock = AllowPrivateLnurlHostsGuard::lock_policy();
+        let _lock = AllowPrivateLnurlHostsGuard::lock_policy().await;
         let _guard = AllowPrivateLnurlHostsGuard::enable();
 
         let app = Router::new().route(

--- a/src/util.rs
+++ b/src/util.rs
@@ -33,6 +33,7 @@ type OrderKind = mostro_core::order::Kind;
 
 /// `true` only for `http`/`https` — the one scheme allow-list every outbound
 /// URL this daemon fetches (LNURL callbacks, Cashu mint URLs) should pass.
+/// LNURL also applies host/IP policy, DNS pin, and timeouts in `src/lnurl.rs`.
 pub fn is_http_or_https(url: &reqwest::Url) -> bool {
     matches!(url.scheme(), "http" | "https")
 }


### PR DESCRIPTION
## Summary

Buyer-controlled LNURL/Lightning Address callbacks could make the daemon GET arbitrary hosts (blind SSRF). This adds a host/IP policy with DNS pinning, refuses redirects, maps permanent LNURL failures to `Err`, and shortens HTTP timeouts so a silent host cannot stall the serial message loop for long.

## Changes

- Reject non-public LNURL destinations (loopback, RFC1918, link-local, etc.) before every GET; pin the checked IP via reqwest `.resolve` and disable redirects
- Map LNURL `ERROR` / invalid `payRequest` / empty `pr` to `Err` instead of `Ok("")`
- Route payout-address resolve failures through `check_failure_retries` in `do_payment`
- Cap LNURL request timeout at 4s and connect timeout at 2s (DoS bound on the dispatcher)
- Test-only allow-private guard for local mock servers (link-local stays forbidden)

## How to test

```bash
cargo test --bin mostrod lnurl
cargo test --bin mostrod lightning::invoice
cargo clippy --bin mostrod --all-features -- -D warnings
```

## Notes for reviewers

- No schema/migration or config changes
- Message-loop hang is mitigated by shorter timeouts only (not offloaded from the event loop)
- Test guard allows loopback/RFC1918 for mocks; `169.254/16` remains blocked even under that guard


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed Lightning Address payments are now recorded correctly, with improved retry handling and clearer failure reporting.
  * Empty or invalid invoices now return clear payment errors.
  * LNURL failures, unsupported responses, invalid amounts, callback errors, and HTTP errors are handled consistently.

* **Security**
  * Strengthened LNURL protections with safer URL validation, credential and network checks, redirect controls, DNS safeguards, and connection and request timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->