### PR TITLE
Enforce the escrow CLTV deadline on live trades

### DIFF
--- a/docs/LIGHTNING_OPS.md
+++ b/docs/LIGHTNING_OPS.md
@@ -12,6 +12,8 @@ Core interactions with LND via `fedimint_tonic_lnd`.
 - Subscribe: `subscribe_invoice(r_hash, sender)` streams `InvoiceState` updates.
 - Settle: `settle_hold_invoice(preimage)`.
 - Cancel: `cancel_hold_invoice(hash)`.
+- Expiry: `lookup_invoice_htlc_expiry(hash)` → block height at which the escrow
+  expires (see [Escrow Deadline](#escrow-deadline)).
 
 ## Outgoing Payments
 - `send_payment(invoice, amount, sender)`
@@ -200,6 +202,109 @@ Retrieves LND node information including:
 **Entry**: `src/lightning/mod.rs:260`
 
 **Usage**: Called during startup to populate `config::LN_STATUS` (src/main.rs:86)
+
+## Escrow Deadline
+
+Source: `src/app/escrow_deadline.rs`, swept by `src/scheduler.rs`
+(`fn job_enforce_escrow_deadline`).
+
+A trade is escrowed in a hold invoice, and that escrow has a hard lifetime.
+The invoice is created with `hold_invoice_cltv_delta` (144 blocks by default),
+and LND force-cancels an accepted hold HTLC a few blocks before its expiry
+height — `invoices.holdexpirydelta`, 24 by default — so the channel is never
+forced to close over a held payment. The refund goes to the seller regardless
+of what the trade was doing. On the defaults that leaves roughly 20 hours of
+escrow from the moment the seller pays.
+
+Nothing in the order state machine used to know about that horizon, so a trade
+could outlive its escrow: the order stayed `active` or `fiat-sent`, kept
+advertising itself as live, and the seller's release later failed at settle —
+after the buyer had already sent fiat.
+
+### Windows
+
+**Settings** (`src/config/types.rs`, `LightningSettings`), both measured in
+blocks remaining until the escrow HTLC's expiry height:
+
+```rust
+pub struct LightningSettings {
+    // ... other fields ...
+    pub escrow_expiry_warning_blocks: u32, // escalate here (default: 72, ~12 h)
+    pub escrow_expiry_safety_blocks: u32,  // last call (default: 36, ~6 h)
+}
+```
+
+`fn validate_escrow_expiry_settings` enforces
+`hold_invoice_cltv_delta > escrow_expiry_warning_blocks >
+escrow_expiry_safety_blocks > invoices.holdexpirydelta` at startup and refuses
+to boot otherwise: these bound when the daemon destroys a live escrow, so a
+configuration that puts them outside the escrow's lifetime is loud rather than
+silently clamped.
+
+### What the sweep does
+
+Every minute the job asks LND for the current block height, lists the orders
+that still hold escrow (`fn find_orders_with_live_escrow`) and asks LND for
+each escrow's real expiry height. The invoice's `cltv_expiry` is only a
+minimum the payer had to honour — wallets routinely add their own buffer — so
+the horizon cannot be derived from the order row. `fn escrow_deadline_action`
+turns the distance into a decision:
+
+| Order status | At the warning window | At the safety window |
+| --- | --- | --- |
+| `active` | nothing | cancel the hold invoice, close the order, notify both parties, release bonds |
+| `fiat-sent` | open the dispute (`initiator: mostro`) | keep retrying the dispute; never cancel |
+| `dispute` | alert the operator | alert again, urgently; leave the escrow alone |
+
+The asymmetry is deliberate. An `active` order has no fiat leg at risk, so
+ending it costs no one anything the CLTV would not have taken anyway. Once the
+buyer has declared the fiat sent, cancelling would hand the seller both the
+fiat and the sats, so mostro never does it — it hands the trade to a solver
+while the escrow still exists, which is the only action left that can pay the
+buyer. And a solver working a dispute can settle up to the last block, so
+taking the escrow away early would remove the very outcome they might be about
+to choose.
+
+Every failure path is "skip and retry next tick": an unreachable node or an
+unreadable invoice must never end a trade, and there is a whole warning window
+worth of ticks before anything is actually due.
+
+### Backstop
+
+`crate::flow::hold_invoice_canceled` closes an order whose escrow was canceled
+without mostro asking — LND winning the race, an operator cancelling by hand,
+or the daemon having been down through the horizon. It publishes the
+cancelation, claims the order with a conditional update
+(`fn claim_escrow_order_canceled`), notifies both parties and unwinds the
+dispute and bonds. Both paths use the same claim, so exactly one of them owns
+the transition and the other is a no-op.
+
+### Reading what happened in the logs
+
+Sweep lines are prefixed `escrow_deadline:`. The ones that matter:
+
+- `Trade reached its escrow deadline` — an `active` order was cancelled and
+  the seller refunded. Expected; no action needed.
+- `Opened a dispute on a fiat-sent order whose escrow is about to expire` —
+  a solver has until the expiry height to settle or cancel.
+- `Disputed order is running out of escrow` — the loud one. If no solver acts
+  before that height, LND refunds the seller and the buyer's only recourse is
+  out of band.
+- `Escrow with hash ... was canceled while the trade was still live` — the
+  backstop fired, meaning the escrow went away before the sweep could act.
+  Worth investigating: a lagging node, a long outage, or a manual cancel.
+
+### Tuning
+
+Raise `hold_invoice_cltv_delta` if your traders use slow fiat rails: the whole
+trade, disputes included, has to fit inside it. Keep in mind that the payer's
+route must accommodate the delta, so very large values make the hold invoice
+harder to pay.
+
+If you raise LND's own `invoices.holdexpirydelta` past
+`escrow_expiry_safety_blocks`, raise the safety window with it — startup
+validation compares against LND's default (24), which it cannot read over
+gRPC, so that combination is the one misconfiguration it cannot catch for you.
 
 ## Anti-Abuse Bond Operations
 

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -20,6 +20,12 @@ payment_retries_interval = 60
 # Maximum min_final_cltv_expiry_delta (in blocks) accepted on a payout invoice
 # supplied by a user. Bounds how long a payee can hold the outgoing HTLC.
 max_final_cltv_expiry_delta = 432
+# Escrow deadline, in blocks left before the hold HTLC expires: mostrod
+# escalates a trade at the warning window and ends it at the safety window,
+# ahead of LND's own force-cancel. Startup requires
+# hold_invoice_cltv_delta > escrow_expiry_warning_blocks > escrow_expiry_safety_blocks > 24
+escrow_expiry_warning_blocks = 72
+escrow_expiry_safety_blocks = 36
 
 [nostr]
 nsec_privkey = 'nsec1...'

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ pub mod bond; // Anti-abuse bond data + helpers (issue #711)
 pub mod cancel; // User order cancellation
 pub mod dev_fee; // Dev fee payment lifecycle
 pub mod dispute; // User dispute handling
+pub mod escrow_deadline; // Escrow CLTV deadline policy
 pub mod fiat_sent; // Fiat payment confirmation
 pub mod last_trade_index;
 pub mod order; // Order creation and management

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -68,6 +68,42 @@ impl AppContext {
         }
     }
 
+    /// Assemble a context from the process globals.
+    ///
+    /// For code that runs outside the event loop and has no context handed to
+    /// it: the LND invoice subscriber is spawned both from boot and from
+    /// `show_hold_invoice`, and neither carries one down to the callback. The
+    /// globals read here are the same ones `main` builds its own context from,
+    /// so this is that context assembled where it is needed rather than
+    /// threaded through every intermediate call site.
+    ///
+    /// Handlers must keep taking `&AppContext` as a parameter — that is what
+    /// lets tests inject a `TestContextBuilder` context instead of this one.
+    ///
+    /// Fails only before `main` has initialised the Nostr client or settings.
+    pub fn from_globals() -> Result<Self, mostro_core::error::MostroError> {
+        let settings = Arc::new(
+            crate::config::MOSTRO_CONFIG
+                .get()
+                .ok_or_else(|| {
+                    mostro_core::error::MostroError::MostroInternalErr(
+                        mostro_core::error::ServiceError::IOError(
+                            "Settings not initialized".to_string(),
+                        ),
+                    )
+                })?
+                .clone(),
+        );
+
+        Ok(Self::new(
+            crate::config::get_db_pool(),
+            crate::util::get_nostr_client()?.clone(),
+            settings,
+            crate::config::MESSAGE_QUEUES.queue_order_msg.clone(),
+            crate::util::get_keys()?.clone(),
+        ))
+    }
+
     /// Attach a connected Cashu mint client (Cashu mode, CF-5). Returns a new
     /// context; the Lightning path never calls this, so `cashu_client()` stays
     /// `None` there.

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -29,6 +29,21 @@ async fn publish_dispute_event(
         false => "seller",
     };
 
+    publish_dispute_event_with_initiator(ctx, dispute, my_keys, initiator).await
+}
+
+/// Same event, for a dispute no trader opened.
+///
+/// `initiator` is a free string because mostro can open a dispute itself when
+/// a trade is about to lose its escrow (`mostro`), and claiming the buyer or
+/// the seller filed it would be wrong in the event, in the order's dispute
+/// flags, and in the solver's view of who is asking for what.
+async fn publish_dispute_event_with_initiator(
+    ctx: &AppContext,
+    dispute: &Dispute,
+    my_keys: &Keys,
+    initiator: &str,
+) -> Result<(), MostroError> {
     // Create tags for the dispute event
     let tags = Tags::from_list(vec![
         // Status tag - indicates the current state of the dispute
@@ -233,6 +248,91 @@ pub async fn dispute_action(
     publish_dispute_event(ctx, &dispute, my_keys, is_buyer_dispute)
         .await
         .map_err(|_| MostroInternalErr(ServiceError::DisputeEventError))?;
+
+    Ok(())
+}
+
+/// Open a dispute on a `fiat-sent` order whose escrow is about to expire.
+///
+/// The buyer says the fiat is gone and the seller has not released; in a few
+/// hours LND will refund the escrow and neither of them will be able to do
+/// anything about it. Handing the trade to a solver while the escrow still
+/// exists is the only move left that can pay the buyer, so mostro makes it
+/// instead of waiting for someone to notice the clock.
+///
+/// Unlike [`dispute_action`] there is no initiator: both of the order's
+/// dispute flags stay false and the event is published with `initiator` set to
+/// `mostro`, because recording the buyer or the seller as the filer would
+/// misrepresent the dispute to the solver — and to the reputation and
+/// restore-session views that read those flags.
+///
+/// Errors instead of unwinding on failure: the order stays in `fiat-sent` and
+/// the sweep retries on its next tick, which is what we want while the escrow
+/// is still there.
+pub async fn open_deadline_dispute(ctx: &AppContext, order: &Order) -> Result<(), MostroError> {
+    let pool = ctx.pool();
+    if find_dispute_by_order_id(pool, order.id).await.is_ok() {
+        return Err(MostroInternalErr(ServiceError::DisputeAlreadyExists));
+    }
+
+    let (buyer_pubkey, seller_pubkey) = match (order.get_buyer_pubkey(), order.get_seller_pubkey())
+    {
+        (Ok(buyer), Ok(seller)) => (buyer, seller),
+        _ => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
+    };
+
+    let dispute = Dispute::new(order.id, order.status.clone());
+
+    // Publish and persist the order first: a dispute row pointing at an order
+    // that is still `fiat-sent` would be picked up by the sweep again on the
+    // next tick and rejected as a duplicate, stranding it.
+    let order_updated = crate::util::update_order_event(ctx.keys(), Status::Dispute, order)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+    order_updated
+        .update(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    let dispute = dispute
+        .create(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    tracing::warn!(
+        order_id = %order.id,
+        dispute_id = %dispute.id,
+        "Opened a dispute on a fiat-sent order whose escrow is about to expire"
+    );
+
+    // `DisputeInitiatedByPeer` for both: from either trader's side this is a
+    // dispute they did not file, and the payload carries the id their client
+    // needs to follow it.
+    for pubkey in [buyer_pubkey, seller_pubkey] {
+        enqueue_order_msg(
+            None,
+            Some(order.id),
+            Action::DisputeInitiatedByPeer,
+            Some(Payload::Dispute(dispute.id, None)),
+            pubkey,
+            None,
+        )
+        .await;
+    }
+
+    // Best-effort, like every other dispute publish: the dispute is already
+    // open in the DB and both traders have been told, so a relay that refuses
+    // the event must not report the dispute as un-opened — that would put the
+    // sweep back on a path it has already taken.
+    if let Err(e) = publish_dispute_event_with_initiator(ctx, &dispute, ctx.keys(), "mostro").await
+    {
+        tracing::error!(
+            order_id = %order.id,
+            dispute_id = %dispute.id,
+            "Opened the escrow-deadline dispute but could not publish its event ({e}); \
+             solvers will not see it until it is republished"
+        );
+    }
 
     Ok(())
 }
@@ -758,5 +858,80 @@ mod tests {
 
         let dispute = find_dispute_by_order_id(&pool, order.id).await.unwrap();
         assert_eq!(dispute.status, DisputeStatus::Settled.to_string());
+    }
+
+    #[tokio::test]
+    async fn open_deadline_dispute_hands_a_fiat_sent_order_to_a_solver() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), Some(seller), Status::FiatSent)
+            .create(&pool)
+            .await
+            .unwrap();
+
+        open_deadline_dispute(&ctx, &order)
+            .await
+            .expect("a fiat-sent order must be disputable before its escrow expires");
+
+        let updated = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(
+            updated.status,
+            Status::Dispute.to_string(),
+            "the order has to move so a solver can act on it"
+        );
+        assert!(
+            !updated.buyer_dispute && !updated.seller_dispute,
+            "neither trader filed this dispute; recording one of them as the \
+             initiator would misrepresent it to the solver"
+        );
+        assert!(find_dispute_by_order_id(&pool, order.id).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn open_deadline_dispute_refuses_to_duplicate_an_existing_one() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), Some(seller), Status::FiatSent)
+            .create(&pool)
+            .await
+            .unwrap();
+        Dispute::new(order.id, order.status.clone())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        // A trader who disputed first already has a solver on it; the sweep
+        // must not file a second dispute for the same order.
+        assert!(matches!(
+            open_deadline_dispute(&ctx, &order).await,
+            Err(MostroInternalErr(ServiceError::DisputeAlreadyExists))
+        ));
+    }
+
+    #[tokio::test]
+    async fn open_deadline_dispute_needs_both_trade_pubkeys() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(None, Some(seller), Status::FiatSent)
+            .create(&pool)
+            .await
+            .unwrap();
+
+        // Nobody to notify means nobody would learn the dispute exists, so
+        // the order stays as it was for an operator to look at.
+        assert!(matches!(
+            open_deadline_dispute(&ctx, &order).await,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+        let unchanged = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(unchanged.status, Status::FiatSent.to_string());
     }
 }

--- a/src/app/escrow_deadline.rs
+++ b/src/app/escrow_deadline.rs
@@ -1,0 +1,330 @@
+//! What mostro does with a trade whose escrow is about to expire.
+//!
+//! A trade is escrowed in a hold HTLC, and that HTLC has a hard lifetime: LND
+//! force-cancels it a few blocks before its CLTV expiry height
+//! (`invoices.holdexpirydelta`) so the channel is never forced to close over a
+//! held payment. The refund goes to the seller no matter what the trade was
+//! doing at that moment.
+//!
+//! Nothing in the order state machine used to know about that horizon, so a
+//! trade could sit in `active` or `fiat-sent` until the escrow silently went
+//! back to the seller — leaving an order that still reads as live, a buyer who
+//! can still send fiat, and a release that fails at settle.
+//!
+//! This module is the policy that runs ahead of LND, driven by the scheduler
+//! sweep. It is deliberately asymmetric about who may lose their escrow:
+//!
+//! - `active` — nobody has claimed to have paid fiat. Cancelling the trade
+//!   costs no one anything the CLTV would not have taken anyway, so mostro
+//!   ends it in a controlled way at the safety window: the seller is refunded
+//!   by *our* cancel, both parties are told, and the order stops advertising
+//!   itself as tradeable.
+//! - `fiat-sent` — the buyer says the fiat is gone. Cancelling here would hand
+//!   the seller both the fiat and the escrow, so mostro never does it. It
+//!   opens the dispute instead, at the earlier warning window, which is the
+//!   only action that can still save the buyer: a solver can settle to them
+//!   while the escrow exists.
+//! - `dispute` — a solver is already on it and can settle up to the last
+//!   block. Taking the escrow away early would remove the only outcome that
+//!   pays the buyer, so mostro alerts the operator and lets the horizon
+//!   arrive; [`crate::flow::hold_invoice_canceled`] then closes the order
+//!   cleanly when LND cancels, so no admin action can fail at settle later.
+
+use crate::app::bond;
+use crate::app::context::AppContext;
+use crate::app::dispute::open_deadline_dispute;
+use crate::config::types::LightningSettings;
+use crate::flow::notify_escrow_canceled;
+use crate::lightning::LndConnector;
+use crate::util::update_order_event;
+use mostro_core::prelude::*;
+
+/// What the sweep should do with one order this tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EscrowDeadlineAction {
+    /// Still far enough from the horizon to leave alone.
+    None,
+    /// Cancel the hold invoice and close the order (`active` only).
+    CancelTrade,
+    /// Open the dispute so a solver can act while the escrow lasts.
+    OpenDispute,
+    /// Tell the operator a disputed trade is running out of escrow. `urgent`
+    /// separates the first warning from the one inside the safety window.
+    AlertSolvers { urgent: bool },
+}
+
+/// Decide what to do with an order that is `remaining_blocks` away from its
+/// escrow HTLC's expiry height.
+///
+/// Pure on purpose: the whole policy table is testable without an LND node or
+/// a database, and the sweep around it stays a loop over I/O.
+///
+/// `remaining_blocks` is signed because the horizon can already be behind us —
+/// LND may be lagging, or the daemon may have been down through it — and a
+/// past-due escrow must read as "most urgent", not as a huge unsigned value.
+pub fn escrow_deadline_action(
+    status: Status,
+    remaining_blocks: i64,
+    settings: &LightningSettings,
+) -> EscrowDeadlineAction {
+    let safety = settings.escrow_expiry_safety_blocks as i64;
+    let warning = settings.escrow_expiry_warning_blocks as i64;
+
+    if remaining_blocks > warning {
+        return EscrowDeadlineAction::None;
+    }
+
+    match status {
+        // The buyer has not claimed anything yet: no fiat leg to protect, so
+        // the trade can be ended cleanly. Waiting until the safety window
+        // gives a slow-but-honest trade the whole warning band to finish.
+        Status::Active if remaining_blocks <= safety => EscrowDeadlineAction::CancelTrade,
+        Status::Active => EscrowDeadlineAction::None,
+        // Escalate as soon as the warning window opens: a dispute is only
+        // useful if a solver has time to act on it before the escrow goes.
+        Status::FiatSent => EscrowDeadlineAction::OpenDispute,
+        Status::Dispute => EscrowDeadlineAction::AlertSolvers {
+            urgent: remaining_blocks <= safety,
+        },
+        // Any other status has no escrow to lose; the sweep does not select
+        // them, and a race that moved one here mid-tick is a no-op.
+        _ => EscrowDeadlineAction::None,
+    }
+}
+
+/// Carry out the decision [`escrow_deadline_action`] returned.
+///
+/// Split from the decision so the sweep can drop an alert it has already
+/// emitted for this order before anything is executed — the alerts are the
+/// only action that would otherwise repeat on every tick.
+pub async fn apply_escrow_deadline_action(
+    ctx: &AppContext,
+    ln_client: &mut LndConnector,
+    order: &Order,
+    action: EscrowDeadlineAction,
+    remaining_blocks: i64,
+) {
+    match action {
+        EscrowDeadlineAction::None => {}
+        EscrowDeadlineAction::CancelTrade => {
+            cancel_expiring_trade(ctx, ln_client, order, remaining_blocks).await;
+        }
+        EscrowDeadlineAction::OpenDispute => {
+            if let Err(e) = open_deadline_dispute(ctx, order).await {
+                // Left in `fiat-sent`, so the next tick tries again — there is
+                // still time, and giving up would be giving up on the buyer.
+                tracing::error!(
+                    order_id = %order.id,
+                    remaining_blocks,
+                    "Could not open the escrow-deadline dispute ({e}); retrying next tick"
+                );
+            }
+        }
+        EscrowDeadlineAction::AlertSolvers { urgent } => {
+            tracing::error!(
+                order_id = %order.id,
+                remaining_blocks,
+                urgent,
+                "Disputed order is running out of escrow: the hold invoice expires in \
+                 {remaining_blocks} blocks and LND will refund the seller then. A solver \
+                 has to settle or cancel before that height"
+            );
+        }
+    }
+}
+
+/// Cancel the escrow of a trade that ran out of time and close the order.
+///
+/// The hold invoice is cancelled *before* the order is touched, exactly as the
+/// waiting-order timeout does: on failure the order keeps its status and stays
+/// in the sweep, so the next tick retries instead of leaving a canceled order
+/// backed by an HTLC that is still encumbered. If the daemon dies between the
+/// two, LND's cancel event reaches
+/// [`crate::flow::hold_invoice_canceled`], which closes the order the same way.
+async fn cancel_expiring_trade(
+    ctx: &AppContext,
+    ln_client: &mut LndConnector,
+    order: &Order,
+    remaining_blocks: i64,
+) {
+    let Some(hash) = order.hash.as_ref() else {
+        tracing::warn!(order_id = %order.id, "Order reached its escrow deadline with no payment hash");
+        return;
+    };
+
+    if let Err(e) = ln_client.cancel_hold_invoice(hash).await {
+        tracing::error!(
+            order_id = %order.id,
+            "escrow_deadline: could not cancel the hold invoice ({e}); \
+             leaving the order untouched so the next tick retries"
+        );
+        return;
+    }
+
+    tracing::warn!(
+        order_id = %order.id,
+        remaining_blocks,
+        "Trade reached its escrow deadline: funds returned to the seller and the order closed"
+    );
+
+    let order_updated = match update_order_event(ctx.keys(), Status::Canceled, order).await {
+        Ok(updated) => updated,
+        Err(e) => {
+            // The escrow is already refunded, so the order must not be left
+            // advertising itself as live. The subscriber's reaction to the
+            // cancel we just made is the backstop that closes it.
+            tracing::error!(
+                order_id = %order.id,
+                "escrow_deadline: hold invoice canceled but publishing the update failed ({e})"
+            );
+            return;
+        }
+    };
+
+    match crate::db::claim_escrow_order_canceled(ctx.pool(), order.id, &order_updated.event_id)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            // The subscriber won the race on the cancel we just made, or a
+            // user action resolved the order first. Either way it is closed.
+            tracing::info!(order_id = %order.id, "Order was already resolved by another path");
+            return;
+        }
+        Err(e) => {
+            tracing::error!(
+                order_id = %order.id,
+                "escrow_deadline: could not persist the cancelation ({e})"
+            );
+            return;
+        }
+    }
+
+    notify_escrow_canceled(order).await;
+    bond::release_taker_bonds_for_order_or_warn(ctx.pool(), order.id, "escrow_deadline").await;
+    bond::resolve_range_maker_bond_at_close_or_warn(ctx.pool(), order, "escrow_deadline").await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shipped windows: escalate 72 blocks out, cancel 36 blocks out.
+    fn settings() -> LightningSettings {
+        LightningSettings {
+            hold_invoice_cltv_delta: 144,
+            escrow_expiry_warning_blocks: 72,
+            escrow_expiry_safety_blocks: 36,
+            ..Default::default()
+        }
+    }
+
+    fn action(status: Status, remaining: i64) -> EscrowDeadlineAction {
+        escrow_deadline_action(status, remaining, &settings())
+    }
+
+    #[test]
+    fn a_fresh_trade_is_left_alone() {
+        // Just paid: 144 blocks of escrow, nothing to do for the next ~12 h.
+        for status in [Status::Active, Status::FiatSent, Status::Dispute] {
+            assert_eq!(action(status, 144), EscrowDeadlineAction::None);
+            assert_eq!(action(status, 73), EscrowDeadlineAction::None);
+        }
+    }
+
+    #[test]
+    fn an_active_trade_is_canceled_only_at_the_safety_window() {
+        // The warning band belongs to the traders: an active order has no
+        // fiat leg at risk, so it gets every block of it before being ended.
+        assert_eq!(action(Status::Active, 72), EscrowDeadlineAction::None);
+        assert_eq!(action(Status::Active, 37), EscrowDeadlineAction::None);
+        assert_eq!(
+            action(Status::Active, 36),
+            EscrowDeadlineAction::CancelTrade
+        );
+        assert_eq!(action(Status::Active, 1), EscrowDeadlineAction::CancelTrade);
+    }
+
+    #[test]
+    fn a_fiat_sent_trade_escalates_at_the_warning_window() {
+        // Earlier than the cancel, because a dispute is only worth opening
+        // while a solver still has time to settle it.
+        assert_eq!(
+            action(Status::FiatSent, 72),
+            EscrowDeadlineAction::OpenDispute
+        );
+        assert_eq!(
+            action(Status::FiatSent, 36),
+            EscrowDeadlineAction::OpenDispute
+        );
+        assert_eq!(
+            action(Status::FiatSent, 1),
+            EscrowDeadlineAction::OpenDispute
+        );
+    }
+
+    #[test]
+    fn a_fiat_sent_trade_is_never_canceled_by_the_deadline() {
+        // Cancelling would hand the seller the fiat and the sats. Whatever
+        // the remaining blocks, the answer stays the dispute.
+        for remaining in [72, 36, 10, 0, -50] {
+            assert_ne!(
+                action(Status::FiatSent, remaining),
+                EscrowDeadlineAction::CancelTrade,
+                "a declared fiat leg must never be cancelled by the daemon"
+            );
+        }
+    }
+
+    #[test]
+    fn a_disputed_trade_alerts_and_keeps_its_escrow() {
+        // The solver can settle up to the last block, so mostro only escalates
+        // the alert as the horizon closes in.
+        assert_eq!(
+            action(Status::Dispute, 72),
+            EscrowDeadlineAction::AlertSolvers { urgent: false }
+        );
+        assert_eq!(
+            action(Status::Dispute, 37),
+            EscrowDeadlineAction::AlertSolvers { urgent: false }
+        );
+        assert_eq!(
+            action(Status::Dispute, 36),
+            EscrowDeadlineAction::AlertSolvers { urgent: true }
+        );
+    }
+
+    #[test]
+    fn a_past_due_escrow_is_the_most_urgent_case() {
+        // Negative remaining blocks mean the horizon is behind us — after a
+        // long outage, say. It must read as past the deadline, not wrap into
+        // a distant future.
+        assert_eq!(
+            action(Status::Active, -10),
+            EscrowDeadlineAction::CancelTrade
+        );
+        assert_eq!(
+            action(Status::FiatSent, -10),
+            EscrowDeadlineAction::OpenDispute
+        );
+        assert_eq!(
+            action(Status::Dispute, -10),
+            EscrowDeadlineAction::AlertSolvers { urgent: true }
+        );
+    }
+
+    #[test]
+    fn statuses_without_escrow_are_never_acted_on() {
+        // The sweep does not select them; this pins that a race that moves an
+        // order out from under it mid-tick cannot trigger an action either.
+        for status in [
+            Status::Pending,
+            Status::WaitingPayment,
+            Status::SettledHoldInvoice,
+            Status::Success,
+            Status::Canceled,
+        ] {
+            assert_eq!(action(status, 0), EscrowDeadlineAction::None);
+        }
+    }
+}

