### PR TITLE
fix(bond): pay the timeout-slash winner instead of forfeiting to the node

### DIFF
--- a/migrations/20260813120000_bond_payout_recipient.sql
+++ b/migrations/20260813120000_bond_payout_recipient.sql
@@ -1,0 +1,21 @@
+-- Persist the winning counterparty's trade pubkey on the bond row at slash
+-- time so the Phase 3 payout resolver does not have to re-derive it from the
+-- order row later.
+--
+-- The timeout-slash path (`scheduler::job_cancel_orders` →
+-- `slash_or_release_on_timeout`) settles the responsible bond into
+-- `PendingPayout` and then calls `edit_pubkeys_order`, which NULLs the
+-- slashed side's trade pubkey on the order (buyer_pubkey on a sell order,
+-- seller_pubkey on a buy order) to reset/republish it. The payout resolver
+-- (`resolve_recipient`) matches `bond.pubkey` against both order pubkeys and
+-- needs *both* present, so once one is wiped it falls through to `None`: the
+-- wronged counterparty is never asked for a payout invoice and the bond
+-- eventually forfeits to the node instead of compensating them.
+--
+-- Capturing the recipient here — while the order is still intact, before the
+-- wipe runs — makes the winner recoverable regardless of any later mutation
+-- to the order row. Written by the slash CAS in `slash_one`, alongside
+-- `slashed_reason` / `slashed_at` / `node_share_sats`. Nullable: rows slashed
+-- before this migration (and paths that do not populate it) leave it NULL,
+-- and the resolver falls back to the order-derived lookup.
+ALTER TABLE bonds ADD COLUMN payout_recipient_pubkey char(64);

