### PR TITLE
Validate payout invoice network and bound final CLTV delta

### DIFF
--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -17,6 +17,9 @@ hold_invoice_expiration_window = 300
 payment_attempts = 3
 # Retries interval for failed payments
 payment_retries_interval = 60
+# Maximum min_final_cltv_expiry_delta (in blocks) accepted on a payout invoice
+# supplied by a user. Bounds how long a payee can hold the outgoing HTLC.
+max_final_cltv_expiry_delta = 432
 
 [nostr]
 nsec_privkey = 'nsec1...'

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -61,7 +61,7 @@
 
 use crate::config::constants::DEV_FEE_LIGHTNING_ADDRESS;
 use crate::db::find_unpaid_dev_fees;
-use crate::lightning::invoice::decode_invoice;
+use crate::lightning::invoice::{decode_invoice, validate_payout_invoice};
 use crate::lightning::LndConnector;
 use crate::lnurl::resolv_ln_address;
 use crate::util::{bytes_to_string, publish_dev_fee_audit_event};
@@ -945,6 +945,9 @@ pub async fn resolve_dev_fee_invoice(
     }
 
     let invoice = decode_invoice(&payment_request)?;
+    // Resolved by an LNURL server rather than validated on the way in, so apply
+    // the chain and final-CLTV rules here too.
+    validate_payout_invoice(&invoice)?;
     let payment_hash_hex = bytes_to_string(invoice.payment_hash().as_ref());
 
     info!(

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -2,6 +2,7 @@ use crate::app::bond;
 use crate::app::context::AppContext;
 use crate::app::dispute::close_dispute_after_user_resolution;
 use crate::escrow::EscrowBackend;
+use crate::lightning::invoice::{decode_invoice, validate_payout_invoice};
 use crate::lightning::LndConnector;
 use crate::lnurl::resolv_ln_address;
 use crate::nip33::{new_order_event, order_to_tags};
@@ -496,9 +497,14 @@ pub async fn do_payment(
         return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
     }
     let payment_request = if let Ok(addr) = ln_addr {
-        resolv_ln_address(&addr.to_string(), amount, None)
+        let resolved = resolv_ln_address(&addr.to_string(), amount, None)
             .await
-            .map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?
+            .map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
+        // The LNURL server picked this invoice, not the buyer, so it never went
+        // through `validate_invoice`. Apply the chain and final-CLTV rules
+        // before handing it to LND.
+        validate_payout_invoice(&decode_invoice(&resolved)?)?;
+        resolved
     } else {
         payment_request
     };

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -10,6 +10,7 @@ use crate::util::{enqueue_order_msg, get_order, settle_seller_hold_invoice, upda
 
 use fedimint_tonic_lnd::lnrpc::payment::PaymentStatus;
 use lnurl::lightning_address::LightningAddress;
+use lnurl::lnurl::LnUrl;
 use mostro_core::db::Crud;
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
@@ -496,17 +497,28 @@ pub async fn do_payment(
     if amount == 0 {
         return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
     }
-    let payment_request = if let Ok(addr) = ln_addr {
-        let resolved = resolv_ln_address(&addr.to_string(), amount, None)
-            .await
-            .map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
-        // The LNURL server picked this invoice, not the buyer, so it never went
-        // through `validate_invoice`. Apply the chain and final-CLTV rules
-        // before handing it to LND.
-        validate_payout_invoice(&decode_invoice(&resolved)?)?;
-        resolved
-    } else {
-        payment_request
+    // `is_valid_invoice` accepts a Lightning Address *and* an encoded LNURL, so
+    // both have to be resolved to a BOLT11 invoice here. An unresolved LNURL
+    // reaches `send_payment`, fails to decode and burns the retry budget
+    // instead of ever paying the buyer.
+    let payout_destination = match &ln_addr {
+        Ok(addr) => Some(addr.to_string()),
+        Err(_) if LnUrl::from_str(&payment_request).is_ok() => Some(payment_request.clone()),
+        Err(_) => None,
+    };
+
+    let payment_request = match payout_destination {
+        Some(destination) => {
+            let resolved = resolv_ln_address(&destination, amount, None)
+                .await
+                .map_err(|_| MostroInternalErr(ServiceError::LnAddressParseError))?;
+            // The LNURL server picked this invoice, not the buyer, so it never
+            // went through `validate_invoice`. Apply the payout rules before
+            // handing it to LND.
+            validate_payout_invoice(&decode_invoice(&resolved)?)?;
+            resolved
+        }
+        None => payment_request,
     };
     let mut ln_client_payment = LndConnector::new().await?;
     let (tx, mut rx) = channel(100);
@@ -1677,6 +1689,84 @@ mod tests {
 
         // Assert
         assert!(result.is_err());
+    }
+
+    /// An expired regtest invoice: rejected by `validate_payout_invoice` on
+    /// every chain, either for the currency or for having expired, so the
+    /// assertion below does not depend on what `LN_STATUS` holds.
+    const EXPIRED_INVOICE: &str = "lnbcrt500u1p3lzwdzpp5t9kgwgwd07y2lrwdscdnkqu4scrcgpm5pt9uwx0rxn5rxawlxlvqdqqcqzpgxqyz5vqsp5a6k7syfxeg8jy63rteywwjla5rrg2pvhedx8ajr2ltm4seydhsqq9qyyssq0n2uwlumsx4d0mtjm8tp7jw3y4da6p6z9gyyjac0d9xugf72lhh4snxpugek6n83geafue9ndgrhuhzk98xcecu2t3z56ut35mkammsqscqp0n";
+
+    /// Stand-in LNURL-pay server: the well-known endpoint points at its own
+    /// callback, which hands back `EXPIRED_INVOICE`.
+    async fn start_lnurl_test_server() -> (String, tokio::task::JoinHandle<()>) {
+        use axum::{routing::get, Json, Router};
+        use serde_json::json;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let callback = format!("http://127.0.0.1:{port}/callback");
+
+        let app = Router::new()
+            .route(
+                "/.well-known/lnurlp/payout",
+                get(move || {
+                    let callback = callback.clone();
+                    async move {
+                        Json(json!({
+                            "tag": "payRequest",
+                            "callback": callback,
+                            "minSendable": 1,
+                            "maxSendable": 100_000_000_000u64,
+                            "metadata": "[[\"text/plain\",\"payout\"]]"
+                        }))
+                    }
+                }),
+            )
+            .route(
+                "/callback",
+                get(|| async { Json(json!({ "pr": EXPIRED_INVOICE })) }),
+            );
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let lnurl = LnUrl {
+            url: format!("http://127.0.0.1:{port}/.well-known/lnurlp/payout"),
+        }
+        .encode();
+
+        (lnurl, handle)
+    }
+
+    /// An encoded LNURL is a payout destination `is_valid_invoice` accepts, so
+    /// `do_payment` has to resolve it and validate the invoice it gets back.
+    /// Reaching `InvoiceInvalidError` proves both happened: unresolved, the
+    /// LNURL string would have travelled on to the LND connector instead.
+    #[tokio::test]
+    async fn do_payment_resolves_and_validates_an_encoded_lnurl() {
+        init_global_config();
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let (lnurl, server) = start_lnurl_test_server().await;
+
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.buyer_invoice = Some(lnurl);
+
+        let result = do_payment(&ctx, order, None).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(MostroInternalErr(ServiceError::InvoiceInvalidError))
+            ),
+            "the resolved invoice must be rejected before LND is contacted: {result:?}"
+        );
+
+        server.abort();
     }
 
     #[tokio::test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -202,6 +202,12 @@ mod tests {
         );
         assert_eq!(lightning_settings.lightning.payment_attempts, 3);
         assert_eq!(lightning_settings.lightning.payment_retries_interval, 60);
+        // Absent from this TOML: an existing operator config keeps working and
+        // picks up the bound from the serde default.
+        assert_eq!(
+            lightning_settings.lightning.max_final_cltv_expiry_delta,
+            432
+        );
     }
 
     #[test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -384,7 +384,7 @@ pub struct DatabaseSettings {
     pub url: String,
 }
 /// Lightning configuration settings
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct LightningSettings {
     /// LND certificate file path
     pub lnd_cert_file: String,
@@ -402,6 +402,35 @@ pub struct LightningSettings {
     pub payment_attempts: u32,
     /// Payment retries interval in seconds
     pub payment_retries_interval: u32,
+    /// Upper bound, in blocks, on the `min_final_cltv_expiry_delta` of a
+    /// user-supplied payout invoice
+    #[serde(default = "default_max_final_cltv_expiry_delta")]
+    pub max_final_cltv_expiry_delta: u32,
+}
+
+/// ~3 days of blocks. High enough for every wallet we know of (18 to 144 is
+/// the usual range) and low enough that a payee holding the outgoing HTLC
+/// cannot pin routing liquidity for weeks.
+fn default_max_final_cltv_expiry_delta() -> u32 {
+    432
+}
+
+// Hand-written so `max_final_cltv_expiry_delta` defaults to the real bound
+// instead of `0`, which would reject every invoice.
+impl Default for LightningSettings {
+    fn default() -> Self {
+        Self {
+            lnd_cert_file: String::new(),
+            lnd_macaroon_file: String::new(),
+            lnd_grpc_host: String::new(),
+            invoice_expiration_window: 0,
+            hold_invoice_cltv_delta: 0,
+            hold_invoice_expiration_window: 0,
+            payment_attempts: 0,
+            payment_retries_interval: 0,
+            max_final_cltv_expiry_delta: default_max_final_cltv_expiry_delta(),
+        }
+    }
 }
 /// Nostr configuration settings
 #[derive(Debug, Deserialize, Serialize, Default, Clone)]

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -145,6 +145,7 @@ fn prompt_lightning_settings() -> Result<LightningSettings, MostroError> {
         hold_invoice_expiration_window: 300,
         payment_attempts: 3,
         payment_retries_interval: 60,
+        max_final_cltv_expiry_delta: 432,
     })
 }
 

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -48,6 +48,31 @@ fn invoice_currency_is_payable(
     }
 }
 
