### PR TITLE
fix: wrongful maker bond slash, waiting-state timeout anchored on take-time taken_at

### DIFF
--- a/src/app/bond/slash.rs
+++ b/src/app/bond/slash.rs
@@ -443,7 +443,11 @@ async fn order_has_range_maker_bond(
 /// guarantees the bond was really forfeited and the notice is truthful.
 ///
 /// `order` MUST carry the pre-cancel waiting status and the trade
-/// pubkeys; call this from the persist-success branch that replaces the
+/// pubkeys, and MUST be a *fresh* read whose timeout eligibility was just
+/// re-confirmed (see `scheduler::reconfirm_timeout_eligibility`): blame
+/// is assigned from `order.status`, so a stale snapshot taken before a
+/// duty handoff would slash the wrong party. Call this from the
+/// persist-success branch that replaces the
 /// Phase 1 release call. `bond_cfg` is the node's `[anti_abuse_bond]`
 /// config (the scheduler passes `Settings::get_bond()`); it is taken as a
 /// parameter rather than read from the global so the gate is unit-testable

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -27,7 +27,7 @@ pub async fn hold_invoice_paid(
     pool: &SqlitePool,
     my_keys: &Keys,
 ) -> Result<(), MostroError> {
-    let order = crate::db::find_order_by_hash(pool, hash)
+    let mut order = crate::db::find_order_by_hash(pool, hash)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
@@ -135,6 +135,15 @@ pub async fn hold_invoice_paid(
         order_data.status = Some(status);
         order_data.buyer_trade_pubkey = None;
         order_data.seller_trade_pubkey = None;
+        // Entering `waiting-buyer-invoice` starts the *buyer's* waiting
+        // duty, and `taken_at` anchors the timeout clock that
+        // `find_order_by_seconds` / `slash_or_release_on_timeout` blame by
+        // current duty. Restart it here so a seller who stalled through
+        // `waiting-payment` can't eat the buyer's window and get the
+        // buyer's bond wrongly slashed (buy-order mirror of the
+        // `show_hold_invoice` re-anchor). Persisted by the
+        // `updated_order.update` below.
+        order.set_timestamp_now();
         // We ask to buyer for a new invoice
         enqueue_order_msg(
             request_id,
@@ -411,6 +420,53 @@ mod tests {
         let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
         assert_eq!(updated.status, Status::WaitingBuyerInvoice.to_string());
         assert!(updated.invoice_held_at > 0, "invoice_held_at must be set");
+    }
+
+    #[tokio::test]
+    async fn hold_invoice_paid_reanchors_taken_at_for_buyer_duty() {
+        init_global_settings();
+        let pool = create_migrated_pool().await;
+        let hash = "dd".repeat(32);
+        let buyer = create_test_keys().public_key().to_string();
+        let seller = create_test_keys().public_key().to_string();
+        let master_buyer = create_test_keys().public_key().to_string();
+        let order = insert_order_with_hash(
+            &pool,
+            &hash,
+            Status::WaitingBuyerInvoice,
+            None,
+            Some(buyer),
+            Some(seller),
+            Some(master_buyer),
+        )
+        .await;
+        // A counterparty that stalled through its own waiting duty: the
+        // take-time anchor is already past any timeout window when the hold
+        // invoice settles. If this stale value survived the transition, the
+        // scheduler would immediately deem the buyer's brand-new duty
+        // expired and slash their bond.
+        let stale_taken_at = Timestamp::now().as_secs() as i64 - 10_000;
+        sqlx::query("UPDATE orders SET taken_at = ?1 WHERE id = ?2")
+            .bind(stale_taken_at)
+            .bind(order.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let result = hold_invoice_paid(&hash, None, &pool, &create_test_keys()).await;
+        assert!(result.is_ok(), "add-invoice path must succeed: {result:?}");
+
+        let updated = crate::db::find_order_by_hash(&pool, &hash).await.unwrap();
+        assert!(
+            updated.taken_at > stale_taken_at,
+            "entering waiting-buyer-invoice must restart the per-duty timeout clock, got {}",
+            updated.taken_at
+        );
+        assert!(
+            updated.taken_at >= Timestamp::now().as_secs() as i64 - 60,
+            "re-anchored taken_at must be current, got {}",
+            updated.taken_at
+        );
     }
 
     #[tokio::test]

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -349,6 +349,48 @@ pub(crate) async fn notify_users_canceled_order(
     .await;
 }
 
+/// Re-read a timeout candidate and confirm it is *still* eligible before
+/// the scheduler acts on it.
+///
+/// `job_cancel_orders` selects its candidates once per tick
+/// (`find_order_by_seconds`) and then works through them sequentially with
+/// LND round-trips in between, so by the time an order is reached its
+/// snapshot can be arbitrarily stale. Acting on the snapshot is not
+/// harmless: the tick cancels the escrow hold invoice, assigns bond blame
+/// from the waiting status, and cancels/republishes the order — all of
+/// which would hit the wrong party or the wrong state if the order moved
+/// on in the meantime (a duty handoff re-anchored `taken_at` via
+/// `show_hold_invoice` / `hold_invoice_paid`, the trade activated, or a
+/// cancel landed).
+///
+/// Returns the fresh row only when it still holds a waiting status and its
+/// `taken_at` is still past the expiration window — the same predicate as
+/// `find_order_by_seconds`, evaluated on current data. Anything else
+/// (transitioned, re-anchored, missing, or a read error) returns `None`
+/// and the caller must skip; skipping never loses a genuine timeout
+/// because the next tick re-selects it.
+async fn reconfirm_timeout_eligibility(
+    pool: &sqlx::Pool<sqlx::Sqlite>,
+    order_id: uuid::Uuid,
+    exp_seconds: u32,
+) -> Option<Order> {
+    let fresh = match Order::by_id(pool, order_id).await {
+        Ok(Some(fresh)) => fresh,
+        Ok(None) => return None,
+        Err(e) => {
+            warn!(
+                "scheduler_timeout: could not re-read order {} to reconfirm eligibility ({e}); skipping so next tick retries",
+                order_id
+            );
+            return None;
+        }
+    };
+    let still_waiting = fresh.status == Status::WaitingBuyerInvoice.to_string()
+        || fresh.status == Status::WaitingPayment.to_string();
+    let still_expired = fresh.taken_at < Utc::now().timestamp() - exp_seconds as i64;
+    (still_waiting && still_expired).then_some(fresh)
+}
+
 async fn job_cancel_orders(ctx: AppContext) {
     info!("Create a pool to connect to db");
 
@@ -369,6 +411,16 @@ async fn job_cancel_orders(ctx: AppContext) {
 
             if let Ok(older_orders_list) = crate::db::find_order_by_seconds(pool).await {
                 for order in older_orders_list.into_iter() {
+                    // The tick-start snapshot may be stale by the time this
+                    // iteration is reached — re-read and re-confirm before
+                    // acting, so the hold-invoice cancel, the bond blame,
+                    // and the cancel/republish below all run against the
+                    // order's *current* duty rather than the snapshot's.
+                    let Some(order) =
+                        reconfirm_timeout_eligibility(pool, order.id, exp_seconds).await
+                    else {
+                        continue;
+                    };
                     // Check if order is a sell order and Buyer is not sending the invoice for too much time.
                     // Same if seller is not paying hold invoice
                     if order.status == Status::WaitingBuyerInvoice.to_string()
@@ -1392,6 +1444,104 @@ mod tests {
             .filter(|(msg, _)| msg.get_inner_message_kind().id == Some(order_id))
             .map(|(msg, _)| msg.get_inner_message_kind().action.clone())
             .collect()
+    }
+
+    // ── reconfirm_timeout_eligibility ────────────────────────────────────
+
+    /// A waiting order whose duty clock is genuinely past the window stays
+    /// eligible on the re-read: the guard must not swallow real timeouts.
+    #[tokio::test]
+    async fn reconfirm_timeout_eligibility_keeps_still_stale_waiting_order() {
+        let ctx = migrated_ctx().await;
+        let pool = ctx.pool();
+        let mut order = order_for_cancel(Kind::Sell, true);
+        order.taken_at = Utc::now().timestamp() - 10_000;
+        let stored = order.create(pool).await.unwrap();
+
+        let fresh = reconfirm_timeout_eligibility(pool, stored.id, 900).await;
+        assert!(
+            fresh.is_some(),
+            "a genuinely expired waiting order must stay eligible"
+        );
+    }
+
+    /// The wrongful-slash race: the tick snapshot says `waiting-buyer-invoice`
+    /// with an expired clock, but before this order's turn comes up the buyer
+    /// hands off — status flips to `waiting-payment` and the per-duty clock
+    /// re-anchors. Acting on the snapshot would cancel the fresh escrow and
+    /// blame (slash) the seller seconds into their duty.
+    #[tokio::test]
+    async fn reconfirm_timeout_eligibility_skips_after_duty_handoff() {
+        let ctx = migrated_ctx().await;
+        let pool = ctx.pool();
+        let mut order = order_for_cancel(Kind::Sell, true);
+        order.taken_at = Utc::now().timestamp() - 10_000;
+        let stored = order.create(pool).await.unwrap();
+
+        sqlx::query("UPDATE orders SET status = ?1, taken_at = ?2 WHERE id = ?3")
+            .bind(Status::WaitingPayment.to_string())
+            .bind(Utc::now().timestamp())
+            .bind(stored.id)
+            .execute(pool)
+            .await
+            .unwrap();
+
+        assert!(
+            reconfirm_timeout_eligibility(pool, stored.id, 900)
+                .await
+                .is_none(),
+            "a just-started duty must not inherit the snapshot's expiry"
+        );
+    }
+
+    /// Same status but a re-anchored clock is equally ineligible: the guard
+    /// re-evaluates the `find_order_by_seconds` predicate, not just the state.
+    #[tokio::test]
+    async fn reconfirm_timeout_eligibility_skips_reanchored_clock() {
+        let ctx = migrated_ctx().await;
+        let pool = ctx.pool();
+        let mut order = order_for_cancel(Kind::Sell, true);
+        order.taken_at = Utc::now().timestamp() - 10_000;
+        let stored = order.create(pool).await.unwrap();
+
+        sqlx::query("UPDATE orders SET taken_at = ?1 WHERE id = ?2")
+            .bind(Utc::now().timestamp())
+            .bind(stored.id)
+            .execute(pool)
+            .await
+            .unwrap();
+
+        assert!(
+            reconfirm_timeout_eligibility(pool, stored.id, 900)
+                .await
+                .is_none(),
+            "a re-anchored clock is no longer expired"
+        );
+    }
+
+    /// Orders that left the waiting window entirely — or vanished — are
+    /// skipped, never acted on from the stale snapshot.
+    #[tokio::test]
+    async fn reconfirm_timeout_eligibility_skips_terminal_and_missing_orders() {
+        let ctx = migrated_ctx().await;
+        let pool = ctx.pool();
+        let mut order = order_for_cancel(Kind::Sell, true);
+        order.status = Status::Canceled.to_string();
+        order.taken_at = Utc::now().timestamp() - 10_000;
+        let stored = order.create(pool).await.unwrap();
+
+        assert!(
+            reconfirm_timeout_eligibility(pool, stored.id, 900)
+                .await
+                .is_none(),
+            "a terminal order is not timeout-eligible however stale its clock"
+        );
+        assert!(
+            reconfirm_timeout_eligibility(pool, Uuid::new_v4(), 900)
+                .await
+                .is_none(),
+            "a missing row is skipped"
+        );
     }
 
     // ── orderbook reconciler ─────────────────────────────────────────────

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -308,8 +308,11 @@ pub(crate) async fn notify_users_canceled_order(
         }
     };
 
+    // Neutral wording on purpose: this helper serves several closure paths
+    // (waiting-state timeout, hold-invoice cancel, actual cancels), so the
+    // specific cause is logged by each caller, not here.
     tracing::info!(
-        "Notifying maker {} that taker {} canceled the order {}",
+        "Notifying maker {} and taker {} that order {} was not completed",
         maker_pubkey.to_string(),
         taker_pubkey.to_string(),
         old_order.id
@@ -445,7 +448,17 @@ async fn job_cancel_orders(ctx: AppContext) {
                                 );
                                 continue;
                             }
-                            info!("Order Id {}: Funds returned to seller - buyer did not sent regular invoice in time", &order.id);
+                            // A hash exists in both waiting states, but they
+                            // mean different things: in `waiting-payment` the
+                            // hold invoice was never paid (canceling voids
+                            // it), while in `waiting-buyer-invoice` the
+                            // seller already paid it and gets their funds
+                            // back.
+                            if order.status == Status::WaitingPayment.to_string() {
+                                info!("Order Id {}: Hold invoice canceled - seller did not pay it in time", &order.id);
+                            } else {
+                                info!("Order Id {}: Funds returned to seller - buyer did not send their invoice in time", &order.id);
+                            }
                         };
                         let mut order = order.clone();
                         // dev_fee should be reset unconditionally
@@ -547,9 +560,14 @@ async fn job_cancel_orders(ctx: AppContext) {
                                     )
                                     .await;
                                     info!(
-                                "Republishing order Id {}, not received regular invoice in time",
-                                order.id
-                            );
+                                        "Republishing order Id {}, {}",
+                                        order.id,
+                                        if order_status == Status::WaitingPayment {
+                                            "taker (seller) did not pay the hold invoice in time"
+                                        } else {
+                                            "taker (buyer) did not send their invoice in time"
+                                        }
+                                    );
                                     (
                                         Some(Action::NewOrder),
                                         Status::Pending,
@@ -560,9 +578,14 @@ async fn job_cancel_orders(ctx: AppContext) {
                                 | (Status::WaitingPayment, Kind::Sell) => {
                                     // Update order status
                                     info!(
-                                    "Canceled order Id {}, not received regular invoice in time",
-                                    order.id
-                                );
+                                        "Canceled order Id {}, {}",
+                                        order.id,
+                                        if order_status == Status::WaitingPayment {
+                                            "maker (seller) did not pay the hold invoice in time"
+                                        } else {
+                                            "maker (buyer) did not send their invoice in time"
+                                        }
+                                    );
                                     (
                                         Some(Action::Canceled),
                                         Status::Canceled,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1424,6 +1424,15 @@ pub async fn show_hold_invoice(
     order.preimage = Some(bytes_to_string(&preimage));
     order.hash = Some(bytes_to_string(&hash));
     order.status = Status::WaitingPayment.to_string();
+    // `taken_at` anchors the waiting-state timeout clock
+    // (`find_order_by_seconds`), and the blame in
+    // `slash_or_release_on_timeout` falls on whoever holds the current
+    // waiting duty. Entering `waiting-payment` starts the *seller's* duty,
+    // so the clock must restart here: keeping the take-time value would let
+    // a buyer who stalled through `waiting-buyer-invoice` eat the seller's
+    // window and get the maker's bond wrongly slashed. The CAS below
+    // persists this same struct, so the fresh anchor rides the same write.
+    order.set_timestamp_now();
     order.buyer_pubkey = Some(buyer_pubkey.to_string());
     order.seller_pubkey = Some(seller_pubkey.to_string());
 


### PR DESCRIPTION
  The waiting-state timeout clock was anchored on a single `taken_at` written at
  take time and never re-anchored when the order moved between the two waiting
  duties (`waiting-buyer-invoice` ↔ `waiting-payment`). Both duties therefore
  shared one `expiration_seconds` window measured from the take: a counterparty
  could stall through its own duty and leave the other party with seconds (or
  nothing) before the scheduler timed the order out — and, with
  `[anti_abuse_bond]` + `slash_on_waiting_timeout` enabled, got the innocent
  party's bond slashed, since `slash_or_release_on_timeout` blames whoever holds
  the duty when the shared clock expires.

  **Exploit (sell order; the buy mirror works too):** the taker (buyer) stalls
  until ~T0+880s, then submits their invoice. The order enters `waiting-payment`
  with `taken_at` still at T0, so the next scheduler tick already finds it
  expired: the seller's escrow hold invoice is canceled, the **maker's** bond is
  slashed, and the attacker's bond is released — zero cost, deterministic, no
  race. Reproduced live on regtest before the fix.

  Not exploitable on default config (requires the opt-in bond feature with
  `slash_on_waiting_timeout = true` and `apply_to` covering the maker), and it
  also hurts honest users with no adversary: a buyer submitting an invoice one
  minute before the deadline left the seller one minute to pay.

  ## Fix (one commit each)

  1. **Per-duty timeout clock** — re-anchor `taken_at` at every waiting-duty
     handoff, so each party gets the full `expiration_seconds` window for its
     own duty:
     - `show_hold_invoice`: entering `waiting-payment` starts the seller's duty
       (covers the `add_invoice` handoff; harmless on take paths, where
       `taken_at` was just set);
     - `hold_invoice_paid`: entering `waiting-buyer-invoice` starts the buyer's
       duty (buy-order mirror).

     The existing persist writes (`cas_complete_pretrade_take` and the Crud
     update) already carry `taken_at` from the struct — no schema or SQL changes.

  2. **Freshness guard in the scheduler** — `job_cancel_orders` selects its
     candidates once per tick and then does sequential LND work, so a snapshot
     can be stale by the time an order's turn comes up; acting on it would
     cancel a fresh escrow, blame the wrong party, and kill a live order if a
     handoff landed in between. New `reconfirm_timeout_eligibility` re-reads
     each candidate at the top of the loop and skips it unless it *still* holds
     a waiting status with `taken_at` past the window (the
     `find_order_by_seconds` predicate on current data). Skipping is always
     safe: a genuine timeout is re-selected next tick. The guard lives in the
     scheduler rather than inside `slash_or_release_on_timeout` because the
     hold-invoice cancel runs before the slash and the order cancel/republish
   scheduler rather than inside `slash_or_release_on_timeout` because the
   hold-invoice cancel runs before the slash and the order cancel/republish
   after it; the freshness contract is now documented on the slasher.

3. **Status-aware timeout logs** — the timeout path always logged "buyer did
   not sent regular invoice in time" / "taker canceled the order", regardless
   of which duty expired. The three log lines now name the responsible role
   and duty, and `notify_users_canceled_order` uses neutral wording (it

## Testing

- New unit tests: `taken_at` re-anchoring on the `hold_invoice_paid` handoff,
  plus four `reconfirm_timeout_eligibility` cases (genuine timeout stays
  eligible; handoff after snapshot skips; re-anchored clock skips; terminal or
  missing order skips).
- Full suite passes (1181 tests), `cargo fmt` / `cargo clippy` clean on the
  touched files.
- Verified end-to-end on regtest (`expiration_seconds = 300`): before the fix,
  a taker stalling 187s got the maker slashed ~160s into the maker's duty;
  after the fix, `taken_at` re-anchors at the handoff and the seller received
  the full 300s window before a now-legitimate timeout, with the corrected log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order timeout handling by restarting waiting periods when payment responsibilities change.
  * Prevented outdated order information from triggering incorrect cancellations or timeout actions.
  * Added safeguards for completed, missing, or reassigned orders.
  * Improved timeout notifications and messages to clarify whether buyer or seller action is required.
  * Updated timeout-slash guidance to ensure cancellations use the latest eligibility-verified order state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->