### PR TITLE
chore: migrate nostr-sdk to 0.45.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -176,20 +176,21 @@ dependencies = [
 
 [[package]]
 name = "async-wsocket"
-version = "0.13.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c92385c7c8b3eb2de1b78aeca225212e4c9a69a78b802832759b108681a5069"
+checksum = "2c713e1f14c7b82e32ea159af1c6e2f070cfadbdf23fb2512acce9af0a26f1a2"
 dependencies = [
- "async-utility",
  "futures",
  "futures-util",
  "js-sys",
  "tokio",
+ "tokio-happy-eyeballs",
  "tokio-rustls",
  "tokio-socks",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "url",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -201,12 +202,6 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "atomic-destructor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef49f5882e4b6afaac09ad239a4f8c70a24b8f2b0897edb1f706008efd109cf4"
 
 [[package]]
 name = "atomic-waker"
@@ -278,7 +273,7 @@ version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "365c0acd5b2e8dd0111a46c4faea83fb3cfb6e39a49a7c73a06e090db7b2eff0"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -294,16 +289,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
+name = "bech32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "bip39"
@@ -311,7 +306,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
  "rand 0.8.6",
  "rand_core 0.6.4",
  "serde",
@@ -320,19 +315,19 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.101"
+version = "0.32.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed8ccb78a9ff7a6fbb90e2fb9b8588b4a9928d49d8af3cb789108a84ea6b0ce"
+checksum = "bb0ce8bd5baaa0d303a19915a6d93afed161f528654e42da2a7a97d05c59499a"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin-io",
  "bitcoin-units",
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
  "hex-conservative 0.2.2",
  "hex_lit",
- "secp256k1",
+ "secp256k1 0.29.1",
  "serde",
 ]
 
@@ -342,7 +337,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.5.0",
 ]
 
 [[package]]
@@ -353,6 +348,12 @@ checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
 dependencies = [
  "hex-conservative 0.3.2",
 ]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
@@ -392,6 +393,18 @@ checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5304e53726dbe5f93141535e102ed97b5bf4714fbecefdda8f9fb98d7fdaff0e"
+dependencies = [
+ "bitcoin-consensus-encoding",
+ "bitcoin-internals 0.6.0",
+ "hex-conservative 1.2.0",
  "serde",
 ]
 
@@ -481,6 +494,12 @@ checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "btreecap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6160c957d8aa33d0a8ba1dbab98e3cb57023ad9374c501441e88559f99e6c4c9"
 
 [[package]]
 name = "build_const"
@@ -663,7 +682,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tracing",
  "url",
  "wasm-bindgen",
@@ -823,7 +842,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -898,6 +917,12 @@ dependencies = [
  "unicode-width",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -1006,7 +1031,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1048,7 +1072,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1059,7 +1083,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1107,7 +1131,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -1117,6 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1150,7 +1174,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1159,7 +1183,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec4f825369fc7134da70ca4040fddc8e03b80a46d249ae38d9c1c39b7b4476bf"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
 ]
 
 [[package]]