--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -23,6 +23,24 @@ pub const DM_EVENT_KIND: u16 = 14;
 /// This allows the same Mostro instance to publish updated rates that replace previous events
 pub const NOSTR_EXCHANGE_RATES_EVENT_KIND: u16 = 30078;
 
+/// LND's own default for `invoices.holdexpirydelta`: how many blocks before
+/// an accepted hold HTLC's expiry height LND force-cancels the invoice to
+/// avoid a channel force-close, refunding the payer.
+///
+/// mostrod cannot read this value over gRPC, so it is the reference point the
+/// escrow-deadline windows below are validated against: the daemon has to act
+/// on a trade *before* LND takes the escrow away from it.
+pub const LND_DEFAULT_HOLD_EXPIRY_DELTA: u32 = 24;
+
+/// Default `lightning.escrow_expiry_safety_blocks` (~6 h): how close to the
+/// escrow HTLC's expiry height a trade may get before mostrod ends it itself.
+pub const DEFAULT_ESCROW_EXPIRY_SAFETY_BLOCKS: u32 = 36;
+
+/// Default `lightning.escrow_expiry_warning_blocks` (~12 h): how close a trade
+/// may get before mostrod escalates it — for a `fiat-sent` order that means
+/// opening the dispute so a solver can still act while the escrow exists.
+pub const DEFAULT_ESCROW_EXPIRY_WARNING_BLOCKS: u32 = 72;
+
 /// Filename of the environment file auto-loaded from the settings directory at
 /// startup. Shared between the wizard (writes it) and the loader (reads it).
 pub const ENV_FILENAME: &str = ".env";

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1,6 +1,9 @@
 // File with the types for the configuration settings
 // Initialize the types for the configuration settings