+/// Checks the properties that must hold for any invoice this node is about to
+/// pay, whatever its origin: it has to be on the node's own chain, and its
+/// final CLTV delta has to stay within the configured bound.
+///
+/// Kept apart from [`validate_bolt11_invoice`] because the amount and expiry
+/// rules there do not apply to invoices minted by an LNURL server: those are
+/// resolved at payment time and are routinely short-lived, so the
+/// `invoice_expiration_window` rule would reject legitimate payouts.
+pub fn validate_payout_invoice(invoice: &Bolt11Invoice) -> Result<(), MostroError> {
+    // LND cannot pay another chain's invoice. Rejecting here keeps the failure
+    // at validation time instead of mid-payout.
+    if !invoice_currency_is_payable(invoice, node_currency()) {
+        return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
+    }
+
+    // Bound the payee-chosen final CLTV delta: a large value lets the payee
+    // hold the outgoing HTLC, and the routing liquidity behind it, for weeks.
+    if invoice.min_final_cltv_expiry_delta() > Settings::get_ln().max_final_cltv_expiry_delta as u64
+    {
+        return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
+    }
+
+    Ok(())
+}
+
 /// Decodes a BOLT11 Lightning invoice from its string representation.
 ///
 /// This function parses a Lightning Network payment request string and returns
