### PR TITLE
fix: keep the public orderbook converged with the DB (ghost orders)

### DIFF
--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -5,8 +5,11 @@ use crate::escrow::EscrowBackend;
 use crate::lightning::invoice::{decode_invoice, validate_payout_invoice};
 use crate::lightning::LndConnector;
 use crate::lnurl::resolv_ln_address;
-use crate::nip33::{new_order_event, order_to_tags};
-use crate::util::{enqueue_order_msg, get_order, settle_seller_hold_invoice, update_order_event};
+use crate::nip33::{new_order_event_with_created_at, order_to_tags};
+use crate::util::{
+    enqueue_order_msg, get_order, mark_orderbook_publish_failed, monotonic_order_event_timestamp,
+    settle_seller_hold_invoice, update_order_event,
+};
 use crate::Result;
 
 use fedimint_tonic_lnd::lnrpc::payment::PaymentStatus;
@@ -267,7 +270,8 @@ pub async fn release_action(
         Ok((Some(child_order), Some(event))) => {
             let client = ctx.nostr_client();
             if client.send_event(&event).await.is_err() {
-                tracing::warn!("Failed sending child order event for order id: {}. This may affect order synchronization", child_order.id)
+                tracing::warn!("Failed sending child order event for order id: {}; queued for republish by the orderbook reconciler", child_order.id);
+                mark_orderbook_publish_failed(child_order.id);
             }
             handle_child_order(child_order, &order, next_trade, ctx.pool(), request_id)
                 .await
@@ -793,9 +797,12 @@ async fn create_order_event(
         Err(_) => order_to_tags(new_order, Some((0.0, 0, 0)), Some(&mostro_pubkey))?,
     };
 
-    // Prepare new child order event for sending (kind 38383 for orders)
+    // Prepare new child order event for sending (kind 38383 for orders).
+    // Stamp it through the monotonic registry so a same-second follow-up
+    // revision of the child order cannot tie on `created_at`.
     let event = if let Some(tags) = tags {
-        new_order_event(my_keys, "", new_order.id.to_string(), tags)
+        let created_at = monotonic_order_event_timestamp(new_order.id, Timestamp::now());
+        new_order_event_with_created_at(my_keys, "", new_order.id.to_string(), tags, created_at)
             .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?
     } else {
         return Err(MostroInternalErr(ServiceError::UnexpectedError(

--- a/src/app/take_buy.rs
+++ b/src/app/take_buy.rs
@@ -3,7 +3,7 @@ use crate::app::bond::TakerContext;
 use crate::app::context::AppContext;
 use crate::util::{
     enqueue_order_msg, get_dev_fee, get_fiat_amount_requested, get_market_amount_and_fee,
-    get_order, show_hold_invoice, HoldInvoiceOrigin,
+    get_order, is_order_take_window_closed, show_hold_invoice, HoldInvoiceOrigin,
 };
 
 use crate::db::{seller_has_pending_order, update_user_trade_index};
@@ -41,6 +41,13 @@ pub async fn take_buy_action(
     if order.check_status(Status::Pending).is_err()
         && order.check_status(Status::WaitingTakerBond).is_err()
     {
+        return Err(MostroCantDo(CantDoReason::InvalidOrderStatus));
+    }
+
+    // Reject takes on an order whose take window already closed: a
+    // `pending` row can outlive its `expires_at` by up to one scheduler
+    // tick (~60 s) before the expiry job cancels it.
+    if is_order_take_window_closed(&order, Timestamp::now().as_secs() as i64) {
         return Err(MostroCantDo(CantDoReason::InvalidOrderStatus));
     }
 

--- a/src/app/take_sell.rs
+++ b/src/app/take_sell.rs
@@ -4,8 +4,8 @@ use crate::app::context::AppContext;
 use crate::db::{buyer_has_pending_order, update_user_trade_index};
 use crate::util::{
     enqueue_order_msg, get_dev_fee, get_fiat_amount_requested, get_market_amount_and_fee,
-    get_order, set_waiting_invoice_status, show_hold_invoice, update_order_event, validate_invoice,
-    HoldInvoiceOrigin,
+    get_order, is_order_take_window_closed, set_waiting_invoice_status, show_hold_invoice,
+    update_order_event, validate_invoice, HoldInvoiceOrigin,
 };
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
@@ -80,6 +80,13 @@ pub async fn take_sell_action(
     if order.check_status(Status::Pending).is_err()
         && order.check_status(Status::WaitingTakerBond).is_err()
     {
+        return Err(MostroCantDo(CantDoReason::InvalidOrderStatus));
+    }
+
+    // Reject takes on an order whose take window already closed: a
+    // `pending` row can outlive its `expires_at` by up to one scheduler
+    // tick (~60 s) before the expiry job cancels it.
+    if is_order_take_window_closed(&order, Timestamp::now().as_secs() as i64) {
         return Err(MostroCantDo(CantDoReason::InvalidOrderStatus));
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -675,6 +675,32 @@ pub async fn find_order_by_date(pool: &SqlitePool) -> Result<Vec<Order>, MostroE
     Ok(order)
 }
 
+/// All orders currently advertised (or advertisable) as `pending` on the
+/// book. Includes `waiting-taker-bond`, which publishes as `pending` on the
+/// wire (Phase 1.5), and excludes `waiting-maker-bond`, which was never
+/// published. Used by the orderbook reconciler to re-assert the book on
+/// relays; only orders whose take window is still open are returned — an
+/// expired row is the expiry job's business, not the reconciler's.
+pub async fn find_pending_orders_for_reconcile(
+    pool: &SqlitePool,
+) -> Result<Vec<Order>, MostroError> {
+    let now = Timestamp::now();
+    let orders = sqlx::query_as::<_, Order>(
+        r#"
+          SELECT *
+          FROM orders
+          WHERE expires_at >= ?1
+            AND status IN ('pending', 'waiting-taker-bond')
+        "#,
+    )
+    .bind(now.as_secs() as i64)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+
+    Ok(orders)
+}
+
 pub async fn find_order_by_seconds(pool: &SqlitePool) -> Result<Vec<Order>, MostroError> {
     let mostro_settings = Settings::get_mostro();
     let exp_seconds = mostro_settings.expiration_seconds as u64;

--- a/src/db.rs
+++ b/src/db.rs
@@ -680,7 +680,9 @@ pub async fn find_order_by_date(pool: &SqlitePool) -> Result<Vec<Order>, MostroE
 /// wire (Phase 1.5), and excludes `waiting-maker-bond`, which was never
 /// published. Used by the orderbook reconciler to re-assert the book on
 /// relays; only orders whose take window is still open are returned — an
-/// expired row is the expiry job's business, not the reconciler's.
+/// expired row is the expiry job's business, not the reconciler's. Legacy
+/// rows with `expires_at = 0` have no take-window TTL (mirroring
+/// `is_order_take_window_closed`) and stay re-assertable.
 pub async fn find_pending_orders_for_reconcile(
     pool: &SqlitePool,
 ) -> Result<Vec<Order>, MostroError> {
@@ -689,7 +691,7 @@ pub async fn find_pending_orders_for_reconcile(
         r#"
           SELECT *
           FROM orders
-          WHERE expires_at >= ?1
+          WHERE (expires_at >= ?1 OR expires_at = 0)
             AND status IN ('pending', 'waiting-taker-bond')
         "#,
     )
@@ -1895,6 +1897,61 @@ mod tests {
         .execute(pool)
         .await
         .unwrap();
+    }
+
+    /// Insert a minimal order row with an explicit status and expiry, for
+    /// the reconciler full-sweep query.
+    async fn insert_book_order(pool: &SqlitePool, status: &str, expires_at: i64) {
+        sqlx::query(
+            r#"
+            INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                                amount, fiat_code, fiat_amount, created_at, expires_at)
+            VALUES (?1, 'sell', 'event123', ?2, 0, 'bank',
+                    100000, 'USD', 100, 1700000000, ?3)
+            "#,
+        )
+        .bind(uuid::Uuid::new_v4())
+        .bind(status)
+        .bind(expires_at)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// The full sweep re-asserts only live pending orders: expired rows are
+    /// the expiry job's business and post-trade rows are not book entries.
+    /// Legacy rows with `expires_at = 0` have no take-window TTL and must
+    /// stay re-assertable (mirroring `is_order_take_window_closed`).
+    #[tokio::test]
+    async fn find_pending_orders_for_reconcile_lists_only_live_pending_orders() {
+        let pool = setup_orders_db().await.unwrap();
+        let now = nostr_sdk::prelude::Timestamp::now().as_secs() as i64;
+
+        for (status, expires_at) in [
+            ("pending", now + 3_600),          // live → listed
+            ("waiting-taker-bond", now + 600), // publishes as pending → listed
+            ("pending", 0),                    // legacy, no TTL → listed
+            ("pending", now - 60),             // expired → expiry job's business
+            ("active", now + 3_600),           // post-trade → not a book entry
+            ("waiting-maker-bond", now + 600), // never published → skipped
+        ] {
+            insert_book_order(&pool, status, expires_at).await;
+        }
+
+        let listed = super::find_pending_orders_for_reconcile(&pool)
+            .await
+            .unwrap();
+        let statuses: Vec<String> = listed.iter().map(|o| o.status.clone()).collect();
+
+        assert_eq!(
+            listed.len(),
+            3,
+            "live pending-published rows plus legacy no-TTL: {statuses:?}"
+        );
+        assert!(statuses.contains(&"waiting-taker-bond".to_string()));
+        assert!(listed
+            .iter()
+            .any(|o| o.status == "pending" && o.expires_at == 0));
     }
 
     async fn setup_disputes_table(pool: &SqlitePool) {

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -412,6 +412,23 @@ fn create_source_tag(
 /// * `mostro_pubkey` - Optional Mostro pubkey override. If None, derived from get_keys().
 ///   Pass Some() in tests to avoid global state dependencies.
 ///
+/// NIP-40 `expiration` for an order's kind-38383 event.
+///
+/// Events published as `pending` self-destruct at the order's real
+/// `expires_at` (the take-window TTL, typically ~24 h): if a terminal
+/// revision is ever lost (dropped publish, relay outage), relays delete the
+/// stale `pending` state at the order's actual deadline instead of
+/// advertising phantom liquidity for the full retention window (default
+/// 30 days). Terminal / in-progress revisions keep the configured retention
+/// so trade history remains queryable.
+fn nip40_expiration_for_order(order: &Order, published_status: Status) -> i64 {
+    if published_status == Status::Pending && order.expires_at > 0 {
+        return order.expires_at;
+    }
+    get_expiration_timestamp_for_kind(NOSTR_ORDER_EVENT_KIND)
+        .expect("expiration is always defined for order events")
+}
+
 pub fn order_to_tags(
     order: &Order,
     reputation_data: Option<(f64, i64, i64)>,
@@ -456,9 +473,7 @@ pub fn order_to_tags(
             Tag::custom("expires_at", vec![order.expires_at.to_string()]),
             Tag::custom(
                 "expiration",
-                vec![get_expiration_timestamp_for_kind(NOSTR_ORDER_EVENT_KIND)
-                    .expect("expiration is always defined for order events")
-                    .to_string()],
+                vec![nip40_expiration_for_order(order, status).to_string()],
             ),
             Tag::custom(
                 "y",
@@ -759,6 +774,81 @@ mod tests {
         assert_eq!(
             create_platform_tag_values(Some("   \t  ")),
             vec!["mostro".to_string()]
+        );
+    }
+
+    // ── NIP-40 expiration: ghost-order TTL ───────────────────────────────────
+    // (uses the shared `get_tag_value` helper defined further below)
+
+    /// A `pending` event must self-destruct at the order's real take-window
+    /// TTL (`expires_at`), not the 30-day retention window: if a terminal
+    /// revision is ever lost, relays delete the stale `pending` state at the
+    /// order's actual deadline instead of advertising phantom liquidity for
+    /// a month.
+    #[test]
+    fn pending_event_nip40_expiration_matches_order_expires_at() {
+        init_test_settings();
+        let mut order = make_pending_order();
+        order.expires_at = 1_900_000_000;
+
+        let tags = order_to_tags(&order, None, Some(TEST_MOSTRO_PUBKEY))
+            .expect("order_to_tags must not error")
+            .expect("pending order must produce Some(tags)");
+
+        let expiration = get_tag_value(&tags, "expiration").expect("expiration tag present");
+        assert_eq!(
+            expiration, "1900000000",
+            "pending events must expire at the order's real expires_at"
+        );
+    }
+
+    /// Terminal revisions keep the configured retention window so trade
+    /// history stays queryable — only the `pending` face of the order gets
+    /// the short TTL.
+    #[test]
+    fn canceled_event_nip40_expiration_keeps_configured_retention() {
+        init_test_settings();
+        let mut order = make_pending_order();
+        order.status = Status::Canceled.to_string();
+        order.expires_at = 1_900_000_000;
+
+        let tags = order_to_tags(&order, None, Some(TEST_MOSTRO_PUBKEY))
+            .expect("order_to_tags must not error")
+            .expect("canceled order must produce Some(tags)");
+
+        let expiration: i64 = get_tag_value(&tags, "expiration")
+            .expect("expiration tag present")
+            .parse()
+            .expect("expiration must be a unix timestamp");
+        let now = Timestamp::now().as_secs() as i64;
+        assert!(
+            expiration > now,
+            "terminal events keep a future retention-based expiration"
+        );
+        assert_ne!(
+            expiration, order.expires_at,
+            "terminal events do not inherit the take-window TTL"
+        );
+    }
+
+    /// Legacy rows without `expires_at` fall back to the configured
+    /// retention window instead of emitting an instantly-expired event.
+    #[test]
+    fn pending_event_without_expires_at_falls_back_to_retention() {
+        init_test_settings();
+        let order = make_pending_order(); // Default: expires_at = 0
+
+        let tags = order_to_tags(&order, None, Some(TEST_MOSTRO_PUBKEY))
+            .expect("order_to_tags must not error")
+            .expect("pending order must produce Some(tags)");
+
+        let expiration: i64 = get_tag_value(&tags, "expiration")
+            .expect("expiration tag present")
+            .parse()
+            .expect("expiration must be a unix timestamp");
+        assert!(
+            expiration > Timestamp::now().as_secs() as i64,
+            "zero expires_at must not produce an already-expired event"
         );
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -47,6 +47,7 @@ pub async fn start_scheduler(ctx: AppContext) {
     }
 
     // Mode-agnostic jobs (the info event self-skips when LN status is absent).
+    job_orderbook_reconciler(ctx.clone()).await;
     job_info_event_send(ctx.clone()).await;
     job_relay_list(ctx.clone()).await;
     job_update_bitcoin_prices().await;
@@ -920,6 +921,95 @@ async fn enforce_escrow_deadline_pass(
     Ok(())
 }
 
+/// How often the orderbook reconciler drains the failed-publish queue.
+const ORDERBOOK_RECONCILE_INTERVAL_SECS: u64 = 60;
+/// Every this many reconciler ticks, the whole `pending` book is
+/// re-asserted on relays (once per hour at the 60 s tick), healing states
+/// relays lost for reasons the daemon never saw (dropped events, relay
+/// restores from backup, NIP-01 ties lost before the monotonic stamp).
+const ORDERBOOK_FULL_SWEEP_EVERY_TICKS: u64 = 60;
+
+/// One reconciler pass: republish every order whose last kind-38383
+/// publish failed (`util::take_failed_orderbook_publishes`), and — when
+/// `full_sweep` — re-assert every live `pending` order from the DB.
+///
+/// `update_order_event` re-queues an order on publish failure, so a relay
+/// outage self-heals on a later pass. The returned order (fresh
+/// `event_id`) is deliberately not persisted, matching the CAS-miss
+/// repair path: the DB row's status is the source of truth being
+/// re-advertised, not mutated.
+async fn reconcile_orderbook_once(pool: &sqlx::SqlitePool, keys: &Keys, full_sweep: bool) {
+    for order_id in util::take_failed_orderbook_publishes() {
+        match Order::by_id(pool, order_id).await {
+            Ok(Some(order)) => match order.get_order_status() {
+                Ok(status) => {
+                    if let Err(e) = update_order_event(keys, status, &order).await {
+                        warn!("orderbook reconciler: republish of order {order_id} failed: {e}");
+                    }
+                }
+                Err(e) => warn!("orderbook reconciler: order {order_id} has bad status: {e}"),
+            },
+            // Row vanished — nothing to advertise; drop the queue entry.
+            Ok(None) => {}
+            Err(e) => {
+                warn!("orderbook reconciler: could not reload order {order_id}: {e}");
+                // Transient DB error: keep it queued for the next pass.
+                util::mark_orderbook_publish_failed(order_id);
+            }
+        }
+    }
+
+    if full_sweep {
+        match crate::db::find_pending_orders_for_reconcile(pool).await {
+            Ok(orders) => {
+                info!(
+                    "orderbook reconciler: re-asserting {} pending order(s) on relays",
+                    orders.len()
+                );
+                for order in orders {
+                    match order.get_order_status() {
+                        Ok(status) => {
+                            if let Err(e) = update_order_event(keys, status, &order).await {
+                                warn!(
+                                    "orderbook reconciler: re-assert of order {} failed: {e}",
+                                    order.id
+                                );
+                            }
+                        }
+                        Err(e) => warn!(
+                            "orderbook reconciler: order {} has bad status: {e}",
+                            order.id
+                        ),
+                    }
+                }
+            }
+            Err(e) => warn!("orderbook reconciler: could not list pending orders: {e}"),
+        }
+    }
+}
+
+/// Keeps the public NIP-33 orderbook converged with the DB: drains the
+/// failed-publish queue every minute and re-asserts the whole pending book
+/// hourly (first sweep right at startup, healing relay state lost across
+/// daemon restarts). Without this job a single dropped publish
+/// leaves a dead order advertised as `pending` until its NIP-40 expiration.
+async fn job_orderbook_reconciler(ctx: AppContext) {
+    let keys = ctx.keys().clone();
+    tokio::spawn(async move {
+        let pool = ctx.pool();
+        let mut tick: u64 = 0;
+        loop {
+            let full_sweep = tick.is_multiple_of(ORDERBOOK_FULL_SWEEP_EVERY_TICKS);
+            reconcile_orderbook_once(pool, &keys, full_sweep).await;
+            tick = tick.wrapping_add(1);
+            tokio::time::sleep(tokio::time::Duration::from_secs(
+                ORDERBOOK_RECONCILE_INTERVAL_SECS,
+            ))
+            .await;
+        }
+    });
+}
+
 async fn job_expire_pending_older_orders(ctx: AppContext) {
     let keys = ctx.keys().clone();
 
@@ -1262,6 +1352,101 @@ mod tests {
             .filter(|(msg, _)| msg.get_inner_message_kind().id == Some(order_id))
             .map(|(msg, _)| msg.get_inner_message_kind().action.clone())
             .collect()
+    }
+
+    // ── orderbook reconciler ─────────────────────────────────────────────
+
+    /// A queue entry whose order row vanished is dropped, not retried
+    /// forever: there is nothing left to advertise.
+    #[tokio::test]
+    async fn reconciler_drops_queue_entry_for_missing_order() {
+        let ctx = migrated_ctx().await;
+        let keys = ctx.keys().clone();
+        let _guard = crate::util::ORDERBOOK_QUEUE_TEST_LOCK.lock().await;
+
+        let ghost = Uuid::new_v4();
+        crate::util::mark_orderbook_publish_failed(ghost);
+
+        reconcile_orderbook_once(ctx.pool(), &keys, false).await;
+
+        assert!(
+            !crate::util::is_orderbook_publish_queued(ghost),
+            "queue entry without a DB row must be dropped"
+        );
+    }
+
+    /// While relays stay unreachable the order re-queues itself through
+    /// `update_order_event`, so a later reconciler pass retries — the
+    /// finding's swallowed-publish defect self-heals instead of diverging.
+    #[tokio::test]
+    async fn reconciler_requeues_order_while_relays_unreachable() {
+        let ctx = migrated_ctx().await;
+        let keys = ctx.keys().clone();
+        let _guard = crate::util::ORDERBOOK_QUEUE_TEST_LOCK.lock().await;
+
+        // A `Canceled` row still publishes a kind-38383 revision but skips
+        // the reputation lookup, keeping this test off the process-global
+        // DB pool.
+        let order = Order {
+            id: Uuid::new_v4(),
+            kind: Kind::Sell.to_string(),
+            status: Status::Canceled.to_string(),
+            fiat_code: "USD".to_string(),
+            payment_method: "bank".to_string(),
+            expires_at: nostr_sdk::prelude::Timestamp::now().as_secs() as i64 + 3_600,
+            ..Default::default()
+        };
+        let order = order.create(ctx.pool()).await.unwrap();
+        crate::util::mark_orderbook_publish_failed(order.id);
+
+        reconcile_orderbook_once(ctx.pool(), &keys, false).await;
+
+        assert!(
+            crate::util::is_orderbook_publish_queued(order.id),
+            "unreachable relays must keep the order queued for the next pass"
+        );
+        // Leave the shared queue clean for other tests.
+        let _ = crate::util::take_failed_orderbook_publishes();
+    }
+
+    /// The full sweep re-asserts only live pending orders: expired rows are
+    /// the expiry job's business and post-trade rows are not book entries.
+    #[tokio::test]
+    async fn reconciler_full_sweep_lists_only_live_pending_orders() {
+        let ctx = migrated_ctx().await;
+        let now = nostr_sdk::prelude::Timestamp::now().as_secs() as i64;
+
+        for (status, expires_at) in [
+            (Status::Pending, now + 3_600),        // live → listed
+            (Status::WaitingTakerBond, now + 600), // publishes as pending → listed
+            (Status::Pending, now - 60),           // expired → expiry job's business
+            (Status::Active, now + 3_600),         // post-trade → not a book entry
+            (Status::WaitingMakerBond, now + 600), // never published → skipped
+        ] {
+            let order = Order {
+                id: Uuid::new_v4(),
+                kind: Kind::Sell.to_string(),
+                status: status.to_string(),
+                fiat_code: "USD".to_string(),
+                payment_method: "bank".to_string(),
+                expires_at,
+                ..Default::default()
+            };
+            order.create(ctx.pool()).await.unwrap();
+        }
+
+        let listed = crate::db::find_pending_orders_for_reconcile(ctx.pool())
+            .await
+            .unwrap();
+        let statuses: Vec<String> = listed.iter().map(|o| o.status.clone()).collect();
+
+        assert_eq!(
+            listed.len(),
+            2,
+            "only live pending-published rows: {statuses:?}"
+        );
+        assert!(statuses.contains(&Status::Pending.to_string()));
+        assert!(statuses.contains(&Status::WaitingTakerBond.to_string()));
     }
 
     // ── notify_users_canceled_order ──────────────────────────────────────

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -929,22 +929,50 @@ const ORDERBOOK_RECONCILE_INTERVAL_SECS: u64 = 60;
 /// restores from backup, NIP-01 ties lost before the monotonic stamp).
 const ORDERBOOK_FULL_SWEEP_EVERY_TICKS: u64 = 60;
 
+/// A reconciler republish only proceeds when the order has not been
+/// stamped for this long. Handlers publish their kind-38383 revision
+/// *before* persisting the CAS, so a background republish that reads the
+/// DB row inside that window could re-advertise the pre-CAS state with a
+/// newer timestamp and the relay would keep it forever. The window only
+/// needs to outlast a handler's publish→persist gap (relay send timeout +
+/// one DB write); anything recently stamped is retried on a later pass.
+const ORDERBOOK_QUIESCENT_SECS: u64 = 120;
+
 /// One reconciler pass: republish every order whose last kind-38383
 /// publish failed (`util::take_failed_orderbook_publishes`), and — when
 /// `full_sweep` — re-assert every live `pending` order from the DB.
 ///
-/// `update_order_event` re-queues an order on publish failure, so a relay
-/// outage self-heals on a later pass. The returned order (fresh
-/// `event_id`) is deliberately not persisted, matching the CAS-miss
-/// repair path: the DB row's status is the source of truth being
-/// re-advertised, not mutated.
+/// Every publish goes through `update_order_event_if_quiescent`: an order
+/// stamped within the last [`ORDERBOOK_QUIESCENT_SECS`] is skipped (queue
+/// entries are kept for the next pass), so a sweep can never supersede a
+/// transition that published before persisting its CAS. On publish
+/// failure the order re-queues itself, so a relay outage self-heals on a
+/// later pass. The returned order (fresh `event_id`) is deliberately not
+/// persisted, matching the CAS-miss repair path: the DB row's status is
+/// the source of truth being re-advertised, not mutated.
 async fn reconcile_orderbook_once(pool: &sqlx::SqlitePool, keys: &Keys, full_sweep: bool) {
-    for order_id in util::take_failed_orderbook_publishes() {
+    for (order_id, generation) in util::take_failed_orderbook_publishes() {
         match Order::by_id(pool, order_id).await {
             Ok(Some(order)) => match order.get_order_status() {
                 Ok(status) => {
-                    if let Err(e) = update_order_event(keys, status, &order).await {
-                        warn!("orderbook reconciler: republish of order {order_id} failed: {e}");
+                    match util::update_order_event_if_quiescent(
+                        keys,
+                        status,
+                        &order,
+                        ORDERBOOK_QUIESCENT_SECS,
+                    )
+                    .await
+                    {
+                        Ok(Some(_)) => {}
+                        // Stamped too recently — another publication may be
+                        // in flight; keep the failure queued for later.
+                        Ok(None) => util::mark_orderbook_publish_failed_at(order_id, generation),
+                        Err(e) => {
+                            warn!(
+                                "orderbook reconciler: republish of order {order_id} failed: {e}"
+                            );
+                            util::mark_orderbook_publish_failed_at(order_id, generation);
+                        }
                     }
                 }
                 Err(e) => warn!("orderbook reconciler: order {order_id} has bad status: {e}"),
@@ -954,7 +982,7 @@ async fn reconcile_orderbook_once(pool: &sqlx::SqlitePool, keys: &Keys, full_swe
             Err(e) => {
                 warn!("orderbook reconciler: could not reload order {order_id}: {e}");
                 // Transient DB error: keep it queued for the next pass.
-                util::mark_orderbook_publish_failed(order_id);
+                util::mark_orderbook_publish_failed_at(order_id, generation);
             }
         }
     }
@@ -969,11 +997,23 @@ async fn reconcile_orderbook_once(pool: &sqlx::SqlitePool, keys: &Keys, full_swe
                 for order in orders {
                     match order.get_order_status() {
                         Ok(status) => {
-                            if let Err(e) = update_order_event(keys, status, &order).await {
-                                warn!(
+                            match util::update_order_event_if_quiescent(
+                                keys,
+                                status,
+                                &order,
+                                ORDERBOOK_QUIESCENT_SECS,
+                            )
+                            .await
+                            {
+                                Ok(Some(_)) => {}
+                                // Recently stamped — the normal publish
+                                // path owns convergence for this order; a
+                                // lost event is healed by the next sweep.
+                                Ok(None) => {}
+                                Err(e) => warn!(
                                     "orderbook reconciler: re-assert of order {} failed: {e}",
                                     order.id
-                                );
+                                ),
                             }
                         }
                         Err(e) => warn!(
@@ -1404,6 +1444,42 @@ mod tests {
         assert!(
             crate::util::is_orderbook_publish_queued(order.id),
             "unreachable relays must keep the order queued for the next pass"
+        );
+        // Leave the shared queue clean for other tests.
+        let _ = crate::util::take_failed_orderbook_publishes();
+    }
+
+    /// An order stamped moments ago may belong to a transition that
+    /// published before persisting its CAS: the reconciler must skip it
+    /// this pass (keeping the queue entry) instead of re-advertising the
+    /// possibly-stale DB row with a newer timestamp.
+    #[tokio::test]
+    async fn reconciler_skips_recently_stamped_order_but_keeps_it_queued() {
+        let ctx = migrated_ctx().await;
+        let keys = ctx.keys().clone();
+        let _guard = crate::util::ORDERBOOK_QUEUE_TEST_LOCK.lock().await;
+
+        let order = Order {
+            id: Uuid::new_v4(),
+            kind: Kind::Sell.to_string(),
+            status: Status::Canceled.to_string(),
+            fiat_code: "USD".to_string(),
+            payment_method: "bank".to_string(),
+            expires_at: nostr_sdk::prelude::Timestamp::now().as_secs() as i64 + 3_600,
+            ..Default::default()
+        };
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        // Simulate an in-flight transition: stamp the order now, then fail
+        // its publish (mark it for the reconciler).
+        let _ = crate::util::stamp_orderbook_event(order.id, nostr_sdk::prelude::Timestamp::now());
+        crate::util::mark_orderbook_publish_failed(order.id);
+
+        reconcile_orderbook_once(ctx.pool(), &keys, false).await;
+
+        assert!(
+            crate::util::is_orderbook_publish_queued(order.id),
+            "a recently stamped order must stay queued, not be republished over a possible in-flight transition"
         );
         // Leave the shared queue clean for other tests.
         let _ = crate::util::take_failed_orderbook_publishes();

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1485,46 +1485,6 @@ mod tests {
         let _ = crate::util::take_failed_orderbook_publishes();
     }
 
-    /// The full sweep re-asserts only live pending orders: expired rows are
-    /// the expiry job's business and post-trade rows are not book entries.
-    #[tokio::test]
-    async fn reconciler_full_sweep_lists_only_live_pending_orders() {
-        let ctx = migrated_ctx().await;
-        let now = nostr_sdk::prelude::Timestamp::now().as_secs() as i64;
-
-        for (status, expires_at) in [
-            (Status::Pending, now + 3_600),        // live → listed
-            (Status::WaitingTakerBond, now + 600), // publishes as pending → listed
-            (Status::Pending, now - 60),           // expired → expiry job's business
-            (Status::Active, now + 3_600),         // post-trade → not a book entry
-            (Status::WaitingMakerBond, now + 600), // never published → skipped
-        ] {
-            let order = Order {
-                id: Uuid::new_v4(),
-                kind: Kind::Sell.to_string(),
-                status: status.to_string(),
-                fiat_code: "USD".to_string(),
-                payment_method: "bank".to_string(),
-                expires_at,
-                ..Default::default()
-            };
-            order.create(ctx.pool()).await.unwrap();
-        }
-
-        let listed = crate::db::find_pending_orders_for_reconcile(ctx.pool())
-            .await
-            .unwrap();
-        let statuses: Vec<String> = listed.iter().map(|o| o.status.clone()).collect();
-
-        assert_eq!(
-            listed.len(),
-            2,
-            "only live pending-published rows: {statuses:?}"
-        );
-        assert!(statuses.contains(&Status::Pending.to_string()));
-        assert!(statuses.contains(&Status::WaitingTakerBond.to_string()));
-    }
-
     // ── notify_users_canceled_order ──────────────────────────────────────
 
     #[tokio::test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -944,19 +944,36 @@ fn repair_timestamp(now: Timestamp) -> Timestamp {
     Timestamp::from(now.as_secs() + 1)
 }
 
-/// Last `created_at` published per order d-tag, so consecutive kind-38383
-/// revisions of the same order never tie on the same Unix second. NIP-01
-/// breaks same-timestamp ties on replaceable events by *lowest* event id —
-/// a coin flip that can leave a dead `pending` revision as the winning
-/// state on relays (e.g. create + instant take, create + maker cancel).
+/// Per-order publication state behind one lock: the last `created_at`
+/// published per order d-tag, plus a process-wide publication generation
+/// counter. Consecutive kind-38383 revisions of the same order never tie
+/// on the same Unix second — NIP-01 breaks same-timestamp ties on
+/// replaceable events by *lowest* event id, a coin flip that can leave a
+/// dead `pending` revision as the winning state on relays (e.g. create +
+/// instant take, create + maker cancel).
+///
+/// The generation counter lives under the same mutex so generation order
+/// always matches stamp order: a publication stamped later is guaranteed a
+/// larger generation, which is what lets a successful send clear only
+/// failures recorded by publications stamped no later than itself.
 ///
 /// Process-local by design: this daemon's key is the only legitimate
 /// publisher of its orders' events, so a per-process registry is enough to
 /// order its own revisions. Across a restart the map starts empty, but two
 /// publishes for the same order on both sides of a restart cannot land in
 /// the same second in practice.
-static LAST_PUBLISHED_ORDER_TS: std::sync::LazyLock<std::sync::Mutex<HashMap<Uuid, u64>>> =
-    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+struct OrderbookRegistry {
+    last_ts: HashMap<Uuid, u64>,
+    generation: u64,
+}
+
+static ORDERBOOK_REGISTRY: std::sync::LazyLock<std::sync::Mutex<OrderbookRegistry>> =
+    std::sync::LazyLock::new(|| {
+        std::sync::Mutex::new(OrderbookRegistry {
+            last_ts: HashMap::new(),
+            generation: 0,
+        })
+    });
 
 /// Registry entries older than this are pruned once the map grows past
 /// [`ORDER_TS_PRUNE_THRESHOLD`]; ties only matter within the same second,
@@ -964,52 +981,140 @@ static LAST_PUBLISHED_ORDER_TS: std::sync::LazyLock<std::sync::Mutex<HashMap<Uui
 const ORDER_TS_MAX_AGE_SECS: u64 = 48 * 3600;
 const ORDER_TS_PRUNE_THRESHOLD: usize = 16_384;
 
-/// Next `created_at` for a kind-38383 revision of `order_id`: the candidate
-/// timestamp, bumped to strictly after the last published revision when both
-/// land in the same second (`max(candidate, last + 1)`). Records the result.
-pub(crate) fn monotonic_order_event_timestamp(order_id: Uuid, candidate: Timestamp) -> Timestamp {
-    let mut registry = LAST_PUBLISHED_ORDER_TS
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let candidate = candidate.as_secs();
-    let effective = match registry.get(&order_id) {
+/// The `created_at` to stamp on a kind-38383 revision plus the publication
+/// generation assigned under the same lock (see [`ORDERBOOK_REGISTRY`]).
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct OrderbookStamp {
+    pub created_at: Timestamp,
+    pub generation: u64,
+}
+
+fn stamp_locked(
+    registry: &mut OrderbookRegistry,
+    order_id: Uuid,
+    candidate: u64,
+) -> OrderbookStamp {
+    let effective = match registry.last_ts.get(&order_id) {
         Some(&last) => candidate.max(last + 1),
         None => candidate,
     };
-    if registry.len() >= ORDER_TS_PRUNE_THRESHOLD {
-        registry.retain(|_, &mut ts| ts + ORDER_TS_MAX_AGE_SECS > effective);
+    if registry.last_ts.len() >= ORDER_TS_PRUNE_THRESHOLD {
+        registry
+            .last_ts
+            .retain(|_, &mut ts| ts + ORDER_TS_MAX_AGE_SECS > effective);
     }
-    registry.insert(order_id, effective);
-    Timestamp::from(effective)
+    registry.last_ts.insert(order_id, effective);
+    registry.generation += 1;
+    OrderbookStamp {
+        created_at: Timestamp::from(effective),
+        generation: registry.generation,
+    }
+}
+
+/// Stamp the next kind-38383 revision of `order_id`: the candidate
+/// timestamp, bumped to strictly after the last published revision when
+/// both land in the same second (`max(candidate, last + 1)`). Records the
+/// result and assigns the publication generation atomically.
+pub(crate) fn stamp_orderbook_event(order_id: Uuid, candidate: Timestamp) -> OrderbookStamp {
+    let mut registry = ORDERBOOK_REGISTRY
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    stamp_locked(&mut registry, order_id, candidate.as_secs())
+}
+
+/// Like [`stamp_orderbook_event`], but refuses to stamp when the order was
+/// already stamped within the last `quiet_secs` — the reconciler's guard
+/// against superseding an in-flight transition. Handlers publish *before*
+/// persisting their CAS, so a background republish that reads the DB row
+/// and stamps after such a handler would advertise the stale pre-CAS state
+/// with a newer `created_at`, and the relay would keep it forever. The
+/// check and the stamp share one lock, so the guard is airtight: any
+/// transition stamped before this call is visible here (and recent →
+/// skip), and any transition stamped after it gets a strictly larger
+/// timestamp and wins on relays regardless.
+pub(crate) fn try_stamp_orderbook_event_quiescent(
+    order_id: Uuid,
+    candidate: Timestamp,
+    quiet_secs: u64,
+) -> Option<OrderbookStamp> {
+    let mut registry = ORDERBOOK_REGISTRY
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let candidate = candidate.as_secs();
+    if let Some(&last) = registry.last_ts.get(&order_id) {
+        if candidate < last.saturating_add(quiet_secs) {
+            return None;
+        }
+    }
+    Some(stamp_locked(&mut registry, order_id, candidate))
+}
+
+/// Next `created_at` for a kind-38383 revision of `order_id`, for callers
+/// that mark publish failures out-of-band (with a fresh generation) and
+/// only need the timestamp half of [`stamp_orderbook_event`].
+pub(crate) fn monotonic_order_event_timestamp(order_id: Uuid, candidate: Timestamp) -> Timestamp {
+    stamp_orderbook_event(order_id, candidate).created_at
 }
 
 /// Orders whose latest kind-38383 publish failed (relay send error or no
 /// Nostr client), so the DB state and the advertised orderbook diverged.
-/// The scheduler's orderbook reconciler drains this set and republishes the
+/// The scheduler's orderbook reconciler drains this map and republishes the
 /// current DB state until the wire converges.
-static PENDING_ORDERBOOK_REPUBLISH: std::sync::LazyLock<
-    std::sync::Mutex<std::collections::HashSet<Uuid>>,
-> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+///
+/// Each entry carries the publication generation that recorded the failure
+/// (see [`ORDERBOOK_REGISTRY`]). A successful send clears an entry only if
+/// the failure is not newer than itself: without the generation, a slow
+/// old send completing *after* a newer publication failed would erase that
+/// newer failure, and the state the newer publication carried would never
+/// be republished.
+static PENDING_ORDERBOOK_REPUBLISH: std::sync::LazyLock<std::sync::Mutex<HashMap<Uuid, u64>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 
-/// Queue `order_id` for republish by the orderbook reconciler.
+/// Queue `order_id` for republish, recording the failure at `generation`.
+/// A newer failure already recorded for the order is never downgraded.
+pub(crate) fn mark_orderbook_publish_failed_at(order_id: Uuid, generation: u64) {
+    let mut queue = PENDING_ORDERBOOK_REPUBLISH
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let entry = queue.entry(order_id).or_insert(generation);
+    *entry = (*entry).max(generation);
+}
+
+/// Queue `order_id` for republish stamped with a fresh generation, for
+/// callers whose failure is detected out-of-band from the stamping path
+/// (initial order publication, child-order events). A fresh generation is
+/// the conservative choice: the entry can only be cleared by a publication
+/// stamped after this failure was recorded.
 pub(crate) fn mark_orderbook_publish_failed(order_id: Uuid) {
-    PENDING_ORDERBOOK_REPUBLISH
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(order_id);
+    let generation = {
+        let mut registry = ORDERBOOK_REGISTRY
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        registry.generation += 1;
+        registry.generation
+    };
+    mark_orderbook_publish_failed_at(order_id, generation);
 }
 
-/// Drop `order_id` from the republish queue after a successful publish.
-pub(crate) fn clear_orderbook_publish_failure(order_id: Uuid) {
-    PENDING_ORDERBOOK_REPUBLISH
+/// Drop `order_id` from the republish queue after a successful publish —
+/// but only if the recorded failure is not newer than the publication that
+/// succeeded (`generation`). A newer failure means a later publication's
+/// event never reached the relay; it must stay queued.
+pub(crate) fn clear_orderbook_publish_failure_up_to(order_id: Uuid, generation: u64) {
+    let mut queue = PENDING_ORDERBOOK_REPUBLISH
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .remove(&order_id);
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(&failed_at) = queue.get(&order_id) {
+        if failed_at <= generation {
+            queue.remove(&order_id);
+        }
+    }
 }
 
-/// Take the current set of orders awaiting republish, leaving the queue
-/// empty. Failed retries re-queue themselves via `update_order_event`.
-pub(crate) fn take_failed_orderbook_publishes() -> Vec<Uuid> {
+/// Take the current set of orders awaiting republish (with the generation
+/// that recorded each failure), leaving the queue empty. Failed retries
+/// re-queue themselves via `update_order_event`.
+pub(crate) fn take_failed_orderbook_publishes() -> Vec<(Uuid, u64)> {
     PENDING_ORDERBOOK_REPUBLISH
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -1039,7 +1144,7 @@ pub(crate) fn is_orderbook_publish_queued(order_id: Uuid) -> bool {
     PENDING_ORDERBOOK_REPUBLISH
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .contains(&order_id)
+        .contains_key(&order_id)
 }
 
 pub async fn update_order_event(
@@ -1059,6 +1164,41 @@ pub async fn update_order_event_with_created_at(
     order: &Order,
     created_at: Option<Timestamp>,
 ) -> Result<Order, MostroError> {
+    update_order_event_stamped(keys, status, order, StampPolicy::Always { created_at })
+        .await
+        .map(|order| order.expect("StampPolicy::Always always stamps"))
+}
+
+/// Same as [`update_order_event`], but publishes only when the order has
+/// not been stamped within the last `quiet_secs` (see
+/// [`try_stamp_orderbook_event_quiescent`]). Returns `Ok(None)` when the
+/// publish was skipped because another publication is (or may be) in
+/// flight. Used by the orderbook reconciler, whose republish must never
+/// supersede a live transition that published before persisting its CAS.
+pub(crate) async fn update_order_event_if_quiescent(
+    keys: &Keys,
+    status: Status,
+    order: &Order,
+    quiet_secs: u64,
+) -> Result<Option<Order>, MostroError> {
+    update_order_event_stamped(keys, status, order, StampPolicy::IfQuiescent { quiet_secs }).await
+}
+
+/// How [`update_order_event_stamped`] obtains its [`OrderbookStamp`].
+enum StampPolicy {
+    /// Stamp unconditionally, optionally overriding the candidate
+    /// `created_at` (CAS-miss repair).
+    Always { created_at: Option<Timestamp> },
+    /// Stamp only if the order has been quiet for `quiet_secs` (reconciler).
+    IfQuiescent { quiet_secs: u64 },
+}
+
+async fn update_order_event_stamped(
+    keys: &Keys,
+    status: Status,
+    order: &Order,
+    policy: StampPolicy,
+) -> Result<Option<Order>, MostroError> {
     let mut order_updated = order.clone();
     // update order.status with new status
     order_updated.status = status.to_string();
@@ -1074,8 +1214,18 @@ pub async fn update_order_event_with_created_at(
         // (create + instant take, create + maker cancel, …) never tie on
         // `created_at` — NIP-01 breaks such ties by lowest event id, which
         // can leave a dead `pending` revision as the winning state.
-        let candidate = created_at.unwrap_or_else(Timestamp::now);
-        let event_created_at = monotonic_order_event_timestamp(order.id, candidate);
+        let stamp = match policy {
+            StampPolicy::Always { created_at } => {
+                stamp_orderbook_event(order.id, created_at.unwrap_or_else(Timestamp::now))
+            }
+            StampPolicy::IfQuiescent { quiet_secs } => {
+                match try_stamp_orderbook_event_quiescent(order.id, Timestamp::now(), quiet_secs) {
+                    Some(stamp) => stamp,
+                    None => return Ok(None),
+                }
+            }
+        };
+        let event_created_at = stamp.created_at;
         // nip33 kind with order id as identifier and order fields as tags (kind 38383 for orders)
         let event =
             new_order_event_with_created_at(keys, "", order.id.to_string(), tags, event_created_at)
@@ -1092,14 +1242,17 @@ pub async fn update_order_event_with_created_at(
         // republishes the current DB state until the wire converges.
         match get_nostr_client() {
             Ok(client) => match client.send_event(&event).await {
-                Ok(_) => clear_orderbook_publish_failure(order.id),
+                // Only failures recorded by publications stamped no later
+                // than this one may be cleared: a newer concurrent
+                // publication's failure must survive this older success.
+                Ok(_) => clear_orderbook_publish_failure_up_to(order.id, stamp.generation),
                 Err(e) => {
                     tracing::warn!(
                         "orderbook publish failed for order {} (status {}): {e}; queued for republish",
                         order_updated.id,
                         status
                     );
-                    mark_orderbook_publish_failed(order.id);
+                    mark_orderbook_publish_failed_at(order.id, stamp.generation);
                 }
             },
             Err(e) => {
@@ -1108,7 +1261,7 @@ pub async fn update_order_event_with_created_at(
                     order_updated.id,
                     status
                 );
-                mark_orderbook_publish_failed(order.id);
+                mark_orderbook_publish_failed_at(order.id, stamp.generation);
             }
         }
     };
@@ -1119,7 +1272,7 @@ pub async fn update_order_event_with_created_at(
         status.to_string()
     );
 
-    Ok(order_updated)
+    Ok(Some(order_updated))
 }
 
 pub async fn connect_nostr() -> Result<Client, MostroError> {
@@ -1988,6 +2141,85 @@ mod tests {
         assert!(repair > stale, "repair must out-order the stale revision");
     }
 
+    /// The quiescence guard: an order stamped within the quiet window must
+    /// not be stamped again by a reconciler republish (it could supersede a
+    /// transition that published before persisting its CAS), while an order
+    /// quiet for longer than the window stamps normally.
+    #[test]
+    fn quiescent_stamp_skips_recently_stamped_order() {
+        let order_id = Uuid::new_v4();
+        let now = Timestamp::from(1_700_000_000);
+        let quiet = 120;
+
+        let transition = stamp_orderbook_event(order_id, now);
+        assert!(
+            try_stamp_orderbook_event_quiescent(order_id, now, quiet).is_none(),
+            "a sweep racing a just-stamped transition must be refused"
+        );
+        assert!(
+            try_stamp_orderbook_event_quiescent(
+                order_id,
+                Timestamp::from(now.as_secs() + quiet - 1),
+                quiet
+            )
+            .is_none(),
+            "still inside the quiet window"
+        );
+
+        let sweep = try_stamp_orderbook_event_quiescent(
+            order_id,
+            Timestamp::from(now.as_secs() + quiet),
+            quiet,
+        )
+        .expect("outside the quiet window the sweep must stamp");
+        assert!(sweep.created_at > transition.created_at);
+        assert!(
+            sweep.generation > transition.generation,
+            "generation order must match stamp order"
+        );
+    }
+
+    /// A never-stamped order (fresh daemon start) has no in-flight
+    /// publication to protect; the quiescent stamp must proceed.
+    #[test]
+    fn quiescent_stamp_allows_never_stamped_order() {
+        let order_id = Uuid::new_v4();
+        let stamp =
+            try_stamp_orderbook_event_quiescent(order_id, Timestamp::from(1_700_000_000), 120)
+                .expect("an order with no registry entry must stamp");
+        assert_eq!(stamp.created_at.as_secs(), 1_700_000_000);
+    }
+
+    /// A slow old send completing after a newer publication failed must not
+    /// erase that newer failure: the newer publication's event never reached
+    /// the relay, so the entry has to stay queued for the reconciler.
+    #[tokio::test]
+    async fn newer_failure_survives_older_success() {
+        let _guard = ORDERBOOK_QUEUE_TEST_LOCK.lock().await;
+        let order_id = Uuid::new_v4();
+
+        mark_orderbook_publish_failed_at(order_id, 10);
+        clear_orderbook_publish_failure_up_to(order_id, 9);
+        assert!(
+            is_orderbook_publish_queued(order_id),
+            "an older success must not clear a newer failure"
+        );
+
+        // Re-marking with an older generation must not downgrade the entry.
+        mark_orderbook_publish_failed_at(order_id, 5);
+        clear_orderbook_publish_failure_up_to(order_id, 9);
+        assert!(
+            is_orderbook_publish_queued(order_id),
+            "a stale re-mark must not downgrade the recorded failure"
+        );
+
+        clear_orderbook_publish_failure_up_to(order_id, 10);
+        assert!(
+            !is_orderbook_publish_queued(order_id),
+            "a success at least as new as the failure clears it"
+        );
+    }
+
     // ───────────────── failed-publish queue (orderbook reconciler) ─────────────────
 
     /// A publish that cannot reach any relay must leave a trace: the order id
@@ -2017,7 +2249,7 @@ mod tests {
 
         // A drained entry stays drained until the next failure.
         let drained = take_failed_orderbook_publishes();
-        assert!(drained.contains(&order.id));
+        assert!(drained.iter().any(|(id, _)| *id == order.id));
         assert!(!is_orderbook_publish_queued(order.id));
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -11,8 +11,7 @@ use crate::lightning;
 use crate::lightning::invoice::is_valid_invoice;
 use crate::messages;
 use crate::nip33::{
-    create_platform_tag_values, new_order_event, new_order_event_with_created_at, new_rating_event,
-    order_to_tags,
+    create_platform_tag_values, new_order_event_with_created_at, new_rating_event, order_to_tags,
 };
 use crate::Result;
 
@@ -460,7 +459,11 @@ async fn finalize_order_publication(
     let event = if let Some(tags) =
         get_tags_for_new_order(&order, pool, &identity_pubkey, &trade_pubkey, keys).await?
     {
-        new_order_event(keys, "", order_id.to_string(), tags)
+        // Register the initial `pending` publish in the monotonic registry
+        // so a same-second follow-up transition (instant take, maker
+        // cancel) is stamped strictly after it and wins NIP-01 ordering.
+        let created_at = monotonic_order_event_timestamp(order_id, Timestamp::now());
+        new_order_event_with_created_at(keys, "", order_id.to_string(), tags, created_at)
             .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?
     } else {
         return Err(MostroInternalErr(ServiceError::InvalidPubkey));
@@ -496,7 +499,13 @@ async fn finalize_order_publication(
         .send_event(&event)
         .await
         .map(|_s| ())
-        .map_err(|err| MostroInternalErr(ServiceError::NostrError(err.to_string())))
+        .map_err(|err| {
+            // The row is already `Pending` in the DB; queue it so the
+            // orderbook reconciler retries the publish instead of leaving
+            // an order that exists in the DB but never reached relays.
+            mark_orderbook_publish_failed(order_id);
+            MostroInternalErr(ServiceError::NostrError(err.to_string()))
+        })
 }
 
 /// Finish publishing an order whose maker bond has just locked.
@@ -935,6 +944,104 @@ fn repair_timestamp(now: Timestamp) -> Timestamp {
     Timestamp::from(now.as_secs() + 1)
 }
 
+/// Last `created_at` published per order d-tag, so consecutive kind-38383
+/// revisions of the same order never tie on the same Unix second. NIP-01
+/// breaks same-timestamp ties on replaceable events by *lowest* event id —
+/// a coin flip that can leave a dead `pending` revision as the winning
+/// state on relays (e.g. create + instant take, create + maker cancel).
+///
+/// Process-local by design: this daemon's key is the only legitimate
+/// publisher of its orders' events, so a per-process registry is enough to
+/// order its own revisions. Across a restart the map starts empty, but two
+/// publishes for the same order on both sides of a restart cannot land in
+/// the same second in practice.
+static LAST_PUBLISHED_ORDER_TS: std::sync::LazyLock<std::sync::Mutex<HashMap<Uuid, u64>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// Registry entries older than this are pruned once the map grows past
+/// [`ORDER_TS_PRUNE_THRESHOLD`]; ties only matter within the same second,
+/// so anything published days ago can never tie with a new revision.
+const ORDER_TS_MAX_AGE_SECS: u64 = 48 * 3600;
+const ORDER_TS_PRUNE_THRESHOLD: usize = 16_384;
+
+/// Next `created_at` for a kind-38383 revision of `order_id`: the candidate
+/// timestamp, bumped to strictly after the last published revision when both
+/// land in the same second (`max(candidate, last + 1)`). Records the result.
+pub(crate) fn monotonic_order_event_timestamp(order_id: Uuid, candidate: Timestamp) -> Timestamp {
+    let mut registry = LAST_PUBLISHED_ORDER_TS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let candidate = candidate.as_secs();
+    let effective = match registry.get(&order_id) {
+        Some(&last) => candidate.max(last + 1),
+        None => candidate,
+    };
+    if registry.len() >= ORDER_TS_PRUNE_THRESHOLD {
+        registry.retain(|_, &mut ts| ts + ORDER_TS_MAX_AGE_SECS > effective);
+    }
+    registry.insert(order_id, effective);
+    Timestamp::from(effective)
+}
+
+/// Orders whose latest kind-38383 publish failed (relay send error or no
+/// Nostr client), so the DB state and the advertised orderbook diverged.
+/// The scheduler's orderbook reconciler drains this set and republishes the
+/// current DB state until the wire converges.
+static PENDING_ORDERBOOK_REPUBLISH: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashSet<Uuid>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashSet::new()));
+
+/// Queue `order_id` for republish by the orderbook reconciler.
+pub(crate) fn mark_orderbook_publish_failed(order_id: Uuid) {
+    PENDING_ORDERBOOK_REPUBLISH
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(order_id);
+}
+
+/// Drop `order_id` from the republish queue after a successful publish.
+pub(crate) fn clear_orderbook_publish_failure(order_id: Uuid) {
+    PENDING_ORDERBOOK_REPUBLISH
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(&order_id);
+}
+
+/// Take the current set of orders awaiting republish, leaving the queue
+/// empty. Failed retries re-queue themselves via `update_order_event`.
+pub(crate) fn take_failed_orderbook_publishes() -> Vec<Uuid> {
+    PENDING_ORDERBOOK_REPUBLISH
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .drain()
+        .collect()
+}
+
+/// `true` when the order's take window has closed (`expires_at` in the
+/// past) but the expiry job has not canceled it yet. The scheduler tick
+/// runs every ~60 s, so a `pending` row can outlive its `expires_at` by up
+/// to a minute; take paths must reject in that window instead of relying
+/// on the tick.
+pub(crate) fn is_order_take_window_closed(order: &Order, now: i64) -> bool {
+    order.expires_at > 0 && order.expires_at < now
+}
+
+/// Serializes tests that touch the process-global failed-publish queue
+/// (util + scheduler test modules share one test binary), so one test's
+/// drain cannot race another's enqueue-then-assert sequence.
+#[cfg(test)]
+pub(crate) static ORDERBOOK_QUEUE_TEST_LOCK: tokio::sync::Mutex<()> =
+    tokio::sync::Mutex::const_new(());
+
+/// Test-only visibility into the republish queue.
+#[cfg(test)]
+pub(crate) fn is_orderbook_publish_queued(order_id: Uuid) -> bool {
+    PENDING_ORDERBOOK_REPUBLISH
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .contains(&order_id)
+}
+
 pub async fn update_order_event(
     keys: &Keys,
     status: Status,
@@ -962,23 +1069,46 @@ pub async fn update_order_event_with_created_at(
     // We transform the order fields to tags to use in the event
     let mostro_pubkey = keys.public_key().to_hex();
     if let Some(tags) = order_to_tags(&order_updated, reputation_data, Some(&mostro_pubkey))? {
+        // Every revision of an order's kind-38383 event is stamped through
+        // the monotonic registry so two transitions in the same Unix second
+        // (create + instant take, create + maker cancel, …) never tie on
+        // `created_at` — NIP-01 breaks such ties by lowest event id, which
+        // can leave a dead `pending` revision as the winning state.
+        let candidate = created_at.unwrap_or_else(Timestamp::now);
+        let event_created_at = monotonic_order_event_timestamp(order.id, candidate);
         // nip33 kind with order id as identifier and order fields as tags (kind 38383 for orders)
-        let event = match created_at {
-            Some(created_at) => {
-                new_order_event_with_created_at(keys, "", order.id.to_string(), tags, created_at)
-            }
-            None => new_order_event(keys, "", order.id.to_string(), tags),
-        }
-        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+        let event =
+            new_order_event_with_created_at(keys, "", order.id.to_string(), tags, event_created_at)
+                .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
 
         info!("Sending replaceable event: {event:#?}");
 
         // We update the order with the new event_id
         order_updated.event_id = event.id.to_string();
 
-        if let Ok(client) = get_nostr_client() {
-            if client.send_event(&event).await.is_err() {
-                tracing::warn!("order id : {} is expired", order_updated.id)
+        // A failed (or impossible) publish must not stay invisible: the DB
+        // is about to advance while relays keep advertising the previous
+        // state. Queue the order so the scheduler's orderbook reconciler
+        // republishes the current DB state until the wire converges.
+        match get_nostr_client() {
+            Ok(client) => match client.send_event(&event).await {
+                Ok(_) => clear_orderbook_publish_failure(order.id),
+                Err(e) => {
+                    tracing::warn!(
+                        "orderbook publish failed for order {} (status {}): {e}; queued for republish",
+                        order_updated.id,
+                        status
+                    );
+                    mark_orderbook_publish_failed(order.id);
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    "orderbook publish skipped for order {} (status {}): no nostr client ({e}); queued for republish",
+                    order_updated.id,
+                    status
+                );
+                mark_orderbook_publish_failed(order.id);
             }
         }
     };
@@ -1794,6 +1924,119 @@ mod tests {
         assert_eq!(repair.as_secs(), now.as_secs() + 1);
     }
 
+    // ───────────────── monotonic per-order created_at registry ─────────────────
+
+    /// Two revisions of the same order in the same Unix second must not tie:
+    /// NIP-01 breaks same-timestamp ties by lowest event id, which can keep a
+    /// dead `pending` revision as the winning state on relays.
+    #[test]
+    fn monotonic_timestamp_bumps_same_second_revisions() {
+        let order_id = Uuid::new_v4();
+        let now = Timestamp::from(1_700_000_000);
+
+        let first = monotonic_order_event_timestamp(order_id, now);
+        let second = monotonic_order_event_timestamp(order_id, now);
+        let third = monotonic_order_event_timestamp(order_id, now);
+
+        assert_eq!(first.as_secs(), 1_700_000_000);
+        assert_eq!(second.as_secs(), 1_700_000_001);
+        assert_eq!(third.as_secs(), 1_700_000_002);
+    }
+
+    /// A later wall-clock candidate wins over `last + 1` — the registry only
+    /// bumps when it must, so timestamps track real time whenever possible.
+    #[test]
+    fn monotonic_timestamp_uses_candidate_when_already_newer() {
+        let order_id = Uuid::new_v4();
+
+        let first = monotonic_order_event_timestamp(order_id, Timestamp::from(1_700_000_000));
+        let later = monotonic_order_event_timestamp(order_id, Timestamp::from(1_700_000_100));
+
+        assert_eq!(first.as_secs(), 1_700_000_000);
+        assert_eq!(later.as_secs(), 1_700_000_100);
+    }
+
+    /// Orders are independent d-tags: one order's revisions must not bump
+    /// another order's timestamps.
+    #[test]
+    fn monotonic_timestamp_is_per_order() {
+        let now = Timestamp::from(1_700_000_000);
+        let order_a = Uuid::new_v4();
+        let order_b = Uuid::new_v4();
+
+        let _ = monotonic_order_event_timestamp(order_a, now);
+        let b = monotonic_order_event_timestamp(order_b, now);
+
+        assert_eq!(
+            b.as_secs(),
+            now.as_secs(),
+            "order_b must not inherit order_a's bump"
+        );
+    }
+
+    /// The CAS-miss repair path still wins ordering when routed through the
+    /// registry: the repair candidate (`now + 1`) can never be flattened back
+    /// onto the stale revision's second.
+    #[test]
+    fn monotonic_timestamp_keeps_repair_strictly_after_stale() {
+        let order_id = Uuid::new_v4();
+        let now = Timestamp::from(1_700_000_000);
+
+        let stale = monotonic_order_event_timestamp(order_id, now);
+        let repair = monotonic_order_event_timestamp(order_id, repair_timestamp(now));
+
+        assert!(repair > stale, "repair must out-order the stale revision");
+    }
+
+    // ───────────────── failed-publish queue (orderbook reconciler) ─────────────────
+
+    /// A publish that cannot reach any relay must leave a trace: the order id
+    /// is queued for the orderbook reconciler instead of silently diverging
+    /// DB state from the advertised book (the finding's swallowed-publish
+    /// defect: pre-fix this was a `warn!` and nothing else).
+    #[tokio::test]
+    async fn update_order_event_queues_republish_when_publish_fails() {
+        init_globals();
+        let _guard = ORDERBOOK_QUEUE_TEST_LOCK.lock().await;
+        let keys = Keys::generate();
+
+        // A `Canceled` transition emits an event but skips the reputation
+        // lookup, so this test never touches the process-global DB pool.
+        let order = base_order(OrderKind::Sell, Status::Pending);
+
+        // The test-global Nostr client has no relays, so the send fails.
+        let updated = update_order_event(&keys, Status::Canceled, &order)
+            .await
+            .expect("publish failure must not fail the caller");
+
+        assert!(!updated.event_id.is_empty(), "event must still be built");
+        assert!(
+            is_orderbook_publish_queued(order.id),
+            "failed publish must queue the order for the reconciler"
+        );
+
+        // A drained entry stays drained until the next failure.
+        let drained = take_failed_orderbook_publishes();
+        assert!(drained.contains(&order.id));
+        assert!(!is_orderbook_publish_queued(order.id));
+    }
+
+    // ───────────────── take-window gate ─────────────────
+
+    #[test]
+    fn take_window_closed_for_expired_order() {
+        let mut order = base_order(OrderKind::Sell, Status::Pending);
+        let now = order.expires_at + 10;
+        assert!(is_order_take_window_closed(&order, now));
+
+        // Still-open window: not closed.
+        assert!(!is_order_take_window_closed(&order, order.expires_at - 10));
+
+        // Legacy rows without expires_at are exempt.
+        order.expires_at = 0;
+        assert!(!is_order_take_window_closed(&order, now));
+    }
+
     #[test]
     // DEPRECATED(v0.19.0, #786): delete along with `stamp_protocol_version`.
     #[allow(deprecated)]
@@ -2260,7 +2503,13 @@ mod tests {
     /// migrations against the live pool unconditionally — they are idempotent
     /// (tracked in `_sqlx_migrations`) and guarantee the tables these tests
     /// need exist regardless of who won.
+    /// Serializes global-pool initialization: two tests racing through this
+    /// helper could interleave `set` + migration runs on the winning pool,
+    /// leaving one of them querying tables that are not applied yet.
+    static GLOBAL_POOL_INIT: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     async fn ensure_global_db_pool() -> std::sync::Arc<SqlitePool> {
+        let _guard = GLOBAL_POOL_INIT.lock().await;
         if DB_POOL.get().is_none() {
             let pool = migrated_pool().await;
             let _ = DB_POOL.set(std::sync::Arc::new(pool));

--- a/src/util.rs
+++ b/src/util.rs
@@ -1122,13 +1122,13 @@ pub(crate) fn take_failed_orderbook_publishes() -> Vec<(Uuid, u64)> {
         .collect()
 }
 
-/// `true` when the order's take window has closed (`expires_at` in the
-/// past) but the expiry job has not canceled it yet. The scheduler tick
-/// runs every ~60 s, so a `pending` row can outlive its `expires_at` by up
-/// to a minute; take paths must reject in that window instead of relying
-/// on the tick.
+/// `true` when the order's take window has closed (`expires_at` reached,
+/// inclusive: the expiry second itself is already closed) but the expiry
+/// job has not canceled it yet. The scheduler tick runs every ~60 s, so a
+/// `pending` row can outlive its `expires_at` by up to a minute; take
+/// paths must reject in that window instead of relying on the tick.
 pub(crate) fn is_order_take_window_closed(order: &Order, now: i64) -> bool {
-    order.expires_at > 0 && order.expires_at < now
+    order.expires_at > 0 && order.expires_at <= now
 }
 
 /// Serializes tests that touch the process-global failed-publish queue
@@ -2260,6 +2260,12 @@ mod tests {
         let mut order = base_order(OrderKind::Sell, Status::Pending);
         let now = order.expires_at + 10;
         assert!(is_order_take_window_closed(&order, now));
+
+        // Equality boundary: the expiry second itself is already closed.
+        // Both take paths (`take_buy`, `take_sell`) gate through this
+        // function with `Timestamp::now()`, so a take landing exactly at
+        // `expires_at` must be rejected.
+        assert!(is_order_take_window_closed(&order, order.expires_at));
 
         // Still-open window: not closed.
         assert!(!is_order_take_window_closed(&order, order.expires_at - 10));


### PR DESCRIPTION
## Summary

Follow-up to #866. That PR's review surfaced the NIP-01 same-second tie problem and fixed it for the CAS-miss repair event; this PR closes the rest of the orderbook ghost-order class: **dead orders staying listed as `pending` on relays for up to 30 days** (phantom liquidity / griefing — takes are DB-gated, so no funds move, but takers burn effort and the book's credibility degrades).

Three root defects remained:

1. **Non-monotonic `created_at` on every regular publish.** All kind-38383 revisions were stamped with wall-clock `Timestamp::now()`, so two transitions of the same order within one Unix second tied on `created_at` — and NIP-01 breaks replaceable-event ties by *lowest event id*, a coin flip that can leave a dead `pending` revision as the winning state. Realistic same-second pairs: create + instant take, create + maker cancel, scheduler timeout vs take.
2. **Swallowed publish failures.** `update_order_event` returned `Ok` with a fresh `event_id` even when the relay send failed (a `warn!` with a misleading "order is expired" message) or when no Nostr client existed. Callers then persisted the new status, silently diverging the DB from the advertised book.
3. **No reconciler.** Once a publish was lost, nothing ever healed the relay view; the NIP-40 expiration was recomputed as `now + 30d` on every publish, so the ghost lingered for a month instead of the order's real ~24 h take window.

## Changes

### Monotonic `created_at` per d-tag (`util.rs`, `release.rs`)

Every kind-38383 publish is now stamped through a per-order registry: `max(now, last_published + 1)`. Covers the initial `pending` publish (`finalize_order_publication`), every status transition (`update_order_event`), range-order children (`release.rs`), and composes with #866's repair stamp (the repair candidate `now + 1` routes through the same registry). Process-local by design — this daemon's key is the only legitimate publisher of its orders' events; the registry prunes entries older than 48 h past ~16 k orders.

### Publish failures leave a trace (`util.rs`)

A failed or impossible send queues the order id for the reconciler instead of vanishing into a `warn!`. A later successful publish clears the entry. The initial-publish path (which already returned an error) and the range-child path (which only warned) queue themselves too.

### Orderbook reconciler (`scheduler.rs`, `db.rs`)

New mode-agnostic scheduler job:

- every **60 s**: drain the failed-publish queue, reload each order from the DB, republish its current state (failed retries re-queue themselves via `update_order_event`, so relay outages self-heal);
- every **hour** (first sweep at startup): re-assert every live `pending` / `waiting-taker-bond` order (`find_pending_orders_for_reconcile`), healing state the daemon never saw fail — dropped events, ties lost before this fix, relay restores, daemon restarts.

### NIP-40 expiration from the order's real TTL (`nip33.rs`)

Events published as `pending` now carry `expiration = order.expires_at` (the ~24 h take window) instead of `now + 30d`, so any ghost that still slips through self-destructs at the order's actual deadline. Terminal / in-progress revisions keep the configured retention so trade history stays queryable. Legacy rows with `expires_at = 0` fall back to the retention window.

### Take-window gate (`take_sell.rs`, `take_buy.rs`)

The take paths validated status but not `expires_at`, so an order could be taken in the up-to-60 s window between its expiry and the scheduler tick that cancels it. Both takes now reject with `CantDo(InvalidOrderStatus)` when the take window has closed.

## Tests

- `util`: monotonic registry (same-second bump, newer-candidate wins, per-order independence, repair composition); failed publish queues + drain; take-window gate.
- `nip33`: `pending` events expire at `expires_at`; terminal events keep retention; `expires_at = 0` fallback.
- `scheduler`: reconciler drops queue entries whose row vanished; keeps retrying while relays are unreachable; full sweep lists only live pending-published rows.
- Also hardened a latent test-infra race in `ensure_global_db_pool` (concurrent init could interleave set + migrations on the shared in-memory pool).

```text
cargo test --bin mostrod                     # 1147 passed, 0 failed, 2 ignored (3 consecutive runs)
cargo clippy --all-targets --all-features    # clean
cargo fmt --all -- --check                   # clean
```

## Not covered here

- Persisting the monotonic registry across restarts (a same-second tie across a restart is not reachable in practice; noted in the code).
- The scheduler/AddInvoice timeout race noted in #866's "not covered" section — unrelated to the orderbook view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic orderbook reconciliation to retry failed publications and refresh active pending orders.
  * Added expiration handling for pending orders and take actions.
  * Added order-specific expiration for applicable events.

* **Bug Fixes**
  * Improved event ordering to prevent updates from being lost.
  * Failed orderbook publications are now tracked and retried automatically.
  * Expired buy and sell orders can no longer be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->