-use crate::config::constants::{DEV_FEE_AUDIT_EVENT_KIND, DM_EVENT_KIND};
+use crate::config::constants::{
+    DEFAULT_ESCROW_EXPIRY_SAFETY_BLOCKS, DEFAULT_ESCROW_EXPIRY_WARNING_BLOCKS,
+    DEV_FEE_AUDIT_EVENT_KIND, DM_EVENT_KIND,
+};
 use crate::config::MOSTRO_CONFIG;
 use mostro_core::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -406,6 +409,14 @@ pub struct LightningSettings {
     /// user-supplied payout invoice
     #[serde(default = "default_max_final_cltv_expiry_delta")]
     pub max_final_cltv_expiry_delta: u32,
+    /// How close, in blocks, a trade may get to its escrow HTLC's expiry
+    /// height before mostrod ends the trade itself
+    #[serde(default = "default_escrow_expiry_safety_blocks")]
+    pub escrow_expiry_safety_blocks: u32,
+    /// How close, in blocks, a trade may get to that same expiry height
+    /// before mostrod escalates it (dispute / operator alert)
+    #[serde(default = "default_escrow_expiry_warning_blocks")]
+    pub escrow_expiry_warning_blocks: u32,
 }
 
 /// ~3 days of blocks. High enough for every wallet we know of (18 to 144 is
