### PR TITLE
fix(yadio): canonicalise currency codes to uppercase

### DIFF
--- a/src/price/providers/yadio.rs
+++ b/src/price/providers/yadio.rs
@@ -47,7 +47,9 @@ impl YadioProvider {
             .btc
             .into_iter()
             .filter_map(|(code, value)| match value {
-                Some(v) if v.is_finite() && v > 0.0 => Some((code.to_uppercase(), Quote::PerBtc(v))),
+                Some(v) if v.is_finite() && v > 0.0 => {
+                    Some((code.to_uppercase(), Quote::PerBtc(v)))
+                }
                 _ => None,
             })
             .collect())
@@ -117,7 +119,10 @@ mod tests {
         let quotes = YadioProvider::parse(body).unwrap();
         assert_eq!(quotes.get("USD"), Some(&Quote::PerBtc(75_000.0)));
         assert_eq!(quotes.get("EUR"), Some(&Quote::PerBtc(65_000.0)));
-        assert!(!quotes.contains_key("usd"), "raw lowercase key must not survive");
+        assert!(
+            !quotes.contains_key("usd"),
+            "raw lowercase key must not survive"
+        );
     }
 
     #[test]

--- a/src/price/providers/yadio.rs
+++ b/src/price/providers/yadio.rs
@@ -48,6 +48,8 @@ impl YadioProvider {
             .into_iter()
             .filter_map(|(code, value)| match value {
                 Some(v) if v.is_finite() && v > 0.0 => {
+                    // Yadio ships uppercase codes today; canonicalise anyway so
+                    // the adapter honours §6.6 even if the API drifts.
                     Some((code.to_uppercase(), Quote::PerBtc(v)))
                 }
                 _ => None,
@@ -115,8 +117,9 @@ mod tests {
 
     #[test]
     fn canonicalises_lowercase_currency_codes() {
-        let body = r#"{"BTC": {"usd": 75000.0, "eur": 65000.0}}"#;
+        let body = r#"{"BTC": {"usd": 75000.0, "Eur": 65000.0}}"#;
         let quotes = YadioProvider::parse(body).unwrap();
+        assert_eq!(quotes.len(), 2, "only the two canonical keys survive");
         assert_eq!(quotes.get("USD"), Some(&Quote::PerBtc(75_000.0)));
         assert_eq!(quotes.get("EUR"), Some(&Quote::PerBtc(65_000.0)));
         assert!(

--- a/src/price/providers/yadio.rs
+++ b/src/price/providers/yadio.rs
@@ -47,7 +47,7 @@ impl YadioProvider {
             .btc
             .into_iter()
             .filter_map(|(code, value)| match value {
-                Some(v) if v.is_finite() && v > 0.0 => Some((code, Quote::PerBtc(v))),
+                Some(v) if v.is_finite() && v > 0.0 => Some((code.to_uppercase(), Quote::PerBtc(v))),
                 _ => None,
             })
             .collect())
@@ -109,6 +109,15 @@ mod tests {
         let quotes = YadioProvider::parse(body).unwrap();
         assert_eq!(quotes.len(), 1, "only GBP is a usable rate");
         assert_eq!(quotes.get("GBP"), Some(&Quote::PerBtc(50_000.0)));
+    }
+
+    #[test]
+    fn canonicalises_lowercase_currency_codes() {
+        let body = r#"{"BTC": {"usd": 75000.0, "eur": 65000.0}}"#;
+        let quotes = YadioProvider::parse(body).unwrap();
+        assert_eq!(quotes.get("USD"), Some(&Quote::PerBtc(75_000.0)));
+        assert_eq!(quotes.get("EUR"), Some(&Quote::PerBtc(65_000.0)));
+        assert!(!quotes.contains_key("usd"), "raw lowercase key must not survive");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `.to_uppercase()` to the currency code at `yadio.rs:50`, making Yadio the sixth of six adapters to honour the §6.6 canonicalisation contract.
- Adds a `canonicalises_lowercase_currency_codes` test that feeds lowercase codes through `parse()` and asserts they emerge uppercase (and that the raw lowercase key is absent) — matching the pattern in `blockchain.rs` and `coingecko.rs`.

## Test plan

- [x] `cargo test price::providers::yadio` — all 5 tests pass
- [x] No behaviour change in production (Yadio ships uppercase codes today; this is a defensive correctness fix)

Closes #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Currency codes from Yadio responses are now consistently normalized to uppercase.
  * Prevented lowercase currency keys from being retained during processing.

* **Tests**
  * Added coverage to verify currency code normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->