### PR TITLE
fix: compare-and-swap every pre-trade order write

### DIFF
--- a/src/app/add_invoice.rs
+++ b/src/app/add_invoice.rs
@@ -1,7 +1,7 @@
 use crate::app::context::AppContext;
 use crate::util::{
     enqueue_order_msg, get_order, notify_taker_reputation, show_hold_invoice, update_order_event,
-    validate_invoice,
+    validate_invoice, HoldInvoiceOrigin,
 };
 use mostro_core::db::Crud;
 use mostro_core::prelude::*;
@@ -139,6 +139,9 @@ pub async fn add_invoice_action(
         &seller_pubkey,
         order,
         msg.get_inner_message_kind().request_id,
+        // The buyer just supplied their payout invoice, so this order
+        // legitimately sits at `waiting-buyer-invoice`.
+        HoldInvoiceOrigin::BuyerInvoice,
     )
     .await
     {

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -917,6 +917,30 @@ async fn on_bond_invoice_accepted(
     if order.status != Status::Pending.to_string()
         && order.status != Status::WaitingTakerBond.to_string()
     {
+        // A canceled order means this taker's bond locked against a trade
+        // that will never start — the maker's cancel beat the promotion,
+        // or the cancel-side release hit a transient LND failure. Release
+        // the bond here (idempotent: the cancel path may already have
+        // done it) and tell the taker, so their sats are not stranded
+        // until the bond invoice's CLTV expiry. Any other non-pre-trade
+        // status is a live trade the bond still backs — leave it alone.
+        if matches!(
+            order.get_order_status(),
+            Ok(Status::Canceled | Status::CooperativelyCanceled | Status::CanceledByAdmin)
+        ) && !current_state.is_terminal()
+        {
+            info!(
+                "Bond {} locked on canceled order {} — releasing and notifying taker",
+                current.id, order.id
+            );
+            if let Err(e) = release_bond(pool, &current).await {
+                warn!(
+                    bond_id = %current.id,
+                    "release_bond on canceled order failed ({}); the next exit path retries", e
+                );
+            }
+            notify_loser(&current).await;
+        }
         info!(
             "Bond {} accepted but order {} is in status {} — skipping resume",
             current.id, order.id, order.status
@@ -1326,6 +1350,12 @@ async fn resume_take_after_bond(
                 )
                 .await?;
                 if !won {
+                    crate::util::republish_winning_state_after_cas_miss(
+                        pool,
+                        my_keys,
+                        order_updated.id,
+                    )
+                    .await;
                     return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
                 }
                 Ok(())
@@ -2737,6 +2767,41 @@ mod tests {
         assert!(
             after.seller_pubkey.is_none(),
             "no taker context may be written past the pre-trade window"
+        );
+    }
+
+    /// A taker bond that reaches `Locked` against an already-canceled
+    /// order (maker cancel won the race, or the cancel-side release hit a
+    /// transient LND failure) must be released and its owner notified —
+    /// never left locked until the bond invoice's CLTV expiry. Without
+    /// LND the release attempt itself fails here, but the notification is
+    /// unconditional.
+    #[tokio::test]
+    async fn accepted_bond_on_canceled_order_notifies_and_skips_resume() {
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = 'canceled' WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let bond = make_bond(order_id, BondState::Locked);
+        create_bond(&pool, bond).await.unwrap();
+
+        on_bond_invoice_accepted(&"c".repeat(64), &pool, None)
+            .await
+            .expect("cancel-observation path returns Ok");
+
+        assert!(
+            count_msgs(order_id, Action::Canceled).await > 0,
+            "the taker must be told the trade is dead"
+        );
+        let order = load_order(&pool, order_id).await;
+        assert_eq!(order.status, Status::Canceled.to_string());
+        assert!(
+            order.buyer_pubkey.is_none() && order.seller_pubkey.is_none(),
+            "no resume may happen on a canceled order"
         );
     }
 

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -1077,10 +1077,15 @@ async fn promote_taker_context_to_order(
         order.dev_fee = v;
     }
     order.set_timestamp_now();
-    order
-        .update(pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+    // Compare-and-swap: write only the promoted columns, and only while the
+    // order is still pre-trade. A maker cancel that committed in the
+    // meantime wins — aborting here leaves the row canceled and drops the
+    // take; the cancel path already released this taker's bond.
+    let won = crate::db::cas_promote_taker_context(pool, &order).await?;
+    if !won {
+        return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+    }
+    Ok(order)
 }
 
 /// Subscriber callback for `InvoiceState::Canceled`: bond never locked
@@ -1310,10 +1315,19 @@ async fn resume_take_after_bond(
                     crate::util::update_order_event(my_keys, Status::WaitingBuyerInvoice, &order)
                         .await
                         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
-                order_updated
-                    .update(pool)
-                    .await
-                    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+                // Compare-and-swap: bail if the order left the pre-trade
+                // window (e.g. a maker cancel committed) instead of
+                // resurrecting it with a stale full-row write.
+                let won = crate::db::cas_pretrade_order_status(
+                    pool,
+                    order_updated.id,
+                    Status::WaitingBuyerInvoice,
+                    &order_updated.event_id,
+                )
+                .await?;
+                if !won {
+                    return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+                }
                 Ok(())
             }
         }
@@ -2692,6 +2706,38 @@ mod tests {
         assert_eq!(updated.trade_index_buyer, Some(4));
         assert_eq!(updated.buyer_invoice.as_deref(), Some("lnbc1pTEST"));
         assert!(updated.seller_pubkey.is_none());
+    }
+
+    /// The promotion is a compare-and-swap: when the maker's cancel (or any
+    /// other transition) committed first, the write must miss and the row
+    /// must stay canceled — a full-row write here would resurrect it.
+    #[tokio::test]
+    async fn promote_taker_context_loses_cas_when_order_already_canceled() {
+        let pool = setup_pool().await;
+        let order_id = Uuid::new_v4();
+        insert_order(&pool, order_id).await;
+        sqlx::query("UPDATE orders SET status = 'canceled' WHERE id = ?")
+            .bind(order_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let order = load_order(&pool, order_id).await;
+
+        let mut bond = make_bond(order_id, BondState::Locked);
+        bond.pubkey = "s".repeat(64);
+
+        let result = promote_taker_context_to_order(&pool, order, &bond).await;
+        assert!(
+            result.is_err(),
+            "a committed cancel must win over the bond promotion"
+        );
+
+        let after = load_order(&pool, order_id).await;
+        assert_eq!(after.status, Status::Canceled.to_string());
+        assert!(
+            after.seller_pubkey.is_none(),
+            "no taker context may be written past the pre-trade window"
+        );
     }
 
     #[tokio::test]

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -57,6 +57,7 @@ use crate::config::settings::Settings;
 use crate::lightning::{InvoiceMessage, LndConnector};
 use crate::util::{
     bytes_to_string, enqueue_order_msg, get_keys, set_waiting_invoice_status, show_hold_invoice,
+    HoldInvoiceOrigin,
 };
 
 use super::db::{create_bond, find_active_bonds, find_active_bonds_for_order, find_bond_by_hash};
@@ -1313,6 +1314,7 @@ async fn resume_take_after_bond(
                 &seller_pubkey,
                 order,
                 request_id,
+                HoldInvoiceOrigin::Take,
             )
             .await
         }
@@ -1329,6 +1331,7 @@ async fn resume_take_after_bond(
                     &seller_pubkey,
                     order,
                     request_id,
+                    HoldInvoiceOrigin::Take,
                 )
                 .await
             } else {

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -418,6 +418,12 @@ async fn cancel_pending_order_from_maker(
             )
             .await?;
             if !won {
+                crate::util::republish_winning_state_after_cas_miss(
+                    pool,
+                    my_keys,
+                    order_updated.id,
+                )
+                .await;
                 return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
             }
         }

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -402,13 +402,24 @@ async fn cancel_pending_order_from_maker(
     order
         .sent_from_maker(event.sender)
         .map_err(|_| MostroCantDo(CantDoReason::IsNotYourOrder))?;
-    // Publish a replaceable nostr event with updated status and persist it.
+    // Publish a replaceable nostr event with updated status and persist it
+    // with a compare-and-swap: a taker's take (or bond promotion) can commit
+    // while the cancel event is being published, and a stale full-row write
+    // would clobber the promoted taker context and escrow material — or
+    // resurrect the row the take just moved on from. Losing the CAS means
+    // the take won, so the cancel is too late.
     match update_order_event(my_keys, Status::Canceled, order).await {
         Ok(order_updated) => {
-            order_updated
-                .update(pool)
-                .await
-                .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+            let won = crate::db::cas_pretrade_order_status(
+                pool,
+                order_updated.id,
+                Status::Canceled,
+                &order_updated.event_id,
+            )
+            .await?;
+            if !won {
+                return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+            }
         }
         Err(e) => {
             return Err(MostroInternalErr(ServiceError::DbAccessError(
@@ -817,6 +828,95 @@ mod tests {
             result,
             Err(MostroCantDo(CantDoReason::IsNotYourOrder))
         ));
+    }
+
+    /// Regression test for the stale full-row write clobber: the maker's
+    /// cancel holds a pre-promotion snapshot (no taker context) while the
+    /// bond subscriber's promotion has already landed on the row. The
+    /// cancel must move `status`/`event_id` only — never NULL the promoted
+    /// columns.
+    #[tokio::test]
+    async fn pending_maker_cancel_preserves_concurrently_promoted_taker_context() {
+        set_global_config();
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+        // The maker's stale snapshot: read before the taker's bond locked.
+        let mut snapshot = create_pending_order(maker, taker);
+        snapshot.buyer_pubkey = None;
+        snapshot.master_buyer_pubkey = None;
+        let snapshot = snapshot.create(&pool).await.unwrap();
+
+        // Externally apply what the bond subscriber's promotion writes
+        // (status still pre-trade: the escrow is not stored yet).
+        sqlx::query(
+            "UPDATE orders SET status = 'waiting-taker-bond', buyer_pubkey = ?1, \
+             master_buyer_pubkey = ?2 WHERE id = ?3",
+        )
+        .bind(taker.to_string())
+        .bind(taker.to_string())
+        .bind(snapshot.id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(maker);
+        let mut stale = snapshot.clone();
+        cancel_pending_order_from_maker(&pool, &event, &mut stale, &Keys::generate(), None)
+            .await
+            .unwrap();
+
+        let after = Order::by_id(&pool, snapshot.id).await.unwrap().unwrap();
+        assert_eq!(after.status, Status::Canceled.to_string());
+        assert_eq!(
+            after.buyer_pubkey.as_deref(),
+            Some(taker.to_string().as_str()),
+            "the promoted taker context must survive the maker's cancel"
+        );
+        assert_eq!(
+            after.master_buyer_pubkey.as_deref(),
+            Some(taker.to_string().as_str())
+        );
+    }
+
+    /// The mirror image: once the take committed past the pre-trade window
+    /// (escrow stored, `waiting-payment`), the maker's pending-cancel must
+    /// lose instead of reverting the row.
+    #[tokio::test]
+    async fn pending_maker_cancel_loses_once_the_take_committed() {
+        set_global_config();
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        let maker = Keys::generate().public_key();
+        let taker = Keys::generate().public_key();
+        let snapshot = create_pending_order(maker, taker)
+            .create(&pool)
+            .await
+            .unwrap();
+        // The take committed: escrow stored, status moved on.
+        sqlx::query("UPDATE orders SET status = 'waiting-payment', hash = ?1 WHERE id = ?2")
+            .bind("ab".repeat(32))
+            .bind(snapshot.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let event = create_unwrapped_message_with_pubkey(maker);
+        let mut stale = snapshot.clone();
+        let result =
+            cancel_pending_order_from_maker(&pool, &event, &mut stale, &Keys::generate(), None)
+                .await;
+
+        assert!(matches!(
+            result,
+            Err(MostroCantDo(CantDoReason::NotAllowedByStatus))
+        ));
+        let after = Order::by_id(&pool, snapshot.id).await.unwrap().unwrap();
+        assert_eq!(after.status, Status::WaitingPayment.to_string());
+        assert_eq!(after.hash.as_deref(), Some("ab".repeat(32).as_str()));
     }
 
     /// Phase 1 fix: a taker who took a `Pending` order but hasn't paid

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -3,7 +3,7 @@ use crate::app::bond::TakerContext;
 use crate::app::context::AppContext;
 use crate::util::{
     enqueue_order_msg, get_dev_fee, get_fiat_amount_requested, get_market_amount_and_fee,
-    get_order, show_hold_invoice,
+    get_order, show_hold_invoice, HoldInvoiceOrigin,
 };
 
 use crate::db::{seller_has_pending_order, update_user_trade_index};
@@ -196,6 +196,7 @@ pub async fn take_buy_action(
         &seller_pubkey,
         order,
         request_id,
+        HoldInvoiceOrigin::Take,
     )
     .await
     {

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -27,9 +27,18 @@ async fn update_order_status(
                     // Compare-and-swap the whole take-context transition:
                     // bail if the order left the pre-trade window (e.g. a
                     // maker cancel committed) instead of resurrecting it
-                    // with a stale full-row write.
-                    let won = crate::db::cas_complete_pretrade_take(pool, &order_updated).await?;
+                    // with a stale full-row write. `waiting-buyer-invoice`
+                    // is not a legitimate source here: only `add_invoice`
+                    // may drive a row out of that state.
+                    let won =
+                        crate::db::cas_complete_pretrade_take(pool, &order_updated, false).await?;
                     if !won {
+                        crate::util::republish_winning_state_after_cas_miss(
+                            pool,
+                            my_keys,
+                            order_updated.id,
+                        )
+                        .await;
                         return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
                     }
                     Ok(())

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -6,7 +6,6 @@ use crate::util::{
     enqueue_order_msg, get_dev_fee, get_fiat_amount_requested, get_market_amount_and_fee,
     get_order, set_waiting_invoice_status, show_hold_invoice, update_order_event, validate_invoice,
 };
-use mostro_core::db::Crud;
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
@@ -25,7 +24,14 @@ async fn update_order_status(
             // Update order status
             match update_order_event(my_keys, Status::WaitingBuyerInvoice, order).await {
                 Ok(order_updated) => {
-                    let _ = order_updated.update(pool).await;
+                    // Compare-and-swap the whole take-context transition:
+                    // bail if the order left the pre-trade window (e.g. a
+                    // maker cancel committed) instead of resurrecting it
+                    // with a stale full-row write.
+                    let won = crate::db::cas_complete_pretrade_take(pool, &order_updated).await?;
+                    if !won {
+                        return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+                    }
                     Ok(())
                 }
                 Err(_) => Err(MostroInternalErr(ServiceError::UpdateOrderStatusError)),

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -5,6 +5,7 @@ use crate::db::{buyer_has_pending_order, update_user_trade_index};
 use crate::util::{
     enqueue_order_msg, get_dev_fee, get_fiat_amount_requested, get_market_amount_and_fee,
     get_order, set_waiting_invoice_status, show_hold_invoice, update_order_event, validate_invoice,
+    HoldInvoiceOrigin,
 };
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
@@ -245,6 +246,7 @@ pub async fn take_sell_action(
             &seller_pubkey,
             order,
             request_id,
+            HoldInvoiceOrigin::Take,
         )
         .await?;
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -805,6 +805,144 @@ pub async fn update_order_invoice_held_at_time(
     Ok(rows_affected > 0)
 }
 
+/// Statuses from which a take (or a maker cancel) may still start: the
+/// order has no live trade escrow yet. Used as the `WHERE` guard for the
+/// pre-trade compare-and-swap writes below, so a writer working from a
+/// stale snapshot loses cleanly instead of clobbering whoever committed
+/// first.
+const PRETRADE_STATUSES: &str = "'pending','waiting-taker-bond'";
+
+/// Compare-and-swap a pre-trade status transition (`status` + `event_id`
+/// only). Returns `false` when the order has already left the pre-trade
+/// window — e.g. a take committed `waiting-payment` while a maker cancel
+/// was publishing — letting the caller bail instead of resurrecting or
+/// clobbering the row with a stale full-row write.
+pub async fn cas_pretrade_order_status(
+    pool: &SqlitePool,
+    order_id: Uuid,
+    new_status: Status,
+    event_id: &str,
+) -> Result<bool, MostroError> {
+    let query = format!(
+        "UPDATE orders SET status = ?1, event_id = ?2 \
+         WHERE id = ?3 AND status IN ({PRETRADE_STATUSES})"
+    );
+    let result = sqlx::query(AssertSqlSafe(query.as_str()))
+        .bind(new_status.to_string())
+        .bind(event_id)
+        .bind(order_id)
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Compare-and-swap the winning taker's bond context onto the order row
+/// (see `promote_taker_context_to_order`). Writes only the promoted
+/// columns — never `status` — and only while the order is still
+/// pre-trade, so a maker cancel that already committed is not undone.
+/// `order` must be the merged in-memory row (taker fields applied).
+/// Returns `false` when the CAS missed.
+pub async fn cas_promote_taker_context(
+    pool: &SqlitePool,
+    order: &Order,
+) -> Result<bool, MostroError> {
+    let kind = order.get_order_kind().map_err(MostroInternalErr)?;
+    let taker_columns = match kind {
+        OrderKind::Buy => "seller_pubkey = ?2, master_seller_pubkey = ?3, trade_index_seller = ?4",
+        OrderKind::Sell => {
+            "buyer_pubkey = ?2, master_buyer_pubkey = ?3, trade_index_buyer = ?4, \
+             buyer_invoice = ?5"
+        }
+    };
+    let query = format!(
+        "UPDATE orders SET {taker_columns}, fiat_amount = ?6, amount = ?7, fee = ?8, \
+         dev_fee = ?9, created_at = ?10 \
+         WHERE id = ?1 AND status IN ({PRETRADE_STATUSES})"
+    );
+    // The unused ?5 slot for buy orders binds a throwaway `None`.
+    let buyer_invoice: Option<&str> = match kind {
+        OrderKind::Sell => order.buyer_invoice.as_deref(),
+        OrderKind::Buy => None,
+    };
+    let (trade_pubkey, identity, trade_index) = match kind {
+        OrderKind::Buy => (
+            &order.seller_pubkey,
+            &order.master_seller_pubkey,
+            order.trade_index_seller,
+        ),
+        OrderKind::Sell => (
+            &order.buyer_pubkey,
+            &order.master_buyer_pubkey,
+            order.trade_index_buyer,
+        ),
+    };
+    let result = sqlx::query(AssertSqlSafe(query.as_str()))
+        .bind(order.id)
+        .bind(trade_pubkey.as_deref())
+        .bind(identity.as_deref())
+        .bind(trade_index)
+        .bind(buyer_invoice)
+        .bind(order.fiat_amount)
+        .bind(order.amount)
+        .bind(order.fee)
+        .bind(order.dev_fee)
+        .bind(order.created_at)
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
+/// Compare-and-swap the full take-context transition: everything the take
+/// handlers mutate on their in-memory row before persisting — taker
+/// context, computed amounts, trade escrow material (when the hold
+/// invoice was created) and the status/event pair — in one guarded write.
+/// The guard additionally allows `waiting-buyer-invoice`, the state the
+/// `add_invoice` caller legitimately arrives from. Returns `false` when
+/// the order moved on meanwhile (e.g. a maker cancel committed while the
+/// hold invoice was being created at LND) — the caller must then cancel
+/// any orphaned invoice instead of resurrecting the row.
+pub async fn cas_complete_pretrade_take(
+    pool: &SqlitePool,
+    order: &Order,
+) -> Result<bool, MostroError> {
+    let query = format!(
+        "UPDATE orders SET status = ?2, event_id = ?3, \
+         buyer_pubkey = ?4, seller_pubkey = ?5, \
+         master_buyer_pubkey = ?6, master_seller_pubkey = ?7, \
+         trade_index_buyer = ?8, trade_index_seller = ?9, \
+         fiat_amount = ?10, amount = ?11, fee = ?12, dev_fee = ?13, created_at = ?14, \
+         buyer_invoice = ?15, preimage = ?16, hash = ?17 \
+         WHERE id = ?1 AND status IN ({PRETRADE_STATUSES}, 'waiting-buyer-invoice')"
+    );
+    let result = sqlx::query(AssertSqlSafe(query.as_str()))
+        .bind(order.id)
+        .bind(order.status.clone())
+        .bind(order.event_id.clone())
+        .bind(order.buyer_pubkey.as_deref())
+        .bind(order.seller_pubkey.as_deref())
+        .bind(order.master_buyer_pubkey.as_deref())
+        .bind(order.master_seller_pubkey.as_deref())
+        .bind(order.trade_index_buyer)
+        .bind(order.trade_index_seller)
+        .bind(order.fiat_amount)
+        .bind(order.amount)
+        .bind(order.fee)
+        .bind(order.dev_fee)
+        .bind(order.created_at)
+        .bind(order.buyer_invoice.as_deref())
+        .bind(order.preimage.as_deref())
+        .bind(order.hash.as_deref())
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(result.rows_affected() > 0)
+}
+
 /// Atomically persist a validated Cashu escrow and advance the order status
 /// (Cashu foundation CF-4, `docs/cashu/01-fundamentals.md` §6).
 ///
@@ -2090,6 +2228,125 @@ mod tests {
 
         let result = super::find_held_invoices(&pool).await.unwrap();
         assert!(result.is_empty(), "rows without a hash must be skipped");
+    }
+
+    // ── pre-trade compare-and-swap writes ────────────────────────────────
+
+    async fn migrated_pool() -> SqlitePool {
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    /// A `pending` sell order carrying escrow material, so a targeted write
+    /// that touches columns it shouldn't is visible in the assertions.
+    async fn insert_pretrade_order(pool: &SqlitePool, status: &str) -> super::Order {
+        use mostro_core::db::Crud;
+        let order = super::Order {
+            id: uuid::Uuid::new_v4(),
+            kind: "sell".to_string(),
+            status: status.to_string(),
+            creator_pubkey: "aa".repeat(32),
+            seller_pubkey: Some("aa".repeat(32)),
+            fiat_code: "USD".to_string(),
+            payment_method: "bank".to_string(),
+            amount: 100_000,
+            fiat_amount: 100,
+            hash: Some("cc".repeat(32)),
+            preimage: Some("dd".repeat(32)),
+            ..Default::default()
+        };
+        order.create(pool).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn cas_pretrade_order_status_flips_only_status_and_event_id() {
+        let pool = migrated_pool().await;
+        let order = insert_pretrade_order(&pool, "pending").await;
+
+        let won =
+            super::cas_pretrade_order_status(&pool, order.id, super::Status::Canceled, "ev-new")
+                .await
+                .unwrap();
+        assert!(won, "pending orders accept the transition");
+
+        use mostro_core::db::Crud;
+        let after = super::Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(after.status, "canceled");
+        assert_eq!(after.event_id, "ev-new");
+        // The targeted write must not clobber unrelated columns.
+        assert_eq!(after.hash, Some("cc".repeat(32)));
+        assert_eq!(after.preimage, Some("dd".repeat(32)));
+    }
+
+    #[tokio::test]
+    async fn cas_pretrade_order_status_loses_once_the_take_committed() {
+        let pool = migrated_pool().await;
+        let order = insert_pretrade_order(&pool, "waiting-payment").await;
+
+        let won =
+            super::cas_pretrade_order_status(&pool, order.id, super::Status::Canceled, "ev-new")
+                .await
+                .unwrap();
+        assert!(!won, "waiting-payment is past the pre-trade window");
+
+        use mostro_core::db::Crud;
+        let after = super::Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(after.status, "waiting-payment");
+        assert_ne!(after.event_id, "ev-new");
+    }
+
+    #[tokio::test]
+    async fn cas_complete_pretrade_take_covers_every_legitimate_caller_state() {
+        let pool = migrated_pool().await;
+        for from in ["pending", "waiting-taker-bond", "waiting-buyer-invoice"] {
+            let mut order = insert_pretrade_order(&pool, from).await;
+            // What the take handlers mutate in memory before persisting:
+            // the transition, the taker context, and the computed amounts.
+            order.status = super::Status::WaitingPayment.to_string();
+            order.event_id = "ev-escrow".to_string();
+            order.buyer_pubkey = Some("bb".repeat(32));
+            order.master_buyer_pubkey = Some("bb".repeat(32));
+            order.trade_index_buyer = Some(3);
+            order.amount = 200_000;
+            order.dev_fee = 5;
+
+            let won = super::cas_complete_pretrade_take(&pool, &order)
+                .await
+                .unwrap();
+            assert!(won, "{from} must accept the take transition");
+
+            use mostro_core::db::Crud;
+            let after = super::Order::by_id(&pool, order.id).await.unwrap().unwrap();
+            assert_eq!(after.status, "waiting-payment");
+            assert_eq!(after.event_id, "ev-escrow");
+            assert_eq!(after.buyer_pubkey, Some("bb".repeat(32)));
+            assert_eq!(after.master_buyer_pubkey, Some("bb".repeat(32)));
+            assert_eq!(after.trade_index_buyer, Some(3));
+            assert_eq!(after.amount, 200_000);
+            assert_eq!(after.dev_fee, 5);
+            // Escrow material from the inserted row rides along untouched.
+            assert_eq!(after.hash, Some("cc".repeat(32)));
+            assert_eq!(after.preimage, Some("dd".repeat(32)));
+        }
+    }
+
+    #[tokio::test]
+    async fn cas_complete_pretrade_take_loses_on_a_canceled_order() {
+        let pool = migrated_pool().await;
+        let mut order = insert_pretrade_order(&pool, "canceled").await;
+        order.status = super::Status::WaitingPayment.to_string();
+        order.event_id = "ev-escrow".to_string();
+
+        let won = super::cas_complete_pretrade_take(&pool, &order)
+            .await
+            .unwrap();
+        assert!(!won, "a committed cancel must win over the escrow storage");
+
+        use mostro_core::db::Crud;
+        let after = super::Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(after.status, "canceled");
+        assert_ne!(after.event_id, "ev-escrow");
     }
 
     #[tokio::test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -900,15 +900,29 @@ pub async fn cas_promote_taker_context(
 /// handlers mutate on their in-memory row before persisting — taker
 /// context, computed amounts, trade escrow material (when the hold
 /// invoice was created) and the status/event pair — in one guarded write.
-/// The guard additionally allows `waiting-buyer-invoice`, the state the
-/// `add_invoice` caller legitimately arrives from. Returns `false` when
-/// the order moved on meanwhile (e.g. a maker cancel committed while the
-/// hold invoice was being created at LND) — the caller must then cancel
-/// any orphaned invoice instead of resurrecting the row.
+///
+/// The `WHERE` guard always covers the pre-trade statuses
+/// (`pending` / `waiting-taker-bond`). `allow_waiting_buyer_invoice`
+/// adds that status for the one caller that legitimately arrives from
+/// it: `show_hold_invoice` when driven by `add_invoice`. Take paths
+/// (`take_sell`, `take_buy`, the bond resume) must pass `false`, so a
+/// stale take can never overwrite an already-committed one even if a
+/// future change lets two take handlers overlap.
+///
+/// Returns `false` when the order moved on meanwhile (e.g. a maker
+/// cancel committed while the hold invoice was being created at LND) —
+/// the caller must then cancel any orphaned invoice instead of
+/// resurrecting the row.
 pub async fn cas_complete_pretrade_take(
     pool: &SqlitePool,
     order: &Order,
+    allow_waiting_buyer_invoice: bool,
 ) -> Result<bool, MostroError> {
+    let extra_status = if allow_waiting_buyer_invoice {
+        ", 'waiting-buyer-invoice'"
+    } else {
+        ""
+    };
     let query = format!(
         "UPDATE orders SET status = ?2, event_id = ?3, \
          buyer_pubkey = ?4, seller_pubkey = ?5, \
@@ -916,7 +930,7 @@ pub async fn cas_complete_pretrade_take(
          trade_index_buyer = ?8, trade_index_seller = ?9, \
          fiat_amount = ?10, amount = ?11, fee = ?12, dev_fee = ?13, created_at = ?14, \
          buyer_invoice = ?15, preimage = ?16, hash = ?17 \
-         WHERE id = ?1 AND status IN ({PRETRADE_STATUSES}, 'waiting-buyer-invoice')"
+         WHERE id = ?1 AND status IN ({PRETRADE_STATUSES}{extra_status})"
     );
     let result = sqlx::query(AssertSqlSafe(query.as_str()))
         .bind(order.id)
@@ -2347,7 +2361,13 @@ mod tests {
     #[tokio::test]
     async fn cas_complete_pretrade_take_covers_every_legitimate_caller_state() {
         let pool = migrated_pool().await;
-        for from in ["pending", "waiting-taker-bond", "waiting-buyer-invoice"] {
+        // `waiting-buyer-invoice` is legitimate only for the `add_invoice`
+        // → `show_hold_invoice` caller, which passes `true`.
+        for (from, allow_wbi) in [
+            ("pending", false),
+            ("waiting-taker-bond", false),
+            ("waiting-buyer-invoice", true),
+        ] {
             let mut order = insert_pretrade_order(&pool, from).await;
             // What the take handlers mutate in memory before persisting:
             // the transition, the taker context, and the computed amounts.
@@ -2358,8 +2378,13 @@ mod tests {
             order.trade_index_buyer = Some(3);
             order.amount = 200_000;
             order.dev_fee = 5;
+            // The helper writes `hash`/`preimage` from the caller's
+            // snapshot: use values that differ from the inserted row's, so
+            // the assertions prove whose values landed.
+            order.hash = Some("ee".repeat(32));
+            order.preimage = Some("ff".repeat(32));
 
-            let won = super::cas_complete_pretrade_take(&pool, &order)
+            let won = super::cas_complete_pretrade_take(&pool, &order, allow_wbi)
                 .await
                 .unwrap();
             assert!(won, "{from} must accept the take transition");
@@ -2373,10 +2398,29 @@ mod tests {
             assert_eq!(after.trade_index_buyer, Some(3));
             assert_eq!(after.amount, 200_000);
             assert_eq!(after.dev_fee, 5);
-            // Escrow material from the inserted row rides along untouched.
-            assert_eq!(after.hash, Some("cc".repeat(32)));
-            assert_eq!(after.preimage, Some("dd".repeat(32)));
+            assert_eq!(after.hash, Some("ee".repeat(32)));
+            assert_eq!(after.preimage, Some("ff".repeat(32)));
         }
+    }
+
+    #[tokio::test]
+    async fn cas_complete_pretrade_take_rejects_waiting_buyer_invoice_for_take_callers() {
+        let pool = migrated_pool().await;
+        let mut order = insert_pretrade_order(&pool, "waiting-buyer-invoice").await;
+        order.status = super::Status::WaitingPayment.to_string();
+        order.buyer_pubkey = Some("bb".repeat(32));
+
+        // A take path must never overwrite a row that is already waiting
+        // for the first buyer's invoice.
+        let won = super::cas_complete_pretrade_take(&pool, &order, false)
+            .await
+            .unwrap();
+        assert!(!won);
+
+        use mostro_core::db::Crud;
+        let after = super::Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(after.status, "waiting-buyer-invoice");
+        assert_ne!(after.buyer_pubkey, Some("bb".repeat(32)));
     }
 
     #[tokio::test]
@@ -2386,7 +2430,7 @@ mod tests {
         order.status = super::Status::WaitingPayment.to_string();
         order.event_id = "ev-escrow".to_string();
 
-        let won = super::cas_complete_pretrade_take(&pool, &order)
+        let won = super::cas_complete_pretrade_take(&pool, &order, true)
             .await
             .unwrap();
         assert!(!won, "a committed cancel must win over the escrow storage");

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -11,13 +11,16 @@ use serde_json::json;
 use std::borrow::Cow;
 use std::vec;
 
-/// Internal helper function to create a NIP-33 replaceable event with a specific kind
+/// Internal helper function to create a NIP-33 replaceable event with a specific kind.
+/// `created_at` overrides the event timestamp when provided; `None` uses the
+/// current time.
 fn create_event(
     keys: &Keys,
     content: &str,
     identifier: String,
     extra_tags: Tags,
     kind: u16,
+    created_at: Option<Timestamp>,
 ) -> Result<Event, Error> {
     let mut tags: Vec<Tag> = Vec::with_capacity(2 + extra_tags.len());
     tags.push(Tag::identifier(identifier));
@@ -38,9 +41,11 @@ fn create_event(
     tags.extend(extra_tags);
     let tags = Tags::from_list(tags);
 
-    EventBuilder::new(nostr::Kind::Custom(kind), content)
-        .tags(tags)
-        .sign_with_keys(keys)
+    let mut builder = EventBuilder::new(nostr::Kind::Custom(kind), content).tags(tags);
+    if let Some(created_at) = created_at {
+        builder = builder.custom_created_at(created_at);
+    }
+    builder.sign_with_keys(keys)
 }
 
 /// Creates a new order event (kind 38383)
@@ -66,6 +71,29 @@ pub fn new_order_event(
         identifier,
         extra_tags,
         NOSTR_ORDER_EVENT_KIND,
+        None,
+    )
+}
+
+/// Creates a new order event (kind 38383) with an explicit `created_at`.
+///
+/// NIP-01 replaceable-event ordering breaks same-second ties by lowest event
+/// id, so a repair event that must supersede an earlier event published in
+/// the same Unix second needs a strictly newer timestamp.
+pub fn new_order_event_with_created_at(
+    keys: &Keys,
+    content: &str,
+    identifier: String,
+    extra_tags: Tags,
+    created_at: Timestamp,
+) -> Result<Event, Error> {
+    create_event(
+        keys,
+        content,
+        identifier,
+        extra_tags,
+        NOSTR_ORDER_EVENT_KIND,
+        Some(created_at),
     )
 }
 
@@ -92,6 +120,7 @@ pub fn new_rating_event(
         identifier,
         extra_tags,
         NOSTR_RATING_EVENT_KIND,
+        None,
     )
 }
 
@@ -112,7 +141,14 @@ pub fn new_info_event(
     identifier: String,
     extra_tags: Tags,
 ) -> Result<Event, Error> {
-    create_event(keys, content, identifier, extra_tags, NOSTR_INFO_EVENT_KIND)
+    create_event(
+        keys,
+        content,
+        identifier,
+        extra_tags,
+        NOSTR_INFO_EVENT_KIND,
+        None,
+    )
 }
 
 /// Creates a new dispute event (kind 38386)
@@ -138,6 +174,7 @@ pub fn new_dispute_event(
         identifier,
         extra_tags,
         NOSTR_DISPUTE_EVENT_KIND,
+        None,
     )
 }
 
@@ -181,6 +218,7 @@ pub fn new_exchange_rates_event(
         "mostro-rates".to_string(), // NIP-33 d tag identifier
         extra_tags,
         NOSTR_EXCHANGE_RATES_EVENT_KIND,
+        None,
     )
 }
 
@@ -1225,6 +1263,57 @@ mod tests {
 
     // ── Event constructors (kinds 38383/38384/38385/38386/30078) ─────────
 
+    /// Regression: after a same-second CAS miss the repair event must win
+    /// NIP-01 replaceable-event ordering. Same-timestamp ties fall back to
+    /// lowest event id — which the repair could lose — so the repair is
+    /// stamped strictly after the stale event and must win on `created_at`
+    /// alone, regardless of how the ids compare.
+    #[test]
+    fn same_second_cas_miss_repair_event_wins_nip01_ordering() {
+        init_test_settings();
+        let keys = Keys::generate();
+        let tags = Tags::from_list(vec![]);
+
+        // The stale event the losing caller already published.
+        let stale = super::new_order_event(&keys, "", "order-id".to_string(), tags.clone())
+            .expect("stale event");
+
+        // The repair runs milliseconds later — same Unix second. It is
+        // stamped one second after the stale event (see
+        // `util::repair_timestamp`).
+        let repair = super::new_order_event_with_created_at(
+            &keys,
+            "",
+            "order-id".to_string(),
+            tags,
+            Timestamp::from(stale.created_at.as_secs() + 1),
+        )
+        .expect("repair event");
+
+        assert!(
+            repair.created_at > stale.created_at,
+            "repair must out-order the stale event on created_at alone"
+        );
+        // NIP-01: for replaceable events the higher created_at wins; the id
+        // tie-breaker only applies on equal timestamps, which the strictly
+        // newer stamp rules out.
+        let nip01_winner = if repair.created_at != stale.created_at {
+            if repair.created_at > stale.created_at {
+                &repair
+            } else {
+                &stale
+            }
+        } else if repair.id < stale.id {
+            &repair
+        } else {
+            &stale
+        };
+        assert_eq!(
+            nip01_winner.id, repair.id,
+            "repair event must replace the stale one"
+        );
+    }
+
     #[test]
     fn event_constructors_emit_expected_kinds_and_identifier() {
         init_test_settings();
@@ -1255,6 +1344,17 @@ mod tests {
         let dispute = super::new_dispute_event(&keys, "", "dispute-id".to_string(), tags.clone())
             .expect("dispute event");
         assert_eq!(dispute.kind.as_u16(), NOSTR_DISPUTE_EVENT_KIND);
+
+        let stamped = super::new_order_event_with_created_at(
+            &keys,
+            "",
+            "order-id".to_string(),
+            tags.clone(),
+            Timestamp::from(1_700_000_000),
+        )
+        .expect("order event with explicit created_at");
+        assert_eq!(stamped.kind.as_u16(), NOSTR_ORDER_EVENT_KIND);
+        assert_eq!(stamped.created_at.as_secs(), 1_700_000_000);
 
         let rates =
             super::new_exchange_rates_event(&keys, "{}", tags.clone()).expect("rates event");

--- a/src/util.rs
+++ b/src/util.rs
@@ -1089,10 +1089,21 @@ pub async fn show_hold_invoice(
     let order_updated = update_order_event(my_keys, Status::WaitingPayment, &order)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
-    order_updated
-        .update(&pool)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    // Compare-and-swap the escrow storage: if the order left the pre-trade
+    // window while the hold invoice was being created at LND (e.g. a maker
+    // cancel committed), persisting this snapshot would resurrect the row
+    // and strand the invoice. On a miss, cancel the orphaned invoice and
+    // bail instead.
+    let won = db::cas_complete_pretrade_take(&pool, &order_updated).await?;
+    if !won {
+        if let Err(e) = ln_client.cancel_hold_invoice(&bytes_to_string(&hash)).await {
+            tracing::warn!(
+                "Order id {}: best-effort cancel of orphaned hold invoice failed: {e}",
+                order.id
+            );
+        }
+        return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
+    }
 
     let mut new_order = order.as_new_order();
     new_order.status = Some(Status::WaitingPayment);

--- a/src/util.rs
+++ b/src/util.rs
@@ -895,6 +895,38 @@ async fn get_ratings_for_pending_order(
     }
 }
 
+/// Best-effort repair of the relay view after a pre-trade CAS miss. The
+/// caller published its transition via `update_order_event` *before*
+/// learning it lost the race, so the newest replaceable event on relays
+/// contradicts the database (e.g. relays advertise `waiting-payment` for
+/// an order that is actually `canceled`). Republish the state that
+/// actually won so the orderbook converges. Never fails the caller: the
+/// database is already correct — this is only the advertised view.
+pub async fn republish_winning_state_after_cas_miss(
+    pool: &Pool<Sqlite>,
+    my_keys: &Keys,
+    order_id: Uuid,
+) {
+    let current = match Order::by_id(pool, order_id).await {
+        Ok(Some(order)) => order,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::warn!("cas miss repair: could not reload order {order_id}: {e}");
+            return;
+        }
+    };
+    match current.get_order_status() {
+        Ok(status) => {
+            if let Err(e) = update_order_event(my_keys, status, &current).await {
+                tracing::warn!(
+                    "cas miss repair: could not republish order {order_id} as {status}: {e}"
+                );
+            }
+        }
+        Err(e) => tracing::warn!("cas miss repair: order {order_id} has bad status: {e}"),
+    }
+}
+
 pub async fn update_order_event(
     keys: &Keys,
     status: Status,
@@ -1081,8 +1113,9 @@ pub async fn show_hold_invoice(
     // window while the hold invoice was being created at LND (e.g. a maker
     // cancel committed), persisting this snapshot would resurrect the row
     // and strand the invoice. On a miss, cancel the orphaned invoice and
-    // bail instead.
-    let won = db::cas_complete_pretrade_take(&pool, &order_updated).await?;
+    // bail instead. `waiting-buyer-invoice` stays an allowed source: the
+    // `add_invoice` caller legitimately arrives from it.
+    let won = db::cas_complete_pretrade_take(&pool, &order_updated, true).await?;
     if !won {
         if let Err(e) = ln_client.cancel_hold_invoice(&bytes_to_string(&hash)).await {
             tracing::warn!(
@@ -1090,6 +1123,7 @@ pub async fn show_hold_invoice(
                 order.id
             );
         }
+        republish_winning_state_after_cas_miss(&pool, my_keys, order.id).await;
         return Err(MostroCantDo(CantDoReason::NotAllowedByStatus));
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,10 @@ use crate::flow;
 use crate::lightning;
 use crate::lightning::invoice::is_valid_invoice;
 use crate::messages;
-use crate::nip33::{create_platform_tag_values, new_order_event, new_rating_event, order_to_tags};
+use crate::nip33::{
+    create_platform_tag_values, new_order_event, new_order_event_with_created_at, new_rating_event,
+    order_to_tags,
+};
 
 use chrono::Duration;
 use fedimint_tonic_lnd::lnrpc::invoice::InvoiceState;
@@ -917,7 +920,19 @@ pub async fn republish_winning_state_after_cas_miss(
     };
     match current.get_order_status() {
         Ok(status) => {
-            if let Err(e) = update_order_event(my_keys, status, &current).await {
+            // The stale event was published moments ago, usually within the
+            // same Unix second. NIP-01 breaks same-timestamp ties by lowest
+            // event id, so stamp the repair strictly after `now` to guarantee
+            // it replaces the stale event on relays.
+            let repair_created_at = repair_timestamp(Timestamp::now());
+            if let Err(e) = update_order_event_with_created_at(
+                my_keys,
+                status,
+                &current,
+                Some(repair_created_at),
+            )
+            .await
+            {
                 tracing::warn!(
                     "cas miss repair: could not republish order {order_id} as {status}: {e}"
                 );
@@ -927,10 +942,30 @@ pub async fn republish_winning_state_after_cas_miss(
     }
 }
 
+/// Timestamp for a CAS-miss repair event: strictly after `now`, so the repair
+/// wins NIP-01 replaceable-event ordering even against a stale event
+/// published in the same Unix second (same-second ties fall back to lowest
+/// event id, which the repair could lose).
+fn repair_timestamp(now: Timestamp) -> Timestamp {
+    Timestamp::from(now.as_secs() + 1)
+}
+
 pub async fn update_order_event(
     keys: &Keys,
     status: Status,
     order: &Order,
+) -> Result<Order, MostroError> {
+    update_order_event_with_created_at(keys, status, order, None).await
+}
+
+/// Same as [`update_order_event`], but allows overriding the published
+/// event's `created_at` (used by the CAS-miss repair path, which must stamp
+/// its event strictly after the stale one to win NIP-01 ordering).
+pub async fn update_order_event_with_created_at(
+    keys: &Keys,
+    status: Status,
+    order: &Order,
+    created_at: Option<Timestamp>,
 ) -> Result<Order, MostroError> {
     let mut order_updated = order.clone();
     // update order.status with new status
@@ -943,8 +978,13 @@ pub async fn update_order_event(
     let mostro_pubkey = keys.public_key().to_hex();
     if let Some(tags) = order_to_tags(&order_updated, reputation_data, Some(&mostro_pubkey))? {
         // nip33 kind with order id as identifier and order fields as tags (kind 38383 for orders)
-        let event = new_order_event(keys, "", order.id.to_string(), tags)
-            .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+        let event = match created_at {
+            Some(created_at) => {
+                new_order_event_with_created_at(keys, "", order.id.to_string(), tags, created_at)
+            }
+            None => new_order_event(keys, "", order.id.to_string(), tags),
+        }
+        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
 
         info!("Sending replaceable event: {event:#?}");
 
@@ -1682,6 +1722,18 @@ mod tests {
         INIT.call_once(|| {
             // Any initialization code goes here
         });
+    }
+
+    /// Regression: the CAS-miss repair timestamp must be strictly newer than
+    /// `now`, otherwise a repair published in the same Unix second as the
+    /// stale event ties on `created_at` and NIP-01's lowest-id tie-breaker
+    /// can keep the stale state on relays.
+    #[test]
+    fn repair_timestamp_is_strictly_after_now() {
+        let now = Timestamp::from(1_700_000_000);
+        let repair = repair_timestamp(now);
+        assert!(repair > now);
+        assert_eq!(repair.as_secs(), now.as_secs() + 1);
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1087,6 +1087,25 @@ pub(crate) fn price_nostr_client_options() -> ClientBuilder {
     client_options_from_policy(price_nostr_client_policy())
 }
 
+/// Which caller drove `show_hold_invoice`, and therefore which order
+/// statuses its compare-and-swap may still overwrite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HoldInvoiceOrigin {
+    /// A take handler: `take_sell`, `take_buy`, or the post-bond resume.
+    /// Only the pre-trade statuses may be swapped out, so a take that raced
+    /// in behind an already-committed one loses instead of clobbering it.
+    Take,
+    /// `add_invoice`: the buyer supplied their payout invoice, so the row
+    /// legitimately sits at `waiting-buyer-invoice`.
+    BuyerInvoice,
+}
+
+impl HoldInvoiceOrigin {
+    fn allows_waiting_buyer_invoice(self) -> bool {
+        matches!(self, Self::BuyerInvoice)
+    }
+}
+
 pub async fn show_hold_invoice(
     my_keys: &Keys,
     payment_request: Option<String>,
@@ -1094,6 +1113,7 @@ pub async fn show_hold_invoice(
     seller_pubkey: &PublicKey,
     mut order: Order,
     request_id: Option<u64>,
+    origin: HoldInvoiceOrigin,
 ) -> Result<(), MostroError> {
     let mut ln_client = lightning::LndConnector::new().await?;
     // Seller pays only the order amount and their Mostro fee
@@ -1135,9 +1155,15 @@ pub async fn show_hold_invoice(
     // window while the hold invoice was being created at LND (e.g. a maker
     // cancel committed), persisting this snapshot would resurrect the row
     // and strand the invoice. On a miss, cancel the orphaned invoice and
-    // bail instead. `waiting-buyer-invoice` stays an allowed source: the
-    // `add_invoice` caller legitimately arrives from it.
-    let won = db::cas_complete_pretrade_take(&pool, &order_updated, true).await?;
+    // bail instead. Only the `add_invoice` origin may also swap out
+    // `waiting-buyer-invoice`; a take arriving from there raced in behind
+    // a committed take and must lose rather than clobber it.
+    let won = db::cas_complete_pretrade_take(
+        &pool,
+        &order_updated,
+        origin.allows_waiting_buyer_invoice(),
+    )
+    .await?;
     if !won {
         if let Err(e) = ln_client.cancel_hold_invoice(&bytes_to_string(&hash)).await {
             tracing::warn!(
@@ -2803,6 +2829,64 @@ mod tests {
             .is_err());
     }
 
+    /// Regression: `show_hold_invoice` used to hardcode
+    /// `allow_waiting_buyer_invoice = true` for every caller, so a take that
+    /// raced in behind an already-committed no-invoice take (row at
+    /// `waiting-buyer-invoice`, first taker recorded) still won the CAS and
+    /// clobbered that taker. Only the `add_invoice` caller may treat
+    /// `waiting-buyer-invoice` as a legitimate source.
+    #[test]
+    fn only_the_buyer_invoice_caller_may_swap_out_waiting_buyer_invoice() {
+        assert!(
+            !HoldInvoiceOrigin::Take.allows_waiting_buyer_invoice(),
+            "take paths must lose against an already-committed take"
+        );
+        assert!(
+            HoldInvoiceOrigin::BuyerInvoice.allows_waiting_buyer_invoice(),
+            "add_invoice legitimately arrives from waiting-buyer-invoice"
+        );
+    }
+
+    /// The take-path scope must actually be refused by the CAS it feeds, so
+    /// the mapping above is wired to real database behaviour rather than
+    /// just asserting an enum against itself.
+    #[tokio::test]
+    async fn take_origin_cas_scope_cannot_clobber_a_committed_take() {
+        use mostro_core::db::Crud;
+
+        let pool = SqlitePoolOptions::new().connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        // First taker already committed: row waits for their invoice.
+        let mut committed = base_order(OrderKind::Sell, Status::WaitingBuyerInvoice);
+        committed.id = Uuid::new_v4();
+        committed.buyer_pubkey = Some("aa".repeat(32));
+        let stored = committed.create(&pool).await.unwrap();
+
+        // Second taker, racing in from a stale `pending` read, reaches
+        // show_hold_invoice and tries to store its own escrow.
+        let mut racer = stored.clone();
+        racer.status = Status::WaitingPayment.to_string();
+        racer.buyer_pubkey = Some("bb".repeat(32));
+
+        let won = db::cas_complete_pretrade_take(
+            &pool,
+            &racer,
+            HoldInvoiceOrigin::Take.allows_waiting_buyer_invoice(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!won, "the racing take must lose");
+        let after = Order::by_id(&pool, stored.id).await.unwrap().unwrap();
+        assert_eq!(after.status, Status::WaitingBuyerInvoice.to_string());
+        assert_eq!(
+            after.buyer_pubkey,
+            Some("aa".repeat(32)),
+            "the first taker must survive"
+        );
+    }
+
     // ───────────────────────── LND-dependent early failures ─────────────────────────
 
     #[tokio::test]
@@ -2813,7 +2897,16 @@ mod tests {
         let seller = Keys::generate().public_key();
         let order = base_order(OrderKind::Sell, Status::WaitingPayment);
 
-        let res = show_hold_invoice(&keys, None, &buyer, &seller, order, None).await;
+        let res = show_hold_invoice(
+            &keys,
+            None,
+            &buyer,
+            &seller,
+            order,
+            None,
+            HoldInvoiceOrigin::Take,
+        )
+        .await;
         assert!(res.is_err(), "no LND reachable in unit tests");
     }
 


### PR DESCRIPTION
## Summary

Another finding from the security review (after #851, #853, #861): a stale full-row write in `cancel_pending_order_from_maker` could clobber a concurrent bond promotion, and — verified while fixing — the race was **bidirectional**, because the promotion/resume side also persisted stale full-row snapshots.

The pre-trade window (`pending` / `waiting-taker-bond`) had up to four writers, all full-row `Crud::update` from read-then-mutate snapshots with a network call in between:

- the maker's cancel (`cancel_pending_order_from_maker`) — nostr publish between read and write;
- the bond subscriber's promotion (`promote_taker_context_to_order`) and the resume tail (`resume_take_after_bond`'s `WaitingBuyerInvoice` branch);
- `show_hold_invoice` (called by `take_sell` / `take_buy` / the resume path) — an LND round-trip (`create_hold_invoice`) between read and write.

Any interleaving of a maker cancel with a take/bond-resume let the last full-row write win: the cancel could NULL the promoted taker context and escrow material (`hash`/`preimage`) while the LND hold invoice lived on (the reported clobber), **or** the promotion/escrow write could resurrect a row the cancel had already moved to `canceled`, reviving a trade the maker believes they canceled.

## The fix — every pre-trade write is now a compare-and-swap

Three focused helpers in `src/db.rs`, all guarded by `WHERE id = ? AND status IN ('pending','waiting-taker-bond')` (plus `'waiting-buyer-invoice'` where the `add_invoice` caller legitimately arrives from it):

- `cas_pretrade_order_status` — narrow `status` + `event_id` flip. Used by the maker cancel and by the resume's `WaitingBuyerInvoice` branch. A miss means the take committed first: the cancel is rejected with `NotAllowedByStatus`.
- `cas_promote_taker_context` — writes only the promoted taker columns (never `status`). A miss means a cancel committed first: the resume aborts and the cancel path has already released the taker's bond, so the loser taker is refunded cleanly.
- `cas_complete_pretrade_take` — the wide take-context transition (taker fields, computed amounts, escrow material, status/event) for `show_hold_invoice` and `take_sell`'s no-invoice branch. This one must stay wide: the legacy take handlers mutate taker context and computed `amount`/`fee`/`dev_fee` on the in-memory row, and the pre-fix full-row write was load-bearing for those fields. On a miss, `show_hold_invoice` additionally cancels the just-created (orphaned) hold invoice at LND before bailing.

Net invariant restored: **pre-trade status ⇔ no live trade escrow**, and cancel-vs-take races resolve first-committer-wins on both directions.

Adjacent pieces already in place that this builds on: the `hold_invoice_paid` status guard (#853) makes a late `Accepted` a no-op outside the pre-payment window, and the bond module's cancel paths already treat "already canceled" as benign.

## Tests

- `db`: each CAS helper's happy path and miss path; the wide write asserts taker context, computed amounts, and pre-existing escrow columns all persist, and that misses leave the row untouched.
- `cancel`: the finding's exact scenario — a maker cancel from a pre-promotion snapshot against a row the promotion already landed on keeps the promoted taker context (pre-fix: NULLed) — plus the mirror case (cancel loses once the take committed to `waiting-payment`).
- `bond`: promotion against an already-canceled order errors and writes nothing.

```text
cargo test --bin mostrod                          # 1127 passed, 0 failed, 2 ignored
cargo clippy --all-targets --all-features         # clean
cargo fmt --all -- --check                        # clean
```

## Not covered here

- The adjacent `add_invoice` branch for `WaitingBuyerInvoice` orders (`preimage.is_some()` → `update_order_event(Active)` + full-row update) still races the scheduler's timeout-cancel — that is the separate scheduler/AddInvoice race noted in the audit's minor findings, not this one.
- `show_hold_invoice`'s CAS-miss path (cancel the orphaned invoice) is not unit-testable without refactoring its internal `LndConnector::new()`; covered by review and by the `db`-level tests of the helper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented canceled or already-advanced orders from being accidentally restored or overwritten during concurrent updates.
  - Preserved taker, payment, and escrow details during simultaneous actions.
  - Rejected stale actions and refreshed the latest order state.
  - Canceled orphaned hold invoices when related order updates failed.
  - Improved event timestamp handling so refreshed states supersede stale updates.

- **Tests**
  - Added coverage for concurrent changes, cancellations, status transitions, timestamp ordering, and preservation of existing order information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->