@@ -148,18 +173,9 @@ async fn validate_bolt11_invoice(
     let amount_sat = invoice.amount_milli_satoshis().unwrap_or(0) / 1000;
     let fee = fee.unwrap_or(0);
 
-    // Reject invoices issued for another chain. LND cannot pay them, and
-    // without this check the failure only surfaces at payout time — after the
-    // seller's hold invoice has already been settled.
-    if !invoice_currency_is_payable(&invoice, node_currency()) {
-        return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
-    }
-
-    // Bound the payee-chosen final CLTV delta: a large value lets the payee
-    // hold the outgoing HTLC, and the routing liquidity behind it, for weeks.
-    if invoice.min_final_cltv_expiry_delta() > ln_settings.max_final_cltv_expiry_delta as u64 {
-        return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
-    }
+    // Chain and final-CLTV rules, shared with the invoices an LNURL server
+    // hands us at payment time.
+    validate_payout_invoice(&invoice)?;
 
     // Validate amount if provided
     if let Some(amt) = amount {
@@ -417,6 +433,61 @@ mod tests {
         assert_eq!(currency_for_network("simnet"), Some(Currency::Simnet));
         // An unmapped name skips the check instead of blocking trading.
         assert_eq!(currency_for_network("testnet4"), None);
+    }
+
+    /// The reason `validate_payout_invoice` exists apart from
+    /// `validate_bolt11_invoice`: LNURL servers mint short-lived invoices, and
+    /// folding the expiry-window rule into the payout path would reject them.
+    #[tokio::test]
+    async fn validate_payout_invoice_ignores_the_expiry_window() {
+        init_settings_test();
+        let window = Settings::get_ln().invoice_expiration_window as u64;
+        let short_lived = build_test_invoice_with(Some(1_000_000), 60, payable_currency(), 144);
+
+        assert!(
+            validate_payout_invoice(&decode_invoice(&short_lived).expect("must decode")).is_ok(),
+            "a short-lived LNURL invoice must pass the payout checks"
+        );
+
+        if window > 60 {
+            assert_eq!(
+                is_valid_invoice(short_lived, None, None).await,
+                Err(MostroInternalErr(ServiceError::InvoiceInvalidError)),
+                "the same invoice is rejected by the buyer-supplied path"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_payout_invoice_rejects_excessive_final_cltv_delta() {
+        init_settings_test();
+        let max_delta = Settings::get_ln().max_final_cltv_expiry_delta as u64;
+        let invoice =
+            build_test_invoice_with(Some(1_000_000), 86_400, payable_currency(), max_delta + 1);
+        assert_eq!(
+            validate_payout_invoice(&decode_invoice(&invoice).expect("must decode")),
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError))
+        );
+    }
+
+    #[tokio::test]
+    async fn validate_payout_invoice_rejects_another_chain() {
+        init_settings_test();
+        // Inactive without a mapped chain; see
+        // `invoice_currency_is_payable_only_on_the_node_chain`.
+        let Some(node_currency) = init_ln_status_test() else {
+            return;
+        };
+        let invoice = build_test_invoice_with(
+            Some(1_000_000),
+            86_400,
+            foreign_currency(node_currency),
+            144,
+        );
+        assert_eq!(
+            validate_payout_invoice(&decode_invoice(&invoice).expect("must decode")),
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError))
+        );
     }
 
     /// The chain comparison itself, independent of the shared `LN_STATUS`.

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -36,6 +36,18 @@ fn node_currency() -> Option<Currency> {
         .and_then(|network| currency_for_network(network))
 }
 
+/// Whether a node on `expected_currency` is able to pay `invoice`. `None` means
+/// the node's chain is unknown, in which case the check is skipped.
+fn invoice_currency_is_payable(
+    invoice: &Bolt11Invoice,
+    expected_currency: Option<Currency>,
+) -> bool {
+    match expected_currency {
+        Some(expected_currency) => invoice.currency() == expected_currency,
+        None => true,
+    }
+}
+
 /// Decodes a BOLT11 Lightning invoice from its string representation.
 ///
 /// This function parses a Lightning Network payment request string and returns
@@ -139,10 +151,8 @@ async fn validate_bolt11_invoice(
     // Reject invoices issued for another chain. LND cannot pay them, and
     // without this check the failure only surfaces at payout time — after the
     // seller's hold invoice has already been settled.
-    if let Some(expected_currency) = node_currency() {
-        if invoice.currency() != expected_currency {
-            return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
-        }
+    if !invoice_currency_is_payable(&invoice, node_currency()) {
+        return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
     }
 
     // Bound the payee-chosen final CLTV delta: a large value lets the payee
@@ -316,7 +326,7 @@ mod tests {
     /// currency it resolves to. `LN_STATUS` is a process-wide `OnceLock` that
     /// other tests also seed, so the installed value may not be ours — read
     /// back whatever won.
-    fn init_ln_status_test() -> Currency {
+    fn init_ln_status_test() -> Option<Currency> {
         let _ = LN_STATUS.set(crate::lightning::LnStatus {
             version: "test".to_string(),
             node_pubkey: "00".repeat(32),
@@ -326,7 +336,17 @@ mod tests {
             networks: vec!["mainnet".to_string()],
             uris: vec![],
         });
-        node_currency().expect("test LN status must map to a known currency")
+        // Setting first means the global is initialised from here on, so every
+        // later read in this process returns the same value. It may still be
+        // `None`: other modules install stubs with no networks, in which case
+        // the network check is inactive for the whole run.
+        node_currency()
+    }
+
+    /// A currency that passes the network check whatever `LN_STATUS` ended up
+    /// holding.
+    fn payable_currency() -> Currency {
+        init_ln_status_test().unwrap_or(Currency::Bitcoin)
     }
 
     /// A currency the node cannot pay, whichever chain it runs on.
@@ -343,7 +363,7 @@ mod tests {
         build_test_invoice_with(
             amount_msat,
             expiry_secs,
-            init_ln_status_test(),
+            payable_currency(),
             DEFAULT_TEST_CLTV_DELTA,
         )
     }
@@ -399,10 +419,42 @@ mod tests {
         assert_eq!(currency_for_network("testnet4"), None);
     }
 
+    /// The chain comparison itself, independent of the shared `LN_STATUS`.
+    #[test]
+    fn invoice_currency_is_payable_only_on_the_node_chain() {
+        let invoice = decode_invoice(&build_test_invoice_with(
+            Some(1_000_000),
+            86_400,
+            Currency::Bitcoin,
+            144,
+        ))
+        .expect("must decode");
+
+        assert!(invoice_currency_is_payable(
+            &invoice,
+            Some(Currency::Bitcoin)
+        ));
+        assert!(!invoice_currency_is_payable(
+            &invoice,
+            Some(Currency::BitcoinTestnet)
+        ));
+        assert!(!invoice_currency_is_payable(
+            &invoice,
+            Some(Currency::Regtest)
+        ));
+        // Unknown chain: skipped rather than rejected.
+        assert!(invoice_currency_is_payable(&invoice, None));
+    }
+
     #[tokio::test]
     async fn test_invoice_for_another_chain_is_rejected() {
         init_settings_test();
-        let node_currency = init_ln_status_test();
+        // With no mapped chain installed the check is inactive by design and
+        // there is nothing to assert end to end; the comparison itself is
+        // covered by `invoice_currency_is_payable_only_on_the_node_chain`.
+        let Some(node_currency) = init_ln_status_test() else {
+            return;
+        };
         let payment_request = build_test_invoice_with(
             Some(1_000_000),
             86_400,
@@ -420,8 +472,8 @@ mod tests {
     #[tokio::test]
     async fn test_invoice_for_the_node_chain_is_accepted() {
         init_settings_test();
-        let node_currency = init_ln_status_test();
-        let payment_request = build_test_invoice_with(Some(1_000_000), 86_400, node_currency, 144);
+        let payment_request =
+            build_test_invoice_with(Some(1_000_000), 86_400, payable_currency(), 144);
         let result = is_valid_invoice(payment_request, Some(1_000), None).await;
         assert!(
             result.is_ok(),
@@ -432,12 +484,11 @@ mod tests {
     #[tokio::test]
     async fn test_excessive_final_cltv_delta_is_rejected() {
         init_settings_test();
-        let node_currency = init_ln_status_test();
         // Read the effective bound so the test holds whichever settings won
         // the process-wide OnceLock race.
         let max_delta = Settings::get_ln().max_final_cltv_expiry_delta as u64;
         let payment_request =
-            build_test_invoice_with(Some(1_000_000), 86_400, node_currency, max_delta + 1);
+            build_test_invoice_with(Some(1_000_000), 86_400, payable_currency(), max_delta + 1);
         let result = is_valid_invoice(payment_request, Some(1_000), None).await;
         assert_eq!(
             result,
@@ -449,10 +500,9 @@ mod tests {
     #[tokio::test]
     async fn test_final_cltv_delta_at_the_bound_is_accepted() {
         init_settings_test();
-        let node_currency = init_ln_status_test();
         let max_delta = Settings::get_ln().max_final_cltv_expiry_delta as u64;
         let payment_request =
-            build_test_invoice_with(Some(1_000_000), 86_400, node_currency, max_delta);
+            build_test_invoice_with(Some(1_000_000), 86_400, payable_currency(), max_delta);
         let result = is_valid_invoice(payment_request, Some(1_000), None).await;
         assert!(
             result.is_ok(),

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -1,13 +1,40 @@
 use crate::config::settings::Settings;
 use crate::lnurl::ln_exists;
+use crate::LN_STATUS;
 
 use chrono::prelude::*;
 use chrono::TimeDelta;
-use lightning_invoice::{Bolt11Invoice, SignedRawBolt11Invoice};
+use lightning_invoice::{Bolt11Invoice, Currency, SignedRawBolt11Invoice};
 use lnurl::lightning_address::LightningAddress;
 use lnurl::lnurl::LnUrl;
 use mostro_core::prelude::*;
 use std::str::FromStr;
+
+/// Maps a network name as reported by LND's `GetInfo` to the BOLT11 currency
+/// a node on that chain is able to pay.
+fn currency_for_network(network: &str) -> Option<Currency> {
+    match network {
+        "mainnet" => Some(Currency::Bitcoin),
+        "testnet" => Some(Currency::BitcoinTestnet),
+        "regtest" => Some(Currency::Regtest),
+        "signet" => Some(Currency::Signet),
+        "simnet" => Some(Currency::Simnet),
+        _ => None,
+    }
+}
+
+/// The currency payout invoices must carry, or `None` when the node's chain is
+/// unknown. `LN_STATUS` is populated by the startup `GetInfo` probe, so it is
+/// always set while the daemon serves requests; the `None` case covers tests
+/// and any network name we don't map. Callers skip the check rather than
+/// reject, so an unmapped chain never blocks trading.
+fn node_currency() -> Option<Currency> {
+    LN_STATUS
+        .get()?
+        .networks
+        .first()
+        .and_then(|network| currency_for_network(network))
+}
 
 /// Decodes a BOLT11 Lightning invoice from its string representation.
 ///
@@ -66,6 +93,8 @@ async fn validate_lightning_address(payment_request: &str) -> Result<(), MostroE
 /// Validates a BOLT11 Lightning invoice with comprehensive checks.
 ///
 /// This function performs thorough validation of a BOLT11 invoice including:
+/// - Chain match against the node's own network
+/// - Final CLTV expiry delta bound
 /// - Amount verification against expected values and fees
 /// - Minimum payment amount enforcement
 /// - Expiration time validation
@@ -84,6 +113,8 @@ async fn validate_lightning_address(payment_request: &str) -> Result<(), MostroE
 ///
 /// # Validation Rules
 ///
+/// - Invoice currency must match the chain the node runs on, when known
+/// - `min_final_cltv_expiry_delta` must not exceed `max_final_cltv_expiry_delta`
 /// - If `amount` is provided, the invoice amount must match `amount - fee`
 /// - Invoice amount must meet minimum payment threshold (if non-zero)
 /// - Invoice must not be expired
@@ -104,6 +135,21 @@ async fn validate_bolt11_invoice(
 
     let amount_sat = invoice.amount_milli_satoshis().unwrap_or(0) / 1000;
     let fee = fee.unwrap_or(0);
+
+    // Reject invoices issued for another chain. LND cannot pay them, and
+    // without this check the failure only surfaces at payout time — after the
+    // seller's hold invoice has already been settled.
+    if let Some(expected_currency) = node_currency() {
+        if invoice.currency() != expected_currency {
+            return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
+        }
+    }
+
+    // Bound the payee-chosen final CLTV delta: a large value lets the payee
+    // hold the outgoing HTLC, and the routing liquidity behind it, for weeks.
+    if invoice.min_final_cltv_expiry_delta() > ln_settings.max_final_cltv_expiry_delta as u64 {
+        return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
+    }
 
     // Validate amount if provided
     if let Some(amt) = amount {
@@ -266,24 +312,68 @@ mod tests {
         (lnurl, handle)
     }
 
+    /// Seed the chain global so the network check is active, and return the
+    /// currency it resolves to. `LN_STATUS` is a process-wide `OnceLock` that
+    /// other tests also seed, so the installed value may not be ours — read
+    /// back whatever won.
+    fn init_ln_status_test() -> Currency {
+        let _ = LN_STATUS.set(crate::lightning::LnStatus {
+            version: "test".to_string(),
+            node_pubkey: "00".repeat(32),
+            commit_hash: "test".to_string(),
+            node_alias: "test-node".to_string(),
+            chains: vec!["bitcoin".to_string()],
+            networks: vec!["mainnet".to_string()],
+            uris: vec![],
+        });
+        node_currency().expect("test LN status must map to a known currency")
+    }
+
+    /// A currency the node cannot pay, whichever chain it runs on.
+    fn foreign_currency(node: Currency) -> Currency {
+        match node {
+            Currency::Bitcoin => Currency::BitcoinTestnet,
+            _ => Currency::Bitcoin,
+        }
+    }
+
     /// Build a freshly-signed BOLT11 invoice locally (no network, no LND).
     /// `amount_msat = None` produces a no-amount invoice.
     fn build_test_invoice(amount_msat: Option<u64>, expiry_secs: u64) -> String {
+        build_test_invoice_with(
+            amount_msat,
+            expiry_secs,
+            init_ln_status_test(),
+            DEFAULT_TEST_CLTV_DELTA,
+        )
+    }
+
+    /// Typical wallet value, well under any sane `max_final_cltv_expiry_delta`.
+    const DEFAULT_TEST_CLTV_DELTA: u64 = 144;
+
+    /// `build_test_invoice` with the two fields the network and final-CLTV
+    /// checks read.
+    fn build_test_invoice_with(
+        amount_msat: Option<u64>,
+        expiry_secs: u64,
+        currency: Currency,
+        min_final_cltv_expiry_delta: u64,
+    ) -> String {
         use bitcoin::hashes::{sha256, Hash};
         use bitcoin::secp256k1::{Secp256k1, SecretKey};
-        use lightning_invoice::{Currency, InvoiceBuilder, PaymentSecret};
+        use lightning_invoice::{InvoiceBuilder, PaymentSecret};
         use std::time::Duration;
 
         let secp = Secp256k1::new();
         let private_key = SecretKey::from_slice(&[0x42; 32]).expect("valid secret key");
         let payment_hash = sha256::Hash::hash(&[0u8; 32]);
 
-        let builder = InvoiceBuilder::new(Currency::Bitcoin)
+        let builder = InvoiceBuilder::new(currency)
             .description("mostro coverage test invoice".into())
             .payment_hash(payment_hash)
             .payment_secret(PaymentSecret([42u8; 32]))
             .current_timestamp()
-            .min_final_cltv_expiry_delta(144)
+            .min_final_cltv_expiry_delta(min_final_cltv_expiry_delta)
             .expiry_time(Duration::from_secs(expiry_secs));
         let builder = match amount_msat {
             Some(msat) => builder.amount_milli_satoshis(msat),
@@ -293,6 +383,81 @@ mod tests {
             .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &private_key))
             .expect("valid signed invoice")
             .to_string()
+    }
+
+    #[test]
+    fn currency_for_network_maps_every_lnd_chain() {
+        assert_eq!(currency_for_network("mainnet"), Some(Currency::Bitcoin));
+        assert_eq!(
+            currency_for_network("testnet"),
+            Some(Currency::BitcoinTestnet)
+        );
+        assert_eq!(currency_for_network("regtest"), Some(Currency::Regtest));
+        assert_eq!(currency_for_network("signet"), Some(Currency::Signet));
+        assert_eq!(currency_for_network("simnet"), Some(Currency::Simnet));
+        // An unmapped name skips the check instead of blocking trading.
+        assert_eq!(currency_for_network("testnet4"), None);
+    }
+
+    #[tokio::test]
+    async fn test_invoice_for_another_chain_is_rejected() {
+        init_settings_test();
+        let node_currency = init_ln_status_test();
+        let payment_request = build_test_invoice_with(
+            Some(1_000_000),
+            86_400,
+            foreign_currency(node_currency),
+            144,
+        );
+        let result = is_valid_invoice(payment_request, Some(1_000), None).await;
+        assert_eq!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError)),
+            "an invoice the node cannot pay must be rejected at validation time"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invoice_for_the_node_chain_is_accepted() {
+        init_settings_test();
+        let node_currency = init_ln_status_test();
+        let payment_request = build_test_invoice_with(Some(1_000_000), 86_400, node_currency, 144);
+        let result = is_valid_invoice(payment_request, Some(1_000), None).await;
+        assert!(
+            result.is_ok(),
+            "an invoice on the node's own chain must pass: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_excessive_final_cltv_delta_is_rejected() {
+        init_settings_test();
+        let node_currency = init_ln_status_test();
+        // Read the effective bound so the test holds whichever settings won
+        // the process-wide OnceLock race.
+        let max_delta = Settings::get_ln().max_final_cltv_expiry_delta as u64;
+        let payment_request =
+            build_test_invoice_with(Some(1_000_000), 86_400, node_currency, max_delta + 1);
+        let result = is_valid_invoice(payment_request, Some(1_000), None).await;
+        assert_eq!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError)),
+            "a final CLTV delta above the configured bound must be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_final_cltv_delta_at_the_bound_is_accepted() {
+        init_settings_test();
+        let node_currency = init_ln_status_test();
+        let max_delta = Settings::get_ln().max_final_cltv_expiry_delta as u64;
+        let payment_request =
+            build_test_invoice_with(Some(1_000_000), 86_400, node_currency, max_delta);
+        let result = is_valid_invoice(payment_request, Some(1_000), None).await;
+        assert!(
+            result.is_ok(),
+            "the bound itself must be inclusive: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/lightning/invoice.rs
+++ b/src/lightning/invoice.rs
@@ -49,8 +49,9 @@ fn invoice_currency_is_payable(
 }
 
 /// Checks the properties that must hold for any invoice this node is about to
-/// pay, whatever its origin: it has to be on the node's own chain, and its
-/// final CLTV delta has to stay within the configured bound.
+/// pay, whatever its origin: it has to be on the node's own chain, its final
+/// CLTV delta has to stay within the configured bound, and it must not have
+/// expired already.
 ///
 /// Kept apart from [`validate_bolt11_invoice`] because the amount and expiry
 /// rules there do not apply to invoices minted by an LNURL server: those are
@@ -67,6 +68,13 @@ pub fn validate_payout_invoice(invoice: &Bolt11Invoice) -> Result<(), MostroErro
     // hold the outgoing HTLC, and the routing liquidity behind it, for weeks.
     if invoice.min_final_cltv_expiry_delta() > Settings::get_ln().max_final_cltv_expiry_delta as u64
     {
+        return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
+    }
+
+    // An already-expired invoice cannot be paid. This is not the
+    // `invoice_expiration_window` rule, which demands remaining lifetime an
+    // LNURL-minted invoice has no reason to satisfy.
+    if invoice.is_expired() {
         return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
     }
 
@@ -191,11 +199,6 @@ async fn validate_bolt11_invoice(
 
     // Check minimum payment amount
     if amount_sat > 0 && amount_sat < mostro_settings.min_payment_amount as u64 {
-        return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
-    }
-
-    // Check if invoice is expired
-    if invoice.is_expired() {
         return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
     }
 
@@ -387,6 +390,32 @@ mod tests {
     /// Typical wallet value, well under any sane `max_final_cltv_expiry_delta`.
     const DEFAULT_TEST_CLTV_DELTA: u64 = 144;
 
+    /// An invoice on the node's own chain whose lifetime already elapsed:
+    /// issued an hour ago with a one-minute expiry.
+    fn build_expired_test_invoice() -> String {
+        use bitcoin::hashes::{sha256, Hash};
+        use bitcoin::secp256k1::{Secp256k1, SecretKey};
+        use lightning_invoice::{InvoiceBuilder, PaymentSecret};
+        use std::time::{Duration, SystemTime};
+
+        let secp = Secp256k1::new();
+        let private_key = SecretKey::from_slice(&[0x42; 32]).expect("valid secret key");
+        let payment_hash = sha256::Hash::hash(&[0u8; 32]);
+        let issued_at = SystemTime::now() - Duration::from_secs(3_600);
+
+        InvoiceBuilder::new(payable_currency())
+            .description("mostro coverage test invoice".into())
+            .payment_hash(payment_hash)
+            .payment_secret(PaymentSecret([42u8; 32]))
+            .timestamp(issued_at)
+            .min_final_cltv_expiry_delta(DEFAULT_TEST_CLTV_DELTA)
+            .expiry_time(Duration::from_secs(60))
+            .amount_milli_satoshis(1_000_000)
+            .build_signed(|hash| secp.sign_ecdsa_recoverable(hash, &private_key))
+            .expect("valid signed invoice")
+            .to_string()
+    }
+
     /// `build_test_invoice` with the two fields the network and final-CLTV
     /// checks read.
     fn build_test_invoice_with(
@@ -456,6 +485,33 @@ mod tests {
                 "the same invoice is rejected by the buyer-supplied path"
             );
         }
+    }
+
+    /// Already expired is rejected; merely short-lived is not. The two are
+    /// separate rules and only the first belongs in the payout path.
+    #[tokio::test]
+    async fn validate_payout_invoice_rejects_only_expired_invoices() {
+        init_settings_test();
+
+        let expired = decode_invoice(&build_expired_test_invoice()).expect("must decode");
+        assert!(expired.is_expired(), "fixture must be expired");
+        assert_eq!(
+            validate_payout_invoice(&expired),
+            Err(MostroInternalErr(ServiceError::InvoiceInvalidError)),
+            "an expired invoice can never be paid"
+        );
+
+        // 60s of remaining lifetime is below `invoice_expiration_window` but
+        // perfectly payable, so the payout path must accept it.
+        let short_lived = decode_invoice(&build_test_invoice_with(
+            Some(1_000_000),
+            60,
+            payable_currency(),
+            144,
+        ))
+        .expect("must decode");
+        assert!(!short_lived.is_expired());
+        assert!(validate_payout_invoice(&short_lived).is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
`validate_bolt11_invoice` checked amount, minimum and expiry, but never the invoice currency against the node's own chain, nor the payee-chosen `min_final_cltv_expiry_delta`.

A payout invoice for another chain passes validation and only fails at payment time — after the seller's hold invoice has been settled, leaving the order stuck in `SettledHoldInvoice` waiting for a replacement invoice. An unbounded final CLTV delta lets a payee hold the outgoing HTLC, and the routing liquidity behind it, far longer than any trade needs.

## Changes

- Reject invoices whose currency does not match the chain reported by LND's `GetInfo` (`LN_STATUS`). Skipped when the chain is unknown or unmapped, so an unrecognised network never blocks trading.
- Reject invoices whose `min_final_cltv_expiry_delta` exceeds the new `lightning.max_final_cltv_expiry_delta` setting (default 432 blocks, roughly three days). Existing operator configs pick up the default via serde.

Both checks live in `validate_bolt11_invoice`, so they cover every user-supplied invoice path: `TakeSell`, order creation, `AddInvoice` retries and bond payouts.

## Tests

Seven new tests covering the network mapping, wrong-chain rejection, the CLTV bound at and above the limit, and the serde default for configs that predate the setting. Full suite passes; clippy and fmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable maximum final CLTV expiry delta, defaulting to 432 blocks.
  - Setup configuration now includes this setting automatically.
  - Payout invoices resolved through Lightning Addresses and LNURL payments are validated before being sent.
  - Invoice validation checks blockchain network compatibility, expiration status, and the configured CLTV limit.

- **Bug Fixes**
  - Improved rejection of invoices from mismatched or unsupported chains.
  - Added validation for CLTV values at and beyond the configured boundary.
  - Expired payout invoices are now rejected before payment processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->