### PR TITLE
fix: restrict trade-pubkey rotation to the maker

### DIFF
--- a/src/app/trade_pubkey.rs
+++ b/src/app/trade_pubkey.rs
@@ -2,6 +2,7 @@ use crate::app::context::AppContext;
 use crate::util::{enqueue_order_msg, get_order};
 
 use mostro_core::db::Crud;
+use mostro_core::order::Kind as OrderKind;
 use mostro_core::prelude::*;
 
 pub async fn trade_pubkey_action(
@@ -26,30 +27,32 @@ pub async fn trade_pubkey_action(
         return Err(MostroCantDo(CantDoReason::InvalidOrderStatus));
     }
 
-    // Get master keys (already plaintext after phase-3/4 encryption migration)
-    let (master_buyer_key, master_seller_key) = if order.master_buyer_pubkey.is_some() {
-        let master_buyer_key = order
-            .get_master_buyer_pubkey()
-            .map_err(MostroInternalErr)?
-            .to_string();
-        (Some(master_buyer_key), None)
-    } else {
-        let master_seller_key = order
+    // Only the maker may rotate the trade key, and the maker side is
+    // fixed by the order kind: the creator of a sell order is the seller,
+    // of a buy order the buyer. Match the caller's identity against the
+    // maker's master key alone — never the taker's. The bond flow can
+    // leave BOTH master keys on a pre-trade order
+    // (`promote_taker_context_to_order`); keying the branch on
+    // `master_buyer_pubkey.is_some()` would let a sell-order taker match
+    // the buyer branch, and an unconditional `creator_pubkey` write would
+    // then hand them maker attribution (`sent_from_maker` compares
+    // `creator_pubkey`).
+    let kind = order.get_order_kind().map_err(MostroInternalErr)?;
+    let maker_master_key = match kind {
+        OrderKind::Sell => order
             .get_master_seller_pubkey()
-            .map_err(MostroInternalErr)?
-            .to_string();
-        (None, Some(master_seller_key))
+            .map_err(MostroInternalErr)?,
+        OrderKind::Buy => order.get_master_buyer_pubkey().map_err(MostroInternalErr)?,
     };
-
-    match (master_buyer_key, master_seller_key) {
-        (Some(master_buyer_pubkey), _) if master_buyer_pubkey == event.identity.to_string() => {
-            order.buyer_pubkey = Some(event.sender.to_string());
-        }
-        (_, Some(master_seller_pubkey)) if master_seller_pubkey == event.identity.to_string() => {
-            order.seller_pubkey = Some(event.sender.to_string());
-        }
-        _ => return Err(MostroInternalErr(ServiceError::InvalidPubkey)),
-    };
+    if maker_master_key != event.identity {
+        return Err(MostroInternalErr(ServiceError::InvalidPubkey));
+    }
+    match kind {
+        OrderKind::Sell => order.seller_pubkey = Some(event.sender.to_string()),
+        OrderKind::Buy => order.buyer_pubkey = Some(event.sender.to_string()),
+    }
+    // The maker is the order creator: `creator_pubkey` tracks the maker's
+    // current trade key and must never move for anyone else.
     order.creator_pubkey = event.sender.to_string();
 
     // We a message to the seller
@@ -114,17 +117,35 @@ mod tests {
         Message::new_order(Some(order_id), Some(1), None, Action::TradePubkey, None)
     }
 
-    fn base_order(status: Status) -> Order {
+    fn base_order(kind: OrderKind, status: Status) -> Order {
         Order {
             id: Uuid::new_v4(),
             status: status.to_string(),
-            kind: mostro_core::order::Kind::Sell.to_string(),
+            kind: kind.to_string(),
             fiat_code: "USD".to_string(),
             creator_pubkey: Keys::generate().public_key().to_string(),
             amount: 10_000,
             fee: 10,
             ..Default::default()
         }
+    }
+
+    /// A coherent maker-owned order: the maker's trade key doubles as
+    /// `creator_pubkey`, exactly as `prepare_new_order` persists it.
+    fn maker_order(kind: OrderKind, status: Status, maker: &Keys) -> Order {
+        let mut order = base_order(kind, status);
+        order.creator_pubkey = maker.public_key().to_string();
+        match kind {
+            OrderKind::Sell => {
+                order.seller_pubkey = Some(maker.public_key().to_string());
+                order.master_seller_pubkey = Some(maker.public_key().to_string());
+            }
+            OrderKind::Buy => {
+                order.buyer_pubkey = Some(maker.public_key().to_string());
+                order.master_buyer_pubkey = Some(maker.public_key().to_string());
+            }
+        }
+        order
     }
 
     async fn order_by_id(pool: &SqlitePool, id: Uuid) -> Order {
@@ -134,13 +155,12 @@ mod tests {
     #[tokio::test]
     async fn trade_pubkey_action_rejects_non_pre_trade_status() {
         let ctx = setup_ctx().await;
-        let identity = Keys::generate().public_key();
+        let maker = Keys::generate();
 
-        let mut order = base_order(Status::Active);
-        order.master_buyer_pubkey = Some(identity.to_string());
+        let order = maker_order(OrderKind::Sell, Status::Active, &maker);
         let order = order.create(ctx.pool()).await.unwrap();
 
-        let event = trade_pubkey_event(Keys::generate().public_key(), identity);
+        let event = trade_pubkey_event(Keys::generate().public_key(), maker.public_key());
         let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
 
         assert!(matches!(
@@ -150,17 +170,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_pubkey_action_rotates_buyer_trade_key_for_master_buyer() {
+    async fn trade_pubkey_action_rotates_buyer_trade_key_for_buy_maker() {
         let ctx = setup_ctx().await;
-        let identity = Keys::generate().public_key();
+        let maker = Keys::generate();
         let new_trade_key = Keys::generate().public_key();
 
-        let mut order = base_order(Status::Pending);
-        order.master_buyer_pubkey = Some(identity.to_string());
-        order.buyer_pubkey = Some(Keys::generate().public_key().to_string());
+        // On a buy order the maker is the buyer.
+        let order = maker_order(OrderKind::Buy, Status::Pending, &maker);
         let order = order.create(ctx.pool()).await.unwrap();
 
-        let event = trade_pubkey_event(new_trade_key, identity);
+        let event = trade_pubkey_event(new_trade_key, maker.public_key());
         let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
 
         assert!(result.is_ok(), "buyer rotation must succeed: {result:?}");
@@ -182,18 +201,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn trade_pubkey_action_rotates_seller_trade_key_for_master_seller() {
+    async fn trade_pubkey_action_rotates_seller_trade_key_for_sell_maker() {
         let ctx = setup_ctx().await;
-        let identity = Keys::generate().public_key();
+        let maker = Keys::generate();
         let new_trade_key = Keys::generate().public_key();
 
         // `WaitingTakerBond` is the other accepted pre-trade entry point.
-        let mut order = base_order(Status::WaitingTakerBond);
-        order.master_seller_pubkey = Some(identity.to_string());
-        order.seller_pubkey = Some(Keys::generate().public_key().to_string());
+        let order = maker_order(OrderKind::Sell, Status::WaitingTakerBond, &maker);
         let order = order.create(ctx.pool()).await.unwrap();
 
-        let event = trade_pubkey_event(new_trade_key, identity);
+        let event = trade_pubkey_event(new_trade_key, maker.public_key());
         let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
 
         assert!(result.is_ok(), "seller rotation must succeed: {result:?}");
@@ -205,12 +222,12 @@ mod tests {
     #[tokio::test]
     async fn trade_pubkey_action_rejects_identity_that_does_not_own_the_order() {
         let ctx = setup_ctx().await;
+        let maker = Keys::generate();
 
-        let mut order = base_order(Status::Pending);
-        order.master_buyer_pubkey = Some(Keys::generate().public_key().to_string());
+        let order = maker_order(OrderKind::Sell, Status::Pending, &maker);
         let order = order.create(ctx.pool()).await.unwrap();
 
-        // A different identity than the stored master buyer key.
+        // A different identity than the stored master seller key.
         let event =
             trade_pubkey_event(Keys::generate().public_key(), Keys::generate().public_key());
         let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
@@ -229,7 +246,7 @@ mod tests {
         let ctx = setup_ctx().await;
 
         // Neither master key present: the master-seller getter errors.
-        let order = base_order(Status::Pending)
+        let order = base_order(OrderKind::Sell, Status::Pending)
             .create(ctx.pool())
             .await
             .unwrap();
@@ -242,5 +259,89 @@ mod tests {
             result,
             Err(MostroInternalErr(ServiceError::InvalidPubkey))
         ));
+    }
+
+    /// Regression test for the order-attribution hijack: the bond flow can
+    /// leave BOTH master keys on a `Pending`/`WaitingTakerBond` order
+    /// (`promote_taker_context_to_order` + a failed `resume_take_after_bond`).
+    /// A sell-order taker whose identity is `master_buyer_pubkey` must not
+    /// rotate anything — above all not `creator_pubkey`, which
+    /// `sent_from_maker` compares for maker-only checks.
+    #[tokio::test]
+    async fn trade_pubkey_action_rejects_sell_taker_in_both_master_keys_window() {
+        let ctx = setup_ctx().await;
+        let maker = Keys::generate();
+        let taker = Keys::generate();
+        let attacker_fresh = Keys::generate().public_key();
+
+        let mut order = maker_order(OrderKind::Sell, Status::Pending, &maker);
+        order.buyer_pubkey = Some(taker.public_key().to_string());
+        order.master_buyer_pubkey = Some(taker.public_key().to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = trade_pubkey_event(attacker_fresh, taker.public_key());
+        let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.creator_pubkey, maker.public_key().to_string());
+        assert_eq!(after.seller_pubkey, Some(maker.public_key().to_string()));
+        assert_eq!(after.buyer_pubkey, Some(taker.public_key().to_string()));
+    }
+
+    /// Same both-master-keys window, but from the maker's side: the genuine
+    /// creator of a sell order must still be able to rotate — keying the
+    /// branch on `master_buyer_pubkey.is_some()` used to lock the maker out.
+    #[tokio::test]
+    async fn trade_pubkey_action_rotates_for_sell_maker_in_both_master_keys_window() {
+        let ctx = setup_ctx().await;
+        let maker = Keys::generate();
+        let taker = Keys::generate();
+        let new_trade_key = Keys::generate().public_key();
+
+        let mut order = maker_order(OrderKind::Sell, Status::WaitingTakerBond, &maker);
+        order.buyer_pubkey = Some(taker.public_key().to_string());
+        order.master_buyer_pubkey = Some(taker.public_key().to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = trade_pubkey_event(new_trade_key, maker.public_key());
+        let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
+
+        assert!(result.is_ok(), "maker rotation must succeed: {result:?}");
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.seller_pubkey, Some(new_trade_key.to_string()));
+        assert_eq!(after.creator_pubkey, new_trade_key.to_string());
+        // The taker side is untouched.
+        assert_eq!(after.buyer_pubkey, Some(taker.public_key().to_string()));
+    }
+
+    /// Symmetric case on a buy order: the taker is the seller side, and the
+    /// seller master key must not pass the maker check either.
+    #[tokio::test]
+    async fn trade_pubkey_action_rejects_buy_taker_in_both_master_keys_window() {
+        let ctx = setup_ctx().await;
+        let maker = Keys::generate();
+        let taker = Keys::generate();
+        let attacker_fresh = Keys::generate().public_key();
+
+        let mut order = maker_order(OrderKind::Buy, Status::Pending, &maker);
+        order.seller_pubkey = Some(taker.public_key().to_string());
+        order.master_seller_pubkey = Some(taker.public_key().to_string());
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        let event = trade_pubkey_event(attacker_fresh, taker.public_key());
+        let result = trade_pubkey_action(&ctx, trade_pubkey_msg(order.id), &event).await;
+
+        assert!(matches!(
+            result,
+            Err(MostroInternalErr(ServiceError::InvalidPubkey))
+        ));
+        let after = order_by_id(ctx.pool(), order.id).await;
+        assert_eq!(after.creator_pubkey, maker.public_key().to_string());
+        assert_eq!(after.buyer_pubkey, Some(maker.public_key().to_string()));
+        assert_eq!(after.seller_pubkey, Some(taker.public_key().to_string()));
     }
 }

--- a/src/app/trade_pubkey.rs
+++ b/src/app/trade_pubkey.rs
@@ -5,6 +5,15 @@ use mostro_core::db::Crud;
 use mostro_core::order::Kind as OrderKind;
 use mostro_core::prelude::*;
 
+/// Rotate the maker's per-trade pubkey for a pre-trade order.
+///
+/// Only the order maker may rotate: maker ownership is determined by the
+/// order kind — the seller is the maker of a [`OrderKind::Sell`] order and
+/// the buyer is the maker of a [`OrderKind::Buy`] order. The caller's
+/// `event.identity` must match the maker-side master key; on success the
+/// maker-side trade pubkey and `creator_pubkey` (which tracks the maker's
+/// current trade key) are set to `event.sender`. Anything else is rejected
+/// with [`ServiceError::InvalidPubkey`] and the order is left untouched.
 pub async fn trade_pubkey_action(
     ctx: &AppContext,
     msg: Message,


### PR DESCRIPTION
## Summary

`trade_pubkey_action` let a sell-order **taker** overwrite `creator_pubkey`, seizing maker/owner attribution of the order. Found during an internal security review; not reported by an external issue.

Two compounding defects in `src/app/trade_pubkey.rs`:

1. **Branch-selection bias** — the rotation branch was selected with `if order.master_buyer_pubkey.is_some()`, which discards the seller master key whenever **both** master keys are present on the order.
2. **Unconditional overwrite** — `order.creator_pubkey = event.sender` ran regardless of which branch matched.

The anti-abuse-bond flow can persist both master keys on a `Pending`/`WaitingTakerBond` order: `promote_taker_context_to_order` writes the taker's master + trade keys onto the row, and a failed `resume_take_after_bond` (LND or relay error) leaves that state behind with no rollback. In that window a sell-order taker (`event.identity == master_buyer_pubkey`) matched the buyer branch and the unconditional write handed them `creator_pubkey`.

Downstream impact (everything keys off `creator_pubkey`):

- `sent_from_maker` compares `creator_pubkey`, so the attacker passes maker-only checks — e.g. the maker-cancel path for a pending order, a costless griefing kill that also releases the attacker's own taker bond — while the **real maker fails them** (lockout).
- Maker-directed notifications (`notify_creator`, scheduler cancel notices) go to the attacker's key.
- On **range orders**, `handle_child_order` requires `seller_pubkey == creator_pubkey` for sells; the hijack makes `release_action` abort **after** `settle_seller_hold_invoice` but **before** the buyer payout — escrow claimed by the daemon, buyer never paid, bonds stuck.

As a side effect of the bias, the genuine maker of a sell order could not rotate their trade key at all during the bond window: the seller branch was unreachable.

## Fix

The maker side is fixed by the order kind — the creator of a sell order is the seller, of a buy order the buyer (the same invariant relied on by `prepare_new_order`, `edit_pubkeys_order`, `handle_child_order`, and `resume_publish_after_maker_bond`):

- `event.identity` is matched against the **maker's master key alone**, never the taker's.
- Only the maker-side trade pubkey is rotated.
- `creator_pubkey` moves only when the genuine creator rotates (it tracks the maker's current trade key).

Out of scope (possible follow-up hardening): making the bond promote→resume path transactional so the both-master-keys pre-trade window cannot persist. The handler is now correct regardless of whether that window exists.

## Compatibility

Behavioral tightening of the `TradePubkey` action only — no event tag/kind changes, no schema or config changes. Pre-trade taker rotation was never possible before the bond model (taker keys only ever sat on orders past the pre-trade states), so no legitimate client flow is affected; maker rotation in `Pending`/`WaitingTakerBond` keeps working, including for sell-order makers inside the bond window (previously blocked).

## Tests

Three new regression tests in `src/app/trade_pubkey.rs`:

- `trade_pubkey_action_rejects_sell_taker_in_both_master_keys_window` — the attack scenario: taker identity on a both-keys sell order is rejected and the row is left untouched.
- `trade_pubkey_action_rotates_for_sell_maker_in_both_master_keys_window` — the genuine maker can still rotate inside that window; taker fields untouched.
- `trade_pubkey_action_rejects_buy_taker_in_both_master_keys_window` — symmetric case for buy orders (taker is the seller side).

Existing rotation tests were updated to model coherent maker-owned orders (buy maker / sell maker).

Full suite:

```text
test result: ok. 1156 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 17.28s
```

`cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trade authorization by validating callers against the correct maker key for each order type.
  * Correctly handles orders containing both maker and taker master keys.
  * Prevents takers from being accepted as makers while allowing valid makers to proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->