### PR TITLE
fix: stamp dispute events with a monotonic created_at

### DIFF
--- a/src/app/admin_take_dispute.rs
+++ b/src/app/admin_take_dispute.rs
@@ -201,6 +201,36 @@ pub async fn admin_take_dispute_action(
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
+    // Get the creator of the dispute
+    let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
+        (true, false) => "seller",
+        (false, true) => "buyer",
+        (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
+    };
+
+    // We create a tag to show status of the dispute
+    let tags = create_dispute_event_tags(
+        Status::InProgress.to_string(),
+        dispute_initiator,
+        dispute.created_at,
+        ctx.settings().mostro.name.as_deref(),
+    );
+    // nip33 kind with dispute id as identifier (kind 38386 for disputes).
+    //
+    // Built here, adjacent to the transition it advertises, rather than
+    // after the notifications below: `new_dispute_event` stamps the
+    // revision from the per-dispute monotonic registry, and relays resolve
+    // kind-38386 replacement by `created_at`, not by arrival order. Signing
+    // it three DM round-trips later would let a concurrent finalizer
+    // (`admin_settle_action`, `admin_cancel_action`) — which becomes
+    // reachable the moment the solver above is persisted — commit and stamp
+    // `settled` first, and this older `in-progress` would then claim the
+    // larger timestamp and replace the terminal status on relays. Stamping
+    // at the committed transition keeps timestamp order equal to state
+    // order; the send itself stays below and can arrive whenever.
+    let dispute_event = new_dispute_event(mostro_keys, "", dispute.id.to_string(), tags)
+        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
+
     // Prepare payload for solver information message
     let dispute_info = prepare_solver_info_message(pool, &order, &dispute).await?;
 
@@ -255,28 +285,11 @@ pub async fn admin_take_dispute_action(
     .await
     .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
 
-    // Get the creator of the dispute
-    let dispute_initiator = match (order.seller_dispute, order.buyer_dispute) {
-        (true, false) => "seller",
-        (false, true) => "buyer",
-        (_, _) => return Err(MostroInternalErr(ServiceError::DisputeEventError)),
-    };
-
-    // We create a tag to show status of the dispute
-    let tags = create_dispute_event_tags(
-        Status::InProgress.to_string(),
-        dispute_initiator,
-        dispute.created_at,
-        ctx.settings().mostro.name.as_deref(),
-    );
-    // nip33 kind with dispute id as identifier (kind 38386 for disputes)
-    let event = new_dispute_event(mostro_keys, "", dispute.id.to_string(), tags)
-        .map_err(|e| MostroInternalErr(ServiceError::NostrError(e.to_string())))?;
-    info!("Dispute event to be published: {event:#?}");
+    info!("Dispute event to be published: {dispute_event:#?}");
 
     let client = ctx.nostr_client();
     client
-        .send_event(&event)
+        .send_event(&dispute_event)
         .await
         .map_err(|e| {
             info!("Failed to send dispute {} status event: {}", dispute.id, e);
@@ -844,6 +857,77 @@ mod tests {
             Some(solver_keys.public_key().to_string())
         );
         assert!(stored.taken_at > 0);
+    }
+
+    /// Regression guard for the kind-38386 stamping order.
+    ///
+    /// `new_dispute_event` draws each revision's `created_at` from the
+    /// per-dispute monotonic registry, and relays resolve replacement by
+    /// that timestamp. So the stamp has to be taken where the transition is
+    /// committed, not after the notification round-trips below it: a
+    /// concurrent finalizer becomes reachable as soon as the solver is
+    /// persisted, and if it committed and stamped `settled` first, a
+    /// late-stamped `in-progress` would take the larger timestamp and
+    /// replace the terminal status on relays.
+    ///
+    /// The observation point here is a solver-payload failure: the order
+    /// carries an unparsable buyer pubkey, so the handler aborts right
+    /// after committing the take and before it would have stamped under
+    /// the old ordering. The dispute must already hold a registry entry by
+    /// then — a tiny candidate timestamp shows it, since an existing entry
+    /// bumps it and a missing one lets it through unchanged.
+    #[tokio::test]
+    async fn dispute_event_is_stamped_before_the_notification_round_trips() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let mostro_keys = Keys::generate();
+        let solver_keys = Keys::generate();
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        insert_solver(
+            &pool,
+            &solver_keys.public_key().to_string(),
+            SOLVER_CATEGORY_READ_WRITE,
+        )
+        .await;
+
+        let mut order = create_dispute_order(buyer, seller);
+        order.buyer_dispute = true;
+        // Aborts the handler between the commit and the notifications.
+        order.buyer_pubkey = Some("not-a-pubkey".to_string());
+        let order = order.create(&pool).await.unwrap();
+        let dispute = Dispute::new(order.id, Status::Active.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        let event = create_admin_event(solver_keys.public_key());
+        let result = admin_take_dispute_action(
+            &ctx,
+            take_dispute_msg(Some(dispute.id)),
+            &event,
+            &mostro_keys,
+        )
+        .await;
+        assert!(
+            matches!(result, Err(MostroInternalErr(ServiceError::InvalidPubkey))),
+            "expected the handler to abort on the unparsable buyer pubkey, got {result:?}"
+        );
+        // The take is committed: a concurrent finalizer is reachable from here.
+        let stored = Dispute::by_id(&pool, dispute.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, DisputeStatus::InProgress.to_string());
+
+        let probe = crate::util::monotonic_dispute_event_timestamp(
+            &dispute.id.to_string(),
+            Timestamp::from(1),
+        );
+        assert!(
+            probe.as_secs() > 1,
+            "taking a dispute must stamp its kind-38386 revision at the committed \
+             transition, not after the notification round-trips a concurrent \
+             finalizer can overtake"
+        );
     }
 
     #[tokio::test]

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -2,7 +2,7 @@ use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
 use crate::config::settings::Settings;
 use crate::config::types::{BondApplyTo, MostroSettings};
 use crate::lightning::LnStatus;
-use crate::util::{get_expiration_timestamp_for_kind, get_keys};
+use crate::util::{get_expiration_timestamp_for_kind, get_keys, monotonic_dispute_event_timestamp};
 use crate::LN_STATUS;
 use mostro_core::prelude::*;
 use nostr::error::Error;
@@ -167,13 +167,23 @@ pub fn new_dispute_event(
     identifier: String,
     extra_tags: Tags,
 ) -> Result<Event, Error> {
+    // Every kind-38386 publish funnels through here, so this is where the
+    // replaceable-event ordering is enforced — no call site can forget it.
+    //
+    // "Signed now" alone is not enough: two revisions of the same dispute
+    // that land in the same Unix second tie on `created_at`, and the relay
+    // then breaks the tie by lowest event id instead of by order, silently
+    // discarding the newer status. Stamp each revision strictly after the
+    // previous one published for this dispute.
+    let created_at = monotonic_dispute_event_timestamp(&identifier, Timestamp::now());
+
     create_event(
         keys,
         content,
         identifier,
         extra_tags,
         NOSTR_DISPUTE_EVENT_KIND,
-        None,
+        Some(created_at),
     )
 }
 
@@ -181,8 +191,10 @@ pub fn new_dispute_event(
 ///
 /// `created_at` is the dispute open time from SQLite (`disputes.created_at`),
 /// carried as a business tag so clients can show when the dispute was opened.
-/// It is independent of the Nostr event's `created_at`, which stays as "signed
-/// now" for NIP-33 replaceable-event ordering.
+/// It is independent of the Nostr event's `created_at`, which stays "now"
+/// (bumped past the dispute's previous revision when they share a second, see
+/// [`new_dispute_event`]) so NIP-33 replacement keeps resolving to the latest
+/// status.
 pub fn create_dispute_event_tags(
     status: impl Into<String>,
     initiator: impl Into<String>,
@@ -1248,6 +1260,10 @@ mod tests {
 
     /// Kind-38386 `event.created_at` stays "signed now"; the business open
     /// time lives only on the `created_at` tag so NIP-33 replace still works.
+    ///
+    /// Uses a `d` tag unique to this test: `created_at` is now stamped
+    /// monotonically per dispute, so a first revision only equals wall-clock
+    /// now when no other test has published under the same identifier.
     #[test]
     fn new_dispute_event_keeps_nostr_created_at_independent_of_open_time_tag() {
         init_test_settings();
@@ -1255,7 +1271,7 @@ mod tests {
         let opened_at = 1_600_000_000_i64;
         let tags = super::create_dispute_event_tags("initiated", "seller", opened_at, None);
         let before = Timestamp::now().as_secs();
-        let event = super::new_dispute_event(&keys, "", "dispute-id".to_string(), tags)
+        let event = super::new_dispute_event(&keys, "", "dispute-open-time-tag".to_string(), tags)
             .expect("dispute event");
         let after = Timestamp::now().as_secs();
 
@@ -1269,6 +1285,68 @@ mod tests {
             Some("1600000000")
         );
         assert_ne!(event.created_at.as_secs() as i64, opened_at);
+    }
+
+    /// Regression guard for the bug this stamping exists to prevent: a
+    /// dispute opened and then taken by a solver within the same Unix second
+    /// produced two kind-38386 events with an identical `created_at`. Relays
+    /// break that tie by lowest event id, not by order, so `in-progress`
+    /// could lose to `initiated` and never reach clients.
+    ///
+    /// Both events are built back to back here, which is exactly the
+    /// same-second case; the assertion is on strict ordering, so it holds
+    /// whether or not the two calls straddle a second boundary.
+    #[test]
+    fn consecutive_dispute_revisions_never_share_a_created_at() {
+        init_test_settings();
+        let keys = Keys::generate();
+        let dispute_id = "same-second-dispute".to_string();
+
+        let opened = super::new_dispute_event(
+            &keys,
+            "",
+            dispute_id.clone(),
+            super::create_dispute_event_tags("initiated", "buyer", 1_600_000_000, None),
+        )
+        .expect("initiated event");
+        let taken = super::new_dispute_event(
+            &keys,
+            "",
+            dispute_id,
+            super::create_dispute_event_tags("in-progress", "buyer", 1_600_000_000, None),
+        )
+        .expect("in-progress event");
+
+        assert!(
+            taken.created_at > opened.created_at,
+            "a later dispute revision must carry a strictly later created_at \
+             (opened at {}, taken at {}), otherwise the relay resolves the two \
+             by lowest event id and can keep the stale status",
+            opened.created_at.as_secs(),
+            taken.created_at.as_secs()
+        );
+    }
+
+    /// The monotonic bump is scoped to one dispute: an unrelated dispute
+    /// published in the same second must still be stamped with plain "now",
+    /// never pushed into the future by another dispute's activity.
+    #[test]
+    fn dispute_stamping_does_not_leak_across_identifiers() {
+        init_test_settings();
+        let keys = Keys::generate();
+        let tags = || super::create_dispute_event_tags("initiated", "buyer", 1_600_000_000, None);
+
+        let before = Timestamp::now().as_secs();
+        let _first = super::new_dispute_event(&keys, "", "dispute-alpha".to_string(), tags())
+            .expect("alpha");
+        let second =
+            super::new_dispute_event(&keys, "", "dispute-beta".to_string(), tags()).expect("beta");
+        let after = Timestamp::now().as_secs();
+
+        assert!(
+            second.created_at.as_secs() >= before && second.created_at.as_secs() <= after,
+            "a different dispute must be stamped with wall-clock now"
+        );
     }
 
     // ── Dev-fee audit event tag list: end-to-end y-tag emission (kind 8383) ─────
@@ -1387,8 +1465,12 @@ mod tests {
             "info events must not carry an expiration tag"
         );
 
-        let dispute = super::new_dispute_event(&keys, "", "dispute-id".to_string(), tags.clone())
-            .expect("dispute event");
+        // `d` tag unique to this test: dispute `created_at` is stamped
+        // monotonically per identifier, so sharing one across tests would
+        // couple them through the process-wide registry.
+        let dispute =
+            super::new_dispute_event(&keys, "", "dispute-expiration".to_string(), tags.clone())
+                .expect("dispute event");
         assert_eq!(dispute.kind.as_u16(), NOSTR_DISPUTE_EVENT_KIND);
 
         let stamped = super::new_order_event_with_created_at(

--- a/src/util.rs
+++ b/src/util.rs
@@ -1109,9 +1109,18 @@ pub(crate) fn monotonic_order_event_timestamp(order_id: Uuid, candidate: Timesta
 /// orderbook's generation counter.
 ///
 /// Process-local by design, exactly as for orders: this daemon's key is the
-/// only legitimate publisher of its disputes' events, and two publishes for
-/// the same dispute on opposite sides of a restart cannot land in the same
-/// second in practice.
+/// only legitimate publisher of its disputes' events, so nothing outside
+/// this process can stamp a revision that has to be ordered against these.
+///
+/// A restart therefore drops the map, and the residual is bounded and
+/// accepted rather than persisted: a bump only ever pushes a revision one
+/// second past the previous one, so the map is "ahead" of wall clock only
+/// while a burst of revisions is being published inside a single second.
+/// Losing the state matters only if the daemon dies *and* comes back
+/// inside that window — a restart takes far longer than the fraction of a
+/// second it lasts. Persisting a value that is stale by construction (the
+/// relay may have rejected the revision it records) would buy no ordering
+/// guarantee the wall clock does not already give after a restart.
 static DISPUTE_EVENT_TIMESTAMPS: std::sync::LazyLock<std::sync::Mutex<HashMap<String, u64>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1004,21 +1004,41 @@ pub(crate) struct OrderbookStamp {
     pub generation: u64,
 }
 
+/// Next `created_at` for a revision of the replaceable event identified by
+/// `key`: `candidate`, bumped to strictly after the last revision recorded
+/// for the same key (`max(candidate, last + 1)`), then recorded.
+///
+/// This is the whole NIP-01 tie-break defence in one place: relays resolve
+/// two replaceable events sharing `(kind, pubkey, d)` *and* `created_at` by
+/// keeping the lowest event id, so consecutive revisions that land in the
+/// same Unix second must never tie. Prunes entries too old to ever tie
+/// again once the map grows past [`ORDER_TS_PRUNE_THRESHOLD`].
+///
+/// Generic over the key so the kind-38383 orderbook registry (keyed by
+/// order id) and the kind-38386 dispute registry (keyed by `d` tag) share
+/// one implementation of the rule.
+fn monotonic_created_at<K: std::hash::Hash + Eq>(
+    last_ts: &mut HashMap<K, u64>,
+    key: K,
+    candidate: u64,
+) -> u64 {
+    let effective = match last_ts.get(&key) {
+        Some(&last) => candidate.max(last + 1),
+        None => candidate,
+    };
+    if last_ts.len() >= ORDER_TS_PRUNE_THRESHOLD {
+        last_ts.retain(|_, &mut ts| ts + ORDER_TS_MAX_AGE_SECS > effective);
+    }
+    last_ts.insert(key, effective);
+    effective
+}
+
 fn stamp_locked(
     registry: &mut OrderbookRegistry,
     order_id: Uuid,
     candidate: u64,
 ) -> OrderbookStamp {
-    let effective = match registry.last_ts.get(&order_id) {
-        Some(&last) => candidate.max(last + 1),
-        None => candidate,
-    };
-    if registry.last_ts.len() >= ORDER_TS_PRUNE_THRESHOLD {
-        registry
-            .last_ts
-            .retain(|_, &mut ts| ts + ORDER_TS_MAX_AGE_SECS > effective);
-    }
-    registry.last_ts.insert(order_id, effective);
+    let effective = monotonic_created_at(&mut registry.last_ts, order_id, candidate);
     registry.generation += 1;
     OrderbookStamp {
         created_at: Timestamp::from(effective),
@@ -1069,6 +1089,44 @@ pub(crate) fn try_stamp_orderbook_event_quiescent(
 /// only need the timestamp half of [`stamp_orderbook_event`].
 pub(crate) fn monotonic_order_event_timestamp(order_id: Uuid, candidate: Timestamp) -> Timestamp {
     stamp_orderbook_event(order_id, candidate).created_at
+}
+
+/// Last `created_at` published per kind-38386 `d` tag (the dispute id).
+///
+/// Dispute events face the same NIP-01 hazard [`ORDERBOOK_REGISTRY`] solves
+/// for orders, and it bites harder: a dispute's transitions are driven by
+/// clients reacting to each other, so they routinely land in the *same*
+/// Unix second as the event before them — a solver taking a dispute the
+/// moment it is opened is two publishes milliseconds apart. On a tie the
+/// relay keeps the lowest event id, a coin flip that can leave `initiated`
+/// as the state on relays while the daemon's DB already says `in-progress`.
+/// The daemon believes it published; clients never see the dispute advance.
+///
+/// Kept separate from [`ORDERBOOK_REGISTRY`] rather than sharing its map:
+/// dispute events carry none of the publication-generation and republish
+/// bookkeeping the orderbook reconciler needs, so they only need the
+/// timestamp half — and a shared map would let dispute publishes bump the
+/// orderbook's generation counter.
+///
+/// Process-local by design, exactly as for orders: this daemon's key is the
+/// only legitimate publisher of its disputes' events, and two publishes for
+/// the same dispute on opposite sides of a restart cannot land in the same
+/// second in practice.
+static DISPUTE_EVENT_TIMESTAMPS: std::sync::LazyLock<std::sync::Mutex<HashMap<String, u64>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// Next `created_at` for a kind-38386 revision of the dispute identified by
+/// `d_tag`: `candidate`, bumped to strictly after the last revision
+/// published for that dispute when both land in the same second.
+pub(crate) fn monotonic_dispute_event_timestamp(d_tag: &str, candidate: Timestamp) -> Timestamp {
+    let mut last_ts = DISPUTE_EVENT_TIMESTAMPS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    Timestamp::from(monotonic_created_at(
+        &mut last_ts,
+        d_tag.to_owned(),
+        candidate.as_secs(),
+    ))
 }
 
 /// Orders whose latest kind-38383 publish failed (a relay rejected the


### PR DESCRIPTION
## The bug

Kind-38386 dispute events are signed with a plain "now" timestamp. Dispute
transitions are driven by clients reacting to each other, so consecutive
revisions of the same dispute routinely land in the **same Unix second** —
a solver taking a dispute the moment it is opened is two publishes
milliseconds apart.

When that happens the two events share `(kind, pubkey, d)` *and*
`created_at`. NIP-01 resolves that tie on replaceable events by keeping the
**lowest event id**, not the newer status — a coin flip. Half the time the
relay keeps the older revision forever, while the daemon's DB has already
moved on. The daemon logs a successful publish; clients never see the
dispute advance.

Caught against a local relay while running the dispute scenarios of the
[Ortsom](https://github.com/MostroP2P/ortsom) e2e harness. A dispute opened
and taken in the same second published:

| `s` | event id | `created_at` |
|---|---|---|
| `initiated` | `24b705b2…` | 1787165374 |
| `in-progress` | `6f54c053…` | 1787165374 |

`24b705b2…` < `6f54c053…`, so the relay kept `initiated` and discarded
`in-progress`:

```
$ nak req -k 38386 -d b3cc4ff7-… ws://127.0.0.1:7000
{"id":"24b705b2…","created_at":1787165374,"tags":[…["s","initiated"]…]}
```

The dispute stayed `initiated` on the wire for the rest of its life: the
later `settled` publish tied against the same stale winner. Any client
watching the orderbook — including an admin UI listing open disputes —
sees a dispute that was resolved minutes ago as still untaken.

This is not specific to the harness. It needs only two dispute events in
one second, which is the normal case whenever a solver is already watching.

## The fix

Order events (kind 38383) already solved exactly this in #872, with a
per-order registry that bumps each revision to `max(now, last + 1)`.
Dispute events never got the same treatment.

- **`src/util.rs`** — extract that rule into `monotonic_created_at`, generic
  over the key, and route the existing orderbook `stamp_locked` through it
  (no behaviour change there). Add `DISPUTE_EVENT_TIMESTAMPS`, a registry
  keyed by the kind-38386 `d` tag, and `monotonic_dispute_event_timestamp`.

  Kept as its own map rather than sharing the orderbook's: dispute events
  carry none of the publication-generation and republish bookkeeping the
  orderbook reconciler needs, and a shared map would let dispute publishes
  bump the orderbook's generation counter.

- **`src/nip33.rs`** — apply the stamp inside `new_dispute_event`. Every
  kind-38386 publish funnels through it (`dispute.rs` ×2,
  `admin_take_dispute.rs`, `admin_settle.rs`, `admin_cancel.rs`), so no
  call site changes and none can forget it in the future.

Process-local by design, same as for orders: this daemon's key is the only
legitimate publisher of its disputes' events, and two publishes for one
dispute on opposite sides of a restart cannot land in the same second.

The business `created_at` **tag** added in #878 is untouched — it still
carries the SQLite open time. Only the Nostr `event.created_at` changes,
and only when it would otherwise tie.

## Tests

- `consecutive_dispute_revisions_never_share_a_created_at` — the regression
  guard. Verified it reproduces the bug: reverting the one-line stamp makes
  it fail with `opened at 1787166389, taken at 1787166389`.
- `dispute_stamping_does_not_leak_across_identifiers` — the bump is scoped
  to one dispute; an unrelated dispute published in the same second is still
  stamped with plain wall-clock now.

Two existing tests shared the `d` tag `"dispute-id"`; they now use distinct
identifiers, since the registry is process-wide and would otherwise couple
them.

Full suite: 1224 passing, `cargo clippy --all-targets` clean.

## End-to-end verification

`ortsom run dispute_resolved_for_buyer` against a local regtest stack
(Polar LND + local relay), which failed by timeout before the fix:

```
test dispute_resolved_for_buyer ... ok (33.5s)
1 passed, 0 failed, 0 skipped, 0 flaky in 33.5s
totals: sent 302 sats, received 298 sats, fees 0 sats
```

All three revisions now carry distinct timestamps (1787167444 →
1787167445 → 1787167446) and the relay holds the real final state:

```
$ nak req -k 38386 -d 69e3ccdb-… ws://127.0.0.1:7000
created_at: 1787167446 | s: settled
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dispute revision ordering so consecutive updates are processed reliably, even when created within the same second.
  * Preserved the original dispute opening time independently from revision ordering.
  * Ensured timestamp sequencing is maintained separately for each dispute.
  * Improved dispute status updates so they are recorded before notifications are sent, helping preserve status changes even if a notification cannot be delivered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->