### PR TITLE
Add created_at tag to kind-38386 dispute events

### DIFF
--- a/docs/SEPARATE_EVENT_KINDS_SPEC.md
+++ b/docs/SEPARATE_EVENT_KINDS_SPEC.md
@@ -347,11 +347,16 @@ client.send_event(&new_event).await?;
     ["d", "660e8400-e29b-41d4-a716-446655440001"],
     ["s", "pending"],
     ["initiator", "buyer"],
+    ["created_at", "1700000100"],
     ["y", "mostro"],
     ["z", "dispute"]
   ]
 }
 ```
+
+The `created_at` tag is the dispute open time from SQLite (`disputes.created_at`).
+It is independent of the Nostr event's `created_at` field, which remains the
+wall-clock time of the latest NIP-33 publish/replace.
 
 ## Client Query Examples
 

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -7,7 +7,7 @@ use crate::db::{
     is_dispute_taken_by_admin,
 };
 use crate::lightning::LndConnector;
-use crate::nip33::{create_platform_tag_values, new_dispute_event};
+use crate::nip33::{create_dispute_event_tags, new_dispute_event};
 use crate::util::{enqueue_order_msg, get_order, send_dm, update_order_event};
 use mostro_core::db::Crud;
 use mostro_core::prelude::*;
@@ -134,22 +134,19 @@ pub async fn admin_cancel_action(
 
     if let Ok(mut d) = dispute {
         let dispute_id = d.id;
+        let opened_at = d.created_at;
         // we update the dispute
         d.status = DisputeStatus::SellerRefunded.to_string();
         d.update(pool)
             .await
             .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
         // We create a tag to show status of the dispute
-        let tags: Tags = Tags::from_list(vec![
-            Tag::custom("s", vec![DisputeStatus::SellerRefunded.to_string()]),
-            // Who is the dispute creator
-            Tag::custom("initiator", vec![dispute_initiator]),
-            Tag::custom(
-                "y",
-                create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
-            ),
-            Tag::custom("z", vec!["dispute".to_string()]),
-        ]);
+        let tags = create_dispute_event_tags(
+            DisputeStatus::SellerRefunded.to_string(),
+            dispute_initiator,
+            opened_at,
+            ctx.settings().mostro.name.as_deref(),
+        );
         // nip33 kind with dispute id as identifier (kind 38386 for disputes)
         let event = new_dispute_event(my_keys, "", dispute_id.to_string(), tags)
             .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;

--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -5,7 +5,7 @@ use crate::db::{
     is_dispute_taken_by_admin,
 };
 use crate::lightning::LndConnector;
-use crate::nip33::{create_platform_tag_values, new_dispute_event};
+use crate::nip33::{create_dispute_event_tags, new_dispute_event};
 use crate::util::{enqueue_order_msg, get_order, settle_seller_hold_invoice, update_order_event};
 
 use mostro_core::db::Crud;
@@ -124,6 +124,7 @@ pub async fn admin_settle_action(
 
     if let Ok(mut d) = dispute {
         let dispute_id = d.id;
+        let opened_at = d.created_at;
         // we update the dispute
         d.status = DisputeStatus::Settled.to_string();
         d.update(pool)
@@ -138,16 +139,12 @@ pub async fn admin_settle_action(
         };
 
         // We create a tag to show status of the dispute
-        let tags: Tags = Tags::from_list(vec![
-            Tag::custom("s", vec![DisputeStatus::Settled.to_string()]),
-            // Who is the dispute creator
-            Tag::custom("initiator", vec![dispute_initiator]),
-            Tag::custom(
-                "y",
-                create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
-            ),
-            Tag::custom("z", vec!["dispute".to_string()]),
-        ]);
+        let tags = create_dispute_event_tags(
+            DisputeStatus::Settled.to_string(),
+            dispute_initiator,
+            opened_at,
+            ctx.settings().mostro.name.as_deref(),
+        );
 
         // nip33 kind with dispute id as identifier (kind 38386 for disputes)
         let event = new_dispute_event(my_keys, "", dispute_id.to_string(), tags)

--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -1,7 +1,7 @@
 use crate::app::admin_add_solver::SOLVER_CATEGORY_READ_ONLY;
 use crate::app::context::AppContext;
 use crate::db::{find_solver_pubkey, is_user_present, user_has_solver_write_permission};
-use crate::nip33::{create_platform_tag_values, new_dispute_event};
+use crate::nip33::{create_dispute_event_tags, new_dispute_event};
 use crate::util::{get_dispute, send_dm};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
@@ -263,16 +263,12 @@ pub async fn admin_take_dispute_action(
     };
 
     // We create a tag to show status of the dispute
-    let tags: Tags = Tags::from_list(vec![
-        Tag::custom("s", vec![Status::InProgress.to_string()]),
-        // Who is the dispute creator
-        Tag::custom("initiator", vec![dispute_initiator]),
-        Tag::custom(
-            "y",
-            create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
-        ),
-        Tag::custom("z", vec!["dispute".to_string()]),
-    ]);
+    let tags = create_dispute_event_tags(
+        Status::InProgress.to_string(),
+        dispute_initiator,
+        dispute.created_at,
+        ctx.settings().mostro.name.as_deref(),
+    );
     // nip33 kind with dispute id as identifier (kind 38386 for disputes)
     let event = new_dispute_event(mostro_keys, "", dispute.id.to_string(), tags)
         .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;

--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -4,7 +4,7 @@
 
 use crate::app::context::AppContext;
 use crate::db::find_dispute_by_order_id;
-use crate::nip33::{create_platform_tag_values, new_dispute_event};
+use crate::nip33::{create_dispute_event_tags, new_dispute_event};
 use crate::util::{enqueue_order_msg, get_order};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
@@ -28,20 +28,14 @@ pub(crate) async fn publish_dispute_event(
         false => "seller",
     };
 
-    // Create tags for the dispute event
-    let tags = Tags::from_list(vec![
-        // Status tag - indicates the current state of the dispute
-        Tag::custom("s", vec![dispute.status.to_string()]),
-        // Who is the dispute creator
-        Tag::custom("initiator", vec![initiator.to_string()]),
-        // Application identifier tag
-        Tag::custom(
-            "y",
-            create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
-        ),
-        // Event type tag
-        Tag::custom("z", vec!["dispute".to_string()]),
-    ]);
+    // Create tags for the dispute event (includes SQLite open time as
+    // `created_at`; Nostr event.created_at remains "signed now").
+    let tags = create_dispute_event_tags(
+        dispute.status.as_str(),
+        initiator,
+        dispute.created_at,
+        ctx.settings().mostro.name.as_deref(),
+    );
 
     // Create a new NIP-33 replaceable event (kind 38386 for disputes)
     // Empty content string as the information is in the tags
@@ -249,6 +243,7 @@ pub async fn close_dispute_after_user_resolution(
     let pool = ctx.pool();
     if let Ok(mut dispute) = find_dispute_by_order_id(pool, order.id).await {
         let dispute_id = dispute.id;
+        let opened_at = dispute.created_at;
         dispute.status = new_status.to_string();
 
         if let Err(e) = dispute.update(pool).await {
@@ -284,15 +279,12 @@ pub async fn close_dispute_after_user_resolution(
             };
 
             // Publish updated dispute event to Nostr so admin clients see it as resolved
-            let tags = Tags::from_list(vec![
-                Tag::custom("s", vec![new_status.to_string()]),
-                Tag::custom("initiator", vec![dispute_initiator.to_string()]),
-                Tag::custom(
-                    "y",
-                    create_platform_tag_values(ctx.settings().mostro.name.as_deref()),
-                ),
-                Tag::custom("z", vec!["dispute".to_string()]),
-            ]);
+            let tags = create_dispute_event_tags(
+                new_status.to_string(),
+                dispute_initiator,
+                opened_at,
+                ctx.settings().mostro.name.as_deref(),
+            );
 
             match new_dispute_event(my_keys, "", dispute_id.to_string(), tags) {
                 Ok(event) => {

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -177,6 +177,27 @@ pub fn new_dispute_event(
     )
 }
 
+/// Builds the standard tag set for a kind-38386 dispute event.
+///
+/// `created_at` is the dispute open time from SQLite (`disputes.created_at`),
+/// carried as a business tag so clients can show when the dispute was opened.
+/// It is independent of the Nostr event's `created_at`, which stays as "signed
+/// now" for NIP-33 replaceable-event ordering.
+pub fn create_dispute_event_tags(
+    status: impl Into<String>,
+    initiator: impl Into<String>,
+    created_at: i64,
+    platform_name: Option<&str>,
+) -> Tags {
+    Tags::from_list(vec![
+        Tag::custom("s", vec![status.into()]),
+        Tag::custom("initiator", vec![initiator.into()]),
+        Tag::custom("created_at", vec![created_at.to_string()]),
+        Tag::custom("y", create_platform_tag_values(platform_name)),
+        Tag::custom("z", vec!["dispute".to_string()]),
+    ])
+}
+
 /// Creates a new exchange rates event (kind 30078, NIP-33)
 ///
 /// This event publishes Bitcoin/fiat exchange rates to Nostr relays,
@@ -1179,25 +1200,19 @@ mod tests {
 
     // ── Dispute event tag list: end-to-end y-tag emission (kind 38386) ──────────
 
-    /// Verifies that the tag list built for dispute events emits the correct y tag.
-    ///
-    /// Mirrors the exact inline tag construction used in `publish_dispute_event` and
-    /// `close_dispute_after_user_resolution` in src/app/dispute.rs, as well as the
-    /// admin handlers in admin_cancel.rs, admin_settle.rs, and admin_take_dispute.rs.
-    /// All five callsites use the identical pattern verified here.
+    /// Verifies that [`create_dispute_event_tags`] emits status, initiator,
+    /// stable open-time `created_at`, platform `y`, and `z=dispute`.
     #[test]
     fn dispute_event_tags_emit_y_tag_matching_platform_helper() {
         init_test_settings();
 
-        let tags = Tags::from_list(vec![
-            Tag::custom("s", vec!["initiated-by-buyer".to_string()]),
-            Tag::custom("initiator", vec!["buyer".to_string()]),
-            Tag::custom(
-                "y",
-                create_platform_tag_values(test_settings().mostro.name.as_deref()),
-            ),
-            Tag::custom("z", vec!["dispute".to_string()]),
-        ]);
+        let opened_at = 1_700_000_100_i64;
+        let tags = super::create_dispute_event_tags(
+            "initiated",
+            "buyer",
+            opened_at,
+            test_settings().mostro.name.as_deref(),
+        );
 
         let y_values = get_y_tag_values(&tags)
             .expect("y tag must be present in dispute event tags (kind 38386)");
@@ -1209,6 +1224,51 @@ mod tests {
             y_values, expected,
             "dispute event tag list must wire create_platform_tag_values correctly"
         );
+        assert_eq!(
+            get_tag_value(&tags, "s").as_deref(),
+            Some("initiated"),
+            "status tag must match"
+        );
+        assert_eq!(
+            get_tag_value(&tags, "initiator").as_deref(),
+            Some("buyer"),
+            "initiator tag must match"
+        );
+        assert_eq!(
+            get_tag_value(&tags, "created_at").as_deref(),
+            Some("1700000100"),
+            "created_at tag must carry the SQLite dispute open time"
+        );
+        assert_eq!(
+            get_tag_value(&tags, "z").as_deref(),
+            Some("dispute"),
+            "z tag must be dispute"
+        );
+    }
+
+    /// Kind-38386 `event.created_at` stays "signed now"; the business open
+    /// time lives only on the `created_at` tag so NIP-33 replace still works.
+    #[test]
+    fn new_dispute_event_keeps_nostr_created_at_independent_of_open_time_tag() {
+        init_test_settings();
+        let keys = Keys::generate();
+        let opened_at = 1_600_000_000_i64;
+        let tags = super::create_dispute_event_tags("initiated", "seller", opened_at, None);
+        let before = Timestamp::now().as_secs();
+        let event = super::new_dispute_event(&keys, "", "dispute-id".to_string(), tags)
+            .expect("dispute event");
+        let after = Timestamp::now().as_secs();
+
+        assert_eq!(event.kind.as_u16(), NOSTR_DISPUTE_EVENT_KIND);
+        assert!(
+            event.created_at.as_secs() >= before && event.created_at.as_secs() <= after,
+            "event.created_at must be wall-clock now, not the open-time tag"
+        );
+        assert_eq!(
+            get_tag_value(&event.tags, "created_at").as_deref(),
+            Some("1600000000")
+        );
+        assert_ne!(event.created_at.as_secs() as i64, opened_at);
     }
 
     // ── Dev-fee audit event tag list: end-to-end y-tag emission (kind 8383) ─────


### PR DESCRIPTION
## Summary

Admin clients (e.g. Mostrix) show confusing “Created” dates for the same dispute UUID: Management/chat can show an old order date (e.g. 2025) while the Pending list shows a recent publish time (e.g. yesterday). This is not a timezone bug. Kind 38386 events never carried the real dispute open time, so Pending could only display Nostr `event.created_at` (when Mostro last signed the replaceable snapshot).

This PR publishes SQLite `disputes.created_at` as a stable `created_at` **tag** on every kind-38386 dispute event, while leaving Nostr `event.created_at` as “signed now” so NIP-33 replaceable ordering still works.

## Problem (in detail)

### What operators saw

1. Pending disputes tab listed many rows as `initiated`, with Created timestamps clustered in the same minute (a publish burst).
2. Opening the same dispute ID in Management/chat showed a much older “Created” date (often the underlying **order** age from test data).
3. A recent Mostrix change switched UTC → local formatting for display. That change did **not** invent rows or flip status; it only made existing timestamps easier to read. Daemon DB still correctly had those test disputes as `initiated`.

### Root cause

Mostro already stores the real open time in SQLite (`disputes.created_at`), but the public notice clients fetch does not expose it:

- Kind **38386** tags were only `s`, `initiator`, `y`, `z` (plus NIP-33 `d` / optional NIP-40 `expiration`).
- `new_dispute_event` always builds the event with `created_at: None`, so the Nostr event timestamp is wall-clock **now**.
- Admin Management/chat “Created” comes from `SolverDisputeInfo.created_at`, which is **`order.created_at`**, not the dispute open time.

So one UUID legitimately had two different clocks, both labeled like “Created”:

| UI surface | Field used | Meaning |
|---|---|---|
| Disputes Management / chat | `SolverDisputeInfo.created_at` | Order creation time |
| Disputes Pending (relay list) | kind-38386 `event.created_at` | Last publish/replace time |

Whenever Mostro (re)publishes a dispute snapshot—first open, take, settle, cancel, auto-close, escrow-deadline reopen—Pending “Created” jumps to that publish time even if the dispute row in SQLite is unchanged.

Clients cannot recover the true open time from the relay event today; the value simply is not on the wire.

## Solution

- Add `create_dispute_event_tags(...)` in `src/nip33.rs` that always includes `["created_at", "<unix secs from disputes.created_at>"]`.
- Route all kind-38386 publish sites through that helper:
  - `publish_dispute_event` / auto-close in `src/app/dispute.rs`
  - `admin_take_dispute`, `admin_settle`, `admin_cancel`
- Keep `new_dispute_event(..., created_at: None)` so Nostr `event.created_at` remains “now” for NIP-33 replace.
- Document the tag in `docs/SEPARATE_EVENT_KINDS_SPEC.md`.

### Example wire shape

```json
{
  "kind": 38386,
  "created_at": 1723663020,
  "tags": [
    ["d", "<dispute-uuid>"],
    ["s", "initiated"],
    ["initiator", "buyer"],
    ["created_at", "1700000100"],
    ["y", "mostro", "..."],
    ["z", "dispute"]
  ]
}
```

- `event.created_at` → last signed revision (replace ordering / “Published”)
- tag `created_at` → stable dispute open time for UI “Created”

## Scope Declaration

- **Event domains affected:** dispute (kind 38386 only)
- **Cross-kind change:** no
- **External compatibility impact:**
  - **Additive / backward compatible.** Old clients ignore unknown tags.
  - New clients (Mostrix Pending, indexers) SHOULD prefer tag `created_at` for “dispute opened” display and keep using event `created_at` only to pick the latest NIP-33 revision.
  - Existing relay events without the tag stay as-is until republished; clients should fall back to event `created_at` or show “Published” when the tag is missing.
  - Relays: no filter/schema change required.

## Changes

- Centralize dispute event tags via `create_dispute_event_tags`
- Emit `created_at` from SQLite open time on all dispute publishes
- Unit tests for tag contents and independence from Nostr event timestamp
- Spec update for kind 38386

## Out of scope / follow-ups

- Mostrix: parse the new tag for the Pending “Created” column (and optionally rename the old meaning to “Published” until then).
- Optional: expose `dispute.created_at` separately on `SolverDisputeInfo` so Management/chat does not show order age as “Created”.
- Cleaning leftover `initiated` test disputes in daemon DB / relays (status listing was correct for those rows).

## How to test

```bash
cargo test nip33::
cargo test dispute_event
cargo fmt --check
cargo clippy --all-targets --all-features
```

Manual: open a dispute, inspect the kind-38386 event on a relay, confirm tag `created_at` matches `disputes.created_at` while event `created_at` is near publish time; take/settle and confirm the tag stays stable across replaces.

## Checklist

- [x] Tests pass locally (`cargo test nip33::` / `dispute_event`)
- [x] Docs updated (`docs/SEPARATE_EVENT_KINDS_SPEC.md`)
- [ ] `cargo sqlx prepare` — N/A (no SQL/query changes)

## Notes for reviewers

Protocol/tag change is **single-kind** (38386). Do not pass SQLite open time into `EventBuilder::custom_created_at`; that would freeze replaceable-event ordering and break later status updates.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dispute events now include the dispute’s original creation time alongside the Nostr event timestamp.
  - Dispute event metadata is consistently included across creation, cancellation, settlement, and takeover actions.

- **Documentation**
  - Updated the dispute event specification to clarify the distinction between database creation time and Nostr publication time.

- **Bug Fixes**
  - Improved consistency and accuracy of dispute event tags across lifecycle updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->