### PR TITLE
fix: handle do_payment early-exit failures so buyer is always retried

### DIFF
--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -57,6 +57,15 @@ pub async fn check_failure_retries(
 
     // Count payment retries up to limit
     order.count_failed_payment(retries_number);
+    // Only update payment-retry fields to avoid overwriting fields modified by
+    // concurrent processes (dev_fee_paid, dev_fee_payment_hash, status, etc.)
+    sqlx::query("UPDATE orders SET failed_payment = ?, payment_attempts = ? WHERE id = ?")
+        .bind(order.failed_payment)
+        .bind(order.payment_attempts)
+        .bind(order.id)
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
     let buyer_pubkey = order.get_buyer_pubkey().map_err(MostroInternalErr)?;
 
@@ -107,16 +116,6 @@ pub async fn check_failure_retries(
         )
         .await;
     }
-
-    // Only update payment-retry fields to avoid overwriting fields modified by
-    // concurrent processes (dev_fee_paid, dev_fee_payment_hash, status, etc.)
-    sqlx::query("UPDATE orders SET failed_payment = ?, payment_attempts = ? WHERE id = ?")
-        .bind(order.failed_payment)
-        .bind(order.payment_attempts)
-        .bind(order.id)
-        .execute(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
     Ok(order)
 }
@@ -507,17 +506,26 @@ async fn handle_child_order(
 /// CLTV bound, not already expired) before LND submission; resolve, decode and
 /// validation failures plus `send_payment` RPC errors go through
 /// [`check_failure_retries_or_log`] and return `Err` (no empty status-watcher
-/// spawn). Streamed `PaymentStatus::Failed` updates also bump retry
-/// bookkeeping. Callers such as `release_action` typically ignore the error
-/// after hold settlement — retries are driven by the failed-payment job.
+/// spawn). Missing buyer invoice, zero amount after fee, and LND connection
+/// failures are also routed through [`check_failure_retries_or_log`] so every
+/// failure path marks the order for retry. Streamed `PaymentStatus::Failed`
+/// updates also bump retry bookkeeping. Callers such as `release_action`
+/// typically ignore the error after hold settlement — retries are driven by
+/// the failed-payment job.
 pub async fn do_payment(
     ctx: &AppContext,
     mut order: Order,
     request_id: Option<u64>,
 ) -> Result<(), MostroError> {
+    // Seller already settled at this point — every failure must call
+    // check_failure_retries_or_log so the retry scheduler can pay the buyer.
     let payment_request = match order.buyer_invoice.as_ref() {
         Some(req) => req.to_string(),
-        _ => return Err(MostroInternalErr(ServiceError::InvoiceInvalidError)),
+        _ => {
+            warn!("Order id {}: no buyer invoice; scheduling retry", order.id);
+            check_failure_retries_or_log(ctx, &order, request_id).await;
+            return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
+        }
     };
 
     let ln_addr = LightningAddress::from_str(&payment_request);
@@ -525,6 +533,11 @@ pub async fn do_payment(
     // Dev fee is NOT charged to buyer - it's paid by mostrod from its earnings
     let amount = (order.amount as u64).saturating_sub(order.fee as u64);
     if amount == 0 {
+        warn!(
+            "Order id {}: payment amount is zero after fee; scheduling retry",
+            order.id
+        );
+        check_failure_retries_or_log(ctx, &order, request_id).await;
         return Err(MostroInternalErr(ServiceError::InvoiceInvalidError));
     }
     // `is_valid_invoice` accepts a Lightning Address *and* an encoded LNURL, so
@@ -583,7 +596,17 @@ pub async fn do_payment(
         },
         None => payment_request,
     };
-    let mut ln_client_payment = LndConnector::new().await?;
+    let mut ln_client_payment = match LndConnector::new().await {
+        Ok(client) => client,
+        Err(e) => {
+            warn!(
+                "Order id {}: failed to connect to LND: {}; scheduling retry",
+                order.id, e
+            );
+            check_failure_retries_or_log(ctx, &order, request_id).await;
+            return Err(e);
+        }
+    };
     let (tx, mut rx) = channel(100);
 
     let payment_task = ln_client_payment.send_payment(&payment_request, amount as i64, tx);
@@ -840,6 +863,7 @@ mod tests {
     use crate::app::context::AppContext;
     use crate::config::{MESSAGE_QUEUES, MOSTRO_CONFIG};
     use async_trait::async_trait;
+    use mostro_core::db;
     use nostr_sdk::{Keys, Timestamp};
     use sqlx::SqlitePool;
     use std::sync::Arc;
@@ -1697,13 +1721,16 @@ mod tests {
         let seller = Keys::generate().public_key();
         let buyer = Keys::generate().public_key();
         let order = fiat_sent_sell_order(seller, buyer);
+        let order = order.create(&pool).await.unwrap();
 
-        let result = do_payment(&ctx, order, None).await;
+        let result = do_payment(&ctx, order.clone(), None).await;
 
         assert!(matches!(
             result,
             Err(MostroInternalErr(ServiceError::InvoiceInvalidError))
         ));
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert!(db_order.failed_payment);
     }
 
     #[tokio::test]
@@ -1716,13 +1743,16 @@ mod tests {
         order.buyer_invoice = Some("lnbc1notchecked".to_string());
         order.amount = 100;
         order.fee = 100;
+        let order = order.create(&pool).await.unwrap();
 
-        let result = do_payment(&ctx, order, None).await;
+        let result = do_payment(&ctx, order.clone(), None).await;
 
         assert!(matches!(
             result,
             Err(MostroInternalErr(ServiceError::InvoiceInvalidError))
         ));
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert!(db_order.failed_payment);
     }
 
     #[tokio::test]
@@ -1737,12 +1767,15 @@ mod tests {
         let buyer = Keys::generate().public_key();
         let mut order = fiat_sent_sell_order(seller, buyer);
         order.buyer_invoice = Some("lnbc1notchecked".to_string());
+        let order = order.create(&pool).await.unwrap();
 
         // Act
-        let result = do_payment(&ctx, order, None).await;
+        let result = do_payment(&ctx, order.clone(), None).await;
 
         // Assert
         assert!(result.is_err());
+        let db_order = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert!(db_order.failed_payment);
     }
 
     /// An expired regtest invoice: rejected by `validate_payout_invoice` on


### PR DESCRIPTION
## Summary

- `do_payment` is called after the seller's hold invoice is already settled (irreversible). On three early-exit paths — missing buyer invoice, zero amount after fee, and LND unreachable — the function returned `Err` without calling `check_failure_retries_or_log`, leaving `failed_payment = false` in the database.
- Because the retry scheduler (`job_retry_failed_payments`) only picks up orders where `failed_payment = true`, these orders were permanently stranded: seller charged, buyer never paid, no log, no retry.
- Fix: call `check_failure_retries_or_log` on each of the three remaining early exits inside `do_payment` so the retry scheduler always finds the order regardless of which failure path was hit.
- The LNURL resolution and `send_payment` sync-failure paths were already handled by prior commits (#858, #861); this PR closes the three remaining gaps to make `do_payment` fully self-contained on all failure paths.

## Test plan

- [ ] New regression test `do_payment_error_marks_failed_payment_for_retry`: creates an order in `SettledHoldInvoice` with no buyer invoice, calls `do_payment` with `let _ =` (mirroring both call sites), and asserts `failed_payment = true` in the database — proving the retry scheduler will find the order

Closes #806 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Failed payments now record retry status when invoices are missing, payment amounts are zero, payout details are invalid, or payment connections fail.
  * Payment destinations and resolved invoices continue to be validated before submission.
  * Settled hold-invoice status is saved before buyer payment begins.
  * Improved reliability when retrying eligible failed payments without overwriting unrelated order updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->