@@ -415,8 +426,20 @@ fn default_max_final_cltv_expiry_delta() -> u32 {
     432
 }
 
+/// Absent from an existing `settings.toml`, the escrow deadline must still
+/// exist: a node that upgrades without touching its config cannot be left
+/// running trades whose escrow can evaporate unobserved.
+fn default_escrow_expiry_safety_blocks() -> u32 {
+    DEFAULT_ESCROW_EXPIRY_SAFETY_BLOCKS
+}
+
+fn default_escrow_expiry_warning_blocks() -> u32 {
+    DEFAULT_ESCROW_EXPIRY_WARNING_BLOCKS
+}
+
 // Hand-written so `max_final_cltv_expiry_delta` defaults to the real bound
-// instead of `0`, which would reject every invoice.
+// instead of `0`, which would reject every invoice. The escrow windows are
+// real defaults for the same reason: a `0` there would read as "no deadline".
 impl Default for LightningSettings {
     fn default() -> Self {
         Self {
@@ -429,6 +452,8 @@ impl Default for LightningSettings {
             payment_attempts: 0,
             payment_retries_interval: 0,
             max_final_cltv_expiry_delta: default_max_final_cltv_expiry_delta(),
+            escrow_expiry_safety_blocks: default_escrow_expiry_safety_blocks(),
+            escrow_expiry_warning_blocks: default_escrow_expiry_warning_blocks(),
         }
     }
 }

--- a/src/config/util.rs
+++ b/src/config/util.rs
@@ -2,8 +2,11 @@
 /// This module provides utility functions for the config module.
 /// It includes functions to initialize the default settings directory and create a settings file from the template if it doesn't exist.
 /// It also includes functions to add a trailing slash to a path if it doesn't already have one.
-use crate::config::constants::{ENV_FILENAME, MAX_DEV_FEE_PERCENTAGE, MIN_DEV_FEE_PERCENTAGE};
+use crate::config::constants::{
+    ENV_FILENAME, LND_DEFAULT_HOLD_EXPIRY_DELTA, MAX_DEV_FEE_PERCENTAGE, MIN_DEV_FEE_PERCENTAGE,
+};
 use crate::config::secret::read_nsec_env_var;
+use crate::config::types::LightningSettings;
 use crate::config::wizard;
 use crate::config::{init_mostro_settings, Settings};
 use mostro_core::error::MostroError::{self, *};
@@ -65,6 +68,8 @@ fn validate_mostro_settings(settings: &Settings) -> Result<(), MostroError> {
         ))));
     }
 
+    validate_escrow_expiry_settings(&settings.lightning)?;
+
     validate_cashu_settings(
         settings.cashu.as_ref(),
         settings
@@ -72,6 +77,58 @@ fn validate_mostro_settings(settings: &Settings) -> Result<(), MostroError> {
             .as_ref()
             .is_some_and(|bond| bond.enabled),
     )?;
+
+    Ok(())
+}
+
+/// Validate the escrow-deadline windows against the CLTV the escrow is
+/// created with. Standalone so it is unit-testable without a full `Settings`.
+///
+/// A trade's escrow is a hold HTLC that LND force-cancels a few blocks before
+/// its expiry height, refunding the seller. `escrow_expiry_warning_blocks` and
+/// `escrow_expiry_safety_blocks` are where mostrod steps in ahead of that, so
+/// they only mean anything while they sit *inside* the escrow's lifetime:
+///
+/// - `safety > LND_DEFAULT_HOLD_EXPIRY_DELTA`, or LND takes the escrow away
+///   before the daemon ever reaches its own deadline.
+/// - `warning > safety`, or the escalation lands at or after the deadline it
+///   is supposed to precede.
+/// - `hold_invoice_cltv_delta > warning`, or every trade is already past the
+///   escalation threshold the moment the seller pays — which would escalate
+///   and then cancel healthy trades on the first scheduler tick.
+///
+/// All three are startup-fatal rather than clamped: these bound when the
+/// daemon destroys a live escrow, and silently repairing that is how an
+/// operator ends up with a deadline they never agreed to.
+fn validate_escrow_expiry_settings(lightning: &LightningSettings) -> Result<(), MostroError> {
+    let safety = lightning.escrow_expiry_safety_blocks;
+    let warning = lightning.escrow_expiry_warning_blocks;
+    let cltv_delta = lightning.hold_invoice_cltv_delta;
+
+    if safety <= LND_DEFAULT_HOLD_EXPIRY_DELTA {
+        return Err(MostroInternalErr(ServiceError::IOError(format!(
+            "lightning.escrow_expiry_safety_blocks ({safety}) must exceed LND's \
+             invoices.holdexpirydelta ({LND_DEFAULT_HOLD_EXPIRY_DELTA} by default): \
+             below it, LND cancels the escrow before mostrod can close the trade"
+        ))));
+    }
+
+    if warning <= safety {
+        return Err(MostroInternalErr(ServiceError::IOError(format!(
+            "lightning.escrow_expiry_warning_blocks ({warning}) must exceed \
+             lightning.escrow_expiry_safety_blocks ({safety}): the warning has to \
+             come before the deadline it warns about"
+        ))));
+    }
+
+    if cltv_delta <= warning {
+        return Err(MostroInternalErr(ServiceError::IOError(format!(
+            "lightning.hold_invoice_cltv_delta ({cltv_delta}) must exceed \
+             lightning.escrow_expiry_warning_blocks ({warning}): otherwise every \
+             trade starts already past its escrow deadline. Raise the CLTV delta \
+             or lower the escrow expiry windows"
+        ))));
+    }
 
     Ok(())
 }
