### PR TITLE
fix(ci): make the release build toolchain verifiable and reproducible

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,11 +105,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo/bin/cross
-          key: cross-${{ runner.os }}-0.2.5
+          # Must change whenever the install command below does: a cache hit
+          # skips that step entirely and restores the previously built binary.
+          key: cross-${{ runner.os }}-0.2.5-locked
 
       - name: Install cross ( pinned version for reproducibility )
         if: matrix.target != 'x86_64-pc-windows-gnu' && steps.cache-cross.outputs.cache-hit != 'true'
-        run: cargo install cross --version 0.2.5
+        run: cargo install cross --version 0.2.5 --locked
 
       - name: Build release
         shell: bash

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,6 +1,10 @@
 [build]
+# cross joins these entries with newlines and runs them as a single `RUN eval`
+# with no `set -e`, so a failing entry does not stop the ones after it. The
+# download, checksum and extraction must stay chained with `&&` or the
+# verification silently becomes a no-op.
 pre-build = [
     "apt update && apt install -y unzip",
-    "curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-linux-x86_64.zip && unzip protoc-28.2-linux-x86_64.zip -d /usr/",
+    "curl -fsSL --proto '=https' --tlsv1.2 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-linux-x86_64.zip && echo '2febfd42b59ce93a28eb789019a470a3dd0449619bc04f84dad1333da261dec1  /tmp/protoc.zip' | sha256sum -c - && unzip /tmp/protoc.zip -d /usr/ && rm -f /tmp/protoc.zip",
     "chmod 755 /usr/bin/protoc"
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,10 +1,17 @@
 [build]
 # cross joins these entries with newlines into a single `RUN eval`, whose exit
-# status is the last entry's. Keep the download, checksum, extraction and chmod
-# in one `&&` chain: split up, a failed checksum would still be followed by a
-# chmod that succeeds whenever a protoc is already present, and the step would
-# exit 0. `set -e` is no help here, since dash exempts `&&` lists from it.
+# status is the last entry's, so a failure in any entry but the last is lost.
+# Everything therefore stays in one `&&` chain, written with TOML line
+# continuations for legibility. `set -e` is no help here, since dash exempts
+# `&&` lists from it.
 pre-build = [
-    "apt update && apt install -y unzip",
-    "curl -fsSL --proto '=https' --tlsv1.2 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-linux-x86_64.zip && echo '2febfd42b59ce93a28eb789019a470a3dd0449619bc04f84dad1333da261dec1  /tmp/protoc.zip' | sha256sum -c - && unzip /tmp/protoc.zip -d /usr/ && chmod 755 /usr/bin/protoc && rm -f /tmp/protoc.zip"
+    """\
+        apt update \
+        && apt install -y unzip \
+        && curl -fsSL --proto '=https' --tlsv1.2 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-linux-x86_64.zip \
+        && echo '2febfd42b59ce93a28eb789019a470a3dd0449619bc04f84dad1333da261dec1  /tmp/protoc.zip' | sha256sum -c - \
+        && unzip /tmp/protoc.zip -d /usr/ \
+        && chmod 755 /usr/bin/protoc \
+        && rm -f /tmp/protoc.zip\
+    """,
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,10 +1,10 @@
 [build]
-# cross joins these entries with newlines and runs them as a single `RUN eval`
-# with no `set -e`, so a failing entry does not stop the ones after it. The
-# download, checksum and extraction must stay chained with `&&` or the
-# verification silently becomes a no-op.
+# cross joins these entries with newlines into a single `RUN eval`, whose exit
+# status is the last entry's. Keep the download, checksum, extraction and chmod
+# in one `&&` chain: split up, a failed checksum would still be followed by a
+# chmod that succeeds whenever a protoc is already present, and the step would
+# exit 0. `set -e` is no help here, since dash exempts `&&` lists from it.
 pre-build = [
     "apt update && apt install -y unzip",
-    "curl -fsSL --proto '=https' --tlsv1.2 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-linux-x86_64.zip && echo '2febfd42b59ce93a28eb789019a470a3dd0449619bc04f84dad1333da261dec1  /tmp/protoc.zip' | sha256sum -c - && unzip /tmp/protoc.zip -d /usr/ && rm -f /tmp/protoc.zip",
-    "chmod 755 /usr/bin/protoc"
+    "curl -fsSL --proto '=https' --tlsv1.2 -o /tmp/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-linux-x86_64.zip && echo '2febfd42b59ce93a28eb789019a470a3dd0449619bc04f84dad1333da261dec1  /tmp/protoc.zip' | sha256sum -c - && unzip /tmp/protoc.zip -d /usr/ && chmod 755 /usr/bin/protoc && rm -f /tmp/protoc.zip"
 ]


### PR DESCRIPTION
Two inputs to the tagged-release build were not pinned to anything verifiable.

**protoc** (`Cross.toml`) — the cross build image downloaded the protoc-28.2 archive and extracted it into `/usr/` without checking it against anything. protoc then runs during the build: `build.rs` compiles `proto/admin.proto` through tonic-prost-build. Now the SHA256 is pinned and a mismatch fails the image build. Added `-f` to curl too, so an HTTP error page is not saved as the archive.

The download, checksum and extraction are chained with `&&` on purpose, and there is a comment saying so. cross joins the `pre-build` entries with newlines and runs them as a single `RUN eval` with no `set -e` — split into separate entries, a failing checksum prints its warning and the extraction proceeds anyway, with the step still exiting 0. Verified against the real `ghcr.io/cross-rs/x86_64-unknown-linux-musl:0.2.5` image: correct hash builds and yields a working `libprotoc 28.2`, corrupted hash aborts with exit 1.

The pinned hash matches the one `taiki-e/install-action` publishes for the same URL (`manifests/protoc.json`, key `3.28.2`).

**cross** (`.github/workflows/rust.yml`) — the version was pinned but the dependencies were not. `cargo install` ignores the published `Cargo.lock` unless `--locked` is passed, so the tool that produces the release binaries was rebuilt against a freshly resolved tree on every run: 58 of the 80 packages cross 0.2.5 shipped resolve to a different version today, plus 25 added and 7 dropped. The step name already claimed reproducibility.

The cache key moves with it. The install step is guarded by `cache-hit`, so leaving the old key would restore the binary built from the floating tree and skip the install entirely — the change would never take effect on a warm runner.

`cargo install cross --version 0.2.5 --locked` was checked to still compile (rustc 1.89, ~35s), since 0.2.5 is from early 2023 and remains the latest stable. `actionlint` reports nothing new on the workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Improved installation security by using HTTPS with enforced protocol and TLS settings.
  * Added checksum verification for downloaded tools before installation.
  * Ensured failures during download, verification, extraction, or setup stop installation safely.

* **Build & Maintenance**
  * Improved dependency reproducibility during build tool installation.
  * Updated caching behavior to reflect locked dependency resolution.
  * Improved build status handling so failed installation steps are reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->