--- a/src/app/bond/crud.rs
+++ b/src/app/bond/crud.rs
@@ -43,6 +43,7 @@ pub(crate) const BOND_INSERT_COLUMNS: &[&str] = &[
     "taker_amount",
     "taker_fee",
     "taker_dev_fee",
+    "payout_recipient_pubkey",
 ];
 
 fn push_bond_insert_binds(b: &mut Separated<'_, Sqlite, &'static str>, bond: &Bond) {
@@ -76,7 +77,8 @@ fn push_bond_insert_binds(b: &mut Separated<'_, Sqlite, &'static str>, bond: &Bo
         .push_bind(bond.taker_fiat_amount)
         .push_bind(bond.taker_amount)
         .push_bind(bond.taker_fee)
-        .push_bind(bond.taker_dev_fee);
+        .push_bind(bond.taker_dev_fee)
+        .push_bind(&bond.payout_recipient_pubkey);
 }
 
 fn push_bond_update_set(set: &mut Separated<'_, Sqlite, &'static str>, bond: &Bond) {
@@ -135,6 +137,8 @@ fn push_bond_update_set(set: &mut Separated<'_, Sqlite, &'static str>, bond: &Bo
         .push_bind_unseparated(bond.taker_fee);
     set.push("taker_dev_fee = ")
         .push_bind_unseparated(bond.taker_dev_fee);
+    set.push("payout_recipient_pubkey = ")
+        .push_bind_unseparated(&bond.payout_recipient_pubkey);
 }
 
 impl Crud for Bond {

--- a/src/app/bond/db.rs
+++ b/src/app/bond/db.rs
@@ -354,6 +354,12 @@ mod tests {
         .await
         .expect("bond_payout_payment_hash migration");
         sqlx::query(include_str!(
+            "../../../migrations/20260813120000_bond_payout_recipient.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bond_payout_recipient migration");
+        sqlx::query(include_str!(
             "../../../migrations/20260611120000_bond_slice_slash_unique.sql"
         ))
         .execute(&pool)
@@ -461,6 +467,7 @@ mod tests {
             taker_amount: Some(29),
             taker_fee: Some(30),
             taker_dev_fee: Some(31),
+            payout_recipient_pubkey: Some("r".repeat(64)),
         }
     }
 
@@ -497,6 +504,7 @@ mod tests {
             "taker_amount" => bond.taker_amount.map(|v| v.to_string()),
             "taker_fee" => bond.taker_fee.map(|v| v.to_string()),
             "taker_dev_fee" => bond.taker_dev_fee.map(|v| v.to_string()),
+            "payout_recipient_pubkey" => bond.payout_recipient_pubkey.clone(),
             other => panic!("BOND_INSERT_COLUMNS entry {other:?} has no sentinel expectation"),
         }
     }
@@ -523,7 +531,8 @@ mod tests {
             | "payout_invoice"
             | "payout_payment_hash"
             | "taker_identity"
-            | "taker_invoice" => row.try_get::<Option<String>, _>(column).unwrap(),
+            | "taker_invoice"
+            | "payout_recipient_pubkey" => row.try_get::<Option<String>, _>(column).unwrap(),
             "payout_routing_fee_sats"
             | "node_share_sats"
             | "last_invoice_request_at"

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -1410,6 +1410,12 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_payout_payment_hash migration");
+        sqlx::query(include_str!(
+            "../../../migrations/20260813120000_bond_payout_recipient.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bond_payout_recipient migration");
         // cashu escrow columns (mostro-core 0.12.1) — `Order::by_id` SELECTs
         // them. Apply each ALTER separately for the same reason as dev_fee.
         for stmt in include_str!("../../../migrations/20260530120000_cashu_escrow_fields.sql")

--- a/src/app/bond/model.rs
+++ b/src/app/bond/model.rs
@@ -92,6 +92,15 @@ pub struct Bond {
     /// then; the counterparty share is always derived as
     /// `amount_sats - node_share_sats` so they cannot drift.
     pub node_share_sats: Option<i64>,
+    /// Trade pubkey of the winning counterparty the slashed share is owed to
+    /// (hex, 64 chars). Captured by the slash CAS at the moment the bond
+    /// enters `PendingPayout`, while the order still carries both trade
+    /// pubkeys — before the scheduler's `edit_pubkeys_order` can NULL the
+    /// slashed side. The payout resolver reads this in preference to
+    /// re-deriving the recipient from the (possibly mutated) order row.
+    /// `None` on rows slashed before this column existed, and on paths that
+    /// leave the resolution to the order-derived fallback.
+    pub payout_recipient_pubkey: Option<String>,
     /// Number of `send_payment` retries against an invoice the counterparty
     /// has already submitted. Bumped only on Phase 3 step 6 (send_payment
     /// failure); `payout_max_retries` is checked against this counter
@@ -169,6 +178,7 @@ impl Bond {
             payout_routing_fee_sats: None,
             payout_payment_hash: None,
             node_share_sats: None,
+            payout_recipient_pubkey: None,
             payout_attempts: 0,
             invoice_request_attempts: 0,
             last_invoice_request_at: None,

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -1043,17 +1043,31 @@ pub(crate) fn resolve_recipient(
 ///   NULL) → the recipient is the **maker themselves** (`bond.pubkey`), not
 ///   a trade counterparty. This is the unslashed remainder being returned
 ///   after a partial range slash.
+/// - **Recipient captured at slash time** (`payout_recipient_pubkey` set) →
+///   trust it directly. The timeout-slash path NULLs one of the order's
+///   trade pubkeys via `edit_pubkeys_order` immediately after the slash, so
+///   re-deriving the winner from the order row here would fall through to
+///   `None` and strand the payout (the funds would forfeit to the node
+///   instead of compensating the wronged party). The slash CAS records the
+///   winner while the order is still intact precisely so this lookup no
+///   longer depends on the mutable order row.
 /// - **Everything else** — a normal slash row, or a Phase 6 *slice-slash*
 ///   child (whose `order_id` is the slice order and whose `pubkey` is the
-///   maker's slice-side key) — resolves via [`resolve_recipient`] to the
-///   non-`bond.pubkey` side of the order, i.e. the winning counterparty.
-fn resolve_payout_recipient(
+///   maker's slice-side key), recorded before the column existed — falls
+///   back to [`resolve_recipient`], resolving the non-`bond.pubkey` side of
+///   the order.
+pub(crate) fn resolve_payout_recipient(
     order: &Order,
     bond: &Bond,
     reason: BondSlashReason,
 ) -> Result<Option<PublicKey>, MostroError> {
     if bond.parent_bond_id.is_some() && bond.child_order_id.is_none() {
         let pk = PublicKey::from_str(&bond.pubkey)
+            .map_err(|e| MostroInternalErr(ServiceError::UnexpectedError(e.to_string())))?;
+        return Ok(Some(pk));
+    }
+    if let Some(recipient) = bond.payout_recipient_pubkey.as_deref() {
+        let pk = PublicKey::from_str(recipient)
             .map_err(|e| MostroInternalErr(ServiceError::UnexpectedError(e.to_string())))?;
         return Ok(Some(pk));
     }
@@ -1773,6 +1787,66 @@ mod tests {
             r.unwrap().to_string(),
             taker_pk(),
             "a slice slash pays the non-maker winner"
+        );
+    }
+
+    #[test]
+    fn resolve_payout_recipient_prefers_captured_pubkey_over_wiped_order() {
+        // The timeout-slash path NULLs the taker's trade pubkey on the order
+        // (via `edit_pubkeys_order`) right after the slash. With the winner
+        // captured on the bond at slash time, the resolver must still return
+        // it even though the order can no longer be matched by `bond.pubkey`.
+        let wiped_order = Order {
+            kind: Kind::Sell.to_string(),
+            seller_pubkey: Some(maker_pk().to_string()),
+            buyer_pubkey: None,
+            ..Order::default()
+        };
+        let mut bond =
+            pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, 5_000, 0, None, None);
+        bond.slashed_reason = Some(BondSlashReason::Timeout.to_string());
+        bond.payout_recipient_pubkey = Some(maker_pk().to_string());
+
+        let r = resolve_payout_recipient(&wiped_order, &bond, BondSlashReason::Timeout).unwrap();
+        assert_eq!(
+            r.unwrap().to_string(),
+            maker_pk(),
+            "the captured recipient survives the order-pubkey wipe"
+        );
+    }
+
+    #[test]
+    fn resolve_payout_recipient_falls_back_when_no_captured_pubkey() {
+        // A row slashed before the column existed carries no captured
+        // recipient (`None`). The resolver must fall back to the order-derived
+        // lookup, preserving the pre-fix behaviour: an intact order still
+        // resolves, and a wiped one still yields `None`.
+        let intact_order = Order {
+            kind: Kind::Sell.to_string(),
+            seller_pubkey: Some(maker_pk().to_string()),
+            buyer_pubkey: Some(taker_pk().to_string()),
+            ..Order::default()
+        };
+        let bond = pending_payout_bond(Uuid::new_v4(), taker_pk(), 10_000, 5_000, 0, None, None);
+        assert!(bond.payout_recipient_pubkey.is_none());
+
+        let resolved =
+            resolve_payout_recipient(&intact_order, &bond, BondSlashReason::LostDispute).unwrap();
+        assert_eq!(
+            resolved.unwrap().to_string(),
+            maker_pk(),
+            "fallback still resolves the winner off an intact order"
+        );
+
+        let wiped_order = Order {
+            buyer_pubkey: None,
+            ..intact_order
+        };
+        let none =
+            resolve_payout_recipient(&wiped_order, &bond, BondSlashReason::LostDispute).unwrap();
+        assert!(
+            none.is_none(),
+            "with no captured recipient a wiped order is unrecoverable (the bug this fix targets)"
         );
     }
 

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -1018,7 +1018,7 @@ async fn on_send_payment_failure(
 ///   one responsible for the elapsed waiting state, and the recipient
 ///   is the other side. The §9.2 table is encoded by *who got
 ///   slashed*, not consulted here.
-fn resolve_recipient(
+pub(crate) fn resolve_recipient(
     order: &Order,
     bond: &Bond,
     _reason: BondSlashReason,
@@ -1626,6 +1626,12 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_payout_payment_hash migration");
+        sqlx::query(include_str!(
+            "../../../migrations/20260813120000_bond_payout_recipient.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bond_payout_recipient migration");
         // cashu escrow columns (mostro-core 0.12.1) — `Order::by_id` SELECTs
         // them. Apply each ALTER separately for the same reason as dev_fee.
         for stmt in include_str!("../../../migrations/20260530120000_cashu_escrow_fields.sql")

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -2346,6 +2346,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn timeout_slash_payout_survives_scheduler_pubkey_wipe() {
+        // Regression for the timeout-slash forfeit bug. `job_cancel_orders`
+        // runs the slash and then calls `edit_pubkeys_order`, which NULLs the
+        // slashed taker's trade pubkey on the order to reset/republish it.
+        // Composing both here proves the payout recipient is still resolvable
+        // afterwards: the winning maker was captured on the bond at slash
+        // time, so it no longer depends on the now-wiped order row.
+        use crate::app::bond::payout::resolve_payout_recipient;
+        use crate::db::edit_pubkeys_order;
+
+        let pool = setup_pool().await;
+        // Sell order, WaitingBuyerInvoice: maker = seller, taker = buyer. The
+        // buyer abandons → the taker bond is slashed and the seller (maker)
+        // is the wronged party owed the counterparty share.
+        let order = waiting_order(
+            Kind::Sell,
+            maker_pk(),
+            taker_pk(),
+            Status::WaitingBuyerInvoice,
+        );
+        insert_order_row(&pool, &order).await;
+        let bond = insert_bond(&pool, order.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        // Step 1 — the real timeout slash. Besides settling the HTLC and
+        // moving the bond to PendingPayout, its CAS captures the recipient.
+        let cfg = timeout_cfg(true, true, BondApplyTo::Take);
+        let slashed = slash_or_release_on_timeout(&pool, &mut ln, &order, Some(&cfg))
+            .await
+            .unwrap()
+            .expect("taker bond is slashed on timeout");
+        assert_eq!(slashed.id, bond.id);
+
+        // Step 2 — the scheduler's republish step wipes the taker pubkey.
+        edit_pubkeys_order(&pool, &order)
+            .await
+            .expect("edit_pubkeys_order");
+
+        // The order row can no longer be matched by `bond.pubkey`...
+        let wiped = Order::by_id(&pool, order.id)
+            .await
+            .unwrap()
+            .expect("order row present");
+        assert!(
+            wiped.buyer_pubkey.is_none(),
+            "the scheduler wipe NULLs the taker (buyer) pubkey"
+        );
+
+        // ...but the slash CAS captured the winner on the bond row.
+        let slashed_row = sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE id = ?")
+            .bind(slashed.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            slashed_row.payout_recipient_pubkey.as_deref(),
+            Some(maker_pk()),
+            "the slash CAS recorded the winning counterparty before the wipe"
+        );
+
+        // So the payout still resolves to the maker instead of falling
+        // through to `None` (which would forfeit the share to the node).
+        let recipient = resolve_payout_recipient(&wiped, &slashed_row, BondSlashReason::Timeout)
+            .unwrap()
+            .expect("recipient must still resolve after the pubkey wipe");
+        assert_eq!(
+            recipient.to_string(),
+            maker_pk(),
+            "the wronged maker is paid, not forfeited to the node"
+        );
+    }
+
+    #[tokio::test]
     async fn timeout_republish_retains_maker_bond_sell_order() {
         // Regression (PR #767 review): sell order, WaitingBuyerInvoice. The
         // buyer (taker) times out, so the order is **republished** to the

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -938,6 +938,17 @@ async fn record_maker_slice_slash(
         );
         return Ok(false);
     };
+    // The slashed maker share is owed to the slice's *other* side (the
+    // winning taker). Capture it now, while the slice order still carries
+    // both trade pubkeys: on a maker-responsible timeout the scheduler calls
+    // `edit_pubkeys_order` right after this, NULLing the taker key — which is
+    // exactly this child row's recipient. Without the capture the payout
+    // would later fall through to `resolve_recipient` → `None` and forfeit to
+    // the node instead of compensating the taker.
+    let recipient_slice_pubkey = match kind {
+        Kind::Sell => slice.buyer_pubkey.as_deref(),
+        Kind::Buy => slice.seller_pubkey.as_deref(),
+    };
     let Some(max_fiat) = root.max_amount.filter(|m| *m > 0) else {
         warn!(
             bond_id = %parent_bond.id,
@@ -995,8 +1006,9 @@ async fn record_maker_slice_slash(
     let insert = sqlx::query(
         "INSERT INTO bonds \
             (id, order_id, parent_bond_id, child_order_id, pubkey, role, \
-             amount_sats, state, slashed_reason, node_share_sats, slashed_at, created_at) \
-         SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? \
+             amount_sats, state, slashed_reason, node_share_sats, \
+             payout_recipient_pubkey, slashed_at, created_at) \
+         SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? \
          WHERE NOT EXISTS ( \
              SELECT 1 FROM bonds WHERE parent_bond_id = ? AND child_order_id = ?) \
            AND EXISTS ( \
@@ -1012,6 +1024,7 @@ async fn record_maker_slice_slash(
     .bind(BondState::PendingPayout.to_string())
     .bind(reason.to_string())
     .bind(node_share)
+    .bind(recipient_slice_pubkey)
     .bind(now)
     .bind(now)
     .bind(parent_bond.id)
@@ -2841,6 +2854,79 @@ mod tests {
             read_bond_state(&pool, taker_bond.id).await,
             BondState::Released.to_string(),
             "taker bond released on the terminal cancel"
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_range_maker_slash_payout_survives_scheduler_pubkey_wipe() {
+        // Regression companion to the taker/non-range case, for the Phase 6
+        // slice-slash child. A maker-responsible *range* timeout records the
+        // child via `record_maker_slice_slash`; the scheduler then cancels the
+        // slice and calls `edit_pubkeys_order`, which NULLs the taker — the
+        // child's own payout recipient. The child must still resolve to that
+        // taker because the winner was captured at slash time.
+        use crate::app::bond::payout::resolve_payout_recipient;
+        use crate::db::edit_pubkeys_order;
+
+        let pool = setup_pool().await;
+        // Sell range, WaitingPayment → the seller (maker) is responsible; the
+        // wronged party owed the slice share is the buyer (taker).
+        let mut root = range_slice(Kind::Sell, maker_pk(), taker_pk(), 40, 10, 100);
+        root.status = Status::WaitingPayment.to_string();
+        insert_range_order_row(&pool, &root).await;
+        let _parent = insert_parent_maker_bond(&pool, root.id, maker_pk(), 1000).await;
+        let _taker_bond = insert_bond(&pool, root.id, taker_pk(), BondState::Locked).await;
+        let mut ln = StubSettle::new();
+
+        // Step 1 — the real range-maker timeout slash records the child row,
+        // capturing the winning taker.
+        let cfg = timeout_cfg(true, true, BondApplyTo::Both);
+        let child = slash_or_release_on_timeout(&pool, &mut ln, &root, Some(&cfg))
+            .await
+            .unwrap()
+            .expect("range maker timeout records the slice-slash child");
+        let child_row = sqlx::query_as::<_, Bond>("SELECT * FROM bonds WHERE id = ?")
+            .bind(child.id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            child_row.payout_recipient_pubkey.as_deref(),
+            Some(taker_pk()),
+            "the slice slash captured the winning taker before the wipe"
+        );
+
+        // Step 2 — the scheduler's cancel step wipes the taker (buyer) pubkey.
+        edit_pubkeys_order(&pool, &root)
+            .await
+            .expect("edit_pubkeys_order");
+        let wiped = Order::by_id(&pool, root.id)
+            .await
+            .unwrap()
+            .expect("order row present");
+        assert!(
+            wiped.buyer_pubkey.is_none(),
+            "the cancel wipe NULLs the taker (buyer) pubkey"
+        );
+
+        // With the capture, the payout still resolves to the taker...
+        let recipient = resolve_payout_recipient(&wiped, &child_row, BondSlashReason::Timeout)
+            .unwrap()
+            .expect("recipient must still resolve after the pubkey wipe");
+        assert_eq!(
+            recipient.to_string(),
+            taker_pk(),
+            "the wronged taker is paid, not forfeited to the node"
+        );
+
+        // ...whereas a pre-fix child row (no captured recipient) would strand
+        // on the wiped order — the gap this commit closes.
+        let mut legacy = child_row.clone();
+        legacy.payout_recipient_pubkey = None;
+        let none = resolve_payout_recipient(&wiped, &legacy, BondSlashReason::Timeout).unwrap();
+        assert!(
+            none.is_none(),
+            "without the capture the wiped slice order is unrecoverable"
         );
     }
 

--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -347,7 +347,22 @@ pub async fn apply_bond_resolution<L: SettleLightning + Send>(
             // a transient settle failure leaves the bond `Locked` for an
             // admin retry, never released. Confirm the slash via the durable
             // `slashed_reason` witness before queueing a notice.
-            slash_one(pool, ln_client, &target, reason, node_share_pct).await;
+            // Persist the recipient from the intact order too. The admin
+            // dispute path never wipes the order pubkeys, so this is not a
+            // correctness requirement here (the order-derived fallback would
+            // resolve), but populating it keeps the column uniform across
+            // every `slash_one` row and lets the resolver trust it directly.
+            let recipient = crate::app::bond::payout::resolve_recipient(order, &target, reason)?
+                .map(|pk| pk.to_string());
+            slash_one(
+                pool,
+                ln_client,
+                &target,
+                reason,
+                node_share_pct,
+                recipient.as_deref(),
+            )
+            .await;
             slashed_ids.insert(target.id);
             if slash_reason_recorded(pool, target.id, reason).await? {
                 notify_rows.push(target.clone());
@@ -581,12 +596,24 @@ pub async fn slash_or_release_on_timeout<L: SettleLightning + Send>(
             None
         }
     } else {
+        // Resolve the winning counterparty *now*, while `order` still carries
+        // both trade pubkeys. The scheduler's `edit_pubkeys_order` runs after
+        // this returns and NULLs the slashed side, so a later order-derived
+        // lookup would fall through to `None`; persisting the recipient on the
+        // bond row keeps the payout addressable regardless.
+        let recipient = crate::app::bond::payout::resolve_recipient(
+            order,
+            &responsible,
+            BondSlashReason::Timeout,
+        )?
+        .map(|pk| pk.to_string());
         slash_one(
             pool,
             ln_client,
             &responsible,
             BondSlashReason::Timeout,
             node_share_pct,
+            recipient.as_deref(),
         )
         .await;
         // Confirm the slash actually landed before claiming it: a transient
@@ -772,16 +799,21 @@ pub async fn notify_bond_slashed(order: &Order, slashed: &Bond) {
 /// `WHERE id = ? AND state = 'locked'` so a duplicate admin call or a
 /// concurrent transition cannot overwrite a row that already moved on.
 ///
-/// The CAS write is the only place `slashed_reason`, `slashed_at`, and
-/// `node_share_sats` are populated for a `LostDispute` row, which is
-/// what makes the split snapshot deterministic across restarts and
-/// config changes.
+/// The CAS write is the only place `slashed_reason`, `slashed_at`,
+/// `node_share_sats`, and `payout_recipient_pubkey` are populated for a
+/// `LostDispute` row, which is what makes the split snapshot
+/// deterministic across restarts and config changes. `recipient` is the
+/// winning counterparty's trade pubkey, resolved by the caller from the
+/// still-intact order (before any `edit_pubkeys_order` wipe); `None`
+/// leaves the column NULL and defers resolution to the order-derived
+/// fallback.
 async fn slash_one<L: SettleLightning + Send>(
     pool: &Pool<Sqlite>,
     ln_client: &mut L,
     bond: &Bond,
     reason: BondSlashReason,
     node_share_pct: f64,
+    recipient: Option<&str>,
 ) {
     let preimage = match bond.preimage.as_deref() {
         Some(p) => p,
@@ -816,13 +848,15 @@ async fn slash_one<L: SettleLightning + Send>(
     let now = Utc::now().timestamp();
     let result = sqlx::query(
         "UPDATE bonds \
-           SET state = ?, slashed_reason = ?, slashed_at = ?, node_share_sats = ? \
+           SET state = ?, slashed_reason = ?, slashed_at = ?, node_share_sats = ?, \
+               payout_recipient_pubkey = ? \
          WHERE id = ? AND state = ?",
     )
     .bind(BondState::PendingPayout.to_string())
     .bind(reason.to_string())
     .bind(now)
     .bind(node_share_sats)
+    .bind(recipient)
     .bind(bond.id)
     .bind(BondState::Locked.to_string())
     .execute(pool)
@@ -1513,6 +1547,12 @@ mod tests {
         .execute(&pool)
         .await
         .expect("bond_payout_payment_hash migration");
+        sqlx::query(include_str!(
+            "../../../migrations/20260813120000_bond_payout_recipient.sql"
+        ))
+        .execute(&pool)
+        .await
+        .expect("bond_payout_recipient migration");
         // Phase 6 chain-walk tests load full `Order` rows via `Order::by_id`,
         // which selects every column the model declares — so the orders
         // table must carry the later Cashu columns too.
@@ -4290,7 +4330,15 @@ mod tests {
         bond.clone().create(&pool).await.unwrap();
         let mut ln = StubSettle::new();
 
-        slash_one(&pool, &mut ln, &bond, BondSlashReason::LostDispute, 0.0).await;
+        slash_one(
+            &pool,
+            &mut ln,
+            &bond,
+            BondSlashReason::LostDispute,
+            0.0,
+            None,
+        )
+        .await;
 
         assert!(
             ln.calls().is_empty(),
@@ -4320,7 +4368,15 @@ mod tests {
             .unwrap();
         let mut ln = StubSettle::new();
 
-        slash_one(&pool, &mut ln, &bond, BondSlashReason::LostDispute, 0.0).await;
+        slash_one(
+            &pool,
+            &mut ln,
+            &bond,
+            BondSlashReason::LostDispute,
+            0.0,
+            None,
+        )
+        .await;
 
         assert_eq!(
             ln.calls(),
@@ -4356,7 +4412,15 @@ mod tests {
         let mut ln = StubSettle::new();
 
         // Must not panic despite the CAS query itself failing.
-        slash_one(&pool, &mut ln, &bond, BondSlashReason::LostDispute, 0.0).await;
+        slash_one(
+            &pool,
+            &mut ln,
+            &bond,
+            BondSlashReason::LostDispute,
+            0.0,
+            None,
+        )
+        .await;
 
         assert_eq!(
             ln.calls(),


### PR DESCRIPTION
On a waiting-state **timeout slash**, the slashed counterparty share was
deterministically misallocated to the node instead of being paid to the
wronged party. The payout resolver derived the winner from the live order
row, but the timeout-cancel path wipes the very pubkey it needs — so the
recipient resolved to `None`, no payout invoice was ever requested, and after
the claim window the bond forfeited to the node.

This affects only deployments running the anti-abuse bond feature with
`[anti_abuse_bond] enabled = true` and `slash_on_waiting_timeout = true`
(non-default). Dispute slashes were never affected.

## The bug

1. A taker abandons a trade in a waiting state past its timeout.
2. `scheduler::job_cancel_orders` slashes t
   (`slash_or_release_on_timeout` → `Pendinty is
   owed `(1 − slash_node_share_pct) × amoun
3. The same job then calls `edit_pubkeys_order`, which NULLs the slashed
   side's trade pubkey on the order (buyer buy
   order) to reset/republish it.
4. `resolve_recipient` matches `bond.pubkey` against **both** order pubkeys
   and requires both present; with one wiped it falls through to `None`.
5. `request_payout_invoice` skips on `None`), so
   the winner is never asked for a bolt11. After `payout_claim_window_days`,
   `forfeit_bond` flips the bond to `Forfeiull
   amount.

With the default `slash_node_share_pct = 0.5` the node collects 2× its
advertised share; with `0.0` (advertised asarty")
it pockets everything. The winner has no wo
`AddBondInvoice` dies in `find_recoverable_bond_for_recipient` via the same
resolver.

## Root cause

The payout recipient was derived on demand from a mutable order row that the cancel path rewrites, and the bond row did not persist the counterparty's identity. Once the order pubkey is wiped, the winner is unrecoverable.

## Fix

Persist the winning counterparty's trade push time**, while the order is still intact (bes), and read it back at payout time.

- **Commit 1 (`refactor`)** — plumbing, ine
  nullable column `bonds.payout_recipient_pubkey` (+ migration), `Bond` model
  / `Crud` / column-alignment test wiring,
  `recipient` and writes it in the slash CAS. Both the timeout and dispute
  call sites resolve it from the intact ord
- **Commit 2 (`fix`)** — activation: `resolve_payout_recipient` now prefers
  the captured pubkey, falling back to the  rows
  slashed before the column existed. This ft
  (`request_payout_invoice`) and the proact
  (`find_recoverable_bond_for_recipient`),

## Why dispute slashes were unaffected

The admin dispute path (`AdminSettle` / `Ad
`edit_pubkeys_order`, so the order pubkeys stay intact and the resolver always found the winner. Those rows now populate a

## Testing

- Unit: resolver returns the captured recipfalls
  back correctly (including the pre-fix `None` on a wiped order with no
  captured recipient — documenting the original bug).
- Integration: composes the real timeout slpe +
  `resolve_payout_recipient`, asserting the maker is paid, not the node — the
  coverage gap that let this ship (no existth the
  payout).
- Full suite green (`cargo test`), `cargo fmt` / `cargo clippy` clean.

## Upgrade notes

The migration is additive (`ALTER TABLE bonllable)
and runs automatically on daemon start agaieset,
no downtime. Rows already slashed **and** wbe
backfilled (the pubkey was never stored ands fix
prevents future losses only. Given the feat, few
if any such rows should exist in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bond-slash payouts by preserving the winning counterparty’s payout information.
  * Payouts remain resolvable even after related order details are cleared.
  * Maintained fallback behavior for older bonds without stored payout information.
  * Applied the fix consistently to standard and range-based bond slashes.

* **Reliability**
  * Added safeguards and coverage for dispute, timeout, and legacy payout scenarios.
  * Improved payout resolution when counterparty details are unavailable during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->