### PR TITLE
fix: clear next-trade fields on sell child orders

### DIFF
--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -416,6 +416,10 @@ fn handle_sell_child_order(
         }
     }
 
+    // Clear next trade fields for sell order
+    child_order.next_trade_index = None;
+    child_order.next_trade_pubkey = None;
+
     Ok((
         child_order.seller_pubkey.clone(),
         child_order.trade_index_seller,
@@ -1729,6 +1733,23 @@ mod tests {
         let mut child = fiat_sent_sell_order(seller, buyer);
         handle_sell_child_order(&mut child, Some((next_seller.to_string(), 3)), None).unwrap();
         assert_eq!(child.master_seller_pubkey, Some(next_seller.to_string()));
+    }
+
+    #[test]
+    fn handle_sell_child_order_clears_next_trade_fields() {
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+        let next_seller = Keys::generate().public_key();
+
+        // The child is cloned from the parent, next-trade fields included.
+        let mut child = fiat_sent_sell_order(seller, buyer);
+        child.next_trade_pubkey = Some(next_seller.to_string());
+        child.next_trade_index = Some(9);
+
+        handle_sell_child_order(&mut child, Some((next_seller.to_string(), 3)), None).unwrap();
+
+        assert_eq!(child.next_trade_pubkey, None);
+        assert_eq!(child.next_trade_index, None);
     }
 
     // ---------------------------------------------------------------

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -377,10 +377,6 @@ fn handle_buy_child_order(
         }
     }
 
-    // Clear next trade fields for buy order
-    child_order.next_trade_index = None;
-    child_order.next_trade_pubkey = None;
-
     Ok((
         child_order.buyer_pubkey.clone(),
         child_order.trade_index_buyer,
@@ -415,10 +411,6 @@ fn handle_sell_child_order(
             child_order.master_seller_pubkey = Some(next_trade_pubkey.to_string());
         }
     }
-
-    // Clear next trade fields for sell order
-    child_order.next_trade_index = None;
-    child_order.next_trade_pubkey = None;
 
     Ok((
         child_order.seller_pubkey.clone(),
@@ -1012,6 +1004,10 @@ fn create_base_order(order: &Order) -> Result<Order, MostroError> {
     new_order.taken_at = 0;
     new_order.invoice_held_at = 0;
     new_order.range_parent_id = Some(order.id);
+    // The next-trade rotation is consumed by the time a child is spawned —
+    // it is how the child got its counterparty. Never carry it forward.
+    new_order.next_trade_index = None;
+    new_order.next_trade_pubkey = None;
 
     match new_order.get_order_kind().map_err(MostroInternalErr)? {
         mostro_core::order::Kind::Sell => {
@@ -1522,6 +1518,8 @@ mod tests {
         order.max_amount = Some(100);
         order.min_amount = Some(10);
         order.fiat_amount = 40;
+        order.next_trade_pubkey = Some(Keys::generate().public_key().to_string());
+        order.next_trade_index = Some(9);
         let order = order.create(&pool).await.unwrap();
         let event = create_unwrapped_message_with_pubkey(seller);
         let msg = release_message(
@@ -1547,6 +1545,8 @@ mod tests {
         assert_eq!(child.fiat_amount, 0);
         assert_eq!(child.seller_pubkey, Some(next_seller.to_string()));
         assert_eq!(child.trade_index_seller, Some(2));
+        assert_eq!(child.next_trade_pubkey, None);
+        assert_eq!(child.next_trade_index, None);
         assert!(queued_actions_for(child.id)
             .await
             .contains(&Action::NewOrder));
@@ -1661,8 +1661,6 @@ mod tests {
         assert_eq!(trade_index, Some(5));
         assert_eq!(child.master_buyer_pubkey, Some(idkey));
         assert_eq!(child.creator_pubkey, next_buyer.to_string());
-        assert_eq!(child.next_trade_pubkey, None);
-        assert_eq!(child.next_trade_index, None);
     }
 
     #[test]
@@ -1735,23 +1733,6 @@ mod tests {
         assert_eq!(child.master_seller_pubkey, Some(next_seller.to_string()));
     }
 
-    #[test]
-    fn handle_sell_child_order_clears_next_trade_fields() {
-        let seller = Keys::generate().public_key();
-        let buyer = Keys::generate().public_key();
-        let next_seller = Keys::generate().public_key();
-
-        // The child is cloned from the parent, next-trade fields included.
-        let mut child = fiat_sent_sell_order(seller, buyer);
-        child.next_trade_pubkey = Some(next_seller.to_string());
-        child.next_trade_index = Some(9);
-
-        handle_sell_child_order(&mut child, Some((next_seller.to_string(), 3)), None).unwrap();
-
-        assert_eq!(child.next_trade_pubkey, None);
-        assert_eq!(child.next_trade_index, None);
-    }
-
     // ---------------------------------------------------------------
     // handle_child_order
     // ---------------------------------------------------------------
@@ -1768,9 +1749,7 @@ mod tests {
         order.creator_pubkey = buyer.to_string();
         order.next_trade_pubkey = Some(next_buyer.to_string());
         order.next_trade_index = Some(4);
-        let mut child = order.clone();
-        child.id = uuid::Uuid::new_v4();
-        child.status = Status::Pending.to_string();
+        let child = create_base_order(&order).unwrap();
 
         // Act
         let result = handle_child_order(child.clone(), &order, None, &pool, None).await;
@@ -1780,6 +1759,8 @@ mod tests {
         let db_child = Order::by_id(&pool, child.id).await.unwrap().unwrap();
         assert_eq!(db_child.buyer_pubkey, Some(next_buyer.to_string()));
         assert_eq!(db_child.trade_index_buyer, Some(4));
+        assert_eq!(db_child.next_trade_pubkey, None);
+        assert_eq!(db_child.next_trade_index, None);
         assert!(queued_actions_for(child.id)
             .await
             .contains(&Action::NewOrder));
@@ -1792,10 +1773,12 @@ mod tests {
         let seller = Keys::generate().public_key();
         let buyer = Keys::generate().public_key();
         let next_seller = Keys::generate().public_key();
-        let order = fiat_sent_sell_order(seller, buyer);
-        let mut child = order.clone();
-        child.id = uuid::Uuid::new_v4();
-        child.status = Status::Pending.to_string();
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        // Seed the rotation on the parent. `create_base_order` is the only
+        // path that builds a child, so this is the shape production sees.
+        order.next_trade_pubkey = Some(Keys::generate().public_key().to_string());
+        order.next_trade_index = Some(9);
+        let child = create_base_order(&order).unwrap();
 
         // Act
         let result = handle_child_order(
@@ -1812,6 +1795,8 @@ mod tests {
         let db_child = Order::by_id(&pool, child.id).await.unwrap().unwrap();
         assert_eq!(db_child.seller_pubkey, Some(next_seller.to_string()));
         assert_eq!(db_child.trade_index_seller, Some(6));
+        assert_eq!(db_child.next_trade_pubkey, None);
+        assert_eq!(db_child.next_trade_index, None);
     }
 
     #[tokio::test]
@@ -1861,7 +1846,9 @@ mod tests {
     fn create_base_order_resets_trade_state_for_sell_orders() {
         let seller = Keys::generate().public_key();
         let buyer = Keys::generate().public_key();
-        let order = fiat_sent_sell_order(seller, buyer);
+        let mut order = fiat_sent_sell_order(seller, buyer);
+        order.next_trade_pubkey = Some(Keys::generate().public_key().to_string());
+        order.next_trade_index = Some(9);
 
         let base = create_base_order(&order).unwrap();
 
@@ -1877,6 +1864,9 @@ mod tests {
         assert_eq!(base.trade_index_buyer, None);
         // ... and keep the seller side.
         assert_eq!(base.seller_pubkey, order.seller_pubkey);
+        // ... and drop the consumed next-trade rotation.
+        assert_eq!(base.next_trade_pubkey, None);
+        assert_eq!(base.next_trade_index, None);
     }
 
     #[test]


### PR DESCRIPTION
Closes #817

## What

`handle_sell_child_order` gains the two lines its buy-path sibling already has:

```rust
// Clear next trade fields for sell order
child_order.next_trade_index = None;
child_order.next_trade_pubkey = None;
```

## Why the child inherits them at all

`create_base_order` derives the child from the parent by cloning it:

```rust
// src/app/release.rs:1001
fn create_base_order(order: &Order) -> Result<Order, MostroError> {
    let mut new_order = order.clone();
    new_order.id = uuid::Uuid::new_v4();
    ...
```

It then resets the fields that must not carry over — `status`, `amount`, `hash`, `preimage`, `buyer_invoice`, `taken_at`, `invoice_held_at` — and blanks the counterparty side per order kind. The next-trade pair is not in that list, so it reaches both helpers still populated, and clearing it is left to them.

`handle_buy_child_order` does it (`src/app/release.rs:379-381`).
`handle_sell_child_order` returns without doing it.

The fields describe who takes over *after* the current trade. By the time a child is spawned that rotation has already been consumed — it is precisely how the child got its seller. Carrying the pair forward leaves the new order advertising a hand-off that already happened.

## That the path is reachable, not theoretical

Those fields are written in exactly one place:

```rust
// src/app/fiat_sent.rs:77-85
// If this is a range order, we need to update next trade fields
if order.is_range_order() {
    // Update next trade fields only when the buyer is the maker of a range order
    // These fields will be used to create the next child order in the range
    if let Some((pubkey, index)) = next_trade {
        order_updated.next_trade_pubkey = Some(pubkey);
        order_updated.next_trade_index = Some(index as i64);
    }
}
```

`fiat-sent` is a buyer action, and the guard is `is_range_order()` alone — the comment says the update is meant for buyer-maker ranges, but nothing checks it. So on a **sell** range order, where the maker is the seller, a buyer who includes a next-trade key still writes it to the parent row. Release then spawns the sell child, and the child was persisted carrying a key supplied by the counterparty of the finished trade.

**Persisted, not published.** `mostro-core-0.14.5/src/db/order.rs:53,102` binds `next_trade_pubkey` on insert, so the stale value did reach the child row. It never went over the wire, though: `SmallOrder` carries no next-trade fields and `as_new_order()` does not populate them, so the `NewOrder` message never contained the pair; and `order_to_tags` emits no next-trade tag, so neither did the 38383 event. The honest severity is hygiene — dead state that looks like live state — not disclosure.

**The parent row is out of scope here.** `fiat_sent.rs:77-85` wrote the pair to the **parent**, and nothing clears it there; this PR only stops it propagating to the child. Whether that guard should also check makership is the actual root cause and a separate question from the symmetry #817 reports, so I have deliberately not touched `fiat_sent.rs`. There is no issue tracking it yet — happy to open one, or to tighten the guard in a follow-up PR, if you want it addressed.


## Testing

New test `handle_sell_child_order_clears_next_trade_fields`, mirroring the assertions `handle_buy_child_order_uses_identity_key_in_normal_mode` already makes on the buy side (`src/app/release.rs:1660-1661`).

Confirmed it fails before the fix and passes after — in that order:

```
---- app::release::tests::handle_sell_child_order_clears_next_trade_fields stdout ----
assertion `left == right` failed
  left: Some("4efdb55da63145f8445006a0d431342c62bb33bf7370d20f9342828d9ba607b6")
 right: None
```

With the fix applied:

```
cargo test --bin mostrod        1200 passed; 0 failed; 2 ignored
cargo clippy --all-targets -- -D warnings   clean
cargo fmt --check                           clean
```

## Notes for the reviewer

- The comment wording copies the buy path (`// Clear next trade fields for
  sell order`) so the two branches read identically side by side. Say the word if you would rather it explained the reasoning instead.
- The existing end-to-end test `release_action_creates_child_order_for_range_order` is left as-is: it builds a parent with no next-trade fields set, so it never exercised this. The new unit test targets the helper directly, which is where the asymmetry lives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed child orders retaining inherited next-trade rotation details when first created.
  * Ensured persisted child orders start with cleared next-trade fields for more reliable order processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->