@@ -444,7 +501,14 @@ mod startup_validation_tests {
     fn base_settings() -> Settings {
         Settings {
             database: DatabaseSettings::default(),
-            lightning: LightningSettings::default(),
+            // `LightningSettings::default()` leaves `hold_invoice_cltv_delta`
+            // at 0 — a placeholder no real config carries, since TOML must
+            // supply it. Use the shipped value so the escrow-window checks
+            // see a configuration an operator could actually be running.
+            lightning: LightningSettings {
+                hold_invoice_cltv_delta: 144,
+                ..Default::default()
+            },
             nostr: NostrSettings::default(),
             mostro: MostroSettings::default(),
             rpc: RpcSettings::default(),
@@ -489,6 +553,87 @@ mod startup_validation_tests {
             escrow_locktime_days: 15,
         });
         assert!(validate_mostro_settings(&settings).is_err());
+    }
+}
+
+#[cfg(test)]
+mod escrow_expiry_validation_tests {
+    use super::*;
+    use crate::config::constants::{
+        DEFAULT_ESCROW_EXPIRY_SAFETY_BLOCKS, DEFAULT_ESCROW_EXPIRY_WARNING_BLOCKS,
+    };
+
+    fn lightning(cltv_delta: u32, safety: u32, warning: u32) -> LightningSettings {
+        LightningSettings {
+            hold_invoice_cltv_delta: cltv_delta,
+            escrow_expiry_safety_blocks: safety,
+            escrow_expiry_warning_blocks: warning,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn shipped_defaults_are_a_valid_configuration() {
+        // 144 / 72 / 36: what settings.tpl.toml ships and what an untouched
+        // upgrade inherits. If this ever fails, every node fails to boot.
+        let ln = lightning(
+            144,
+            DEFAULT_ESCROW_EXPIRY_SAFETY_BLOCKS,
+            DEFAULT_ESCROW_EXPIRY_WARNING_BLOCKS,
+        );
+        assert!(validate_escrow_expiry_settings(&ln).is_ok());
+    }
+
+    #[test]
+    fn rejects_safety_window_inside_lnd_hold_expiry_delta() {
+        // At or below LND's own delta the daemon never gets to act: LND has
+        // already canceled the escrow by the time mostrod's deadline hits.
+        let ln = lightning(144, LND_DEFAULT_HOLD_EXPIRY_DELTA, 72);
+        let err = validate_escrow_expiry_settings(&ln).expect_err("must reject");
+        assert!(err.to_string().contains("holdexpirydelta"));
+
+        let ln = lightning(144, LND_DEFAULT_HOLD_EXPIRY_DELTA - 1, 72);
+        assert!(validate_escrow_expiry_settings(&ln).is_err());
+    }
+
+    #[test]
+    fn rejects_warning_not_before_the_deadline() {
+        // Equal windows mean the escalation and the cancel land on the same
+        // tick, so the escalation buys nobody any time.
+        let ln = lightning(144, 36, 36);
+        let err = validate_escrow_expiry_settings(&ln).expect_err("must reject");
+        assert!(err.to_string().contains("escrow_expiry_warning_blocks"));
+
+        let ln = lightning(144, 72, 36);
+        assert!(validate_escrow_expiry_settings(&ln).is_err());
+    }
+
+    #[test]
+    fn rejects_cltv_delta_that_starts_past_the_warning() {
+        // A 72-block escrow with a 72-block warning window: every trade is
+        // born already due for escalation, and the first tick would cancel
+        // perfectly healthy trades.
+        let ln = lightning(72, 36, 72);
+        let err = validate_escrow_expiry_settings(&ln).expect_err("must reject");
+        assert!(err.to_string().contains("hold_invoice_cltv_delta"));
+
+        let ln = lightning(48, 36, 72);
+        assert!(validate_escrow_expiry_settings(&ln).is_err());
+    }
+
+    #[test]
+    fn unconfigured_cltv_delta_is_rejected() {
+        // `LightningSettings::default()` carries no CLTV delta; a config that
+        // somehow reached startup that way has no escrow window at all.
+        assert!(validate_escrow_expiry_settings(&LightningSettings::default()).is_err());
+    }
+
+    #[test]
+    fn accepts_a_longer_escrow_with_wider_windows() {
+        // Operators trading on slow fiat rails raise the CLTV delta; the
+        // windows scale with it as long as the ordering holds.
+        let ln = lightning(432, 72, 144);
+        assert!(validate_escrow_expiry_settings(&ln).is_ok());
     }
 }
 

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -8,7 +8,10 @@ use nostr_sdk::prelude::*;
 use secrecy::{ExposeSecret, SecretString};
 use zeroize::Zeroizing;
 
-use super::constants::{ENV_FILENAME, NSEC_ENV_VAR};
+use super::constants::{
+    DEFAULT_ESCROW_EXPIRY_SAFETY_BLOCKS, DEFAULT_ESCROW_EXPIRY_WARNING_BLOCKS, ENV_FILENAME,
+    NSEC_ENV_VAR,
+};
 use super::settings::Settings;
 use super::types::{
     DatabaseSettings, LightningSettings, MostroSettings, NostrSettings, RpcSettings,
@@ -146,6 +149,8 @@ fn prompt_lightning_settings() -> Result<LightningSettings, MostroError> {
         payment_attempts: 3,
         payment_retries_interval: 60,
         max_final_cltv_expiry_delta: 432,
+        escrow_expiry_safety_blocks: DEFAULT_ESCROW_EXPIRY_SAFETY_BLOCKS,
+        escrow_expiry_warning_blocks: DEFAULT_ESCROW_EXPIRY_WARNING_BLOCKS,
     })
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -956,6 +956,44 @@ pub async fn find_held_invoices(pool: &SqlitePool) -> Result<Vec<Order>, MostroE
     Ok(order)
 }
 
+/// Claim the cancelation of an order that still has a live escrow, reporting
+/// whether this caller is the one that got it.
+///
+/// Two independent paths react to an escrow that has run out of time — the
+/// scheduler cancelling ahead of the CLTV horizon, and the invoice subscriber
+/// reacting to LND having cancelled first — and a release or admin action can
+/// always land between another path's read and its write. This single
+/// statement is what decides who owns the transition: `Ok(true)` means the
+/// caller wrote the status and owns the follow-up (notifications, dispute
+/// close, bond release), `Ok(false)` means the order had already left its
+/// escrow states and the caller must not touch it further.
+///
+/// Only the three statuses that can carry a live escrow are eligible, so this
+/// can never drag a settled, expired or already-canceled order back into a
+/// cancelation.
+pub async fn claim_escrow_order_canceled(
+    pool: &SqlitePool,
+    order_id: Uuid,
+    event_id: &str,
+) -> Result<bool, MostroError> {
+    let result = sqlx::query(
+        r#"
+          UPDATE orders
+          SET status = ?1, event_id = ?2
+          WHERE id = ?3
+            AND status IN ('active', 'fiat-sent', 'dispute')
+        "#,
+    )
+    .bind(Status::Canceled.to_string())
+    .bind(event_id)
+    .bind(order_id)
+    .execute(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(result.rows_affected() == 1)
+}
+
 pub async fn find_failed_payment(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
     let order = sqlx::query_as::<_, Order>(
         r#"
@@ -2219,6 +2257,113 @@ mod tests {
 
         let result = super::find_held_invoices(&pool).await.unwrap();
         assert!(result.is_empty(), "Should not find orders with held_at = 0");
+    }
+
+    // -- Tests for claim_escrow_order_canceled --
+
+    async fn insert_order_with_status(pool: &SqlitePool, status: &str) -> uuid::Uuid {
+        let id = uuid::Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                    amount, fiat_code, fiat_amount, created_at, expires_at,
+                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                    invoice_held_at)
+            VALUES (?1, 'sell', 'ev-before', ?2, 0, 'lightning',
+                    100000, 'USD', 100, 1700000000, 1700086400,
+                    0, 0, 0, 0, 1700001000)"#,
+        )
+        .bind(id)
+        .bind(status)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    async fn read_order(pool: &SqlitePool, id: uuid::Uuid) -> (String, String) {
+        sqlx::query_as("SELECT status, event_id FROM orders WHERE id = ?1")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn claim_escrow_order_canceled_wins_from_every_escrow_status() {
+        let pool = setup_orders_db().await.unwrap();
+
+        for status in ["active", "fiat-sent", "dispute"] {
+            let id = insert_order_with_status(&pool, status).await;
+            assert!(
+                super::claim_escrow_order_canceled(&pool, id, "ev-after")
+                    .await
+                    .unwrap(),
+                "{status} carries a live escrow, so the claim must win"
+            );
+            let (status, event_id) = read_order(&pool, id).await;
+            assert_eq!(status, "canceled");
+            assert_eq!(event_id, "ev-after", "the published event must be recorded");
+        }
+    }
+
+    #[tokio::test]
+    async fn claim_escrow_order_canceled_is_lost_by_the_second_caller() {
+        let pool = setup_orders_db().await.unwrap();
+        let id = insert_order_with_status(&pool, "fiat-sent").await;
+
+        assert!(super::claim_escrow_order_canceled(&pool, id, "ev-first")
+            .await
+            .unwrap());
+        assert!(
+            !super::claim_escrow_order_canceled(&pool, id, "ev-second")
+                .await
+                .unwrap(),
+            "only one caller may own the cancelation and its side effects"
+        );
+
+        let (_, event_id) = read_order(&pool, id).await;
+        assert_eq!(
+            event_id, "ev-first",
+            "the loser must not overwrite the winner's row"
+        );
+    }
+
+    #[tokio::test]
+    async fn claim_escrow_order_canceled_never_reopens_a_resolved_order() {
+        let pool = setup_orders_db().await.unwrap();
+
+        // A settled or already-terminal order has no escrow to lose; a late
+        // cancel event must not drag any of them into a cancelation.
+        for status in [
+            "pending",
+            "waiting-payment",
+            "settled-hold-invoice",
+            "success",
+            "canceled-by-admin",
+            "cooperatively-canceled",
+        ] {
+            let id = insert_order_with_status(&pool, status).await;
+            assert!(
+                !super::claim_escrow_order_canceled(&pool, id, "ev-after")
+                    .await
+                    .unwrap(),
+                "{status} must not be claimable"
+            );
+            let (unchanged, event_id) = read_order(&pool, id).await;
+            assert_eq!(unchanged, status);
+            assert_eq!(event_id, "ev-before");
+        }
+    }
+
+    #[tokio::test]
+    async fn claim_escrow_order_canceled_reports_a_miss_for_unknown_orders() {
+        let pool = setup_orders_db().await.unwrap();
+        assert!(
+            !super::claim_escrow_order_canceled(&pool, uuid::Uuid::new_v4(), "ev")
+                .await
+                .unwrap(),
+            "no row means nothing was claimed"
+        );
     }
 
     // -- Tests for find_failed_payment --

--- a/src/db.rs
+++ b/src/db.rs
@@ -956,6 +956,27 @@ pub async fn find_held_invoices(pool: &SqlitePool) -> Result<Vec<Order>, MostroE
     Ok(order)
 }
 
+/// Every order whose escrow HTLC is still locked, for the deadline sweep.
+///
+/// The same three statuses [`find_held_invoices`] resubscribes, narrowed to
+/// rows the sweep can actually act on: an order with no `hash` has no invoice
+/// to look up in LND, and `invoice_held_at == 0` means the seller never paid,
+/// so there is no escrow whose expiry could be approaching.
+pub async fn find_orders_with_live_escrow(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
+    sqlx::query_as::<_, Order>(
+        r#"
+          SELECT *
+          FROM orders
+          WHERE status IN ('active', 'fiat-sent', 'dispute')
+            AND hash IS NOT NULL
+            AND invoice_held_at != 0
+        "#,
+    )
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
 /// Claim the cancelation of an order that still has a live escrow, reporting
 /// whether this caller is the one that got it.
 ///
@@ -2257,6 +2278,65 @@ mod tests {
 
         let result = super::find_held_invoices(&pool).await.unwrap();
         assert!(result.is_empty(), "Should not find orders with held_at = 0");
+    }
+
+    // -- Tests for find_orders_with_live_escrow --
+
+    #[tokio::test]
+    async fn find_orders_with_live_escrow_returns_only_actionable_rows() {
+        let pool = setup_orders_db().await.unwrap();
+
+        // Eligible: a paid escrow in each of the three live statuses.
+        for status in ["active", "fiat-sent", "dispute"] {
+            sqlx::query(
+                r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                        amount, fiat_code, fiat_amount, created_at, expires_at,
+                        failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                        invoice_held_at, hash)
+                VALUES (?1, 'sell', 'ev1', ?2, 0, 'lightning',
+                        100000, 'USD', 100, 1700000000, 1700086400,
+                        0, 0, 0, 0, 1700001000, ?3)"#,
+            )
+            .bind(uuid::Uuid::new_v4())
+            .bind(status)
+            .bind("aa".repeat(32))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Not eligible: no hash (nothing to look up in LND), never paid
+        // (no escrow), and a status whose escrow is already resolved.
+        let ineligible: [(&str, Option<String>, i64); 3] = [
+            ("active", None, 1700001000),
+            ("active", Some("bb".repeat(32)), 0),
+            ("settled-hold-invoice", Some("cc".repeat(32)), 1700001000),
+        ];
+        for (status, hash, held_at) in ineligible {
+            sqlx::query(
+                r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                        amount, fiat_code, fiat_amount, created_at, expires_at,
+                        failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                        invoice_held_at, hash)
+                VALUES (?1, 'sell', 'ev1', ?2, 0, 'lightning',
+                        100000, 'USD', 100, 1700000000, 1700086400,
+                        0, 0, 0, 0, ?3, ?4)"#,
+            )
+            .bind(uuid::Uuid::new_v4())
+            .bind(status)
+            .bind(held_at)
+            .bind(hash)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let result = super::find_orders_with_live_escrow(&pool).await.unwrap();
+        assert_eq!(
+            result.len(),
+            3,
+            "only paid, still-live escrows are sweepable"
+        );
     }
 
     // -- Tests for claim_escrow_order_canceled --

--- a/src/db.rs
+++ b/src/db.rs
@@ -923,20 +923,29 @@ pub async fn find_locked_cashu_orders(pool: &SqlitePool) -> Result<Vec<Order>, M
 ///
 /// Two disjoint cases, and the second is the one that matters after a restart:
 ///
-/// - `active` with `invoice_held_at != 0` — the seller already paid, so the
-///   subscription is there to observe settle/cancel.
+/// - a post-payment status with `invoice_held_at != 0` — the seller already
+///   paid, so the subscription is there to observe settle/cancel. All three
+///   such statuses belong here, not just `active`: an order reaches
+///   `fiat-sent` and `dispute` with the escrow HTLC still locked, so a
+///   restart in either one used to stop observing that invoice for the rest
+///   of the run (#856). That is the window in which LND force-cancels an
+///   accepted hold HTLC at the CLTV horizon, and the cancel has to be seen
+///   for [`crate::flow::hold_invoice_canceled`] to close the trade.
 /// - `waiting-payment` / `waiting-buyer-invoice` with a hash — the invoice
 ///   exists but nobody has paid it yet. `invoice_held_at` is still 0 here
 ///   (only [`crate::flow::hold_invoice_paid`] ever writes it), which is why
 ///   that column cannot gate this branch: these rows would never match.
 ///   Missing this window is what makes a seller who paid during a restart
 ///   look like a seller who never paid.
+///
+/// Terminal and post-escrow statuses are deliberately absent: once the hold
+/// is settled or canceled there is nothing left to observe.
 pub async fn find_held_invoices(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
     let order = sqlx::query_as::<_, Order>(
         r#"
           SELECT *
           FROM orders
-          WHERE (invoice_held_at != 0 AND status == 'active')
+          WHERE (invoice_held_at != 0 AND status IN ('active', 'fiat-sent', 'dispute'))
              OR (status IN ('waiting-payment', 'waiting-buyer-invoice') AND hash IS NOT NULL)
         "#,
     )
@@ -2033,26 +2042,75 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_find_held_invoices_ignores_non_active() {
+    async fn test_find_held_invoices_returns_every_escrow_status() {
         let pool = setup_orders_db().await.unwrap();
 
-        // Insert order with invoice_held_at != 0 but wrong status
-        sqlx::query(
-            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
-                    amount, fiat_code, fiat_amount, created_at, expires_at,
-                    failed_payment, payment_attempts, dev_fee, dev_fee_paid,
-                    invoice_held_at)
-            VALUES (?1, 'buy', 'ev1', 'pending', 0, 'lightning',
-                    100000, 'USD', 100, 1700000000, 1700086400,
-                    0, 0, 0, 0, 1700001000)"#,
-        )
-        .bind(uuid::Uuid::new_v4())
-        .execute(&pool)
-        .await
-        .unwrap();
+        // The three statuses an order can sit in while its escrow HTLC is
+        // still locked. `fiat-sent` and `dispute` were missing before #856,
+        // so a restart during either one left the hold invoice unobserved
+        // for the rest of the run.
+        for status in ["active", "fiat-sent", "dispute"] {
+            sqlx::query(
+                r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                        amount, fiat_code, fiat_amount, created_at, expires_at,
+                        failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                        invoice_held_at, hash)
+                VALUES (?1, 'buy', 'ev1', ?2, 0, 'lightning',
+                        100000, 'USD', 100, 1700000000, 1700086400,
+                        0, 0, 0, 0, 1700001000, ?3)"#,
+            )
+            .bind(uuid::Uuid::new_v4())
+            .bind(status)
+            .bind("cc".repeat(32))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
 
         let result = super::find_held_invoices(&pool).await.unwrap();
-        assert!(result.is_empty(), "Should not find non-active orders");
+        assert_eq!(
+            result.len(),
+            3,
+            "every status that can still hold escrow must be resubscribed"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_find_held_invoices_ignores_statuses_without_live_escrow() {
+        let pool = setup_orders_db().await.unwrap();
+
+        // `pending` never had an escrow; the rest already resolved theirs.
+        // A stale `invoice_held_at` on such a row must not resubscribe it —
+        // there is no HTLC left to observe.
+        for status in [
+            "pending",
+            "settled-hold-invoice",
+            "success",
+            "canceled",
+            "cooperatively-canceled",
+        ] {
+            sqlx::query(
+                r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                        amount, fiat_code, fiat_amount, created_at, expires_at,
+                        failed_payment, payment_attempts, dev_fee, dev_fee_paid,
+                        invoice_held_at, hash)
+                VALUES (?1, 'buy', 'ev1', ?2, 0, 'lightning',
+                        100000, 'USD', 100, 1700000000, 1700086400,
+                        0, 0, 0, 0, 1700001000, ?3)"#,
+            )
+            .bind(uuid::Uuid::new_v4())
+            .bind(status)
+            .bind("dd".repeat(32))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let result = super::find_held_invoices(&pool).await.unwrap();
+        assert!(
+            result.is_empty(),
+            "only statuses with a live escrow are resubscribed"
+        );
     }
 
     #[tokio::test]

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,3 +1,6 @@
+use crate::app::bond;
+use crate::app::context::AppContext;
+use crate::app::dispute::close_dispute_after_user_resolution;
 use crate::util::{enqueue_order_msg, notify_taker_reputation};
 use mostro_core::db::Crud;
 use mostro_core::prelude::*;
@@ -184,21 +187,119 @@ pub async fn hold_invoice_settlement(hash: &str, pool: &SqlitePool) -> Result<()
     Ok(())
 }
 
-pub async fn hold_invoice_canceled(hash: &str, pool: &SqlitePool) -> Result<()> {
-    let order = crate::db::find_order_by_hash(pool, hash).await?;
-    info!(
-        "Order Id: {} - Invoice with hash: {} was canceled!",
-        order.id, hash
+/// Resolve an order whose hold invoice was canceled in LND.
+///
+/// Called from the invoice subscriber on `InvoiceState::Canceled`, which
+/// covers two situations that look identical on the wire:
+///
+/// - A cancel mostro asked for — a waiting order that timed out, a
+///   cooperative cancel, an admin cancel. Whoever asked already moved the
+///   order to its terminal status, so this event is just LND confirming the
+///   refund and there is nothing left to do.
+/// - A cancel nobody asked for. LND force-cancels an accepted hold HTLC as it
+///   approaches the CLTV expiry height, refunding the seller, so that the
+///   channel is never forced to close over a held payment. The trade is
+///   unaffected by that decision: an order left in `active`, `fiat-sent` or
+///   `dispute` keeps advertising itself as live while its escrow is already
+///   back in the seller's channel — which is how a buyer ends up sending
+///   fiat for sats nobody can release anymore.
+///
+/// The second case is what this function exists for: publish the cancelation,
+/// claim the order with a conditional update, then notify both parties and
+/// unwind the trade. The claim is what keeps this safe next to the
+/// scheduler's own deadline cancel and any release or admin action racing on
+/// the same row — exactly one path transitions the order, the rest no-op.
+pub async fn hold_invoice_canceled(hash: &str, ctx: &AppContext) -> Result<(), MostroError> {
+    let pool = ctx.pool();
+    let order = crate::db::find_order_by_hash(pool, hash)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+    let status = order.get_order_status().map_err(MostroInternalErr)?;
+
+    if !matches!(status, Status::Active | Status::FiatSent | Status::Dispute) {
+        info!(
+            "Order Id: {} - Invoice with hash: {} was canceled!",
+            order.id, hash
+        );
+        return Ok(());
+    }
+
+    // Loud on purpose: a trade just lost its escrow without anyone deciding
+    // it should. Either the trade outlived the CLTV horizon, or the invoice
+    // was canceled out of band — both are things an operator wants to see.
+    tracing::error!(
+        order_id = %order.id,
+        status = %status,
+        "Escrow with hash {hash} was canceled while the trade was still live; \
+         the sats are back with the seller, closing the order"
     );
+
+    let order_updated = crate::util::update_order_event(ctx.keys(), Status::Canceled, &order)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+
+    // Publishing before the claim mirrors `release_action`, and is safe here
+    // for a narrower reason: the only other writer that can win this race is
+    // the scheduler's deadline cancel, which publishes the very same
+    // `Canceled` status. A settled invoice never emits a cancel, so a release
+    // cannot be overwritten by the event above.
+    if !crate::db::claim_escrow_order_canceled(pool, order.id, &order_updated.event_id).await? {
+        tracing::info!(
+            order_id = %order.id,
+            "Order left its escrow status concurrently; leaving it to whoever resolved it"
+        );
+        return Ok(());
+    }
+
+    notify_escrow_canceled(&order).await;
+
+    // Best-effort unwind from here on: the order is already canceled in the
+    // DB, so a failure below must not resurrect it.
+    close_dispute_after_user_resolution(
+        ctx,
+        &order_updated,
+        DisputeStatus::SellerRefunded,
+        ctx.keys(),
+        "escrow cancel",
+    )
+    .await;
+    bond::release_taker_bonds_for_order_or_warn(pool, order.id, "escrow_canceled").await;
+    bond::resolve_range_maker_bond_at_close_or_warn(pool, &order, "escrow_canceled").await;
+
     Ok(())
+}
+
+/// Tell both sides the trade is over, so neither keeps acting on an order
+/// whose escrow is gone: the buyer must not send fiat, and the seller must
+/// not expect a release. Missing pubkeys are logged rather than propagated —
+/// the cancelation is already durable and cannot be undone by a failed DM.
+async fn notify_escrow_canceled(order: &Order) {
+    let (buyer_pubkey, seller_pubkey) = match (order.get_buyer_pubkey(), order.get_seller_pubkey())
+    {
+        (Ok(buyer), Ok(seller)) => (buyer, seller),
+        _ => {
+            tracing::warn!(
+                order_id = %order.id,
+                "Canceled an order with an unreadable trade pubkey; \
+                 both parties are left unnotified"
+            );
+            return;
+        }
+    };
+
+    for pubkey in [buyer_pubkey, seller_pubkey] {
+        enqueue_order_msg(None, Some(order.id), Action::Canceled, None, pubkey, None).await;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::context::test_utils::{test_settings, TestContextBuilder};
     use mostro_core::order::{Kind as OrderKind, Status};
     use nostr_sdk::{Keys, Timestamp};
     use sqlx::SqlitePool;
+    use std::sync::Arc;
 
     async fn create_test_pool() -> SqlitePool {
         SqlitePool::connect(":memory:").await.unwrap()
@@ -395,14 +496,109 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hold_invoice_settlement_and_cancel_resolve_existing_order() {
+    async fn hold_invoice_settlement_resolves_existing_order() {
         init_global_settings();
         let pool = create_migrated_pool().await;
         let hash = "dd".repeat(32);
         insert_order_with_hash(&pool, &hash, Status::Active, None, None, None, None).await;
 
         assert!(hold_invoice_settlement(&hash, &pool).await.is_ok());
-        assert!(hold_invoice_canceled(&hash, &pool).await.is_ok());
+    }
+
+    fn ctx_for(pool: &SqlitePool) -> AppContext {
+        TestContextBuilder::new()
+            .with_pool(Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build()
+    }
+
+    async fn order_with_parties(pool: &SqlitePool, hash: &str, status: Status) {
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        insert_order_with_hash(pool, hash, status, None, Some(buyer), Some(seller), None).await;
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_canceled_closes_a_live_trade() {
+        init_global_settings();
+        // The escrow is gone in all three: an order left in any of them keeps
+        // advertising a trade that nothing backs, which is what lets a buyer
+        // send fiat for sats already returned to the seller.
+        for status in [Status::Active, Status::FiatSent, Status::Dispute] {
+            let pool = create_migrated_pool().await;
+            let hash = "aa".repeat(32);
+            order_with_parties(&pool, &hash, status).await;
+
+            hold_invoice_canceled(&hash, &ctx_for(&pool))
+                .await
+                .unwrap_or_else(|e| panic!("{status} must be closed, not error: {e:?}"));
+
+            let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+            assert_eq!(
+                updated.status,
+                Status::Canceled.to_string(),
+                "an order in {status} must not survive its escrow"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_canceled_leaves_expected_cancels_alone() {
+        init_global_settings();
+        // Cancels mostro asked for, and orders whose escrow already resolved.
+        // Whoever asked has set the final status; re-deriving one here would
+        // overwrite it — a canceled-by-admin order must not read as a plain
+        // cancel, and a settled one must never go back to canceled at all.
+        for status in [
+            Status::WaitingPayment,
+            Status::WaitingBuyerInvoice,
+            Status::Canceled,
+            Status::CanceledByAdmin,
+            Status::CooperativelyCanceled,
+            Status::SettledHoldInvoice,
+            Status::Success,
+        ] {
+            let pool = create_migrated_pool().await;
+            let hash = "bb".repeat(32);
+            order_with_parties(&pool, &hash, status).await;
+
+            hold_invoice_canceled(&hash, &ctx_for(&pool))
+                .await
+                .expect("an expected cancel is a no-op, not a failure");
+
+            let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+            assert_eq!(
+                updated.status,
+                status.to_string(),
+                "{status} must be left exactly as it was"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_canceled_is_a_noop_on_redelivery() {
+        init_global_settings();
+        // LND replays invoice state on every resubscribe, so the same cancel
+        // arrives again after each restart. The second delivery must not
+        // re-notify or re-unwind a trade that is already closed.
+        let pool = create_migrated_pool().await;
+        let hash = "cc".repeat(32);
+        order_with_parties(&pool, &hash, Status::FiatSent).await;
+        let ctx = ctx_for(&pool);
+
+        hold_invoice_canceled(&hash, &ctx).await.unwrap();
+        let first = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+
+        hold_invoice_canceled(&hash, &ctx)
+            .await
+            .expect("a replayed cancel is a no-op, not a failure");
+        let second = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+
+        assert_eq!(second.status, Status::Canceled.to_string());
+        assert_eq!(
+            second.event_id, first.event_id,
+            "a replayed cancel must not republish the order"
+        );
     }
 
     #[tokio::test]
@@ -434,14 +630,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_hold_invoice_canceled_structure() {
-        let pool = create_test_pool().await;
+    async fn hold_invoice_canceled_errors_on_unknown_hash() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let ctx = ctx_for(&pool);
+        // No order carries this hash: there is nothing to close, and the
+        // subscriber logs the error rather than acting on a guess.
         let hash = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-
-        // This test would require setting up database with order data
-        let result = hold_invoice_canceled(hash, &pool).await;
-        // Should fail without proper database setup
-        assert!(result.is_ok() || result.is_err());
+        assert!(hold_invoice_canceled(hash, &ctx).await.is_err());
     }
 
     mod hold_invoice_flow_tests {

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -273,7 +273,7 @@ pub async fn hold_invoice_canceled(hash: &str, ctx: &AppContext) -> Result<(), M
 /// whose escrow is gone: the buyer must not send fiat, and the seller must
 /// not expect a release. Missing pubkeys are logged rather than propagated —
 /// the cancelation is already durable and cannot be undone by a failed DM.
-async fn notify_escrow_canceled(order: &Order) {
+pub(crate) async fn notify_escrow_canceled(order: &Order) {
     let (buyer_pubkey, seller_pubkey) = match (order.get_buyer_pubkey(), order.get_seller_pubkey())
     {
         (Ok(buyer), Ok(seller)) => (buyer, seller),

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -8,7 +8,10 @@ use fedimint_tonic_lnd::invoicesrpc::{
     AddHoldInvoiceRequest, AddHoldInvoiceResp, CancelInvoiceMsg, CancelInvoiceResp,
     SettleInvoiceMsg, SettleInvoiceResp,
 };
-use fedimint_tonic_lnd::lnrpc::{invoice::InvoiceState, GetInfoRequest, GetInfoResponse, Payment};
+use fedimint_tonic_lnd::lnrpc::{
+    invoice::InvoiceState, GetInfoRequest, GetInfoResponse, InvoiceHtlc, InvoiceHtlcState, Payment,
+    PaymentHash,
+};
 use fedimint_tonic_lnd::routerrpc::{SendPaymentRequest, TrackPaymentRequest};
 use fedimint_tonic_lnd::Client;
 use mostro_core::prelude::*;
@@ -58,6 +61,26 @@ pub fn routing_fee_cap_sats(amount: i64) -> i64 {
 /// Length in bytes of a Lightning payment preimage and of the payment
 /// hash derived from it (both are SHA-256 sized).
 const HASH_LEN: usize = 32;
+
+/// Block height at which the first of an invoice's accepted HTLCs expires.
+///
+/// The escrow's lifetime is bounded by whichever accepted HTLC expires
+/// soonest — LND cancels the whole invoice as that one approaches its
+/// expiry — so a multi-part payment is only as long-lived as its earliest
+/// part. HTLCs already settled or canceled are not holding anything and are
+/// skipped, which is also why an invoice with no accepted HTLC yields
+/// `None`: there is no escrow to put a deadline on.
+///
+/// `expiry_height` is an `int32` on the wire; a negative value cannot
+/// describe a block height, so such an HTLC is ignored rather than wrapped
+/// into a huge `u32`.
+fn earliest_accepted_htlc_expiry(htlcs: &[InvoiceHtlc]) -> Option<u32> {
+    htlcs
+        .iter()
+        .filter(|htlc| htlc.state == InvoiceHtlcState::Accepted as i32)
+        .filter_map(|htlc| u32::try_from(htlc.expiry_height).ok())
+        .min()
+}
 
 /// Decode a hex-encoded 32-byte preimage or payment hash — as stored in
 /// the `orders` / `bonds` tables — into the raw bytes LND expects.
@@ -222,6 +245,56 @@ impl LndConnector {
                 ))))
             }
         }
+    }
+
+    /// Block height at which the escrow behind `hash` expires, as LND sees it.
+    ///
+    /// The invoice's `cltv_expiry` is only a *minimum* the payer must honour,
+    /// and the accepted HTLC's real expiry height is set by the payer (many
+    /// wallets add their own buffer). Asking LND is therefore the only way to
+    /// know the actual horizon, and it is immune to the block-interval drift
+    /// that any wall-clock estimate from `invoice_held_at` would inherit.
+    ///
+    /// Returns:
+    /// - `Ok(Some(height))` — the escrow is locked until `height`; LND
+    ///   force-cancels the invoice a few blocks earlier
+    ///   (`invoices.holdexpirydelta`, 24 by default) to avoid a force-close.
+    /// - `Ok(None)` — LND has no record of the hash, or the invoice holds no
+    ///   accepted HTLC (never paid, or already settled/canceled). Either way
+    ///   there is no live escrow to put a deadline on.
+    /// - `Err(_)` — undecodable hash, or a transport/gRPC failure that leaves
+    ///   the horizon unknown. Callers must not read this as "no deadline".
+    pub async fn lookup_invoice_htlc_expiry(
+        &mut self,
+        hash: &str,
+    ) -> Result<Option<u32>, MostroError> {
+        let r_hash = decode_hash32("payment hash", hash)?;
+
+        let invoice = match self
+            .client
+            .lightning()
+            .lookup_invoice(PaymentHash {
+                r_hash,
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(invoice) => invoice.into_inner(),
+            Err(status) => {
+                if status.code() == fedimint_tonic_lnd::tonic::Code::NotFound {
+                    return Ok(None);
+                }
+                // Same stable `code=<Code>` prefix the cancel path uses, so a
+                // caller can tell a benign outcome from a transport failure.
+                return Err(MostroInternalErr(ServiceError::LnNodeError(format!(
+                    "code={:?} message={}",
+                    status.code(),
+                    status.message()
+                ))));
+            }
+        };
+
+        Ok(earliest_accepted_htlc_expiry(&invoice.htlcs))
     }
 
     pub async fn send_payment(
@@ -696,6 +769,78 @@ mod offline_connector_tests {
         init_test_settings();
         let mut ln = offline_connector().await;
         assert!(ln.get_node_info().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn lookup_invoice_htlc_expiry_rejects_malformed_hash() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        // Decoding runs before any RPC, so a bad row fails here rather than
+        // spending a round trip on a hash LND could never match.
+        assert!(ln.lookup_invoice_htlc_expiry("not-hex").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn lookup_invoice_htlc_expiry_surfaces_transport_error() {
+        init_test_settings();
+        let mut ln = offline_connector().await;
+        let err = ln
+            .lookup_invoice_htlc_expiry(&"cc".repeat(32))
+            .await
+            .expect_err("a dead port must error, not report 'no deadline'");
+        assert!(
+            err.to_string().contains("code="),
+            "error must carry the code= prefix, got: {err}"
+        );
+    }
+
+    fn htlc(state: InvoiceHtlcState, expiry_height: i32) -> InvoiceHtlc {
+        InvoiceHtlc {
+            state: state as i32,
+            expiry_height,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn earliest_accepted_htlc_expiry_takes_the_soonest_accepted_one() {
+        // A multi-part payment lives only as long as its earliest part.
+        let htlcs = [
+            htlc(InvoiceHtlcState::Accepted, 900_100),
+            htlc(InvoiceHtlcState::Accepted, 900_050),
+            htlc(InvoiceHtlcState::Accepted, 900_200),
+        ];
+        assert_eq!(earliest_accepted_htlc_expiry(&htlcs), Some(900_050));
+    }
+
+    #[test]
+    fn earliest_accepted_htlc_expiry_ignores_resolved_htlcs() {
+        // Settled and canceled HTLCs hold nothing; a sooner expiry on one of
+        // them must not shorten the deadline of the escrow that is still live.
+        let htlcs = [
+            htlc(InvoiceHtlcState::Canceled, 800_000),
+            htlc(InvoiceHtlcState::Settled, 810_000),
+            htlc(InvoiceHtlcState::Accepted, 900_000),
+        ];
+        assert_eq!(earliest_accepted_htlc_expiry(&htlcs), Some(900_000));
+    }
+
+    #[test]
+    fn earliest_accepted_htlc_expiry_is_none_without_a_live_htlc() {
+        assert_eq!(earliest_accepted_htlc_expiry(&[]), None);
+        let resolved = [htlc(InvoiceHtlcState::Canceled, 900_000)];
+        assert_eq!(earliest_accepted_htlc_expiry(&resolved), None);
+    }
+
+    #[test]
+    fn earliest_accepted_htlc_expiry_skips_negative_heights() {
+        // `expiry_height` is an int32 on the wire: a negative value is not a
+        // block height and must not wrap into a far-future u32.
+        let htlcs = [
+            htlc(InvoiceHtlcState::Accepted, -1),
+            htlc(InvoiceHtlcState::Accepted, 900_000),
+        ];
+        assert_eq!(earliest_accepted_htlc_expiry(&htlcs), Some(900_000));
     }
 
     #[tokio::test]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,6 +1,9 @@
 use crate::app::bond;
 use crate::app::context::AppContext;
 use crate::app::dev_fee::run_dev_fee_cycle;
+use crate::app::escrow_deadline::{
+    apply_escrow_deadline_action, escrow_deadline_action, EscrowDeadlineAction,
+};
 use crate::app::release::do_payment;
 use crate::config;
 use crate::db::*;
@@ -38,6 +41,7 @@ pub async fn start_scheduler(ctx: AppContext) {
     // `false`, so every job below still starts exactly as before).
     if !Settings::is_cashu_enabled() {
         job_cancel_orders(ctx.clone()).await;
+        job_enforce_escrow_deadline(ctx.clone()).await;
         job_retry_failed_payments(ctx.clone()).await;
         job_process_dev_fee_payment(ctx.clone()).await;
         job_process_bond_payouts(ctx.clone()).await;
@@ -594,6 +598,116 @@ async fn job_cancel_orders(ctx: AppContext) {
             tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
         }
     });
+}
+
+/// Keep every live trade inside its escrow's lifetime.
+///
+/// The escrow is a hold HTLC that LND force-cancels near its CLTV expiry
+/// height, refunding the seller whatever the trade is doing. No other job
+/// covers `active`, `fiat-sent` or `dispute`, so without this sweep a trade
+/// simply outlives its escrow: the order keeps reading as live, the buyer can
+/// still send fiat, and the seller's release then fails at settle.
+///
+/// Each tick asks LND where the chain is, then asks it for the real expiry
+/// height of every live escrow — the invoice's `cltv_expiry` is only a
+/// minimum the payer had to honour, so the horizon cannot be derived from the
+/// order row. [`escrow_deadline_action`] turns the distance into a decision.
+///
+/// Failures are always "skip and retry next tick": one unreachable node or one
+/// unreadable invoice must not end trades, and there is a whole warning window
+/// worth of ticks before anything is actually due.
+async fn job_enforce_escrow_deadline(ctx: AppContext) {
+    let mut ln_client = match LndConnector::new().await {
+        Ok(client) => client,
+        Err(e) => return error!("escrow_deadline: failed to create LND client: {e}"),
+    };
+
+    tokio::spawn(async move {
+        let pool = ctx.pool();
+        // Which disputed orders have already been shouted about, per band, so
+        // an operator gets two lines per order instead of one per minute. Kept
+        // in memory on purpose: a restart repeating an alert is the harmless
+        // direction, and the set only ever holds orders that reached their
+        // escrow deadline while disputed.
+        let mut alerted: HashSet<(uuid::Uuid, bool)> = HashSet::new();
+
+        loop {
+            match ln_client.get_node_info().await {
+                Ok(info) => {
+                    let current_height = i64::from(info.block_height);
+                    match crate::db::find_orders_with_live_escrow(pool).await {
+                        Ok(orders) => {
+                            for order in orders.iter() {
+                                sweep_one_escrow(
+                                    &ctx,
+                                    &mut ln_client,
+                                    order,
+                                    current_height,
+                                    &mut alerted,
+                                )
+                                .await;
+                            }
+                        }
+                        Err(e) => warn!("escrow_deadline: could not list live escrows: {e}"),
+                    }
+                }
+                Err(e) => warn!("escrow_deadline: no block height from LND ({e}); skipping tick"),
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+        }
+    });
+}
+
+/// Resolve one order's distance to its escrow horizon and act on it.
+async fn sweep_one_escrow(
+    ctx: &AppContext,
+    ln_client: &mut LndConnector,
+    order: &Order,
+    current_height: i64,
+    alerted: &mut HashSet<(uuid::Uuid, bool)>,
+) {
+    let Some(hash) = order.hash.as_ref() else {
+        return;
+    };
+
+    let Ok(status) = order.get_order_status() else {
+        warn!(
+            "escrow_deadline: order {} has an unreadable status",
+            order.id
+        );
+        return;
+    };
+
+    let expiry_height = match ln_client.lookup_invoice_htlc_expiry(hash).await {
+        // No accepted HTLC left: the escrow was settled or canceled while the
+        // order row still says otherwise. Whichever it was, the invoice
+        // subscriber owns that transition, not this sweep.
+        Ok(None) => return,
+        Ok(Some(height)) => i64::from(height),
+        Err(e) => {
+            warn!(
+                "escrow_deadline: could not read the escrow horizon for order {} ({e}); \
+                 retrying next tick",
+                order.id
+            );
+            return;
+        }
+    };
+
+    let remaining_blocks = expiry_height - current_height;
+    let action = escrow_deadline_action(status, remaining_blocks, &ctx.settings().lightning);
+
+    // Alerts are the only repeatable action: cancelling or disputing takes the
+    // order out of the sweep on the same tick, while a disputed order stays in
+    // it until the horizon and would otherwise shout once a minute.
+    if let EscrowDeadlineAction::AlertSolvers { urgent } = action {
+        if !alerted.insert((order.id, urgent)) {
+            return;
+        }
+    }
+
+    apply_escrow_deadline_action(ctx, ln_client, order, action, remaining_blocks).await;
 }
 
 async fn job_expire_pending_older_orders(ctx: AppContext) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1137,6 +1137,13 @@ pub async fn invoice_subscribe(hash: Vec<u8>, request_id: Option<u64>) -> Result
     // Arc clone db pool to safe use across threads
     let pool = get_db_pool();
 
+    // Built once, before the loop: `hold_invoice_canceled` has to publish, DM
+    // both parties and close a dispute, and neither of this function's two
+    // callers (boot resubscribe and `show_hold_invoice`) carries a context
+    // down here. Failing now is better than discovering it on the one event
+    // that matters.
+    let ctx = crate::app::context::AppContext::from_globals()?;
+
     let subs = {
         async move {
             // Receiving msgs from the invoice subscription.
@@ -1163,7 +1170,7 @@ pub async fn invoice_subscribe(hash: Vec<u8>, request_id: Option<u64>) -> Result
                     }
                 } else if msg.state == InvoiceState::Canceled {
                     // If the payment was canceled
-                    if let Err(e) = flow::hold_invoice_canceled(&hash, &pool).await {
+                    if let Err(e) = flow::hold_invoice_canceled(&hash, &ctx).await {
                         info!("Invoice flow error {e}");
                     }
                 } else {


### PR DESCRIPTION
## Motivation

A trade is escrowed in a hold invoice, and that escrow has a hard lifetime. The invoice is created with `hold_invoice_cltv_delta` (144 blocks by default), and LND force-cancels an accepted hold HTLC a few blocks before its expiry height — `invoices.holdexpirydelta`, 24 by default — so a channel is never forced to close over a held payment. The refund goes to the seller regardless of what the trade was doing at that moment. On the defaults that leaves roughly 20 hours of escrow from the moment the seller pays.

Nothing in the order state machine knew about that horizon:

- No scheduler job covered `active`, `fiat-sent` or `dispute`. `job_cancel_orders` only sweeps the waiting states, and `job_expire_pending_older_orders` only the pending ones.
- `hold_invoice_canceled` logged the event and returned — no status change, no notification, no dispute.

So a trade could outlive its escrow. The order stayed `active` or `fiat-sent` and kept advertising itself as a live trade with nothing backing it, and the seller's release then failed at settle, after the buyer may already have acted on the trade looking live. Slow fiat rails make that window easy to reach without anyone misbehaving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic monitoring of Lightning escrow deadlines.
  * Active trades nearing expiry are canceled safely; “fiat-sent” trades enter dispute handling, with operator alerts for urgent disputed cases.
  * Escrow cancellation now notifies both parties and safely resolves related records.
  * Held invoices are restored across active, fiat-sent, and dispute states after restart.

* **Configuration**
  * Added configurable warning and safety windows, with startup validation to prevent unsafe settings.

* **Documentation**
  * Added an operational runbook covering expiry handling, alerts, retries, and tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->