### PR TITLE
fix: report retry interval in seconds, not minutes

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -226,7 +226,7 @@ async fn job_retry_failed_payments(ctx: AppContext) {
     tokio::spawn(async move {
         loop {
             info!(
-                "I run async every {} minutes - checking for failed lighting payment",
+                "I run async every {} seconds - checking for failed lightning payment",
                 interval
             );
 


### PR DESCRIPTION
## What

`job_retry_failed_payments` announces its cadence in minutes while printing a
value expressed in seconds:

```rust
// src/scheduler.rs:224
let interval = ln_settings.payment_retries_interval as u64;
...
info!(
    "I run async every {} minutes - checking for failed lighting payment",
    interval
);
...
tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
```

Two words change on that line: `minutes` → `seconds`, and `lighting` →
`lightning`.

## Why the code is right and the message is wrong

The unit is unambiguous everywhere else:

- the same loop sleeps `Duration::from_secs(interval)`;
- `README.md:563` — `payment_retries_interval = 60  # seconds between retries`;
- `docs/STARTUP_AND_CONFIG.md:112` — "Retry interval in seconds (default: 60)";
- `docs/LIGHTNING_OPS.md:115` — `// Seconds between retries (default: 60)`;
- `settings.tpl.toml:19` ships `60`.

So with the shipped default the job runs once a minute and reports once an
hour — a factor of sixty, in the direction that makes an operator wait.

What settles it as a slip rather than a local convention is
`job_update_rate_events`, eighty lines below in the same file:

```rust
// src/scheduler.rs:319-326
let interval = mostro_settings.user_rates_sent_interval_seconds as u64;
...
info!(
    "I run async every {} minutes - update rate event of users",
    interval / 60
);
```

Same phrasing, same seconds-valued setting — but converted. Two sibling jobs,
one honoured the conversion and the other did not.

## How it surfaced

While operating a live instance I needed to know whether the retry job had
already swept a buyer payout stranded in `settled-hold-invoice`. The log line
implied the next sweep was an hour off, so the natural reading was that
nothing had happened yet. Comparing timestamps showed it had run three times
in the preceding three minutes:

```
INFO mostrod::scheduler: I run async every 60 minutes - checking for failed lighting payment
INFO mostrod::scheduler: I run async every 60 minutes - checking for failed lighting payment
INFO mostrod::scheduler: I run async every 60 minutes - checking for failed lighting payment
```

Sixty seconds apart. During an incident that is the difference between "the
retry has not been attempted" and "the retry has already been attempted and
did not fire", which are opposite conclusions about whether to intervene by
hand.

## Testing

`cargo test --bin mostrod` — 1199 passed, 0 failed.
`cargo clippy --all-targets -- -D warnings` — clean.
`cargo fmt --check` — clean.

No test is added: the change is the wording of a log line, with no observable
behaviour to assert. Asserting on log output would couple the suite to a
string without testing anything real.

## Notes for the reviewer

- `test_lighting_settings` in `src/config/mod.rs:184` carries the same
  misspelling. Left untouched — renaming a test is a different change from
  correcting operator-facing output, and it belongs in whatever PR next touches
  that module.
- `job_update_rate_events` computes `interval / 60` with integer division, so
  an interval under 60 seconds would report `0 minutes`. Out of scope here and
  not currently reachable with the shipped defaults, but flagging it in case
  you want it tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the failed Lightning payment job log message.
  * The retry interval is now reported in seconds for clearer diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->