### PR TITLE
fix: enforce trade escrow CLTV deadline

### DIFF
--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -110,6 +110,7 @@ Configuration is loaded from `~/.mostro/settings.toml` (template: `settings.tpl.
 - `hold_invoice_expiration_window` (u32): Hold invoice expiration in seconds (default: 300)
 - `payment_attempts` (u32): Max payment retry attempts (default: 3)
 - `payment_retries_interval` (u32): Retry interval in seconds (default: 60)
+- `escrow_deadline_margin_blocks` (u32): Safety margin in blocks before the hold invoice's CLTV horizon; at `hold_invoice_cltv_delta - escrow_deadline_margin_blocks` blocks after the escrow was paid, mostrod cancels the trade (Active) or opens a dispute (FiatSent) before LND auto-refunds the escrow. Must exceed the LND node's `invoices.holdexpirydelta` (LND default: 12) (default: 24)
 
 **Mostro** (`src/config/types.rs:76-108`):
 

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -22,11 +22,12 @@ payment_retries_interval = 60
 max_final_cltv_expiry_delta = 432
 # Safety margin (in blocks) before the hold invoice's CLTV horizon. LND
 # auto-cancels an accepted hold invoice `invoices.holdexpirydelta` blocks
-# (default 12) before its HTLC expires, refunding the seller; at
-# hold_invoice_cltv_delta - escrow_deadline_margin_blocks blocks after the
-# escrow was paid, mostrod cancels the trade (Active) or opens a dispute
-# (FiatSent) while the escrow still exists. Must comfortably exceed your
-# node's holdexpirydelta.
+# (default 12) before its HTLC expires, refunding the seller; once the
+# chain tip is within escrow_deadline_margin_blocks of the accepted
+# HTLC's expiry height (nominal 10-minute-block clock as fallback when
+# LND cannot answer), mostrod cancels the trade (Active) or opens a
+# dispute (FiatSent) while the escrow still exists. Must comfortably
+# exceed your node's holdexpirydelta.
 escrow_deadline_margin_blocks = 24
 
 [nostr]

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -20,6 +20,14 @@ payment_retries_interval = 60
 # Maximum min_final_cltv_expiry_delta (in blocks) accepted on a payout invoice
 # supplied by a user. Bounds how long a payee can hold the outgoing HTLC.
 max_final_cltv_expiry_delta = 432
+# Safety margin (in blocks) before the hold invoice's CLTV horizon. LND
+# auto-cancels an accepted hold invoice `invoices.holdexpirydelta` blocks
+# (default 12) before its HTLC expires, refunding the seller; at
+# hold_invoice_cltv_delta - escrow_deadline_margin_blocks blocks after the
+# escrow was paid, mostrod cancels the trade (Active) or opens a dispute
+# (FiatSent) while the escrow still exists. Must comfortably exceed your
+# node's holdexpirydelta.
+escrow_deadline_margin_blocks = 24
 
 [nostr]
 nsec_privkey = 'nsec1...'

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -428,7 +428,7 @@ pub async fn request_maker_bond(
 /// from the structured gRPC error so the caller can decide whether the
 /// HTLC is verifiably no longer encumbered.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CancelOutcome {
+pub(crate) enum CancelOutcome {
     /// The cancel landed at LND (or didn't need to: the invoice was
     /// already canceled / never existed). The HTLC, if there ever was
     /// one, is no longer encumbered. Safe to mark `Released`.
@@ -450,7 +450,7 @@ enum CancelOutcome {
 /// Anything we can't classify confidently maps to `Transient`: the
 /// safer side is to delay cleanup until the next exit path or CLTV
 /// expiry, never to falsely report a release on an HTLC LND still has.
-fn classify_cancel_error(err: &MostroError) -> CancelOutcome {
+pub(crate) fn classify_cancel_error(err: &MostroError) -> CancelOutcome {
     let s = err.to_string().to_lowercase();
 
     // gRPC codes that mean the cancel was idempotent / target wasn't there.

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -17,7 +17,7 @@ use uuid::Uuid;
 ///
 /// Creates and publishes a NIP-33 replaceable event containing dispute details,
 /// including status, initiator (`buyer` or `seller`), and application metadata.
-async fn publish_dispute_event(
+pub(crate) async fn publish_dispute_event(
     ctx: &AppContext,
     dispute: &Dispute,
     my_keys: &Keys,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -406,6 +406,12 @@ pub struct LightningSettings {
     /// user-supplied payout invoice
     #[serde(default = "default_max_final_cltv_expiry_delta")]
     pub max_final_cltv_expiry_delta: u32,
+    /// Safety margin, in blocks, before the hold invoice's CLTV horizon at
+    /// which the daemon cancels/escalates trades whose escrow is about to
+    /// be auto-refunded by LND. Must exceed the node's
+    /// `invoices.holdexpirydelta` (LND default: 12) with room to spare.
+    #[serde(default = "default_escrow_deadline_margin_blocks")]
+    pub escrow_deadline_margin_blocks: u32,
 }
 
 /// ~3 days of blocks. High enough for every wallet we know of (18 to 144 is
@@ -413,6 +419,13 @@ pub struct LightningSettings {
 /// cannot pin routing liquidity for weeks.
 fn default_max_final_cltv_expiry_delta() -> u32 {
     432
+}
+
+/// 24 blocks ≈ 4 hours at the nominal 10 min/block: twice LND's default
+/// `holdexpirydelta` (12) plus slack for block-time variance and the
+/// guardian job's tick.
+fn default_escrow_deadline_margin_blocks() -> u32 {
+    24
 }
 
 // Hand-written so `max_final_cltv_expiry_delta` defaults to the real bound
@@ -429,6 +442,7 @@ impl Default for LightningSettings {
             payment_attempts: 0,
             payment_retries_interval: 0,
             max_final_cltv_expiry_delta: default_max_final_cltv_expiry_delta(),
+            escrow_deadline_margin_blocks: default_escrow_deadline_margin_blocks(),
         }
     }
 }

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -146,6 +146,7 @@ fn prompt_lightning_settings() -> Result<LightningSettings, MostroError> {
         payment_attempts: 3,
         payment_retries_interval: 60,
         max_final_cltv_expiry_delta: 432,
+        escrow_deadline_margin_blocks: 24,
     })
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -2157,6 +2157,8 @@ mod tests {
         // Due: escrow-backed states observed paid before the cutoff.
         insert_order(&pool, "active", cutoff - 1, true).await;
         insert_order(&pool, "fiat-sent", cutoff - 1, true).await;
+        // Due: exactly at the cutoff — the bound is inclusive.
+        insert_order(&pool, "active", cutoff, true).await;
         // Not due: inside the window still.
         insert_order(&pool, "active", cutoff + 1, true).await;
         // Excluded: a dispute already has a solver in the loop.
@@ -2172,7 +2174,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             result.len(),
-            2,
+            3,
             "only due active/fiat-sent orders with a hash qualify: {result:?}"
         );
         assert!(result

--- a/src/db.rs
+++ b/src/db.rs
@@ -947,6 +947,40 @@ pub async fn find_held_invoices(pool: &SqlitePool) -> Result<Vec<Order>, MostroE
     Ok(order)
 }
 
+/// Orders whose trade escrow is a paid hold invoice approaching the point
+/// where the daemon must act before LND does: LND auto-cancels an accepted
+/// hold invoice `invoices.holdexpirydelta` blocks before the HTLC's CLTV
+/// expiry, silently refunding the seller while the order still looks live.
+///
+/// `held_before` is a unix cutoff on `invoice_held_at` (written by
+/// [`crate::flow::hold_invoice_paid`] when the escrow was observed paid):
+/// rows at or before it are due. Only `active` / `fiat-sent` qualify —
+/// `dispute` already has a human solver in the loop (the reactive
+/// `hold_invoice_canceled` path raises the alarm there), and every other
+/// state has no live escrow to protect. `hash IS NOT NULL` because the
+/// guardian needs the payment hash to cancel the invoice proactively.
+pub async fn find_escrow_deadline_orders(
+    pool: &SqlitePool,
+    held_before: i64,
+) -> Result<Vec<Order>, MostroError> {
+    let orders = sqlx::query_as::<_, Order>(
+        r#"
+          SELECT *
+          FROM orders
+          WHERE status IN ('active', 'fiat-sent')
+            AND invoice_held_at != 0
+            AND invoice_held_at <= ?1
+            AND hash IS NOT NULL
+        "#,
+    )
+    .bind(held_before)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(orders)
+}
+
 pub async fn find_failed_payment(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
     let order = sqlx::query_as::<_, Order>(
         r#"
@@ -2090,6 +2124,60 @@ mod tests {
 
         let result = super::find_held_invoices(&pool).await.unwrap();
         assert!(result.is_empty(), "rows without a hash must be skipped");
+    }
+
+    #[tokio::test]
+    async fn test_find_escrow_deadline_orders_selects_only_due_escrows() {
+        async fn insert_order(pool: &SqlitePool, status: &str, held_at: i64, with_hash: bool) {
+            sqlx::query(
+                r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                        amount, fiat_code, fiat_amount, created_at, expires_at,
+                        failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                        invoice_held_at, hash)
+                VALUES (?1, 'sell', 'ev1', ?2, 0, 'lightning',
+                        100000, 'USD', 100, 1700000000, 1700086400,
+                        0, 0, 0, 0, ?3, ?4)"#,
+            )
+            .bind(uuid::Uuid::new_v4())
+            .bind(status)
+            .bind(held_at)
+            .bind(if with_hash {
+                Some("aa".repeat(32))
+            } else {
+                None
+            })
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+
+        let pool = setup_orders_db().await.unwrap();
+        let cutoff = 1_700_100_000i64;
+
+        // Due: escrow-backed states observed paid before the cutoff.
+        insert_order(&pool, "active", cutoff - 1, true).await;
+        insert_order(&pool, "fiat-sent", cutoff - 1, true).await;
+        // Not due: inside the window still.
+        insert_order(&pool, "active", cutoff + 1, true).await;
+        // Excluded: a dispute already has a solver in the loop.
+        insert_order(&pool, "dispute", cutoff - 1, true).await;
+        // Excluded: no live escrow behind these.
+        insert_order(&pool, "waiting-payment", cutoff - 1, true).await;
+        insert_order(&pool, "active", 0, true).await;
+        // Excluded: nothing to cancel without the payment hash.
+        insert_order(&pool, "active", cutoff - 1, false).await;
+
+        let result = super::find_escrow_deadline_orders(&pool, cutoff)
+            .await
+            .unwrap();
+        assert_eq!(
+            result.len(),
+            2,
+            "only due active/fiat-sent orders with a hash qualify: {result:?}"
+        );
+        assert!(result
+            .iter()
+            .all(|o| o.invoice_held_at <= cutoff && o.invoice_held_at != 0));
     }
 
     #[tokio::test]

--- a/src/escrow.rs
+++ b/src/escrow.rs
@@ -32,6 +32,27 @@ pub trait EscrowBackend: Send {
 
     /// Cancel a held invoice by payment hash (hex).
     async fn cancel_hold_invoice(&mut self, hash: &str) -> Result<(), MostroError>;
+
+    /// Current chain tip height as seen by the node backing the escrow,
+    /// for CLTV-deadline math. Backends without a chain view return an
+    /// error; callers must fall back to time-based approximations.
+    async fn chain_height(&mut self) -> Result<u32, MostroError> {
+        Err(MostroInternalErr(ServiceError::LnNodeError(
+            "chain height not available for this escrow backend".to_string(),
+        )))
+    }
+
+    /// Earliest CLTV expiry height among the ACCEPTED HTLCs backing the
+    /// hold invoice `hash` (hex). `Ok(None)` means no accepted HTLC backs
+    /// the invoice anymore (canceled, settled, or never held).
+    async fn hold_invoice_expiry_height(
+        &mut self,
+        _hash: &str,
+    ) -> Result<Option<u32>, MostroError> {
+        Err(MostroInternalErr(ServiceError::LnNodeError(
+            "HTLC expiry height not available for this escrow backend".to_string(),
+        )))
+    }
 }
 
 #[async_trait]
@@ -60,6 +81,14 @@ impl EscrowBackend for LndConnector {
         LndConnector::cancel_hold_invoice(self, hash)
             .await
             .map(|_| ())
+    }
+
+    async fn chain_height(&mut self) -> Result<u32, MostroError> {
+        LndConnector::get_chain_height(self).await
+    }
+
+    async fn hold_invoice_expiry_height(&mut self, hash: &str) -> Result<Option<u32>, MostroError> {
+        LndConnector::get_hold_invoice_expiry_height(self, hash).await
     }
 }
 

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -184,12 +184,115 @@ pub async fn hold_invoice_settlement(hash: &str, pool: &SqlitePool) -> Result<()
     Ok(())
 }
 
-pub async fn hold_invoice_canceled(hash: &str, pool: &SqlitePool) -> Result<()> {
-    let order = crate::db::find_order_by_hash(pool, hash).await?;
-    info!(
-        "Order Id: {} - Invoice with hash: {} was canceled!",
-        order.id, hash
+/// Handle an LND `Canceled` update for an order's hold invoice.
+///
+/// Most cancels are expected: the daemon itself canceled the invoice
+/// (waiting-state timeout, cooperative cancel, admin cancel) and already
+/// moved the order on, so the event only earns a log line.
+///
+/// The dangerous case is a cancel landing while the order is still in an
+/// escrow-backed state (`Active` / `FiatSent` / `Dispute`): the trade
+/// relies on that HTLC, so its loss means LND auto-canceled it at the
+/// CLTV horizon, refunding the escrow to the seller (or the deadline
+/// guardian job could not act — e.g. the daemon was down past the
+/// horizon and this is the restart replay). To avoid misreading an
+/// in-flight *intentional* cancel as an evaporation, the alarm only
+/// fires once the order is past the guardian's action deadline
+/// ([`crate::util::escrow_action_deadline_unix`]); before that, an
+/// escrow-backed cancel is treated as intentional and only logged.
+///
+/// Past the deadline:
+///
+/// - every escrow-backed state gets both parties notified with
+///   [`Action::HoldInvoicePaymentCanceled`], plus an `error!` for the
+///   operator;
+/// - `Active` additionally transitions to `Canceled`: with no fiat claim
+///   on record the trade is simply dead, and leaving it `Active` would
+///   keep showing a trade that no escrow backs;
+/// - `FiatSent` / `Dispute` keep their status — the fiat leg may already
+///   have moved, so a human must resolve the fallout. The notifications
+///   and the `error!` are the alarm.
+pub async fn hold_invoice_canceled(
+    hash: &str,
+    pool: &SqlitePool,
+    my_keys: &Keys,
+) -> Result<(), MostroError> {
+    let order = crate::db::find_order_by_hash(pool, hash)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    let status = order.get_order_status().map_err(MostroInternalErr)?;
+
+    let is_escrow_backed = matches!(status, Status::Active | Status::FiatSent | Status::Dispute);
+    // `invoice_held_at == 0` (escrow never observed, or a row predating the
+    // column) yields no deadline: nothing reliable to reason about, keep
+    // the legacy log-only behaviour.
+    let ln_settings = crate::config::Settings::get_ln();
+    let past_action_deadline = crate::util::escrow_action_deadline_unix(
+        order.invoice_held_at,
+        ln_settings.hold_invoice_cltv_delta,
+        ln_settings.escrow_deadline_margin_blocks,
+    )
+    .map(|deadline| Timestamp::now().as_secs() as i64 >= deadline)
+    .unwrap_or(false);
+
+    if !is_escrow_backed || !past_action_deadline {
+        info!(
+            "Order Id: {} - Invoice with hash: {} was canceled!",
+            order.id, hash
+        );
+        return Ok(());
+    }
+
+    tracing::error!(
+        order_id = %order.id,
+        status = %status,
+        "Hold invoice canceled while the order still relies on its escrow: \
+         the escrow was refunded to the seller at the CLTV horizon and the \
+         trade can no longer be settled — manual intervention required"
     );
+
+    // Missing party keys must not mute the alarm: the operator-facing
+    // error above still fires, and whichever key resolves gets notified.
+    for party in [order.get_buyer_pubkey(), order.get_seller_pubkey()]
+        .into_iter()
+        .flatten()
+    {
+        enqueue_order_msg(
+            None,
+            Some(order.id),
+            Action::HoldInvoicePaymentCanceled,
+            None,
+            party,
+            None,
+        )
+        .await;
+    }
+
+    if status == Status::Active {
+        match crate::util::update_order_event(my_keys, Status::Canceled, &order).await {
+            Ok(updated) => {
+                let updated = updated
+                    .update(pool)
+                    .await
+                    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+                crate::scheduler::notify_users_canceled_order(
+                    &updated,
+                    &order,
+                    Some(Action::Canceled),
+                )
+                .await;
+            }
+            Err(e) => {
+                // The next subscription replay (or restart) retries; the
+                // error above already flagged the order for the operator.
+                tracing::warn!(
+                    "Could not publish the cancel for order {} ({e}); will retry",
+                    order.id
+                );
+            }
+        }
+    }
+
     Ok(())
 }
 
@@ -402,7 +505,9 @@ mod tests {
         insert_order_with_hash(&pool, &hash, Status::Active, None, None, None, None).await;
 
         assert!(hold_invoice_settlement(&hash, &pool).await.is_ok());
-        assert!(hold_invoice_canceled(&hash, &pool).await.is_ok());
+        assert!(hold_invoice_canceled(&hash, &pool, &create_test_keys())
+            .await
+            .is_ok());
     }
 
     #[tokio::test]
@@ -439,9 +544,131 @@ mod tests {
         let hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
         // This test would require setting up database with order data
-        let result = hold_invoice_canceled(hash, &pool).await;
+        let result = hold_invoice_canceled(hash, &pool, &create_test_keys()).await;
         // Should fail without proper database setup
         assert!(result.is_ok() || result.is_err());
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_canceled_closes_active_order_past_the_escrow_deadline() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "f1".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        let order = insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::Active,
+            None,
+            Some(buyer),
+            Some(seller),
+            None,
+        )
+        .await;
+        // The escrow was observed long enough ago that the guardian's
+        // action deadline is behind us (test settings clamp the window,
+        // so any past timestamp qualifies).
+        crate::db::update_order_invoice_held_at_time(&pool, order.id, 1_700_000_000)
+            .await
+            .unwrap();
+
+        let result = hold_invoice_canceled(&hash, &pool, &create_test_keys()).await;
+        assert!(
+            result.is_ok(),
+            "evaporation handling must not error: {result:?}"
+        );
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(
+            updated.status,
+            Status::Canceled.to_string(),
+            "an Active order whose escrow evaporated must stop looking live"
+        );
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_canceled_ignores_active_order_inside_the_escrow_window() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "f2".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        let order = insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::Active,
+            None,
+            Some(buyer),
+            Some(seller),
+            None,
+        )
+        .await;
+        // The action deadline is still ahead (test settings clamp the
+        // guard window to zero, so only a future held_at lands inside the
+        // window): an intentional cooperative/admin cancel in flight must
+        // not be misread as an evaporation.
+        let future = Timestamp::now().as_secs() as i64 + 86_400;
+        crate::db::update_order_invoice_held_at_time(&pool, order.id, future)
+            .await
+            .unwrap();
+
+        let result = hold_invoice_canceled(&hash, &pool, &create_test_keys()).await;
+        assert!(
+            result.is_ok(),
+            "intentional cancels stay no-ops: {result:?}"
+        );
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_canceled_leaves_fiat_sent_order_for_a_human() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "f3".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        let order = insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::FiatSent,
+            Some("lnbcrt1invoice".to_string()),
+            Some(buyer),
+            Some(seller),
+            None,
+        )
+        .await;
+        crate::db::update_order_invoice_held_at_time(&pool, order.id, 1_700_000_000)
+            .await
+            .unwrap();
+
+        let result = hold_invoice_canceled(&hash, &pool, &create_test_keys()).await;
+        assert!(result.is_ok(), "the alarm must not error: {result:?}");
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(
+            updated.status,
+            Status::FiatSent.to_string(),
+            "fiat may already have moved: only a human can resolve this"
+        );
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_canceled_without_held_timestamp_keeps_legacy_noop() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "f4".repeat(32);
+        // Active with invoice_held_at == 0: no deadline to reason about
+        // (escrow never observed, or a row predating the column).
+        insert_order_with_hash(&pool, &hash, Status::Active, None, None, None, None).await;
+
+        let result = hold_invoice_canceled(&hash, &pool, &create_test_keys()).await;
+        assert!(result.is_ok(), "legacy no-op must not error: {result:?}");
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
     }
 
     mod hold_invoice_flow_tests {

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -197,9 +197,12 @@ pub async fn hold_invoice_settlement(hash: &str, pool: &SqlitePool) -> Result<()
 /// guardian job could not act — e.g. the daemon was down past the
 /// horizon and this is the restart replay). To avoid misreading an
 /// in-flight *intentional* cancel as an evaporation, the alarm only
-/// fires once the order is past the guardian's action deadline
+/// fires once the order is past the guardian's nominal action deadline
 /// ([`crate::util::escrow_action_deadline_unix`]); before that, an
-/// escrow-backed cancel is treated as intentional and only logged.
+/// escrow-backed cancel is treated as intentional and only logged. This
+/// gate is a wall-clock approximation of the block-height horizon (no
+/// LND handle here to consult the chain); the guardian job is the
+/// height-accurate layer and normally acts first.
 ///
 /// Past the deadline:
 ///

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -8,7 +8,9 @@ use fedimint_tonic_lnd::invoicesrpc::{
     AddHoldInvoiceRequest, AddHoldInvoiceResp, CancelInvoiceMsg, CancelInvoiceResp,
     SettleInvoiceMsg, SettleInvoiceResp,
 };
-use fedimint_tonic_lnd::lnrpc::{invoice::InvoiceState, GetInfoRequest, GetInfoResponse, Payment};
+use fedimint_tonic_lnd::lnrpc::{
+    invoice::InvoiceState, GetInfoRequest, GetInfoResponse, InvoiceHtlcState, Payment, PaymentHash,
+};
 use fedimint_tonic_lnd::routerrpc::{SendPaymentRequest, TrackPaymentRequest};
 use fedimint_tonic_lnd::Client;
 use mostro_core::prelude::*;
@@ -222,6 +224,39 @@ impl LndConnector {
                 ))))
             }
         }
+    }
+
+    /// Current chain tip height as seen by LND, for CLTV-deadline math.
+    pub async fn get_chain_height(&mut self) -> Result<u32, MostroError> {
+        self.get_node_info().await.map(|info| info.block_height)
+    }
+
+    /// Earliest CLTV expiry height among the ACCEPTED HTLCs backing the
+    /// hold invoice `hash` (hex). `None` when no accepted HTLC backs it
+    /// anymore — the invoice was canceled, settled, or never held.
+    pub async fn get_hold_invoice_expiry_height(
+        &mut self,
+        hash: &str,
+    ) -> Result<Option<u32>, MostroError> {
+        let r_hash = decode_hash32("payment hash", hash)?;
+
+        let invoice = self
+            .client
+            .lightning()
+            .lookup_invoice(PaymentHash {
+                r_hash,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::LnNodeError(e.to_string())))?
+            .into_inner();
+
+        Ok(invoice
+            .htlcs
+            .iter()
+            .filter(|htlc| htlc.state == InvoiceHtlcState::Accepted as i32)
+            .map(|htlc| htlc.expiry_height.max(0) as u32)
+            .min())
     }
 
     pub async fn send_payment(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -610,10 +610,11 @@ async fn job_cancel_orders(ctx: AppContext) {
 /// the buyer loses the fiat and the seller keeps both the fiat and the
 /// refunded sats.
 ///
-/// Each tick, orders past their action deadline
-/// ([`util::escrow_action_deadline_unix`], the horizon minus
-/// `escrow_deadline_margin_blocks`) are resolved while the escrow still
-/// exists:
+/// Each tick, orders whose accepted HTLC is within
+/// `escrow_deadline_margin_blocks` of its CLTV expiry height — measured
+/// against the actual chain tip, with the nominal 10-minute clock
+/// ([`util::escrow_action_deadline_unix`]) only as a fallback when LND
+/// cannot answer — are resolved while the escrow still exists:
 ///
 /// - `active` — nobody claims the fiat moved: cancel the hold invoice
 ///   proactively (a clean, observed refund instead of LND's silent one),
@@ -651,10 +652,22 @@ async fn enforce_escrow_deadline_pass(
     let cltv = ln_settings.hold_invoice_cltv_delta;
     let margin = ln_settings.escrow_deadline_margin_blocks;
 
-    // Acting cutoff: escrows observed paid at or before this timestamp are
-    // due — their action deadline (held_at + guard window) is now or past.
-    let cutoff = now - util::escrow_guard_window_secs(cltv, margin);
+    // Candidate prefilter only — real due-ness is decided from chain
+    // height below. CLTV expiry is measured in blocks, not seconds, so a
+    // stretch of fast blocks shortens the wall-clock window; half the
+    // nominal window keeps escrows in view even at twice the 10-minute
+    // average block rate.
+    let cutoff = now - util::escrow_guard_window_secs(cltv, margin) / 2;
     let due_orders = find_escrow_deadline_orders(pool, cutoff).await?;
+
+    // One probe per tick; per-order lookups below reuse it.
+    let chain_height = match escrow.chain_height().await {
+        Ok(height) => Some(height),
+        Err(e) => {
+            warn!("escrow_deadline: chain height unavailable ({e}); falling back to nominal block time");
+            None
+        }
+    };
 
     for order in due_orders {
         let status = match order.get_order_status() {
@@ -672,18 +685,48 @@ async fn enforce_escrow_deadline_pass(
             None => continue, // query guarantees one; defensive
         };
 
+        // Real deadline: the accepted HTLC's expiry height vs the chain
+        // tip. `due` = the guardian must act now; `escrow_gone` = the
+        // HTLC verifiably no longer backs the trade (past its expiry, or
+        // no accepted HTLC at LND at all).
+        let heights = match chain_height {
+            Some(chain) => match escrow.hold_invoice_expiry_height(&hash).await {
+                Ok(Some(expiry)) => Some((chain.saturating_add(margin) >= expiry, chain >= expiry)),
+                Ok(None) => Some((true, true)),
+                Err(e) => {
+                    warn!(
+                        "escrow_deadline: HTLC expiry lookup failed for order {} ({e}); falling back to nominal block time",
+                        order.id
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+        let (due, escrow_gone) = heights.unwrap_or_else(|| {
+            // Nominal-time fallback (10-minute blocks): good enough to
+            // decide to act, but never proof the escrow is gone — that
+            // requires chain evidence.
+            (
+                util::escrow_action_deadline_unix(order.invoice_held_at, cltv, margin)
+                    .map(|deadline| now >= deadline)
+                    .unwrap_or(false),
+                false,
+            )
+        });
+        if !due {
+            continue;
+        }
+
         match status {
             Status::Active => {
                 // Cancel proactively so the seller's refund is clean and
                 // observed rather than LND's silent auto-cancel. On
                 // failure, stay eligible and retry next tick — unless the
-                // hard horizon already passed, in which case LND has
-                // auto-refunded no matter what this RPC reports and the
-                // state must be fixed regardless.
+                // HTLC is verifiably past its CLTV lifetime on-chain, in
+                // which case LND has auto-refunded no matter what this
+                // RPC reports and the state must be fixed regardless.
                 if let Err(e) = escrow.cancel_hold_invoice(&hash).await {
-                    let past_hard = util::escrow_hard_deadline_unix(order.invoice_held_at, cltv)
-                        .map(|deadline| now >= deadline)
-                        .unwrap_or(false);
                     match bond::flow::classify_cancel_error(&e) {
                         bond::flow::CancelOutcome::AlreadyDone => {
                             info!(
@@ -691,7 +734,7 @@ async fn enforce_escrow_deadline_pass(
                                 order.id
                             );
                         }
-                        bond::flow::CancelOutcome::Transient if !past_hard => {
+                        bond::flow::CancelOutcome::Transient if !escrow_gone => {
                             warn!(
                                 "escrow_deadline: cancel_hold_invoice failed for order {} ({e}); retrying next tick",
                                 order.id
@@ -700,7 +743,7 @@ async fn enforce_escrow_deadline_pass(
                         }
                         bond::flow::CancelOutcome::Transient => {
                             warn!(
-                                "escrow_deadline: cancel_hold_invoice failed for order {} ({e}) but the CLTV horizon passed; the escrow is auto-refunded — fixing state",
+                                "escrow_deadline: cancel_hold_invoice failed for order {} ({e}) but the HTLC is past its CLTV expiry height; the escrow is auto-refunded — fixing state",
                                 order.id
                             );
                         }
@@ -759,8 +802,14 @@ async fn enforce_escrow_deadline_pass(
                             Ok(DisputeStatus::Initiated | DisputeStatus::InProgress)
                         ) =>
                     {
-                        // A solver is already in the loop; nothing to add.
-                        continue;
+                        // The query only returns `fiat-sent` orders, so a
+                        // live dispute row here means a previous pass (or
+                        // a user-filed dispute) died between writing the
+                        // row and flipping the order. Resume with the
+                        // existing row and finish the transition below —
+                        // skipping would strand the order in `fiat-sent`
+                        // with nobody notified.
+                        dispute
                     }
                     Ok(mut dispute) => {
                         dispute.status = DisputeStatus::Initiated.to_string();
@@ -823,27 +872,29 @@ async fn enforce_escrow_deadline_pass(
                     "escrow_deadline: order {} moved to dispute — fiat claimed sent and the escrow is near its CLTV horizon",
                     order.id
                 );
-                if let (Ok(buyer), Ok(seller)) =
-                    (order.get_buyer_pubkey(), order.get_seller_pubkey())
-                {
-                    enqueue_order_msg(
-                        None,
-                        Some(order.id),
-                        Action::DisputeInitiatedByYou,
-                        Some(Payload::Dispute(dispute.id, None)),
-                        buyer,
-                        None,
-                    )
-                    .await;
-                    enqueue_order_msg(
-                        None,
-                        Some(order.id),
-                        Action::DisputeInitiatedByPeer,
-                        Some(Payload::Dispute(dispute.id, None)),
-                        seller,
-                        None,
-                    )
-                    .await;
+                // A missing party key must not mute the other party's
+                // notification, mirroring `flow::hold_invoice_canceled`.
+                for (party, action) in [
+                    (order.get_buyer_pubkey(), Action::DisputeInitiatedByYou),
+                    (order.get_seller_pubkey(), Action::DisputeInitiatedByPeer),
+                ] {
+                    match party {
+                        Ok(party) => {
+                            enqueue_order_msg(
+                                None,
+                                Some(order.id),
+                                action,
+                                Some(Payload::Dispute(dispute.id, None)),
+                                party,
+                                None,
+                            )
+                            .await;
+                        }
+                        Err(e) => warn!(
+                            "escrow_deadline: could not resolve a party key for order {} ({e}); that party is not notified",
+                            order.id
+                        ),
+                    }
                 }
                 // Best-effort: the dispute row is durable either way, and
                 // solvers can also enumerate disputes from the admin RPC.
@@ -1256,6 +1307,9 @@ mod tests {
     struct StubEscrow {
         cancel_error: Option<&'static str>,
         canceled: std::sync::Mutex<Vec<String>>,
+        /// `(chain tip, HTLC expiry lookup result)`. `None` = no chain
+        /// view (both probes error), driving the nominal-time fallback.
+        heights: Option<(u32, Option<u32>)>,
     }
 
     impl StubEscrow {
@@ -1263,6 +1317,7 @@ mod tests {
             Self {
                 cancel_error: None,
                 canceled: std::sync::Mutex::new(Vec::new()),
+                heights: None,
             }
         }
 
@@ -1270,7 +1325,13 @@ mod tests {
             Self {
                 cancel_error: Some(msg),
                 canceled: std::sync::Mutex::new(Vec::new()),
+                heights: None,
             }
+        }
+
+        fn with_heights(mut self, chain: u32, expiry: Option<u32>) -> Self {
+            self.heights = Some((chain, expiry));
+            self
         }
 
         fn canceled(&self) -> Vec<String> {
@@ -1300,6 +1361,21 @@ mod tests {
                 ))),
                 None => Ok(()),
             }
+        }
+
+        async fn chain_height(&mut self) -> Result<u32, MostroError> {
+            self.heights.map(|(chain, _)| chain).ok_or_else(|| {
+                MostroInternalErr(ServiceError::LnNodeError("no chain view".to_string()))
+            })
+        }
+
+        async fn hold_invoice_expiry_height(
+            &mut self,
+            _hash: &str,
+        ) -> Result<Option<u32>, MostroError> {
+            self.heights.map(|(_, expiry)| expiry).ok_or_else(|| {
+                MostroInternalErr(ServiceError::LnNodeError("no chain view".to_string()))
+            })
         }
     }
 
@@ -1435,14 +1511,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn escrow_deadline_leaves_an_existing_dispute_to_the_solver() {
+    async fn escrow_deadline_resumes_a_half_completed_dispute_transition() {
         let ctx = escrow_guardian_ctx(144, 24).await;
         let now = Utc::now().timestamp();
         let order = escrow_backed_order(Status::FiatSent, now - 80_000)
             .create(ctx.pool())
             .await
             .unwrap();
-        Dispute::new(order.id, order.status.clone())
+        // An `initiated` dispute row on a still-`fiat-sent` order can only
+        // mean a previous pass (or a user dispute) died between the two
+        // writes: the pass must finish the transition, not skip it.
+        let prior = Dispute::new(order.id, order.status.clone())
             .create(ctx.pool())
             .await
             .unwrap();
@@ -1453,9 +1532,16 @@ mod tests {
             .unwrap();
 
         let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
-        assert_eq!(updated.status, Status::FiatSent.to_string());
+        assert_eq!(updated.status, Status::Dispute.to_string());
+        let dispute = find_dispute_by_order_id(ctx.pool(), order.id)
+            .await
+            .unwrap();
+        assert_eq!(dispute.id, prior.id, "the existing row is reused");
+        assert_eq!(dispute.status, DisputeStatus::Initiated.to_string());
         assert!(escrow.canceled().is_empty());
-        assert!(queued_actions_for(order.id).await.is_empty());
+        let actions = queued_actions_for(order.id).await;
+        assert!(actions.contains(&Action::DisputeInitiatedByYou));
+        assert!(actions.contains(&Action::DisputeInitiatedByPeer));
     }
 
     #[tokio::test]
@@ -1493,6 +1579,118 @@ mod tests {
         let actions = queued_actions_for(order.id).await;
         assert!(actions.contains(&Action::DisputeInitiatedByYou));
         assert!(actions.contains(&Action::DisputeInitiatedByPeer));
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_acts_on_chain_height_when_blocks_run_fast() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        // Only 40_000s elapsed — inside the nominal 72_000s window — but
+        // the chain says the HTLC is within the 24-block margin of its
+        // expiry: blocks came in fast, and the guardian must act now.
+        let order = escrow_backed_order(Status::Active, now - 40_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::ok().with_heights(900_000, Some(900_010));
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Canceled.to_string());
+        assert_eq!(escrow.canceled(), vec![order.hash.clone().unwrap()]);
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_trusts_a_live_htlc_over_the_nominal_clock() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        // The nominal clock says long overdue, but the chain shows the
+        // HTLC still 100 blocks from expiry (slow blocks, or a payer that
+        // chose a larger final CLTV delta): nothing to do yet.
+        let order = escrow_backed_order(Status::Active, now - 200_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::ok().with_heights(900_000, Some(900_100));
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
+        assert!(escrow.canceled().is_empty());
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_retries_transient_cancel_while_the_htlc_is_alive() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        // Past the nominal hard horizon (86_400s), but the chain shows the
+        // accepted HTLC still alive (10 blocks left): a transient cancel
+        // failure must NOT be taken as proof of an auto-refund — the order
+        // stays eligible and is retried.
+        let order = escrow_backed_order(Status::Active, now - 90_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::failing("transport: connection refused")
+            .with_heights(900_000, Some(900_010));
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
+        assert!(queued_actions_for(order.id).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_fixes_state_when_no_htlc_backs_the_invoice() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        // LND reports no accepted HTLC behind the invoice: the escrow is
+        // verifiably gone, so even a transient cancel error must not keep
+        // the order looking live.
+        let order = escrow_backed_order(Status::Active, now - 40_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow =
+            StubEscrow::failing("transport: connection refused").with_heights(900_000, None);
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Canceled.to_string());
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_never_assumes_refund_without_chain_evidence() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        // No chain view at all and a transient cancel failure, way past
+        // the nominal hard horizon: the old timestamp-based inference
+        // would have marked the order canceled; now only chain evidence
+        // (or an already-canceled report) may fix state.
+        let order = escrow_backed_order(Status::Active, now - 90_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::failing("transport: connection refused");
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
     }
 
     #[tokio::test]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -4,6 +4,7 @@ use crate::app::dev_fee::run_dev_fee_cycle;
 use crate::app::release::do_payment;
 use crate::config;
 use crate::db::*;
+use crate::escrow::EscrowBackend;
 use crate::lightning::LndConnector;
 use crate::price::PriceManager;
 use crate::util;
@@ -38,6 +39,7 @@ pub async fn start_scheduler(ctx: AppContext) {
     // `false`, so every job below still starts exactly as before).
     if !Settings::is_cashu_enabled() {
         job_cancel_orders(ctx.clone()).await;
+        job_enforce_escrow_deadline(ctx.clone()).await;
         job_retry_failed_payments(ctx.clone()).await;
         job_process_dev_fee_payment(ctx.clone()).await;
         job_process_bond_payouts(ctx.clone()).await;
@@ -271,7 +273,7 @@ async fn job_update_rate_events(ctx: AppContext) {
     });
 }
 
-async fn notify_users_canceled_order(
+pub(crate) async fn notify_users_canceled_order(
     updated_order: &Order,
     old_order: &Order,
     maker_action: Option<Action>,
@@ -594,6 +596,271 @@ async fn job_cancel_orders(ctx: AppContext) {
             tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
         }
     });
+}
+
+/// Guardian for the trade escrow's CLTV lifetime.
+///
+/// A trade's escrow is a hold invoice whose HTLC LND auto-cancels
+/// `invoices.holdexpirydelta` blocks (default 12) before its CLTV expiry,
+/// refunding the seller — while the order still reads `active` /
+/// `fiat-sent` and the buyer may still send (or already sent) the fiat
+/// leg. No other job covers those states, so without this pass the escrow
+/// silently evaporates ~`hold_invoice_cltv_delta - 12` blocks after the
+/// seller paid (~22 h on defaults) and the trade can no longer settle:
+/// the buyer loses the fiat and the seller keeps both the fiat and the
+/// refunded sats.
+///
+/// Each tick, orders past their action deadline
+/// ([`util::escrow_action_deadline_unix`], the horizon minus
+/// `escrow_deadline_margin_blocks`) are resolved while the escrow still
+/// exists:
+///
+/// - `active` — nobody claims the fiat moved: cancel the hold invoice
+///   proactively (a clean, observed refund instead of LND's silent one),
+///   move the order to `canceled`, notify both parties.
+/// - `fiat-sent` — the buyer says the fiat moved: open a dispute so a
+///   solver can settle or cancel *while the escrow is still settleable*.
+///   The hold invoice is deliberately NOT canceled here.
+async fn job_enforce_escrow_deadline(ctx: AppContext) {
+    let mut ln_client = if let Ok(client) = LndConnector::new().await {
+        client
+    } else {
+        return error!("Failed to create LND client");
+    };
+
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = enforce_escrow_deadline_pass(&ctx, &mut ln_client).await {
+                error!("escrow deadline pass failed: {e}");
+            }
+            tokio::time::sleep(tokio::time::Duration::from_secs(300)).await;
+        }
+    });
+}
+
+/// One guardian tick, split out for testing. See
+/// [`job_enforce_escrow_deadline`] for the semantics.
+async fn enforce_escrow_deadline_pass(
+    ctx: &AppContext,
+    escrow: &mut dyn EscrowBackend,
+) -> Result<(), MostroError> {
+    let pool = ctx.pool();
+    let keys = ctx.keys().clone();
+    let now = Utc::now().timestamp();
+    let ln_settings = &ctx.settings().lightning;
+    let cltv = ln_settings.hold_invoice_cltv_delta;
+    let margin = ln_settings.escrow_deadline_margin_blocks;
+
+    // Acting cutoff: escrows observed paid at or before this timestamp are
+    // due — their action deadline (held_at + guard window) is now or past.
+    let cutoff = now - util::escrow_guard_window_secs(cltv, margin);
+    let due_orders = find_escrow_deadline_orders(pool, cutoff).await?;
+
+    for order in due_orders {
+        let status = match order.get_order_status() {
+            Ok(status) => status,
+            Err(e) => {
+                warn!(
+                    "escrow_deadline: unparseable status on order {} ({e}); skipping",
+                    order.id
+                );
+                continue;
+            }
+        };
+        let hash = match order.hash.as_ref() {
+            Some(hash) => hash.clone(),
+            None => continue, // query guarantees one; defensive
+        };
+
+        match status {
+            Status::Active => {
+                // Cancel proactively so the seller's refund is clean and
+                // observed rather than LND's silent auto-cancel. On
+                // failure, stay eligible and retry next tick — unless the
+                // hard horizon already passed, in which case LND has
+                // auto-refunded no matter what this RPC reports and the
+                // state must be fixed regardless.
+                if let Err(e) = escrow.cancel_hold_invoice(&hash).await {
+                    let past_hard = util::escrow_hard_deadline_unix(order.invoice_held_at, cltv)
+                        .map(|deadline| now >= deadline)
+                        .unwrap_or(false);
+                    match bond::flow::classify_cancel_error(&e) {
+                        bond::flow::CancelOutcome::AlreadyDone => {
+                            info!(
+                                "escrow_deadline: order {} hold invoice already canceled at LND; fixing state",
+                                order.id
+                            );
+                        }
+                        bond::flow::CancelOutcome::Transient if !past_hard => {
+                            warn!(
+                                "escrow_deadline: cancel_hold_invoice failed for order {} ({e}); retrying next tick",
+                                order.id
+                            );
+                            continue;
+                        }
+                        bond::flow::CancelOutcome::Transient => {
+                            warn!(
+                                "escrow_deadline: cancel_hold_invoice failed for order {} ({e}) but the CLTV horizon passed; the escrow is auto-refunded — fixing state",
+                                order.id
+                            );
+                        }
+                    }
+                }
+
+                let updated = match update_order_event(&keys, Status::Canceled, &order).await {
+                    Ok(updated) => updated,
+                    Err(e) => {
+                        warn!(
+                            "escrow_deadline: could not publish cancel for order {} ({e}); retrying next tick",
+                            order.id
+                        );
+                        continue;
+                    }
+                };
+                let updated = match updated.update(pool).await {
+                    Ok(updated) => updated,
+                    Err(e) => {
+                        // Next tick retries: the order is still eligible, and
+                        // the repeated cancel reports already-done, so the
+                        // pass proceeds straight back here.
+                        warn!(
+                            "escrow_deadline: persist failed for order {} ({e}); retrying next tick",
+                            order.id
+                        );
+                        continue;
+                    }
+                };
+                info!(
+                    "escrow_deadline: order {} canceled — trade escrow reached its CLTV lifetime",
+                    order.id
+                );
+                notify_users_canceled_order(&updated, &order, Some(Action::Canceled)).await;
+                // Idempotent close of any range maker bond, mirroring the
+                // waiting-state timeout path.
+                bond::resolve_range_maker_bond_at_close_or_warn(pool, &order, "escrow_deadline")
+                    .await;
+            }
+            Status::FiatSent => {
+                // The fiat leg may already be with the seller — only a
+                // human can resolve this, and only while the escrow still
+                // exists. Open (or reopen) the dispute now; do NOT cancel
+                // the hold invoice, it is the solver's only leverage.
+                //
+                // There is at most one dispute row per order, and resolved
+                // disputes keep theirs (`settled` / `seller-refunded` /
+                // `released`), so an existence check is not enough: a row
+                // left over from a dispute the users resolved themselves
+                // earlier in the trade must be reopened, not mistaken for
+                // a solver already working.
+                let dispute = match find_dispute_by_order_id(pool, order.id).await {
+                    Ok(dispute)
+                        if matches!(
+                            dispute.status.parse(),
+                            Ok(DisputeStatus::Initiated | DisputeStatus::InProgress)
+                        ) =>
+                    {
+                        // A solver is already in the loop; nothing to add.
+                        continue;
+                    }
+                    Ok(mut dispute) => {
+                        dispute.status = DisputeStatus::Initiated.to_string();
+                        dispute.solver_pubkey = None;
+                        dispute.taken_at = 0;
+                        dispute.order_previous_status = order.status.clone();
+                        match dispute.update(pool).await {
+                            Ok(dispute) => dispute,
+                            Err(e) => {
+                                warn!(
+                                    "escrow_deadline: could not reopen dispute for order {} ({e}); retrying next tick",
+                                    order.id
+                                );
+                                continue;
+                            }
+                        }
+                    }
+                    Err(_) => {
+                        // The buyer's claim is the one at stake, so the
+                        // dispute is filed as buyer-initiated. Row first,
+                        // then the status flip: a dispute row pointing at a
+                        // `fiat-sent` order is recoverable (the next tick
+                        // sees it and stops), a `dispute` order with no row
+                        // would be invisible.
+                        match Dispute::new(order.id, order.status.clone())
+                            .create(pool)
+                            .await
+                        {
+                            Ok(dispute) => dispute,
+                            Err(e) => {
+                                warn!(
+                                    "escrow_deadline: could not create dispute for order {} ({e}); retrying next tick",
+                                    order.id
+                                );
+                                continue;
+                            }
+                        }
+                    }
+                };
+                let mut disputed = order.clone();
+                if disputed.buyer_dispute {
+                    // The buyer flag is already set by the earlier dispute
+                    // this row was reopened from; just move the status back.
+                    disputed.status = Status::Dispute.to_string();
+                } else if let Err(e) = disputed.setup_dispute(true) {
+                    warn!(
+                        "escrow_deadline: could not move order {} to dispute ({e:?}); retrying next tick",
+                        order.id
+                    );
+                    continue;
+                }
+                if let Err(e) = disputed.update(pool).await {
+                    warn!(
+                        "escrow_deadline: could not persist dispute status for order {} ({e}); retrying next tick",
+                        order.id
+                    );
+                    continue;
+                }
+                info!(
+                    "escrow_deadline: order {} moved to dispute — fiat claimed sent and the escrow is near its CLTV horizon",
+                    order.id
+                );
+                if let (Ok(buyer), Ok(seller)) =
+                    (order.get_buyer_pubkey(), order.get_seller_pubkey())
+                {
+                    enqueue_order_msg(
+                        None,
+                        Some(order.id),
+                        Action::DisputeInitiatedByYou,
+                        Some(Payload::Dispute(dispute.id, None)),
+                        buyer,
+                        None,
+                    )
+                    .await;
+                    enqueue_order_msg(
+                        None,
+                        Some(order.id),
+                        Action::DisputeInitiatedByPeer,
+                        Some(Payload::Dispute(dispute.id, None)),
+                        seller,
+                        None,
+                    )
+                    .await;
+                }
+                // Best-effort: the dispute row is durable either way, and
+                // solvers can also enumerate disputes from the admin RPC.
+                if let Err(e) =
+                    crate::app::dispute::publish_dispute_event(ctx, &dispute, &keys, true).await
+                {
+                    warn!(
+                        "escrow_deadline: could not publish the dispute event for order {} ({e})",
+                        order.id
+                    );
+                }
+            }
+            _ => {} // the query only returns active / fiat-sent
+        }
+    }
+
+    Ok(())
 }
 
 async fn job_expire_pending_older_orders(ctx: AppContext) {
@@ -982,6 +1249,270 @@ mod tests {
         let order = order_for_cancel(Kind::Sell, false);
         notify_users_canceled_order(&order, &order, None).await;
         assert!(queued_actions_for(order.id).await.is_empty());
+    }
+
+    // ── enforce_escrow_deadline_pass ─────────────────────────────────────
+
+    struct StubEscrow {
+        cancel_error: Option<&'static str>,
+        canceled: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl StubEscrow {
+        fn ok() -> Self {
+            Self {
+                cancel_error: None,
+                canceled: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn failing(msg: &'static str) -> Self {
+            Self {
+                cancel_error: Some(msg),
+                canceled: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+
+        fn canceled(&self) -> Vec<String> {
+            self.canceled.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl EscrowBackend for StubEscrow {
+        async fn create_hold_invoice(
+            &mut self,
+            _description: &str,
+            _amount: i64,
+        ) -> Result<(String, Vec<u8>, Vec<u8>), MostroError> {
+            unreachable!("the guardian never creates invoices")
+        }
+
+        async fn settle_hold_invoice(&mut self, _preimage: &str) -> Result<(), MostroError> {
+            unreachable!("the guardian never settles")
+        }
+
+        async fn cancel_hold_invoice(&mut self, hash: &str) -> Result<(), MostroError> {
+            self.canceled.lock().unwrap().push(hash.to_string());
+            match self.cancel_error {
+                Some(msg) => Err(MostroInternalErr(ServiceError::LnNodeError(
+                    msg.to_string(),
+                ))),
+                None => Ok(()),
+            }
+        }
+    }
+
+    async fn escrow_guardian_ctx(cltv: u32, margin: u32) -> AppContext {
+        init_test_settings();
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        let mut settings = test_settings();
+        settings.lightning.hold_invoice_cltv_delta = cltv;
+        settings.lightning.escrow_deadline_margin_blocks = margin;
+        TestContextBuilder::new()
+            .with_pool(Arc::new(pool))
+            .with_settings(settings)
+            .build()
+    }
+
+    fn escrow_backed_order(status: Status, held_at: i64) -> Order {
+        Order {
+            id: Uuid::new_v4(),
+            kind: Kind::Sell.to_string(),
+            status: status.to_string(),
+            buyer_pubkey: Some(hex_key()),
+            seller_pubkey: Some(hex_key()),
+            creator_pubkey: hex_key(),
+            fiat_code: "USD".to_string(),
+            payment_method: "bank".to_string(),
+            hash: Some("ab".repeat(32)),
+            preimage: Some("cd".repeat(32)),
+            invoice_held_at: held_at,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_cancels_due_active_order_and_refunds_seller() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        // Guard window is (144 - 24) * 600 = 72_000s; this escrow was
+        // observed 80_000s ago, so it is due.
+        let order = escrow_backed_order(Status::Active, now - 80_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::ok();
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Canceled.to_string());
+        assert_eq!(
+            escrow.canceled(),
+            vec![order.hash.clone().unwrap()],
+            "the hold invoice must be canceled proactively, before LND does it"
+        );
+        let actions = queued_actions_for(order.id).await;
+        assert_eq!(actions.len(), 2, "both parties must be told: {actions:?}");
+        assert!(actions.iter().all(|a| *a == Action::Canceled));
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_retries_when_cancel_fails_before_the_horizon() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        // Due (past the 72_000s action window) but the 86_400s hard horizon
+        // has not passed: a transient LND failure must leave the order
+        // eligible for the next tick instead of stranding it.
+        let order = escrow_backed_order(Status::Active, now - 80_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::failing("transport: connection refused");
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
+        assert!(queued_actions_for(order.id).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_fixes_state_when_lnd_already_canceled() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        let order = escrow_backed_order(Status::Active, now - 80_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::failing("invoice already canceled");
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(
+            updated.status,
+            Status::Canceled.to_string(),
+            "the HTLC is verifiably gone — the order must not keep looking live"
+        );
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_opens_dispute_on_fiat_sent_without_touching_escrow() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        let order = escrow_backed_order(Status::FiatSent, now - 80_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::ok();
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Dispute.to_string());
+        assert!(
+            find_dispute_by_order_id(ctx.pool(), order.id).await.is_ok(),
+            "a solver must be able to pick up the dispute"
+        );
+        assert!(
+            escrow.canceled().is_empty(),
+            "the escrow is the solver's only leverage — never canceled here"
+        );
+        let actions = queued_actions_for(order.id).await;
+        assert!(actions.contains(&Action::DisputeInitiatedByYou));
+        assert!(actions.contains(&Action::DisputeInitiatedByPeer));
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_leaves_an_existing_dispute_to_the_solver() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        let order = escrow_backed_order(Status::FiatSent, now - 80_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        Dispute::new(order.id, order.status.clone())
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::ok();
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::FiatSent.to_string());
+        assert!(escrow.canceled().is_empty());
+        assert!(queued_actions_for(order.id).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_reopens_a_dispute_the_users_resolved_themselves() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        let order = escrow_backed_order(Status::FiatSent, now - 80_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        // A dispute the users resolved cooperatively earlier in the trade:
+        // its row lingers with a terminal status and must not masquerade
+        // as a solver already working on the escrow deadline.
+        let mut prior = Dispute::new(order.id, order.status.clone());
+        prior.status = DisputeStatus::Settled.to_string();
+        prior.solver_pubkey = Some(hex_key());
+        prior.taken_at = now - 90_000;
+        let prior = prior.create(ctx.pool()).await.unwrap();
+        let mut escrow = StubEscrow::ok();
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Dispute.to_string());
+        let dispute = find_dispute_by_order_id(ctx.pool(), order.id)
+            .await
+            .unwrap();
+        assert_eq!(dispute.id, prior.id, "one dispute row per order, reopened");
+        assert_eq!(dispute.status, DisputeStatus::Initiated.to_string());
+        assert_eq!(dispute.solver_pubkey, None);
+        assert_eq!(dispute.taken_at, 0);
+        assert!(escrow.canceled().is_empty());
+        let actions = queued_actions_for(order.id).await;
+        assert!(actions.contains(&Action::DisputeInitiatedByYou));
+        assert!(actions.contains(&Action::DisputeInitiatedByPeer));
+    }
+
+    #[tokio::test]
+    async fn escrow_deadline_ignores_orders_inside_the_window() {
+        let ctx = escrow_guardian_ctx(144, 24).await;
+        let now = Utc::now().timestamp();
+        // Only 1_000s into the 72_000s guard window: not due.
+        let order = escrow_backed_order(Status::Active, now - 1_000)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+        let mut escrow = StubEscrow::ok();
+
+        enforce_escrow_deadline_pass(&ctx, &mut escrow)
+            .await
+            .unwrap();
+
+        let updated = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(updated.status, Status::Active.to_string());
+        assert!(escrow.canceled().is_empty());
     }
 
     // ── job smoke tests ──────────────────────────────────────────────────

--- a/src/util.rs
+++ b/src/util.rs
@@ -1336,8 +1336,11 @@ pub async fn settle_seller_hold_invoice(
 }
 
 /// Nominal seconds per block for CLTV-horizon math (10 min). Bitcoin's
-/// long-run average; the configured safety margin absorbs short-run
-/// variance, so the daemon always acts *before* LND's auto-cancel.
+/// long-run average. Time-based deadlines derived from it are only an
+/// approximation of the real, block-height-measured CLTV horizon — the
+/// escrow-deadline guardian consults the chain height and the accepted
+/// HTLC's actual expiry height when LND can answer, and falls back to
+/// this nominal clock only when it cannot.
 const SECS_PER_BLOCK: i64 = 600;
 
 /// Seconds between the escrow payment and the moment the deadline
@@ -1358,23 +1361,12 @@ pub fn escrow_guard_window_secs(cltv_delta_blocks: u32, margin_blocks: u32) -> i
     i64::from(cltv_delta_blocks - effective_margin) * SECS_PER_BLOCK
 }
 
-/// Unix timestamp at which the order's trade escrow is gone for sure:
-/// LND auto-cancels an accepted hold invoice `invoices.holdexpirydelta`
-/// blocks before the HTLC expires, and a compliant sender sets that
-/// expiry at least `hold_invoice_cltv_delta` blocks after the HTLC
-/// locked in (`invoice_held_at`). A larger sender-chosen delta only
-/// moves this later, so the value is a safe lower bound. `None` when
-/// `invoice_held_at` is 0 (escrow never observed — nothing to protect).
-pub fn escrow_hard_deadline_unix(invoice_held_at: i64, cltv_delta_blocks: u32) -> Option<i64> {
-    if invoice_held_at == 0 {
-        return None;
-    }
-    Some(invoice_held_at + i64::from(cltv_delta_blocks) * SECS_PER_BLOCK)
-}
-
 /// Unix timestamp from which the escrow-deadline guardian acts on an
-/// order: the hard deadline minus the safety margin. `None` when
-/// `invoice_held_at` is 0.
+/// order when no chain view is available: the nominal CLTV horizon minus
+/// the safety margin, measured in 10-minute blocks from the moment the
+/// escrow was observed (`invoice_held_at`). Only a fallback — the real
+/// deadline is the accepted HTLC's expiry height vs the chain tip.
+/// `None` when `invoice_held_at` is 0 (escrow never observed).
 pub fn escrow_action_deadline_unix(
     invoice_held_at: i64,
     cltv_delta_blocks: u32,
@@ -2908,8 +2900,6 @@ mod tests {
         // never firing on brand-new escrows.
         assert_eq!(escrow_guard_window_secs(144, 144), 43_200);
         assert_eq!(escrow_guard_window_secs(144, 1_000), 43_200);
-        assert_eq!(escrow_hard_deadline_unix(0, 144), None);
-        assert_eq!(escrow_hard_deadline_unix(1_000, 144), Some(1_000 + 86_400));
         assert_eq!(escrow_action_deadline_unix(0, 144, 24), None);
         assert_eq!(
             escrow_action_deadline_unix(1_000, 144, 24),

--- a/src/util.rs
+++ b/src/util.rs
@@ -1175,7 +1175,14 @@ pub async fn invoice_subscribe(hash: Vec<u8>, request_id: Option<u64>) -> Result
                     }
                 } else if msg.state == InvoiceState::Canceled {
                     // If the payment was canceled
-                    if let Err(e) = flow::hold_invoice_canceled(&hash, &pool).await {
+                    let keys = match get_keys() {
+                        Ok(k) => k,
+                        Err(e) => {
+                            info!("Failed to get keys: {e}");
+                            continue;
+                        }
+                    };
+                    if let Err(e) = flow::hold_invoice_canceled(&hash, &pool, keys).await {
                         info!("Invoice flow error {e}");
                     }
                 } else {
@@ -1326,6 +1333,57 @@ pub async fn settle_seller_hold_invoice(
         return Err(MostroCantDo(CantDoReason::InvalidInvoice));
     }
     Ok(())
+}
+
+/// Nominal seconds per block for CLTV-horizon math (10 min). Bitcoin's
+/// long-run average; the configured safety margin absorbs short-run
+/// variance, so the daemon always acts *before* LND's auto-cancel.
+const SECS_PER_BLOCK: i64 = 600;
+
+/// Seconds between the escrow payment and the moment the deadline
+/// guardian acts: `(cltv_delta - margin)` blocks. A misconfigured margin
+/// `>= cltv_delta` would make the guardian fire on brand-new escrows, so
+/// it is clamped to half the window (loudly) instead of being honored.
+pub fn escrow_guard_window_secs(cltv_delta_blocks: u32, margin_blocks: u32) -> i64 {
+    let effective_margin = if margin_blocks >= cltv_delta_blocks {
+        tracing::error!(
+            "escrow_deadline_margin_blocks ({margin_blocks}) must be below \
+             hold_invoice_cltv_delta ({cltv_delta_blocks}); clamping to half \
+             the window"
+        );
+        cltv_delta_blocks / 2
+    } else {
+        margin_blocks
+    };
+    i64::from(cltv_delta_blocks - effective_margin) * SECS_PER_BLOCK
+}
+
+/// Unix timestamp at which the order's trade escrow is gone for sure:
+/// LND auto-cancels an accepted hold invoice `invoices.holdexpirydelta`
+/// blocks before the HTLC expires, and a compliant sender sets that
+/// expiry at least `hold_invoice_cltv_delta` blocks after the HTLC
+/// locked in (`invoice_held_at`). A larger sender-chosen delta only
+/// moves this later, so the value is a safe lower bound. `None` when
+/// `invoice_held_at` is 0 (escrow never observed — nothing to protect).
+pub fn escrow_hard_deadline_unix(invoice_held_at: i64, cltv_delta_blocks: u32) -> Option<i64> {
+    if invoice_held_at == 0 {
+        return None;
+    }
+    Some(invoice_held_at + i64::from(cltv_delta_blocks) * SECS_PER_BLOCK)
+}
+
+/// Unix timestamp from which the escrow-deadline guardian acts on an
+/// order: the hard deadline minus the safety margin. `None` when
+/// `invoice_held_at` is 0.
+pub fn escrow_action_deadline_unix(
+    invoice_held_at: i64,
+    cltv_delta_blocks: u32,
+    margin_blocks: u32,
+) -> Option<i64> {
+    if invoice_held_at == 0 {
+        return None;
+    }
+    Some(invoice_held_at + escrow_guard_window_secs(cltv_delta_blocks, margin_blocks))
 }
 
 pub fn bytes_to_string(bytes: &[u8]) -> String {
@@ -2840,6 +2898,23 @@ mod tests {
             identity: trade.public_key(),
             created_at: Timestamp::now(),
         }
+    }
+
+    #[test]
+    fn escrow_deadline_math_matches_the_cltv_horizon() {
+        // 10-minute blocks: (144 - 24) * 600.
+        assert_eq!(escrow_guard_window_secs(144, 24), 72_000);
+        // A margin at/above the window clamps to half — never negative,
+        // never firing on brand-new escrows.
+        assert_eq!(escrow_guard_window_secs(144, 144), 43_200);
+        assert_eq!(escrow_guard_window_secs(144, 1_000), 43_200);
+        assert_eq!(escrow_hard_deadline_unix(0, 144), None);
+        assert_eq!(escrow_hard_deadline_unix(1_000, 144), Some(1_000 + 86_400));
+        assert_eq!(escrow_action_deadline_unix(0, 144, 24), None);
+        assert_eq!(
+            escrow_action_deadline_unix(1_000, 144, 24),
+            Some(1_000 + 72_000)
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Third finding from the security review (#851, #853 landed before).

LND auto-cancels an **accepted** hold invoice `invoices.holdexpirydelta` blocks (default 12) before the HTLC's CLTV expiry, refunding the seller off-chain. mostrod only *logged* that cancellation, and no scheduler job covered `Active`/`FiatSent` orders — so with the default `hold_invoice_cltv_delta = 144`, **~22 hours after the seller paid, the trade escrow silently evaporated while the order still looked live**. A buyer who sent fiat after (or before) that point lost it: `release` fails with "invoice already canceled", a dispute can't help (`admin_settle` settles the same dead invoice), and a malicious seller keeps both the fiat and the refunded sats. No attacker sophistication needed — just stalling.

## The fix — two layers

**1. Guardian job** (`job_enforce_escrow_deadline`, Lightning mode only, 5-min tick). At `cltv_delta - escrow_deadline_margin_blocks` blocks after the escrow was observed paid, it resolves the trade **while the escrow still exists**:

- `active` — nobody claims fiat moved: cancel the hold invoice proactively (clean, observed refund instead of LND's silent one), order → `canceled`, both parties notified, range maker bonds closed like the waiting-state timeout path. Cancel failures use the bond module's `classify_cancel_error`: already-done proceeds, transient retries next tick — unless the hard horizon already passed, in which case the state is fixed regardless.
- `fiat-sent` — the fiat leg may already be with the seller: open a dispute **without touching the escrow** (it is the solver's only leverage). A dispute already *open* is left alone; a row left over from a dispute the users resolved themselves is **reopened** (there is at most one dispute row per order); otherwise a fresh buyer-initiated dispute is created, both parties are notified, and the dispute event is published best-effort.

**2. Reactive handler** (`hold_invoice_canceled`). Covers the daemon-down window: when a cancel lands on an escrow-backed order (`Active`/`FiatSent`/`Dispute`) **past** the guardian's action deadline — e.g. the restart replay of an LND auto-cancel — it now notifies both parties (`HoldInvoicePaymentCanceled`), raises an operator-facing `error!`, and closes `Active` orders instead of leaving them looking live. Before the deadline it stays log-only, so in-flight cooperative/admin cancels are not misread as evaporations.

## Config change

New `[lightning]` setting **`escrow_deadline_margin_blocks`** (default 24, serde-defaulted so existing `settings.toml` files keep working). It must exceed the LND node's `invoices.holdexpirydelta` (LND default 12); a misconfigured margin `>= hold_invoice_cltv_delta` is clamped to half the window with an `error!` instead of firing on brand-new escrows. Documented in `settings.tpl.toml` and `docs/STARTUP_AND_CONFIG.md`.

**Intentional behavior change:** `Active` trades no longer linger indefinitely — they are canceled at ~`cltv_delta - margin` blocks (~20 h on defaults). Operators with slow fiat rails can raise `hold_invoice_cltv_delta`.

## Compatibility note

No wire-format or tag changes. Clients may observe existing actions in new situations: `HoldInvoicePaymentCanceled` (previously never emitted), `Canceled` for expired-escrow trades, and daemon-initiated `DisputeInitiatedByYou`/`DisputeInitiatedByPeer`.

## Tests

Written against the unfixed code first where applicable (the PoC for the finding demonstrated `hold_invoice_canceled` leaving a `FiatSent` order untouched and `release` failing on a canceled invoice):

- `db`: `find_escrow_deadline_orders` selects exactly the due `active`/`fiat-sent` rows with a hash (excludes `dispute`, waiting states, no-hash, `invoice_held_at = 0`, not-yet-due).
- `util`: pure CLTV-deadline math, including the misconfiguration clamp.
- `flow`: `hold_invoice_canceled` closes a past-deadline `Active` order, ignores pre-deadline cancels, leaves `FiatSent` for a human, and keeps the legacy no-op when `invoice_held_at = 0`.
- `scheduler`: the guardian pass with a stub escrow — due `Active` canceled + seller refunded + parties notified; transient cancel failure before the horizon retries without state change; already-canceled at LND still fixes state; `FiatSent` opens a dispute and never touches the escrow; an open dispute is left to the solver; a resolved dispute is reopened; inside-window orders untouched.

```text
cargo test --bin mostrod          # 1133 passed, 0 failed, 2 ignored
cargo clippy --all-targets --all-features   # clean
cargo fmt --all -- --check                  # clean
```

## Not covered here

Orders already in `Dispute` are not touched by the guardian (a human is already in the loop); if the solver does not act before the horizon, the reactive path raises the operator alarm. A client-side display of the per-trade escrow deadline (the daemon already advertises `hold_invoice_cltv_delta` in the info event) is follow-up material. The LND auto-cancel behavior (`InvoiceExpiryWatcher`, `holdexpirydelta = 12` default since v0.13) was code-verified upstream, not exercised against a live node here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable escrow deadline safety margins, defaulting to 24 Lightning blocks.
  * Added automatic monitoring of overdue escrow orders.
  * Active orders are canceled after the deadline with notifications to both parties.
  * Fiat-sent and disputed orders now open or reopen disputes when appropriate.
  * Added setup and configuration documentation for the new setting.

* **Bug Fixes**
  * Improved handling of canceled hold invoices, retries, missing timestamps, and already-canceled invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->