@@ -1257,6 +1281,16 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "fastrand"
@@ -1410,7 +1444,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1543,6 +1577,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1633,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1673,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,16 +1693,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac 0.13.0",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -1957,18 +2010,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2084,7 +2125,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63a1ab99a13ab3343a9b4d1d25c455bf72322819fc5a5f05c5182e704528a583"
 dependencies = [
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "dnssec-prover",
  "hashbrown 0.13.2",
@@ -2101,7 +2142,7 @@ version = "0.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39b494954ed8f1d774d86473224fadf9f0dfcca38c2d16a7dbdf2b5800c8943"
 dependencies = [
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "lightning-types 0.2.1",
 ]
@@ -2112,7 +2153,7 @@ version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d83bd798e04ab9eecc8bbef1fa17d3808859bcdc0406bd16c55d51c8834444"
 dependencies = [
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "lightning-types 0.3.2",
  "serde",
@@ -2126,7 +2167,7 @@ checksum = "d4c717494cdc2c8bb85bee7113031248f5f6c64f8802b33c1c9e2d98e594aa71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2168,7 +2209,7 @@ dependencies = [
  "aes",
  "anyhow",
  "base64 0.22.1",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "cbc",
  "email_address",
@@ -2195,9 +2236,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 
 [[package]]
 name = "lru-slab"
@@ -2304,7 +2345,7 @@ version = "0.18.1"
 dependencies = [
  "async-trait",
  "axum",
- "bech32",
+ "bech32 0.11.1",
  "bitcoin",
  "cdk",
  "chrono",
@@ -2320,11 +2361,13 @@ dependencies = [
  "lnurl-rs",
  "mostro-core",
  "mutants",
- "nostr-relay-builder",
+ "nostr",
  "nostr-sdk",
  "once_cell",
  "prost 0.14.4",
+ "rand 0.8.6",
  "reqwest",
+ "secp256k1 0.30.0",
  "secrecy",
  "serde",
  "serde_json",
@@ -2343,15 +2386,19 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30391197a9de16ce45b7ee5a92d5b3f74c3d12da4d13d442aff00c93c2424038"
+checksum = "976a8cfc914710e7acfe08645f1ec3467672c60d581e73963fbdd13b53a51b15"
 dependencies = [
  "bitcoin",
  "chrono",
+ "hkdf",
+ "nostr",
  "nostr-sdk",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "sqlx",
  "uuid",
  "wasm-bindgen",
@@ -2399,96 +2446,83 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.6"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e826dd648489de2c5b293920e20b92932ef820302007c1987c758d4d06eeb2cf"
+checksum = "5dde8c76076d334409d86c2e1db3e97abe5deb8cb92744f939cbc1fa45bd69e7"
 dependencies = [
  "base64 0.22.1",
- "bech32",
+ "bech32 0.12.0",
  "bip39",
- "bitcoin_hashes",
+ "bitcoin_hashes 1.2.0",
  "cbc",
  "chacha20 0.9.1",
  "chacha20poly1305",
- "getrandom 0.2.17",
- "hex",
- "instant",
- "scrypt",
- "secp256k1",
+ "faster-hex",
+ "opaquerr",
+ "rand 0.10.1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "unicode-normalization",
+ "universal-time",
  "url",
+ "zeroize",
 ]
 
 [[package]]
 name = "nostr-database"
-version = "0.44.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
+checksum = "4b1fdb9fcba732e32719662afad1b267e50322dbe89e506017ec13f24361bddf"
 dependencies = [
- "lru",
  "nostr",
- "tokio",
+ "opaquerr",
 ]
 
 [[package]]
 name = "nostr-gossip"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
+checksum = "fa07539e52a71cb91fe0d693facaa298f03fcf9edcd66a521094e18e286e2336"
 dependencies = [
  "nostr",
+ "opaquerr",
 ]
 
 [[package]]
-name = "nostr-relay-builder"
-version = "0.44.1"
+name = "nostr-memory"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ed09e8363503c6f464087b530a1f43cf68be6292bd4928b5ea1141b03dc11c"
+checksum = "dd2b7b21ffca47ad6dc32474d06d7fd1e8f83f218f7b350f4309eb5f49e7f97d"
 dependencies = [
- "async-utility",
- "async-wsocket",
- "atomic-destructor",
- "hex",
- "negentropy",
+ "btreecap",
  "nostr",
  "nostr-database",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "nostr-relay-pool"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b2c039df4f96c4bf7dae52a74fd5516ad6dda83a11c0c69dea91b5255a4f37"
-dependencies = [
- "async-utility",
- "async-wsocket",
- "atomic-destructor",
- "hex",
- "lru",
- "negentropy",
- "nostr",
- "nostr-database",
- "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "nostr-sdk"
-version = "0.44.1"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "471732576710e779b64f04c55e3f8b5292f865fea228436daf19694f0bf70393"
+checksum = "26c86342f367bd9b173ec4a697e936e3a82d6dad5b4aa06c0d35d9b4f88a8e72"
 dependencies = [
  "async-utility",
+ "async-wsocket",
+ "faster-hex",
+ "futures",
+ "lru",
+ "negentropy",
  "nostr",
  "nostr-database",
  "nostr-gossip",
- "nostr-relay-pool",
+ "nostr-memory",
+ "opaquerr",
+ "rand 0.10.1",
  "tokio",
+ "tokio-stream",
  "tracing",
+ "universal-time",
 ]
 
 [[package]]
@@ -2570,6 +2604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "opaquerr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f933a4265d5cdad61d19bbdfc972ea5726d56cd8d3d57b8f2d3c365dd42bee9"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2611,31 +2651,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
-dependencies = [
- "base64ct",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac 0.12.1",
-]
 
 [[package]]
 name = "pem"
@@ -2729,7 +2748,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2795,7 +2814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2843,7 +2862,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -2864,7 +2883,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -2878,7 +2897,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2891,7 +2910,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3121,7 +3140,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3295,15 +3314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3343,24 +3353,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
+ "rand 0.8.6",
+ "secp256k1-sys",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes 0.14.101",
  "rand 0.8.6",
  "secp256k1-sys",
  "serde",
@@ -3416,9 +3426,9 @@ checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3426,29 +3436,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -3518,7 +3528,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3765,7 +3775,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3788,7 +3798,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.118",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -3841,7 +3851,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac 0.13.0",
+ "hmac",
  "itoa",
  "log",
  "md-5",
@@ -3923,7 +3933,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3937,6 +3947,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3960,7 +3981,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4014,7 +4035,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4025,7 +4046,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4110,6 +4131,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-happy-eyeballs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8564c32dfb6f4257f8bc6edfc178a34af97520e0b7b9815500c55eb3d092f29f"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4117,7 +4147,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4151,6 +4181,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4166,7 +4197,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.28.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -4291,7 +4337,7 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4303,7 +4349,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4328,7 +4374,7 @@ dependencies = [
  "prost-build 0.14.4",
  "prost-types 0.14.4",
  "quote",
- "syn",
+ "syn 2.0.118",
  "tempfile",
  "tonic-build 0.14.6",
 ]
@@ -4407,7 +4453,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4460,6 +4506,25 @@ name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -4530,6 +4595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-time"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a939edecc3c5a7b83c02e5f6b3c31d2bc69eabcc9a87ab12c6d37ee6dbc856"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4586,9 +4657,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4641,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4654,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4664,9 +4735,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4674,31 +4745,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4768,7 +4839,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4779,7 +4850,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5014,7 +5085,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5035,7 +5106,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5055,7 +5126,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5095,7 +5166,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,9 @@ mutants = "0.0.3" # For #[mutants::skip] annotations
 chrono = "0.4.35"
 easy-hasher = "2.2.1"
 lightning-invoice = { version = "0.33.1", features = ["std"] }
-nostr-sdk = { version = "0.44.1", features = ["nip44", "nip59"] }
+nostr = { version = "0.45.1" }
+nostr-sdk = { version = "0.45.1" }
+rand = "0.8"
 serde = { version = "1.0.210" }
 toml = "0.9.5"
 serde_json = "1.0.128"
@@ -69,7 +71,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.14.1", features = ["sqlx"] }
+mostro-core = { version = "0.14.3", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 async-trait = "0.1.83"
@@ -86,6 +88,7 @@ tonic = "0.14.2"
 prost = "0.14.1"
 tonic-prost = "0.14.1"
 cdk = { version = "0.17.2", default-features = false, features = ["wallet"] }
+secp256k1 = { version = "0.30", features = ["serde"] }
 secrecy = { version = "0.10", features = ["serde"] }
 zeroize = "1.8"
 
@@ -94,7 +97,7 @@ tokio = { version = "1.47.1", features = ["full", "test-util", "macros"] }
 axum = "0.8.4"
 tower-http = { version = "0.6.6", features = ["cors"] }
 bech32 = "0.11.0"
-nostr-relay-builder = "0.44.1"
+nostr-sdk = { version = "0.45.1", features = ["local-relay"] }
 
 [build-dependencies]
 tonic-prost-build = "0.14.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,6 +52,7 @@ use crate::db::add_new_user;
 use crate::db::is_user_present;
 use crate::lightning::LndConnector;
 use crate::util::enqueue_cant_do_msg;
+use crate::Result;
 
 // External dependencies
 use mostro_core::error::CantDoReason;
@@ -460,8 +461,8 @@ pub async fn run(ctx: AppContext, ln_client: &mut LndConnector) -> Result<()> {
     loop {
         let mut notifications = client.notifications();
 
-        while let Ok(notification) = notifications.recv().await {
-            if let RelayPoolNotification::Event { event, .. } = notification {
+        while let Some(notification) = notifications.next().await {
+            if let ClientNotification::Event { event, .. } = notification {
                 let Some((action, message, unwrapped)) = accept_event(
                     &ctx,
                     &event,
@@ -511,8 +512,8 @@ pub async fn run_cashu(ctx: AppContext) -> Result<()> {
     loop {
         let mut notifications = client.notifications();
 
-        while let Ok(notification) = notifications.recv().await {
-            if let RelayPoolNotification::Event { event, .. } = notification {
+        while let Some(notification) = notifications.next().await {
+            if let ClientNotification::Event { event, .. } = notification {
                 let Some((action, message, unwrapped)) = accept_event(
                     &ctx,
                     &event,
@@ -576,8 +577,8 @@ mod tests {
     use super::*;
     use mostro_core::message::Action;
 
-    use nostr_sdk::secp256k1::schnorr::Signature;
-    use nostr_sdk::{Keys, Kind as NostrKind, Timestamp};
+    use nostr_sdk::prelude::{Keys, Kind as NostrKind, Timestamp};
+    use secp256k1::schnorr::Signature;
 
     // Helper function to create test keys
     fn create_test_keys() -> Keys {
@@ -956,7 +957,7 @@ mod tests {
             // Globals some handlers reach for; installing them is idempotent.
             let _ =
                 crate::config::MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
-            let _ = crate::NOSTR_CLIENT.set(nostr_sdk::Client::default());
+            let _ = crate::NOSTR_CLIENT.set(nostr_sdk::prelude::Client::default());
 
             let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
             sqlx::migrate!("./migrations")
@@ -1061,7 +1062,7 @@ mod tests {
         async fn blocks_every_order_lifecycle_action_with_invalid_action() {
             let _ =
                 crate::config::MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
-            let _ = crate::NOSTR_CLIENT.set(nostr_sdk::Client::default());
+            let _ = crate::NOSTR_CLIENT.set(nostr_sdk::prelude::Client::default());
             let ctx = create_ctx().await;
             let my_keys = create_test_keys();
             let event = create_test_unwrapped_message();

--- a/src/app/add_cashu_escrow.rs
+++ b/src/app/add_cashu_escrow.rs
@@ -331,7 +331,7 @@ pub async fn add_cashu_escrow_action(
 mod tests {
     use super::*;
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::SqlitePool;
     use std::sync::Arc;
 

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::str::FromStr;
 
 use crate::app::bond::{self, BondSlashReason};
@@ -142,23 +141,14 @@ pub async fn admin_cancel_action(
             .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
         // We create a tag to show status of the dispute
         let tags: Tags = Tags::from_list(vec![
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("s")),
-                vec![DisputeStatus::SellerRefunded.to_string()],
-            ),
+            Tag::custom("s", vec![DisputeStatus::SellerRefunded.to_string()]),
             // Who is the dispute creator
+            Tag::custom("initiator", vec![dispute_initiator]),
             Tag::custom(
-                TagKind::Custom(std::borrow::Cow::Borrowed("initiator")),
-                vec![dispute_initiator],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("y")),
+                "y",
                 create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
             ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("z")),
-                vec!["dispute".to_string()],
-            ),
+            Tag::custom("z", vec!["dispute".to_string()]),
         ]);
         // nip33 kind with dispute id as identifier (kind 38386 for disputes)
         let event = new_dispute_event(my_keys, "", dispute_id.to_string(), tags)

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -139,23 +139,14 @@ pub async fn admin_settle_action(
 
         // We create a tag to show status of the dispute
         let tags: Tags = Tags::from_list(vec![
-            Tag::custom(
-                TagKind::Custom(std::borrow::Cow::Borrowed("s")),
-                vec![DisputeStatus::Settled.to_string()],
-            ),
+            Tag::custom("s", vec![DisputeStatus::Settled.to_string()]),
             // Who is the dispute creator
+            Tag::custom("initiator", vec![dispute_initiator]),
             Tag::custom(
-                TagKind::Custom(std::borrow::Cow::Borrowed("initiator")),
-                vec![dispute_initiator],
-            ),
-            Tag::custom(
-                TagKind::Custom(std::borrow::Cow::Borrowed("y")),
+                "y",
                 create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
             ),
-            Tag::custom(
-                TagKind::Custom(std::borrow::Cow::Borrowed("z")),
-                vec!["dispute".to_string()],
-            ),
+            Tag::custom("z", vec!["dispute".to_string()]),
         ]);
 
         // nip33 kind with dispute id as identifier (kind 38386 for disputes)

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -264,23 +264,14 @@ pub async fn admin_take_dispute_action(
 
     // We create a tag to show status of the dispute
     let tags: Tags = Tags::from_list(vec![
-        Tag::custom(
-            TagKind::Custom(std::borrow::Cow::Borrowed("s")),
-            vec![Status::InProgress.to_string()],
-        ),
+        Tag::custom("s", vec![Status::InProgress.to_string()]),
         // Who is the dispute creator
+        Tag::custom("initiator", vec![dispute_initiator]),
         Tag::custom(
-            TagKind::Custom(std::borrow::Cow::Borrowed("initiator")),
-            vec![dispute_initiator],
-        ),
-        Tag::custom(
-            TagKind::Custom(std::borrow::Cow::Borrowed("y")),
+            "y",
             create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
         ),
-        Tag::custom(
-            TagKind::Custom(std::borrow::Cow::Borrowed("z")),
-            vec!["dispute".to_string()],
-        ),
+        Tag::custom("z", vec!["dispute".to_string()]),
     ]);
     // nip33 kind with dispute id as identifier (kind 38386 for disputes)
     let event = new_dispute_event(mostro_keys, "", dispute.id.to_string(), tags)

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -41,12 +41,12 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
+use bitcoin::hashes::hex::FromHex;
 use chrono::Utc;
 use fedimint_tonic_lnd::lnrpc::invoice::InvoiceState;
 use mostro_core::db::Crud;
 use mostro_core::error::{MostroError, MostroError::MostroInternalErr, ServiceError};
 use mostro_core::prelude::*;
-use nostr_sdk::nostr::hashes::hex::FromHex;
 use nostr_sdk::prelude::*;
 use sqlx::{Pool, Sqlite};
 use tokio::sync::mpsc::channel;

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -3784,7 +3784,7 @@ mod tests {
 
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
     use mostro_core::message::MessageKind;
-    use nostr_sdk::Timestamp;
+    use nostr_sdk::prelude::Timestamp;
 
     fn build_ctx(pool: &Pool<Sqlite>) -> crate::app::context::AppContext {
         TestContextBuilder::new()

--- a/src/app/cancel.rs
+++ b/src/app/cancel.rs
@@ -702,7 +702,7 @@ mod tests {
     use super::*;
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
     use mostro_core::db::Crud;
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::SqlitePool;
     use std::sync::Arc;
 

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -9,7 +9,7 @@
 use crate::cashu::CashuClient;
 use crate::config::settings::Settings;
 use mostro_core::prelude::Message;
-use nostr_sdk::{Client, Keys, PublicKey};
+use nostr_sdk::prelude::{Client, Keys, PublicKey};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -335,8 +335,8 @@ mod tests {
     #[tokio::test]
     async fn context_accessors_expose_injected_dependencies() {
         let pool = Arc::new(SqlitePool::connect("sqlite::memory:").await.unwrap());
-        let keys = nostr_sdk::Keys::generate();
-        let client = nostr_sdk::Client::default();
+        let keys = nostr_sdk::prelude::Keys::generate();
+        let client = nostr_sdk::prelude::Client::default();
 
         let ctx = TestContextBuilder::new()
             .with_pool(pool.clone())
@@ -379,7 +379,7 @@ mod tests {
 
         // Push through the context handle, observe through the mock handle.
         let msg = mostro_core::prelude::Message::new_restore(None);
-        let key = nostr_sdk::Keys::generate().public_key();
+        let key = nostr_sdk::prelude::Keys::generate().public_key();
         ctx.order_msg_queue().write().await.push((msg, key));
         assert_eq!(mock.len().await, 1);
         assert!(!mock.is_empty().await);

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -72,7 +72,7 @@ use mostro_core::error::MostroError::MostroInternalErr;
 use mostro_core::error::ServiceError;
 use mostro_core::order::Order;
 use nostr_sdk::prelude::ToBech32;
-use nostr_sdk::{Keys, PublicKey};
+use nostr_sdk::prelude::{Keys, PublicKey};
 use sqlx::SqlitePool;
 use std::collections::HashSet;
 use tokio::sync::mpsc::channel;
@@ -783,7 +783,7 @@ async fn check_dev_fee_payment_status(
         }
     };
 
-    use nostr_sdk::nostr::hashes::hex::FromHex;
+    use bitcoin::hashes::hex::FromHex;
     let payment_hash_bytes: Vec<u8> = match FromHex::from_hex(&payment_hash_str) {
         Ok(bytes) => bytes,
         Err(e) => {
@@ -1529,7 +1529,7 @@ mod tests {
         verify_confirmed_orders,
     };
     use crate::lightning::LndConnector;
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
 
     /// Real `LndConnector` against a dead endpoint: `connect` is lazy,
     /// so it always builds; every RPC fails in ~1ms with a transport

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -10,7 +10,6 @@ use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
 
 use mostro_core::db::Crud;
-use std::borrow::Cow;
 use uuid::Uuid;
 
 /// Publishes a dispute event to the Nostr network.
@@ -32,25 +31,16 @@ async fn publish_dispute_event(
     // Create tags for the dispute event
     let tags = Tags::from_list(vec![
         // Status tag - indicates the current state of the dispute
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("s")),
-            vec![dispute.status.to_string()],
-        ),
+        Tag::custom("s", vec![dispute.status.to_string()]),
         // Who is the dispute creator
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("initiator")),
-            vec![initiator.to_string()],
-        ),
+        Tag::custom("initiator", vec![initiator.to_string()]),
         // Application identifier tag
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("y")),
+            "y",
             create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
         ),
         // Event type tag
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("z")),
-            vec!["dispute".to_string()],
-        ),
+        Tag::custom("z", vec!["dispute".to_string()]),
     ]);
 
     // Create a new NIP-33 replaceable event (kind 38386 for disputes)
@@ -295,22 +285,13 @@ pub async fn close_dispute_after_user_resolution(
 
             // Publish updated dispute event to Nostr so admin clients see it as resolved
             let tags = Tags::from_list(vec![
+                Tag::custom("s", vec![new_status.to_string()]),
+                Tag::custom("initiator", vec![dispute_initiator.to_string()]),
                 Tag::custom(
-                    TagKind::Custom(Cow::Borrowed("s")),
-                    vec![new_status.to_string()],
-                ),
-                Tag::custom(
-                    TagKind::Custom(Cow::Borrowed("initiator")),
-                    vec![dispute_initiator.to_string()],
-                ),
-                Tag::custom(
-                    TagKind::Custom(Cow::Borrowed("y")),
+                    "y",
                     create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
                 ),
-                Tag::custom(
-                    TagKind::Custom(Cow::Borrowed("z")),
-                    vec!["dispute".to_string()],
-                ),
+                Tag::custom("z", vec!["dispute".to_string()]),
             ]);
 
             match new_dispute_event(my_keys, "", dispute_id.to_string(), tags) {
@@ -338,7 +319,7 @@ mod tests {
     use super::*;
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
     use crate::config::MESSAGE_QUEUES;
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
     use sqlx::SqlitePool;
     use std::sync::Arc;
 

--- a/src/app/fiat_sent.rs
+++ b/src/app/fiat_sent.rs
@@ -98,7 +98,7 @@ mod tests {
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
     use crate::app::context::AppContext;
     use crate::config::{MESSAGE_QUEUES, MOSTRO_CONFIG};
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::SqlitePool;
     use std::sync::Arc;
 

--- a/src/app/last_trade_index.rs
+++ b/src/app/last_trade_index.rs
@@ -100,7 +100,7 @@ pub async fn last_trade_index(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::sqlite::SqlitePoolOptions;
     use sqlx::SqlitePool;
 

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -2,8 +2,7 @@ use crate::app::context::AppContext;
 use crate::db::update_user_trade_index;
 use crate::util::{get_bitcoin_price, publish_order, validate_invoice};
 use mostro_core::prelude::*;
-use nostr_sdk::prelude::*;
-use nostr_sdk::Keys;
+use nostr_sdk::prelude::Keys;
 
 async fn calculate_and_check_quote(
     ctx: &AppContext,
@@ -169,7 +168,7 @@ mod tests {
     use super::*;
     use mostro_core::message::MessageKind;
 
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::SqlitePool;
 
     async fn create_test_pool() -> SqlitePool {
@@ -504,7 +503,7 @@ mod tests {
         fn init_globals() {
             let _ =
                 crate::config::MOSTRO_CONFIG.set(crate::app::context::test_utils::test_settings());
-            let _ = crate::NOSTR_CLIENT.set(nostr_sdk::Client::default());
+            let _ = crate::NOSTR_CLIENT.set(nostr_sdk::prelude::Client::default());
         }
 
         fn order_message(fiat_code: &str, trade_index: Option<i64>) -> Message {

--- a/src/app/orders.rs
+++ b/src/app/orders.rs
@@ -1,7 +1,6 @@
 use crate::app::context::AppContext;
 use crate::util::{enqueue_order_msg, get_user_orders_by_id};
 use mostro_core::prelude::*;
-use nostr_sdk::prelude::*;
 
 // Handle orders action
 pub async fn orders_action(
@@ -62,7 +61,7 @@ mod tests {
     use super::*;
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
     use mostro_core::db::Crud;
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, PublicKey, Timestamp};
     use sqlx::SqlitePool;
     use std::sync::Arc;
     use uuid::Uuid;

--- a/src/app/rate_user.rs
+++ b/src/app/rate_user.rs
@@ -180,15 +180,11 @@ pub async fn update_user_reputation_action(
         user_to_vote.min_rating as u8,
         user_to_vote.max_rating as u8,
     )
-    .to_tags()
-    .map_err(|cause| MostroInternalErr(ServiceError::NostrError(cause.to_string())))?;
+    .to_tags();
 
     let days = calculate_days_since_creation(user_to_vote.created_at);
     let mut tags: Vec<Tag> = reputation_event.into_iter().collect();
-    tags.push(Tag::custom(
-        TagKind::Custom(std::borrow::Cow::Borrowed("days")),
-        vec![days.to_string()],
-    ));
+    tags.push(Tag::custom("days", vec![days.to_string()]));
     let reputation_event = Tags::from_list(tags);
 
     if buyer_rating || seller_rating {
@@ -227,7 +223,7 @@ mod tests {
     use mostro_core::db::Crud;
     use mostro_core::message::{MessageKind, Payload};
     use mostro_core::order::Order;
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::SqlitePool;
     use uuid::Uuid;
 

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -7,6 +7,7 @@ use crate::lightning::LndConnector;
 use crate::lnurl::resolv_ln_address;
 use crate::nip33::{new_order_event, order_to_tags};
 use crate::util::{enqueue_order_msg, get_order, settle_seller_hold_invoice, update_order_event};
+use crate::Result;
 
 use fedimint_tonic_lnd::lnrpc::payment::PaymentStatus;
 use lnurl::lightning_address::LightningAddress;
@@ -840,7 +841,7 @@ mod tests {
     use crate::app::context::AppContext;
     use crate::config::{MESSAGE_QUEUES, MOSTRO_CONFIG};
     use async_trait::async_trait;
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::SqlitePool;
     use std::sync::Arc;
 

--- a/src/app/restore_session.rs
+++ b/src/app/restore_session.rs
@@ -124,7 +124,7 @@ mod tests {
     use super::*;
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
     use crate::config::MESSAGE_QUEUES;
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
     use sqlx::SqlitePool;
     use std::sync::Arc;
 

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -242,7 +242,7 @@ mod tests {
     use super::*;
 
     use mostro_core::order::{Kind as OrderKind, Status};
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::SqlitePool;
 
     async fn create_test_pool() -> SqlitePool {

--- a/src/app/trade_pubkey.rs
+++ b/src/app/trade_pubkey.rs
@@ -3,7 +3,6 @@ use crate::util::{enqueue_order_msg, get_order};
 
 use mostro_core::db::Crud;
 use mostro_core::prelude::*;
-use nostr_sdk::prelude::*;
 
 pub async fn trade_pubkey_action(
     ctx: &AppContext,
@@ -76,7 +75,7 @@ pub async fn trade_pubkey_action(
 mod tests {
     use super::*;
     use crate::app::context::test_utils::{test_settings, TestContextBuilder};
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, PublicKey, Timestamp};
     use sqlx::SqlitePool;
     use std::sync::Arc;
     use uuid::Uuid;

--- a/src/cashu/mod.rs
+++ b/src/cashu/mod.rs
@@ -995,7 +995,7 @@ mod tests {
     fn odd_y_nostr_key_signs_for_derived_cashu_pubkey() {
         use cdk::nuts::nut00::Witness;
         use cdk::nuts::nut11::P2PKWitness;
-        use nostr_sdk::Keys;
+        use nostr_sdk::prelude::Keys;
 
         // Find a Nostr key whose secp256k1 point has odd-Y parity (`0x03`).
         let (keys, nut_sk) = loop {

--- a/src/config/secret.rs
+++ b/src/config/secret.rs
@@ -5,7 +5,7 @@ use crate::config::constants::NSEC_ENV_VAR;
 use crate::config::types::NostrSettings;
 use mostro_core::error::MostroError::{self, *};
 use mostro_core::error::ServiceError;
-use nostr_sdk::Keys;
+use nostr_sdk::prelude::Keys;
 use secrecy::{ExposeSecret, SecretString};
 use serde::Serializer;
 use zeroize::Zeroize;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -8,7 +8,7 @@ use crate::price::PriceSettings;
 use mostro_core::error::MostroError::{self, *};
 use mostro_core::error::ServiceError;
 use mostro_core::transport::Transport;
-use nostr_sdk::Keys;
+use nostr_sdk::prelude::Keys;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -2275,7 +2275,7 @@ mod tests {
     #[tokio::test]
     async fn test_find_order_by_date_includes_waiting_taker_bond() {
         let pool = setup_orders_db().await.unwrap();
-        let now = nostr_sdk::Timestamp::now().as_secs() as i64;
+        let now = nostr_sdk::prelude::Timestamp::now().as_secs() as i64;
         let past = now - 3600;
         let future = now + 3600;
 

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,4 +1,5 @@
 use crate::util::{enqueue_order_msg, notify_taker_reputation};
+use crate::Result;
 use mostro_core::db::Crud;
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
@@ -197,7 +198,7 @@ pub async fn hold_invoice_canceled(hash: &str, pool: &SqlitePool) -> Result<()> 
 mod tests {
     use super::*;
     use mostro_core::order::{Kind as OrderKind, Status};
-    use nostr_sdk::{Keys, Timestamp};
+    use nostr_sdk::prelude::{Keys, Timestamp};
     use sqlx::SqlitePool;
 
     async fn create_test_pool() -> SqlitePool {

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -3,6 +3,7 @@ pub mod invoice;
 use crate::config::settings::Settings;
 use crate::lightning::invoice::decode_invoice;
 use crate::util::bytes_to_string;
+use bitcoin::hashes::hex::FromHex;
 use easy_hasher::easy_hasher::*;
 use fedimint_tonic_lnd::invoicesrpc::{
     AddHoldInvoiceRequest, AddHoldInvoiceResp, CancelInvoiceMsg, CancelInvoiceResp,
@@ -12,8 +13,7 @@ use fedimint_tonic_lnd::lnrpc::{invoice::InvoiceState, GetInfoRequest, GetInfoRe
 use fedimint_tonic_lnd::routerrpc::{SendPaymentRequest, TrackPaymentRequest};
 use fedimint_tonic_lnd::Client;
 use mostro_core::prelude::*;
-use nostr_sdk::nostr::hashes::hex::FromHex;
-use nostr_sdk::nostr::secp256k1::rand::{self, RngCore};
+use rand::{self, RngCore};
 use std::cmp::Ordering;
 use tokio::sync::mpsc::Sender;
 use tracing::info;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,11 @@ pub mod scheduler;
 pub mod spam_gate;
 pub mod util;
 
+/// Convenience alias mirroring the one `nostr` (pre-0.45) used to re-export
+/// via `nostr_sdk::prelude::*`; nostr 0.45 dropped it, so it's recreated here
+/// for the crate root and pulled into other modules via `use crate::Result;`.
+pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
+
 use crate::app::context::AppContext;
 use crate::app::{run, run_cashu};
 use crate::cli::settings_init;
@@ -112,12 +117,12 @@ async fn main() -> Result<()> {
     };
 
     // Client subscription
-    client.subscribe(subscription, None).await?;
+    client.subscribe(subscription).await?;
 
     // Publish NIP-01 kind 0 metadata event
     let mostro_settings = Settings::get_mostro();
     let mut has_metadata = false;
-    let mut metadata = nostr_sdk::Metadata::new();
+    let mut metadata = Metadata::new();
 
     if let Some(ref name) = mostro_settings.name {
         metadata = metadata.name(name);
@@ -128,7 +133,7 @@ async fn main() -> Result<()> {
         has_metadata = true;
     }
     if let Some(ref picture) = mostro_settings.picture {
-        if let Ok(url) = nostr_sdk::Url::parse(picture) {
+        if let Ok(url) = Url::parse(picture) {
             metadata = metadata.picture(url);
             has_metadata = true;
         } else {
@@ -136,7 +141,7 @@ async fn main() -> Result<()> {
         }
     }
     if let Some(ref website) = mostro_settings.website {
-        if let Ok(url) = nostr_sdk::Url::parse(website) {
+        if let Ok(url) = Url::parse(website) {
             metadata = metadata.website(url);
             has_metadata = true;
         } else {
@@ -145,7 +150,7 @@ async fn main() -> Result<()> {
     }
 
     if has_metadata {
-        if let Ok(metadata_ev) = EventBuilder::metadata(&metadata).sign_with_keys(mostro_keys) {
+        if let Ok(metadata_ev) = metadata.finalize(mostro_keys) {
             let _ = client.send_event(&metadata_ev).await;
             tracing::info!("Published NIP-01 kind 0 metadata event");
         }

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -5,10 +5,9 @@ use crate::lightning::LnStatus;
 use crate::util::{get_expiration_timestamp_for_kind, get_keys};
 use crate::LN_STATUS;
 use mostro_core::prelude::*;
-use nostr::event::builder::Error;
+use nostr::error::Error;
 use nostr_sdk::prelude::*;
 use serde_json::json;
-use std::borrow::Cow;
 use std::vec;
 
 /// Internal helper function to create a NIP-33 replaceable event with a specific kind
@@ -23,10 +22,10 @@ fn create_event(
     tags.push(Tag::identifier(identifier));
 
     // Add NIP-40 expiration tag if configured and not already provided.
-    let has_expiration_tag = tags.iter().chain(extra_tags.iter()).any(|t| {
-        matches!(t.kind(), TagKind::Expiration)
-            || (matches!(t.kind(), TagKind::Custom(ref c) if c == "expiration"))
-    });
+    let has_expiration_tag = tags
+        .iter()
+        .chain(extra_tags.iter())
+        .any(|t| t.kind() == "expiration");
     if !has_expiration_tag {
         if let Some(expiration_timestamp) = get_expiration_timestamp_for_kind(kind) {
             tags.push(Tag::expiration(Timestamp::from(
@@ -38,9 +37,9 @@ fn create_event(
     tags.extend(extra_tags);
     let tags = Tags::from_list(tags);
 
-    EventBuilder::new(nostr::Kind::Custom(kind), content)
+    EventBuilder::new(nostr::event::Kind::Custom(kind), content)
         .tags(tags)
-        .sign_with_keys(keys)
+        .finalize(keys)
 }
 
 /// Creates a new order event (kind 38383)
@@ -164,8 +163,8 @@ pub fn new_dispute_event(
 /// wrapper.insert("BTC".to_string(), bitcoin_prices.clone());
 /// let content = serde_json::to_string(&wrapper)?;
 /// let tags = Tags::from_list(vec![
-///     Tag::custom(TagKind::Custom("published_at".into()), vec![timestamp.to_string()]),
-///     Tag::custom(TagKind::Custom("source".into()), vec!["yadio".to_string()]),
+///     Tag::custom("published_at", vec![timestamp.to_string()]),
+///     Tag::custom("source", vec!["yadio".to_string()]),
 ///     Tag::expiration(Timestamp::from(expiration)),
 /// ]);
 /// let event = new_exchange_rates_event(&keys, &content, tags)?;
@@ -407,72 +406,39 @@ pub fn order_to_tags(
             .map(|s| s.to_string())
             .collect();
         let mut tags: Vec<Tag> = vec![
+            Tag::custom("k", vec![order.kind.to_string()]),
+            Tag::custom("f", vec![order.fiat_code.to_string()]),
+            Tag::custom("s", vec![status.to_string()]),
+            Tag::custom("amt", vec![order.amount.to_string()]),
+            Tag::custom("fa", create_fiat_amt_array(order)),
+            Tag::custom("pm", payment_method),
+            Tag::custom("premium", vec![order.premium.to_string()]),
+            Tag::custom("network", vec![ln_network]),
+            Tag::custom("layer", vec!["lightning".to_string()]),
+            Tag::custom("expires_at", vec![order.expires_at.to_string()]),
             Tag::custom(
-                TagKind::Custom(Cow::Borrowed("k")),
-                vec![order.kind.to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("f")),
-                vec![order.fiat_code.to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("s")),
-                vec![status.to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("amt")),
-                vec![order.amount.to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("fa")),
-                create_fiat_amt_array(order),
-            ),
-            Tag::custom(TagKind::Custom(Cow::Borrowed("pm")), payment_method),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("premium")),
-                vec![order.premium.to_string()],
-            ),
-            Tag::custom(TagKind::Custom(Cow::Borrowed("network")), vec![ln_network]),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("layer")),
-                vec!["lightning".to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("expires_at")),
-                vec![order.expires_at.to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("expiration")),
+                "expiration",
                 vec![get_expiration_timestamp_for_kind(NOSTR_ORDER_EVENT_KIND)
                     .expect("expiration is always defined for order events")
                     .to_string()],
             ),
             Tag::custom(
-                TagKind::Custom(Cow::Borrowed("y")),
+                "y",
                 create_platform_tag_values(Settings::get_mostro().name.as_deref()),
             ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("z")),
-                vec!["order".to_string()],
-            ),
+            Tag::custom("z", vec!["order".to_string()]),
         ];
 
         // Add reputation data if available
         if reputation_data.is_some() {
             tags.insert(
                 RATING_TAG_INDEX,
-                Tag::custom(
-                    TagKind::Custom(Cow::Borrowed("rating")),
-                    vec![create_rating_tag(reputation_data)],
-                ),
+                Tag::custom("rating", vec![create_rating_tag(reputation_data)]),
             );
         }
         // Add source tag if available
         if let Some(source) = mostro_link {
-            tags.insert(
-                SOURCE_TAG_INDEX,
-                Tag::custom(TagKind::Custom(Cow::Borrowed("source")), vec![source]),
-            );
+            tags.insert(SOURCE_TAG_INDEX, Tag::custom("source", vec![source]));
         }
         Ok(Some(Tags::from_list(tags)))
     } else {
@@ -528,45 +494,36 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
 
     let mut tags_vec: Vec<Tag> = vec![
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("mostro_version")),
+            "mostro_version",
             vec![env!("CARGO_PKG_VERSION").to_string()],
         ),
+        Tag::custom("mostro_commit_hash", vec![env!("GIT_HASH").to_string()]),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("mostro_commit_hash")),
-            vec![env!("GIT_HASH").to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("max_order_amount")),
+            "max_order_amount",
             vec![mostro_settings.max_order_amount.to_string()],
         ),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("min_order_amount")),
+            "min_order_amount",
             vec![mostro_settings.min_payment_amount.to_string()],
         ),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("expiration_hours")),
+            "expiration_hours",
             vec![mostro_settings.expiration_hours.to_string()],
         ),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("expiration_seconds")),
+            "expiration_seconds",
             vec![mostro_settings.expiration_seconds.to_string()],
         ),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("fiat_currencies_accepted")),
+            "fiat_currencies_accepted",
             vec![mostro_settings.fiat_currencies_accepted.join(",")],
         ),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("max_orders_per_response")),
+            "max_orders_per_response",
             vec![mostro_settings.max_orders_per_response.to_string()],
         ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("fee")),
-            vec![mostro_settings.fee.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("pow")),
-            vec![mostro_settings.pow.to_string()],
-        ),
+        Tag::custom("fee", vec![mostro_settings.fee.to_string()]),
+        Tag::custom("pow", vec![mostro_settings.pow.to_string()]),
         // Companion of `pow` for the Phase 2 anti-spam gate: the difficulty an
         // event from a sender that is *not* in the active-trade cache must
         // clear. Advertised as an already-resolved absolute difficulty so a
@@ -580,65 +537,38 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
         // its first accepted event and its follow-ups must carry the same
         // work. See docs/TRANSPORT_V2_SPEC.md §6 Phase 2.
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("pow_first_contact")),
+            "pow_first_contact",
             vec![advertised_first_contact_pow(mostro_settings).to_string()],
         ),
         // Capability advertisement: which Mostro protocol version this node
         // speaks ("1" = gift wrap, "2" = NIP-44 direct), derived from the
         // `transport` setting so clients pick the right wire format before
         // sending anything. See docs/TRANSPORT_V2_SPEC.md.
+        Tag::custom("protocol_version", vec![protocol_version.to_string()]),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("protocol_version")),
-            vec![protocol_version.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("hold_invoice_expiration_window")),
+            "hold_invoice_expiration_window",
             vec![ln_settings.hold_invoice_expiration_window.to_string()],
         ),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("hold_invoice_cltv_delta")),
+            "hold_invoice_cltv_delta",
             vec![ln_settings.hold_invoice_cltv_delta.to_string()],
         ),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("invoice_expiration_window")),
+            "invoice_expiration_window",
             vec![ln_settings.hold_invoice_expiration_window.to_string()],
         ),
+        Tag::custom("lnd_version", vec![ln_status.version.to_string()]),
+        Tag::custom("lnd_node_pubkey", vec![ln_status.node_pubkey.to_string()]),
+        Tag::custom("lnd_commit_hash", vec![ln_status.commit_hash.to_string()]),
+        Tag::custom("lnd_node_alias", vec![ln_status.node_alias.to_string()]),
+        Tag::custom("lnd_chains", vec![ln_status.chains.join(",")]),
+        Tag::custom("lnd_networks", vec![ln_status.networks.join(",")]),
+        Tag::custom("lnd_uris", vec![ln_status.uris.join(",")]),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("lnd_version")),
-            vec![ln_status.version.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("lnd_node_pubkey")),
-            vec![ln_status.node_pubkey.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("lnd_commit_hash")),
-            vec![ln_status.commit_hash.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("lnd_node_alias")),
-            vec![ln_status.node_alias.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("lnd_chains")),
-            vec![ln_status.chains.join(",")],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("lnd_networks")),
-            vec![ln_status.networks.join(",")],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("lnd_uris")),
-            vec![ln_status.uris.join(",")],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("y")),
+            "y",
             create_platform_tag_values(mostro_settings.name.as_deref()),
         ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("z")),
-            vec!["info".to_string()],
-        ),
+        Tag::custom("z", vec!["info".to_string()]),
     ];
 
     tags_vec.extend(bond_policy_tags(bond_settings));
@@ -664,10 +594,7 @@ fn bond_policy_tags(
 ) -> Vec<Tag> {
     let mut tags = Vec::with_capacity(7);
     let bond_enabled = bond_settings.is_some_and(|b| b.enabled);
-    tags.push(Tag::custom(
-        TagKind::Custom(Cow::Borrowed("bond_enabled")),
-        vec![bond_enabled.to_string()],
-    ));
+    tags.push(Tag::custom("bond_enabled", vec![bond_enabled.to_string()]));
     if let Some(bond) = bond_settings {
         if bond.enabled {
             let apply_to_str = match bond.apply_to {
@@ -676,27 +603,24 @@ fn bond_policy_tags(
                 BondApplyTo::Both => "both",
             };
             tags.push(Tag::custom(
-                TagKind::Custom(Cow::Borrowed("bond_amount_pct")),
+                "bond_amount_pct",
                 vec![bond.amount_pct.to_string()],
             ));
             tags.push(Tag::custom(
-                TagKind::Custom(Cow::Borrowed("bond_base_amount_sats")),
+                "bond_base_amount_sats",
                 vec![bond.base_amount_sats.to_string()],
             ));
+            tags.push(Tag::custom("bond_apply_to", vec![apply_to_str.to_string()]));
             tags.push(Tag::custom(
-                TagKind::Custom(Cow::Borrowed("bond_apply_to")),
-                vec![apply_to_str.to_string()],
-            ));
-            tags.push(Tag::custom(
-                TagKind::Custom(Cow::Borrowed("bond_slash_on_waiting_timeout")),
+                "bond_slash_on_waiting_timeout",
                 vec![bond.slash_on_waiting_timeout.to_string()],
             ));
             tags.push(Tag::custom(
-                TagKind::Custom(Cow::Borrowed("bond_slash_node_share_pct")),
+                "bond_slash_node_share_pct",
                 vec![bond.slash_node_share_pct.to_string()],
             ));
             tags.push(Tag::custom(
-                TagKind::Custom(Cow::Borrowed("bond_payout_claim_window_days")),
+                "bond_payout_claim_window_days",
                 vec![bond.payout_claim_window_days.to_string()],
             ));
         }
@@ -714,7 +638,6 @@ mod tests {
     use crate::lightning::LnStatus;
     use mostro_core::prelude::*;
     use nostr_sdk::prelude::*;
-    use std::borrow::Cow;
 
     // ── Shared test helpers ──────────────────────────────────────────────────────
 
@@ -1139,22 +1062,13 @@ mod tests {
         init_test_settings();
 
         let tags = Tags::from_list(vec![
+            Tag::custom("s", vec!["initiated-by-buyer".to_string()]),
+            Tag::custom("initiator", vec!["buyer".to_string()]),
             Tag::custom(
-                TagKind::Custom(Cow::Borrowed("s")),
-                vec!["initiated-by-buyer".to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("initiator")),
-                vec!["buyer".to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("y")),
+                "y",
                 create_platform_tag_values(test_settings().mostro.name.as_deref()),
             ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("z")),
-                vec!["dispute".to_string()],
-            ),
+            Tag::custom("z", vec!["dispute".to_string()]),
         ]);
 
         let y_values = get_y_tag_values(&tags)
@@ -1182,33 +1096,18 @@ mod tests {
 
         let tags = Tags::from_list(vec![
             Tag::custom(
-                TagKind::Custom(Cow::Borrowed("order-id")),
+                "order-id",
                 vec!["00000000-0000-0000-0000-000000000000".to_string()],
             ),
+            Tag::custom("amount", vec!["300".to_string()]),
+            Tag::custom("hash", vec!["deadbeef".to_string()]),
+            Tag::custom("destination", vec!["dev@lightning.address".to_string()]),
+            Tag::custom("network", vec!["mainnet".to_string()]),
             Tag::custom(
-                TagKind::Custom(Cow::Borrowed("amount")),
-                vec!["300".to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("hash")),
-                vec!["deadbeef".to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("destination")),
-                vec!["dev@lightning.address".to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("network")),
-                vec!["mainnet".to_string()],
-            ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("y")),
+                "y",
                 create_platform_tag_values(test_settings().mostro.name.as_deref()),
             ),
-            Tag::custom(
-                TagKind::Custom(Cow::Borrowed("z")),
-                vec!["dev-fee-payment".to_string()],
-            ),
+            Tag::custom("z", vec!["dev-fee-payment".to_string()]),
         ]);
 
         let y_values = get_y_tag_values(&tags)
@@ -1245,10 +1144,7 @@ mod tests {
             super::new_info_event(&keys, "", "mostro-pk".to_string(), tags.clone()).expect("info");
         assert_eq!(info.kind.as_u16(), NOSTR_INFO_EVENT_KIND);
         assert!(
-            !info
-                .tags
-                .iter()
-                .any(|t| matches!(t.kind(), TagKind::Expiration)),
+            !info.tags.iter().any(|t| t.kind() == "expiration"),
             "info events must not carry an expiration tag"
         );
 
@@ -1271,10 +1167,7 @@ mod tests {
 
         // Order events DO get an expiration tag from configuration.
         assert!(
-            order
-                .tags
-                .iter()
-                .any(|t| matches!(t.kind(), TagKind::Expiration)),
+            order.tags.iter().any(|t| t.kind() == "expiration"),
             "order events must carry an expiration tag"
         );
     }

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -538,11 +538,8 @@ impl PriceManager {
         let expiration_seconds = std::cmp::min(self.settings.update_interval_seconds * 2, 3600);
         let expiration = timestamp + expiration_seconds as i64;
         let tags = Tags::from_list(vec![
-            Tag::custom(
-                TagKind::Custom("published_at".into()),
-                vec![timestamp.to_string()],
-            ),
-            Tag::custom(TagKind::Custom("source".into()), vec![source_tag]),
+            Tag::custom("published_at", vec![timestamp.to_string()]),
+            Tag::custom("source", vec![source_tag]),
             Tag::expiration(Timestamp::from(expiration as u64)),
         ]);
 

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -186,12 +186,12 @@ impl NostrProvider {
             .iter()
             .filter(|e| trusted.contains(&e.pubkey))
             .filter(|e| e.kind == Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND))
-            .filter(|e| e.tags.identifier() == Some("mostro-rates"))
+            .filter(|e| e.tags.identifier() == Some("mostro-rates".to_string()))
             // A future-dated `created_at` (forged or clock-skewed relay) would
             // otherwise saturate the age check to 0 and win the ranking outright.
             .filter(|e| e.created_at <= now)
             .filter(|e| now.as_secs().saturating_sub(e.created_at.as_secs()) <= max_age_secs)
-            .filter(|e| !e.is_expired_at(&now))
+            .filter(|e| !e.is_expired_at(now))
             .collect();
         candidates.sort_unstable_by(|a, b| b.created_at.cmp(&a.created_at));
         candidates
@@ -232,7 +232,7 @@ impl NostrProvider {
     pub(crate) fn is_plausible_candidate(event: &Event, trusted: &[PublicKey]) -> bool {
         trusted.contains(&event.pubkey)
             && event.kind == Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND)
-            && event.tags.identifier() == Some("mostro-rates")
+            && event.tags.identifier() == Some("mostro-rates".to_string())
     }
 
     /// Keep at most `limit` plausible candidates from `incoming`, dropping
@@ -281,12 +281,16 @@ impl PriceProvider for NostrProvider {
         // relays into one stream, so one noisy peer could fill a global
         // first-N cutoff before an honest relay's trusted event arrives.
         let mut stream = client
-            .stream_events(self.build_filter(), self.query_timeout)
+            .stream_events(self.build_filter())
+            .timeout(self.query_timeout)
             .await
             .map_err(|e| ProviderError::Http(format!("nostr: relay query failed: {e}")))?;
 
         let mut events = Vec::new();
-        while let Some(event) = stream.next().await {
+        while let Some((_relay_url, result)) = stream.next().await {
+            let Ok(event) = result else {
+                continue;
+            };
             if Self::is_plausible_candidate(&event, &self.trusted_nodes) {
                 events.push(event);
                 if events.len() >= MAX_FETCHED_RATE_EVENTS {
@@ -341,7 +345,7 @@ mod tests {
         EventBuilder::new(Kind::Custom(NOSTR_EXCHANGE_RATES_EVENT_KIND), content)
             .tags(vec![Tag::identifier("mostro-rates")])
             .custom_created_at(Timestamp::from(created_at))
-            .sign_with_keys(keys)
+            .finalize(keys)
             .expect("event must sign")
     }
 
@@ -360,7 +364,7 @@ mod tests {
                 Tag::expiration(Timestamp::from(expiration)),
             ])
             .custom_created_at(Timestamp::from(created_at))
-            .sign_with_keys(keys)
+            .finalize(keys)
             .expect("event must sign")
     }
 
@@ -507,7 +511,7 @@ mod tests {
         EventBuilder::new(Kind::Custom(kind), content)
             .tags(vec![Tag::identifier(identifier)])
             .custom_created_at(Timestamp::from(created_at))
-            .sign_with_keys(keys)
+            .finalize(keys)
             .expect("event must sign")
     }
 
@@ -711,9 +715,7 @@ mod tests {
     #[tokio::test]
     #[ignore = "hits a real Nostr relay; run explicitly for manual verification"]
     async fn live_relay_fetch_returns_real_rates() {
-        let client = ClientBuilder::default()
-            .opts(crate::util::price_nostr_client_options())
-            .build();
+        let client = crate::util::price_nostr_client_options().build();
         client
             .add_relay("wss://relay.mostro.network")
             .await

--- a/src/rpc/server.rs
+++ b/src/rpc/server.rs
@@ -3,7 +3,7 @@
 use crate::config::settings::Settings;
 use crate::lightning::LndConnector;
 use crate::rpc::service::AdminServiceImpl;
-use nostr_sdk::Keys;
+use nostr_sdk::prelude::Keys;
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use tonic::transport::Server;
@@ -104,7 +104,7 @@ mod tests {
 
     use crate::app::context::test_utils::test_settings;
     use crate::config::MOSTRO_CONFIG;
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
     use std::sync::Arc;
 
     fn init_test_settings() {

--- a/src/rpc/service.rs
+++ b/src/rpc/service.rs
@@ -10,7 +10,7 @@ use crate::rpc::admin::{
 };
 use crate::rpc::rate_limiter::RateLimiter;
 use mostro_core::nip59::UnwrappedMessage;
-use nostr_sdk::Keys;
+use nostr_sdk::prelude::Keys;
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use std::time::Duration;
@@ -49,7 +49,7 @@ impl AdminServiceImpl {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::app::admin_cancel::admin_cancel_action;
         use mostro_core::message::{Action, Message};
-        use nostr_sdk::Timestamp;
+        use nostr_sdk::prelude::Timestamp;
         use uuid::Uuid;
 
         // Create a mock message for the admin cancel action
@@ -111,7 +111,7 @@ impl AdminServiceImpl {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::app::admin_settle::admin_settle_action;
         use mostro_core::message::{Action, Message};
-        use nostr_sdk::Timestamp;
+        use nostr_sdk::prelude::Timestamp;
         use uuid::Uuid;
 
         let msg = Message::new_order(
@@ -166,7 +166,7 @@ impl AdminServiceImpl {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::app::admin_add_solver::admin_add_solver_action;
         use mostro_core::message::{Action, Message, Payload};
-        use nostr_sdk::Timestamp;
+        use nostr_sdk::prelude::Timestamp;
 
         let msg = Message::new_dispute(
             None,
@@ -219,7 +219,7 @@ impl AdminServiceImpl {
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         use crate::app::admin_take_dispute::admin_take_dispute_action;
         use mostro_core::message::{Action, Message};
-        use nostr_sdk::Timestamp;
+        use nostr_sdk::prelude::Timestamp;
         use uuid::Uuid;
 
         let msg = Message::new_dispute(
@@ -504,7 +504,7 @@ mod tests {
     use crate::app::context::test_utils::test_settings;
     use crate::config::MOSTRO_CONFIG;
     use crate::rpc::admin::{GetVersionRequest, ValidateDbPasswordRequest};
-    use nostr_sdk::Keys;
+    use nostr_sdk::prelude::Keys;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
     use tonic::transport::server::TcpConnectInfo;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -14,8 +14,8 @@ use chrono::{TimeDelta, Utc};
 use config::*;
 use mostro_core::db::Crud;
 use mostro_core::prelude::*;
-use nostr_sdk::EventBuilder;
-use nostr_sdk::{Kind as NostrKind, Tag};
+use nostr_sdk::prelude::EventBuilder;
+use nostr_sdk::prelude::{FinalizeEvent, Kind as NostrKind, Nip65Tag, Tag};
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -162,13 +162,19 @@ async fn job_relay_list(ctx: AppContext) {
                 let mut relay_tags: Vec<Tag> = vec![];
 
                 for (_, r) in relays.iter() {
-                    if r.is_connected() {
-                        relay_tags.push(Tag::relay_metadata(r.url().clone(), None))
+                    if r.status().is_connected() {
+                        relay_tags.push(
+                            Nip65Tag::RelayMetadata {
+                                relay_url: r.url().clone(),
+                                metadata: None,
+                            }
+                            .into(),
+                        )
                     }
                 }
                 if let Ok(relay_ev) = EventBuilder::new(NostrKind::RelayList, "")
                     .tags(relay_tags)
-                    .sign_with_keys(&mostro_keys)
+                    .finalize(&mostro_keys)
                 {
                     let _ = client.send_event(&relay_ev).await;
                 }
@@ -907,7 +913,7 @@ mod tests {
     }
 
     fn hex_key() -> String {
-        nostr_sdk::Keys::generate().public_key().to_hex()
+        nostr_sdk::prelude::Keys::generate().public_key().to_hex()
     }
 
     fn order_for_cancel(kind: Kind, with_pubkeys: bool) -> Order {
@@ -1055,9 +1061,9 @@ mod tests {
         let ctx = migrated_ctx().await;
         // Seed a signed dummy event; the job publishes (best-effort, no
         // relays) and clears the queue.
-        let keys = nostr_sdk::Keys::generate();
-        let event = nostr_sdk::EventBuilder::text_note("rate")
-            .sign_with_keys(&keys)
+        let keys = nostr_sdk::prelude::Keys::generate();
+        let event = nostr_sdk::prelude::EventBuilder::new(nostr::event::Kind::TextNote, "rate")
+            .finalize(&keys)
             .unwrap();
         MESSAGE_QUEUES.queue_order_rate.write().await.push(event);
 

--- a/src/spam_gate.rs
+++ b/src/spam_gate.rs
@@ -29,7 +29,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock, RwLock};
 
-use nostr_sdk::EventId;
+use nostr_sdk::prelude::EventId;
 
 /// How long (seconds) a seen event id is remembered for replay dedup. Must be
 /// ≥ the event loop's 10-second freshness window so a duplicate can never slip
@@ -149,11 +149,11 @@ impl SpamGate {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nostr_sdk::{EventBuilder, Keys};
+    use nostr_sdk::prelude::{EventBuilder, FinalizeEvent, Keys, Kind};
 
     fn an_event_id(note: &str) -> EventId {
-        EventBuilder::text_note(note)
-            .sign_with_keys(&Keys::generate())
+        EventBuilder::new(Kind::TextNote, note)
+            .finalize(&Keys::generate())
             .expect("sign test event")
             .id
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,6 +11,7 @@ use crate::lightning;
 use crate::lightning::invoice::is_valid_invoice;
 use crate::messages;
 use crate::nip33::{create_platform_tag_values, new_order_event, new_rating_event, order_to_tags};
+use crate::Result;
 
 use chrono::Duration;
 use fedimint_tonic_lnd::lnrpc::invoice::InvoiceState;
@@ -742,7 +743,6 @@ pub async fn publish_dev_fee_audit_event(
     order: &Order,
     payment_hash: &str,
 ) -> Result<(), MostroError> {
-    use std::borrow::Cow;
     let ln_network = match LN_STATUS.get() {
         Some(status) => status.networks.join(","),
         None => "unknown".to_string(),
@@ -755,31 +755,16 @@ pub async fn publish_dev_fee_audit_event(
 
     // Create tags for queryability
     let mut tag_list = vec![
+        Tag::custom("order-id", vec![order.id.to_string()]),
+        Tag::custom("amount", vec![order.dev_fee.to_string()]),
+        Tag::custom("hash", vec![payment_hash.to_string()]),
+        Tag::custom("destination", vec![DEV_FEE_LIGHTNING_ADDRESS.to_string()]),
+        Tag::custom("network", vec![ln_network]),
         Tag::custom(
-            TagKind::Custom(Cow::Borrowed("order-id")),
-            vec![order.id.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("amount")),
-            vec![order.dev_fee.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("hash")),
-            vec![payment_hash.to_string()],
-        ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("destination")),
-            vec![DEV_FEE_LIGHTNING_ADDRESS.to_string()],
-        ),
-        Tag::custom(TagKind::Custom(Cow::Borrowed("network")), vec![ln_network]),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("y")),
+            "y",
             create_platform_tag_values(Settings::get_mostro().name.as_deref()),
         ),
-        Tag::custom(
-            TagKind::Custom(Cow::Borrowed("z")),
-            vec!["dev-fee-payment".to_string()],
-        ),
+        Tag::custom("z", vec!["dev-fee-payment".to_string()]),
     ];
 
     // Add expiration tag if configured
@@ -793,9 +778,9 @@ pub async fn publish_dev_fee_audit_event(
     let tags = Tags::from_list(tag_list);
 
     // Create and sign event
-    let event = EventBuilder::new(nostr_sdk::Kind::Custom(DEV_FEE_AUDIT_EVENT_KIND), "")
+    let event = EventBuilder::new(nostr::event::Kind::Custom(DEV_FEE_AUDIT_EVENT_KIND), "")
         .tags(tags)
-        .sign_with_keys(keys)
+        .finalize(keys)
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
 
     // Publish event to relays
@@ -944,8 +929,7 @@ pub async fn connect_nostr() -> Result<Client, MostroError> {
     // would drop matching trade messages before dispatch (hermeme, PR #841).
     // Price queries use [`connect_price_nostr`] / [`PRICE_NOSTR_CLIENT`] with
     // verification enabled instead.
-    let opts = mostro_nostr_client_options();
-    let client = ClientBuilder::default().opts(opts).build();
+    let client = mostro_nostr_client_options().build();
 
     // Add relays
     for relay in nostr_settings.relays.iter() {
@@ -965,9 +949,7 @@ pub async fn connect_nostr() -> Result<Client, MostroError> {
 /// daemon client, with [`price_nostr_client_options`]).
 pub async fn connect_price_nostr() -> Result<Client, MostroError> {
     let nostr_settings = Settings::get_nostr();
-    let client = ClientBuilder::default()
-        .opts(price_nostr_client_options())
-        .build();
+    let client = price_nostr_client_options().build();
 
     for relay in nostr_settings.relays.iter() {
         client
@@ -980,9 +962,9 @@ pub async fn connect_price_nostr() -> Result<Client, MostroError> {
     Ok(client)
 }
 
-/// Observable policy for Mostro Nostr clients. [`ClientOptions`] fields are
-/// not publicly readable, so production paths go through this struct and
-/// tests assert on it directly (hermeme, PR #841).
+/// Observable policy for Mostro Nostr clients. [`ClientBuilder`] is
+/// constructed fresh by [`client_options_from_policy`], so production paths
+/// go through this struct and tests assert on it directly (hermeme, PR #841).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct MostroNostrClientPolicy {
     /// When true, the relay driver rejects non-matching / over-limit events
@@ -1014,22 +996,22 @@ fn mostro_nostr_relay_limits() -> RelayLimits {
     limits
 }
 
-fn client_options_from_policy(policy: MostroNostrClientPolicy) -> ClientOptions {
-    let mut opts = ClientOptions::new().relay_limits(mostro_nostr_relay_limits());
+fn client_options_from_policy(policy: MostroNostrClientPolicy) -> ClientBuilder {
+    let mut builder = ClientBuilder::new().relay_limits(mostro_nostr_relay_limits());
     if policy.verify_subscriptions {
-        opts = opts.verify_subscriptions(true);
+        builder = builder.verify_subscriptions(true);
     }
-    opts
+    builder
 }
 
-/// Process-wide daemon Nostr [`ClientOptions`] (inbox / publishing).
-pub(crate) fn mostro_nostr_client_options() -> ClientOptions {
+/// Process-wide daemon Nostr [`ClientBuilder`] (inbox / publishing).
+pub(crate) fn mostro_nostr_client_options() -> ClientBuilder {
     client_options_from_policy(daemon_nostr_client_policy())
 }
 
-/// Price-provider Nostr [`ClientOptions`]: size limits plus subscription
+/// Price-provider Nostr [`ClientBuilder`]: size limits plus subscription
 /// filter verification, scoped away from the daemon inbox client.
-pub(crate) fn price_nostr_client_options() -> ClientOptions {
+pub(crate) fn price_nostr_client_options() -> ClientBuilder {
     client_options_from_policy(price_nostr_client_policy())
 }
 
@@ -2549,23 +2531,18 @@ mod tests {
             "price client must enable verify_subscriptions"
         );
         // Helpers remain constructible (SDK copies the flag into RelayOptions).
-        let _daemon = ClientBuilder::default()
-            .opts(mostro_nostr_client_options())
-            .build();
-        let _price = ClientBuilder::default()
-            .opts(price_nostr_client_options())
-            .build();
+        let _daemon = mostro_nostr_client_options().build();
+        let _price = price_nostr_client_options().build();
     }
 
     #[tokio::test]
     async fn price_client_rejects_mismatched_events_before_pool() {
         use futures::StreamExt;
-        use nostr_relay_builder::builder::RelayTestOptions;
-        use nostr_relay_builder::MockRelay;
+        use nostr_sdk::local_relay::{LocalRelayTestOptions, MockRelay};
         use std::time::Duration;
 
         // Noncompliant relay floods random events that do not match the REQ.
-        let mock = MockRelay::run_with_opts(RelayTestOptions {
+        let mock = MockRelay::run_with_opts(LocalRelayTestOptions {
             unresponsive_connection: None,
             send_random_events: true,
         })
@@ -2573,18 +2550,17 @@ mod tests {
         .expect("mock relay");
         let url = mock.url().await;
 
-        let price_client = ClientBuilder::default()
-            .opts(price_nostr_client_options())
-            .build();
+        let price_client = price_nostr_client_options().build();
         price_client
             .add_relay(url.clone())
             .await
             .expect("add_relay");
         price_client.connect().await;
 
-        let filter = Filter::new().kind(nostr_sdk::Kind::Metadata).limit(3);
+        let filter = Filter::new().kind(nostr::event::Kind::Metadata).limit(3);
         let mut stream = price_client
-            .stream_events(filter, Duration::from_secs(3))
+            .stream_events(filter)
+            .timeout(Duration::from_secs(3))
             .await
             .expect("stream");
         let mut received = 0usize;
@@ -2599,7 +2575,8 @@ mod tests {
 
     #[tokio::test]
     async fn daemon_client_limit_zero_still_delivers_live_after_eose() {
-        use nostr_relay_builder::MockRelay;
+        use futures::StreamExt;
+        use nostr_sdk::local_relay::MockRelay;
         use std::time::Duration;
 
         // Clean mock (no random flood): mirrors main.rs `.limit(0)` inbox —
@@ -2609,9 +2586,7 @@ mod tests {
         let mock = MockRelay::run().await.expect("mock relay");
         let url = mock.url().await;
 
-        let daemon = ClientBuilder::default()
-            .opts(mostro_nostr_client_options())
-            .build();
+        let daemon = mostro_nostr_client_options().build();
         daemon.add_relay(url.clone()).await.expect("add_relay");
         daemon.connect().await;
 
@@ -2623,15 +2598,15 @@ mod tests {
         // the live event.
         let mut notifications = daemon.notifications();
 
-        let filter = Filter::new().kind(nostr_sdk::Kind::TextNote).limit(0);
-        daemon.subscribe(filter, None).await.expect("subscribe");
+        let filter = Filter::new().kind(nostr::event::Kind::TextNote).limit(0);
+        daemon.subscribe(filter).await.expect("subscribe");
 
         // Empty relay ⇒ EOSE quickly; then publish a matching live event.
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         let keys = Keys::generate();
-        let live = EventBuilder::text_note("live-after-eose")
-            .sign_with_keys(&keys)
+        let live = EventBuilder::new(nostr::event::Kind::TextNote, "live-after-eose")
+            .finalize(&keys)
             .expect("sign");
         let live_id = live.id;
         publisher
@@ -2640,8 +2615,8 @@ mod tests {
             .expect("publish live event");
 
         let got = tokio::time::timeout(Duration::from_secs(8), async {
-            while let Ok(notification) = notifications.recv().await {
-                if let RelayPoolNotification::Event { event, .. } = notification {
+            while let Some(notification) = notifications.next().await {
+                if let ClientNotification::Event { event, .. } = notification {
                     if event.id == live_id {
                         return true;
                     }
@@ -2660,7 +2635,7 @@ mod tests {
     #[tokio::test]
     async fn price_client_enforces_filter_limit_before_pool() {
         use futures::StreamExt;
-        use nostr_relay_builder::MockRelay;
+        use nostr_sdk::local_relay::MockRelay;
         use std::time::Duration;
 
         let mock = MockRelay::run().await.expect("mock relay");
@@ -2672,21 +2647,20 @@ mod tests {
         seeder.connect().await;
         let keys = Keys::generate();
         for i in 0..10 {
-            let event = EventBuilder::text_note(format!("seed-{i}"))
-                .sign_with_keys(&keys)
+            let event = EventBuilder::new(nostr::event::Kind::TextNote, format!("seed-{i}"))
+                .finalize(&keys)
                 .expect("sign");
             seeder.send_event(&event).await.expect("seed");
         }
 
-        let price_client = ClientBuilder::default()
-            .opts(price_nostr_client_options())
-            .build();
+        let price_client = price_nostr_client_options().build();
         price_client.add_relay(url).await.expect("add_relay");
         price_client.connect().await;
 
-        let filter = Filter::new().kind(nostr_sdk::Kind::TextNote).limit(3);
+        let filter = Filter::new().kind(nostr::event::Kind::TextNote).limit(3);
         let mut stream = price_client
-            .stream_events(filter, Duration::from_secs(5))
+            .stream_events(filter)
+            .timeout(Duration::from_secs(5))
             .await
             .expect("stream");
         let mut received = 0usize;


### PR DESCRIPTION
## Summary

Migrates the daemon from `nostr-sdk` 0.44.1 to **0.45.1**, together with `mostro-core` 0.14.3 (already built against nostr 0.45). All changes are mechanical API migrations — no behavior changes intended.

### API migrations

- **Notifications**: `RelayPoolNotification` → `ClientNotification`; `notifications()` now returns a stream consumed with `.next().await` instead of `.recv().await`.
- **Event signing**: `EventBuilder::sign_with_keys(keys)` → `finalize(keys)` (via the new `FinalizeEvent` trait). `EventBuilder::metadata(&m)` is replaced by `metadata.finalize(keys)`, and `EventBuilder::text_note(..)` by `EventBuilder::new(Kind::TextNote, ..)`.
- **Tags**: `Tag::custom(TagKind::Custom(Cow::Borrowed("s")), ..)` simplifies to `Tag::custom("s", ..)`; tag-kind checks use `t.kind() == "expiration"`. `Tag::relay_metadata()` is replaced by `Nip65Tag::RelayMetadata`.
- **Streaming**: `stream_events(filter, timeout)` → `stream_events(filter).timeout(..)`, and the stream now yields `(relay_url, Result<Event>)` pairs (errored items are skipped in the price provider).
- **Client construction**: `ClientOptions` was removed; the policy helpers in `util.rs` now return a preconfigured `ClientBuilder` directly.
- **Re-exports dropped by nostr 0.45**: `rand`, `secp256k1`, and `bitcoin::hashes` are now direct dependencies; the prelude's `Result<T>` alias is recreated at the crate root.
- **Dev-deps**: `nostr-relay-builder` is replaced by the `local-relay` feature of `nostr-sdk` (`MockRelay` now lives in `nostr_sdk::local_relay`).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test`: 1122 passed, 0 failed (2 ignored: live-relay tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay event processing so temporary errors do not stop valid price updates.
  * Added timeout handling for relay responses to improve reliability.
  * Updated event publishing and subscription behavior for compatibility with current Nostr services.

* **Refactor**
  * Modernized Nostr integration and event handling across the application without changing existing workflows.
  * Improved consistency of dispute, order, bond, and payment event metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->