### PR TITLE
fix(ci): scope publishing to version tag pushes

### DIFF
--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -20,17 +20,21 @@ jobs:
 
       - name: Set image tag for metadata
         id: set_tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.image_tag }}
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${{ github.event.inputs.image_tag || 'latest' }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${INPUT_TAG:-latest}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check if stable release
         id: check_stable
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/v && "${{ github.ref }}" != *"-"* ]]; then
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/tags/v && "$GITHUB_REF" != *"-"* ]]; then
             echo "is_stable=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_stable=false" >> "$GITHUB_OUTPUT"
@@ -77,17 +81,21 @@ jobs:
 
       - name: Set image tag for metadata
         id: set_tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.image_tag }}
         run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=${{ github.event.inputs.image_tag || 'latest' }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${INPUT_TAG:-latest}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check if stable release
         id: check_stable
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" =~ ^refs/tags/v && "${{ github.ref }}" != *"-"* ]]; then
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/tags/v && "$GITHUB_REF" != *"-"* ]]; then
             echo "is_stable=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_stable=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -65,7 +65,10 @@ jobs:
         id: check_stable
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/tags/v && "$GITHUB_REF" != *"-"* ]]; then
+          # Anchored: the v*.*.* trigger is a glob, so it also admits refs like
+          # v1.2.3foo. Only an exact vX.Y.Z names a stable release.
+          release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ $release_re ]]; then
             echo "is_stable=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_stable=false" >> "$GITHUB_OUTPUT"
@@ -143,7 +146,10 @@ jobs:
         id: check_stable
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ ^refs/tags/v && "$GITHUB_REF" != *"-"* ]]; then
+          # Anchored: the v*.*.* trigger is a glob, so it also admits refs like
+          # v1.2.3foo. Only an exact vX.Y.Z names a stable release.
+          release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ $release_re ]]; then
             echo "is_stable=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_stable=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -182,8 +182,8 @@ jobs:
           # than from a checkout of the whole history.
           tags="$(git ls-remote --tags --refs "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" 'v*')"
           mapfile -t candidates < <(
-            sed 's#.*refs/tags/##' <<<"$tags" \
-              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            grep -oE 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$' <<<"$tags" \
+              | cut -d/ -f3 \
               | sort -rV \
               | head -n "$max_candidates"
           )

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -37,11 +37,12 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.image_tag }}
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == refs/tags/* ]]; then
             tag="${GITHUB_REF#refs/tags/}"
           else
-            # A manual run gets a build-specific tag. latest and vX.Y.Z name
-            # published images, so only a tag push is allowed to write them.
+            # Anything that is not a tag push takes the guarded path, including a
+            # dispatch aimed at a tag: latest and vX.Y.Z name published images,
+            # so only a tag push is allowed to write them.
             tag="${INPUT_TAG:-dev-${GITHUB_SHA::7}}"
             release_re='^v[0-9]+\.[0-9]+\.[0-9]+'
             if [[ "$tag" == "latest" || "$tag" =~ $release_re ]]; then
@@ -114,11 +115,12 @@ jobs:
           INPUT_TAG: ${{ github.event.inputs.image_tag }}
         run: |
           set -euo pipefail
-          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == refs/tags/* ]]; then
             tag="${GITHUB_REF#refs/tags/}"
           else
-            # A manual run gets a build-specific tag. latest and vX.Y.Z name
-            # published images, so only a tag push is allowed to write them.
+            # Anything that is not a tag push takes the guarded path, including a
+            # dispatch aimed at a tag: latest and vX.Y.Z name published images,
+            # so only a tag push is allowed to write them.
             tag="${INPUT_TAG:-dev-${GITHUB_SHA::7}}"
             release_re='^v[0-9]+\.[0-9]+\.[0-9]+'
             if [[ "$tag" == "latest" || "$tag" =~ $release_re ]]; then

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag (used when run manually; default: latest)'
+        description: 'Image tag for manual runs (cannot be "latest" or a vX.Y.Z release tag; default: dev-<short-sha>)'
         required: false
-        default: 'latest'
+        default: ''
 
 jobs:
   build-and-push-plain:
@@ -25,10 +25,26 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            tag="${GITHUB_REF#refs/tags/}"
           else
-            echo "tag=${INPUT_TAG:-latest}" >> "$GITHUB_OUTPUT"
+            # A manual run gets a build-specific tag. latest and vX.Y.Z name
+            # published images, so only a tag push is allowed to write them.
+            tag="${INPUT_TAG:-dev-${GITHUB_SHA::7}}"
+            release_re='^v[0-9]+\.[0-9]+\.[0-9]+'
+            if [[ "$tag" == "latest" || "$tag" =~ $release_re ]]; then
+              echo "::error::manual runs must not publish release tags (latest or vX.Y.Z); got '$tag'"
+              exit 1
+            fi
           fi
+          # Anything outside the OCI tag charset is rejected before the write:
+          # a newline would append a second tag= line and silently override the
+          # value checked above.
+          oci_re='^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$'
+          if [[ ! "$tag" =~ $oci_re ]]; then
+            echo "::error::not a valid OCI image tag: '$tag'"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Check if stable release
         id: check_stable
@@ -86,10 +102,26 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            tag="${GITHUB_REF#refs/tags/}"
           else
-            echo "tag=${INPUT_TAG:-latest}" >> "$GITHUB_OUTPUT"
+            # A manual run gets a build-specific tag. latest and vX.Y.Z name
+            # published images, so only a tag push is allowed to write them.
+            tag="${INPUT_TAG:-dev-${GITHUB_SHA::7}}"
+            release_re='^v[0-9]+\.[0-9]+\.[0-9]+'
+            if [[ "$tag" == "latest" || "$tag" =~ $release_re ]]; then
+              echo "::error::manual runs must not publish release tags (latest or vX.Y.Z); got '$tag'"
+              exit 1
+            fi
           fi
+          # Anything outside the OCI tag charset is rejected before the write:
+          # a newline would append a second tag= line and silently override the
+          # value checked above.
+          oci_re='^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$'
+          if [[ ! "$tag" =~ $oci_re ]]; then
+            echo "::error::not a valid OCI image tag: '$tag'"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Check if stable release
         id: check_stable

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -17,11 +17,12 @@ on:
 permissions:
   contents: read
 
-# Two runs must never push to the registry at once: they would race on the
-# shared `latest` tag and the slower one would win. Queue instead of cancelling,
-# so every version tag still gets its image.
+# Two runs of the same ref must never push to the registry at once: they would
+# race on the tags they share. The group is per-ref because GitHub keeps only one
+# pending run per group, so a single global group would drop an intermediate
+# version tag when several tag pushes arrive together.
 concurrency:
-  group: docker-images
+  group: docker-images-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -31,6 +31,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # check_stable compares the pushed tag against every other version tag.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set image tag for metadata
         id: set_tag
@@ -75,11 +79,19 @@ jobs:
           # Anchored: the v*.*.* trigger is a glob, so it also admits refs like
           # v1.2.3foo. Only an exact vX.Y.Z names a stable release.
           release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+          is_stable=false
           if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ $release_re ]]; then
-            echo "is_stable=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+            # latest follows the highest version rather than whichever run
+            # finishes last, so two overlapping tag pushes cannot leave it
+            # pointing at the older release.
+            newest=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+            if [[ -z "$newest" ]]; then
+              echo "::warning::no version tags visible, leaving latest untouched"
+            elif [[ "${GITHUB_REF#refs/tags/}" == "$newest" ]]; then
+              is_stable=true
+            fi
           fi
+          echo "is_stable=$is_stable" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -119,6 +131,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          # check_stable compares the pushed tag against every other version tag.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set image tag for metadata
         id: set_tag
@@ -163,11 +179,19 @@ jobs:
           # Anchored: the v*.*.* trigger is a glob, so it also admits refs like
           # v1.2.3foo. Only an exact vX.Y.Z names a stable release.
           release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+          is_stable=false
           if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ $release_re ]]; then
-            echo "is_stable=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_stable=false" >> "$GITHUB_OUTPUT"
+            # latest follows the highest version rather than whichever run
+            # finishes last, so two overlapping tag pushes cannot leave it
+            # pointing at the older release.
+            newest=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+            if [[ -z "$newest" ]]; then
+              echo "::warning::no version tags visible, leaving latest untouched"
+            elif [[ "${GITHUB_REF#refs/tags/}" == "$newest" ]]; then
+              is_stable=true
+            fi
           fi
+          echo "is_stable=$is_stable" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -39,6 +39,13 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == refs/tags/* ]]; then
+            # The v*.*.* trigger is a glob and also admits refs like v1.2.3foo or
+            # v1.2.3-rc.1. Only an exact vX.Y.Z is published.
+            release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+            if [[ ! "$GITHUB_REF" =~ $release_re ]]; then
+              echo "::error::not a release tag, nothing is published: $GITHUB_REF"
+              exit 1
+            fi
             tag="${GITHUB_REF#refs/tags/}"
           else
             # Anything that is not a tag push takes the guarded path, including a
@@ -120,6 +127,13 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == refs/tags/* ]]; then
+            # The v*.*.* trigger is a glob and also admits refs like v1.2.3foo or
+            # v1.2.3-rc.1. Only an exact vX.Y.Z is published.
+            release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+            if [[ ! "$GITHUB_REF" =~ $release_re ]]; then
+              echo "::error::not a release tag, nothing is published: $GITHUB_REF"
+              exit 1
+            fi
             tag="${GITHUB_REF#refs/tags/}"
           else
             # Anything that is not a tag push takes the guarded path, including a

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -11,6 +11,12 @@ on:
         required: false
         default: ''
 
+# The images are pushed with the Docker Hub credentials and the layer cache
+# uses the runner's own token, so nothing here needs GITHUB_TOKEN beyond the
+# checkout. Narrow it rather than inheriting the repository default.
+permissions:
+  contents: read
+
 jobs:
   build-and-push-plain:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -31,10 +31,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          # check_stable compares the pushed tag against every other version tag.
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Set image tag for metadata
         id: set_tag
@@ -71,27 +67,6 @@ jobs:
             exit 1
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
-      - name: Check if stable release
-        id: check_stable
-        run: |
-          set -euo pipefail
-          # Anchored: the v*.*.* trigger is a glob, so it also admits refs like
-          # v1.2.3foo. Only an exact vX.Y.Z names a stable release.
-          release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
-          is_stable=false
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ $release_re ]]; then
-            # latest follows the highest version rather than whichever run
-            # finishes last, so two overlapping tag pushes cannot leave it
-            # pointing at the older release.
-            newest=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
-            if [[ -z "$newest" ]]; then
-              echo "::warning::no version tags visible, leaving latest untouched"
-            elif [[ "${GITHUB_REF#refs/tags/}" == "$newest" ]]; then
-              is_stable=true
-            fi
-          fi
-          echo "is_stable=$is_stable" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -112,7 +87,6 @@ jobs:
           images: mostrop2p/mostro
           tags: |
             type=raw,value=${{ steps.set_tag.outputs.tag }}
-            type=raw,value=latest,enable=${{ steps.check_stable.outputs.is_stable }}
 
       - name: Build and push plain Docker image
         uses: docker/build-push-action@v5
@@ -131,10 +105,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          # check_stable compares the pushed tag against every other version tag.
-          fetch-depth: 0
-          fetch-tags: true
 
       - name: Set image tag for metadata
         id: set_tag
@@ -172,27 +142,6 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
-      - name: Check if stable release
-        id: check_stable
-        run: |
-          set -euo pipefail
-          # Anchored: the v*.*.* trigger is a glob, so it also admits refs like
-          # v1.2.3foo. Only an exact vX.Y.Z names a stable release.
-          release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
-          is_stable=false
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ $release_re ]]; then
-            # latest follows the highest version rather than whichever run
-            # finishes last, so two overlapping tag pushes cannot leave it
-            # pointing at the older release.
-            newest=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
-            if [[ -z "$newest" ]]; then
-              echo "::warning::no version tags visible, leaving latest untouched"
-            elif [[ "${GITHUB_REF#refs/tags/}" == "$newest" ]]; then
-              is_stable=true
-            fi
-          fi
-          echo "is_stable=$is_stable" >> "$GITHUB_OUTPUT"
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -212,7 +161,6 @@ jobs:
           images: mostrop2p/mostro-startos
           tags: |
             type=raw,value=${{ steps.set_tag.outputs.tag }}
-            type=raw,value=latest,enable=${{ steps.check_stable.outputs.is_stable }}
 
       - name: Build and push StartOS Docker image
         uses: docker/build-push-action@v5
@@ -225,3 +173,52 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # `latest` is moved after both images exist, not while they are being built:
+  # deciding at build time froze the answer for the length of a multi-arch
+  # build, so a release tagged during that window could be overwritten by the
+  # older run finishing later. The group is shared by every ref, which makes
+  # this the one place where release runs serialize, and the tag list is
+  # refetched inside it so the decision is current at the moment of the move.
+  promote-latest:
+    runs-on: ubuntu-latest
+    needs: [build-and-push-plain, build-and-push-startos]
+    if: github.event_name == 'push'
+    concurrency:
+      group: docker-latest-promotion
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Move latest to this release
+        run: |
+          set -euo pipefail
+          git fetch --tags --force --prune
+          release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ ! "$GITHUB_REF" =~ $release_re ]]; then
+            echo "$GITHUB_REF is not a release tag, leaving latest untouched"
+            exit 0
+          fi
+          tag="${GITHUB_REF#refs/tags/}"
+          newest=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
+          if [[ -z "$newest" ]]; then
+            echo "::warning::no version tags visible, leaving latest untouched"
+            exit 0
+          fi
+          if [[ "$tag" != "$newest" ]]; then
+            echo "$tag is not the highest version ($newest), leaving latest untouched"
+            exit 0
+          fi
+          for image in mostrop2p/mostro mostrop2p/mostro-startos; do
+            docker buildx imagetools create -t "$image:latest" "$image:$tag"
+          done

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -2,8 +2,11 @@ name: Build and Push Docker Images
 
 on:
   push:
+    # Filter patterns are anchored and support `+` and character ranges, so a
+    # pre-release or a suffixed tag never starts a run instead of starting one
+    # that is designed to fail.
     tags:
-      - 'v*.*.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       image_tag:
@@ -26,12 +29,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-push-plain:
+  # Both images publish the same tag, so it is resolved once for the whole run:
+  # a rejected ref or input fails here, before any QEMU and buildx setup, and
+  # the two builds cannot disagree on what they are about to push.
+  resolve-tag:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.set_tag.outputs.tag }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
       - name: Set image tag for metadata
         id: set_tag
         env:
@@ -39,8 +44,8 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == refs/tags/* ]]; then
-            # The v*.*.* trigger is a glob and also admits refs like v1.2.3foo or
-            # v1.2.3-rc.1. Only an exact vX.Y.Z is published.
+            # Defence in depth: the trigger pattern already keeps refs like
+            # v1.2.3foo or v1.2.3-rc.1 from reaching this workflow at all.
             release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
             if [[ ! "$GITHUB_REF" =~ $release_re ]]; then
               echo "::error::not a release tag, nothing is published: $GITHUB_REF"
@@ -68,80 +73,26 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: mostrop2p/mostro
-          tags: |
-            type=raw,value=${{ steps.set_tag.outputs.tag }}
-
-      - name: Build and push plain Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-  build-and-push-startos:
+  # The two images differ only in the repository they are pushed to and the
+  # Dockerfile they are built from. fail-fast stays off so one failing image
+  # does not cancel the other mid-push.
+  build-and-push:
     runs-on: ubuntu-latest
+    needs: resolve-tag
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: plain
+            image: mostrop2p/mostro
+            dockerfile: ./docker/Dockerfile
+          - name: startos
+            image: mostrop2p/mostro-startos
+            dockerfile: ./docker/dockerfile-startos
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set image tag for metadata
-        id: set_tag
-        env:
-          INPUT_TAG: ${{ github.event.inputs.image_tag }}
-        run: |
-          set -euo pipefail
-          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == refs/tags/* ]]; then
-            # The v*.*.* trigger is a glob and also admits refs like v1.2.3foo or
-            # v1.2.3-rc.1. Only an exact vX.Y.Z is published.
-            release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
-            if [[ ! "$GITHUB_REF" =~ $release_re ]]; then
-              echo "::error::not a release tag, nothing is published: $GITHUB_REF"
-              exit 1
-            fi
-            tag="${GITHUB_REF#refs/tags/}"
-          else
-            # Anything that is not a tag push takes the guarded path, including a
-            # dispatch aimed at a tag: latest and vX.Y.Z name published images,
-            # so only a tag push is allowed to write them.
-            tag="${INPUT_TAG:-dev-${GITHUB_SHA::7}}"
-            release_re='^v[0-9]+\.[0-9]+\.[0-9]+'
-            if [[ "$tag" == "latest" || "$tag" =~ $release_re ]]; then
-              echo "::error::manual runs must not publish release tags (latest or vX.Y.Z); got '$tag'"
-              exit 1
-            fi
-          fi
-          # Anything outside the OCI tag charset is rejected before the write:
-          # a newline would append a second tag= line and silently override the
-          # value checked above.
-          oci_re='^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$'
-          if [[ ! "$tag" =~ $oci_re ]]; then
-            echo "::error::not a valid OCI image tag: '$tag'"
-            exit 1
-          fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -158,15 +109,15 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: mostrop2p/mostro-startos
+          images: ${{ matrix.image }}
           tags: |
-            type=raw,value=${{ steps.set_tag.outputs.tag }}
+            type=raw,value=${{ needs.resolve-tag.outputs.tag }}
 
-      - name: Build and push StartOS Docker image
+      - name: Build and push ${{ matrix.name }} Docker image
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./docker/dockerfile-startos
+          file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -177,48 +128,55 @@ jobs:
   # `latest` is moved after both images exist, not while they are being built:
   # deciding at build time froze the answer for the length of a multi-arch
   # build, so a release tagged during that window could be overwritten by the
-  # older run finishing later. The group is shared by every ref, which makes
-  # this the one place where release runs serialize, and the tag list is
-  # refetched inside it so the decision is current at the moment of the move.
+  # older run finishing later.
+  #
+  # The move is deliberately independent of the tag that triggered the run.
+  # GitHub keeps a single pending job per concurrency group, so a burst of
+  # releases can have its queued promotion replaced by a later one; because a
+  # promotion is only queued once its own images are pushed, whichever job
+  # survives the queue already sees the images of the ones that were dropped
+  # and repairs `latest` for all of them. Promoting the highest published
+  # version also never regresses (a backport run finds the newer images first)
+  # and covers a failed build of the highest tag, which would otherwise freeze
+  # `latest` until someone re-ran the job by hand.
   promote-latest:
     runs-on: ubuntu-latest
-    needs: [build-and-push-plain, build-and-push-startos]
+    needs: build-and-push
     if: github.event_name == 'push'
     concurrency:
       group: docker-latest-promotion
       cancel-in-progress: false
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Move latest to this release
+      - name: Move latest to the highest published release
         run: |
           set -euo pipefail
-          git fetch --tags --force --prune
-          release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
-          if [[ ! "$GITHUB_REF" =~ $release_re ]]; then
-            echo "$GITHUB_REF is not a release tag, leaving latest untouched"
+          # Only the tag list is needed, so it is read from the remote rather
+          # than from a checkout of the whole history.
+          mapfile -t candidates < <(
+            git ls-remote --tags --refs "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" 'v*' \
+              | sed 's#.*refs/tags/##' \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -rV
+          )
+          for candidate in "${candidates[@]}"; do
+            published=true
+            for image in mostrop2p/mostro mostrop2p/mostro-startos; do
+              docker buildx imagetools inspect "$image:$candidate" >/dev/null 2>&1 || {
+                published=false
+                break
+              }
+            done
+            [[ "$published" == true ]] || continue
+            for image in mostrop2p/mostro mostrop2p/mostro-startos; do
+              docker buildx imagetools create -t "$image:latest" "$image:$candidate"
+            done
+            echo "latest -> $candidate"
             exit 0
-          fi
-          tag="${GITHUB_REF#refs/tags/}"
-          newest=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1 || true)
-          if [[ -z "$newest" ]]; then
-            echo "::warning::no version tags visible, leaving latest untouched"
-            exit 0
-          fi
-          if [[ "$tag" != "$newest" ]]; then
-            echo "$tag is not the highest version ($newest), leaving latest untouched"
-            exit 0
-          fi
-          for image in mostrop2p/mostro mostrop2p/mostro-startos; do
-            docker buildx imagetools create -t "$image:latest" "$image:$tag"
           done
+          echo "::warning::no published version tag found, leaving latest untouched"

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -17,6 +17,13 @@ on:
 permissions:
   contents: read
 
+# Two runs must never push to the registry at once: they would race on the
+# shared `latest` tag and the slower one would win. Queue instead of cancelling,
+# so every version tag still gets its image.
+concurrency:
+  group: docker-images
+  cancel-in-progress: false
+
 jobs:
   build-and-push-plain:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-startOs.yml
+++ b/.github/workflows/docker-build-startOs.yml
@@ -13,6 +13,11 @@ on:
         description: 'Image tag for manual runs (cannot be "latest" or a vX.Y.Z release tag; default: dev-<short-sha>)'
         required: false
         default: ''
+      dry_run:
+        description: 'Build without pushing and print the latest promotion target without writing it'
+        type: boolean
+        required: false
+        default: false
 
 # The images are pushed with the Docker Hub credentials and the layer cache
 # uses the runner's own token, so nothing here needs GITHUB_TOKEN beyond the
@@ -119,11 +124,14 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
-          push: true
+          # A dry run exercises the whole chain without writing to the registry.
+          push: ${{ !inputs.dry_run }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Scoped per image: a single shared scope makes the two matrix jobs
+          # evict each other's cache on every run.
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 
   # `latest` is moved after both images exist, not while they are being built:
   # deciding at build time froze the answer for the length of a multi-arch
@@ -142,9 +150,11 @@ jobs:
   promote-latest:
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.dry_run
     concurrency:
-      group: docker-latest-promotion
+      # A dry run resolves the target without writing it, so it must stay out of
+      # the real queue: taking a slot there would cancel a pending promotion.
+      group: docker-latest-promotion${{ inputs.dry_run && '-dry-run' || '' }}
       cancel-in-progress: false
     steps:
       - name: Login to Docker Hub
@@ -154,29 +164,69 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Move latest to the highest published release
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
+
+          # `latest` belongs to one of the newest releases. Walking the whole
+          # tag list costs two registry calls per tag and is also the path that
+          # ends with an old version being promoted.
+          max_candidates=5
+          images=(mostrop2p/mostro mostrop2p/mostro-startos)
+
+          # Assigned before the pipeline so `set -e` sees a failing ls-remote:
+          # inside a process substitution its status is lost and an unreachable
+          # remote would end the step on the "nothing to promote" path.
           # Only the tag list is needed, so it is read from the remote rather
           # than from a checkout of the whole history.
+          tags="$(git ls-remote --tags --refs "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" 'v*')"
           mapfile -t candidates < <(
-            git ls-remote --tags --refs "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" 'v*' \
-              | sed 's#.*refs/tags/##' \
+            sed 's#.*refs/tags/##' <<<"$tags" \
               | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-              | sort -rV
+              | sort -rV \
+              | head -n "$max_candidates"
           )
+
+          # A missing manifest is the only failure that means "not published
+          # yet". Reading a rate limit, a 5xx or an expired token as absence
+          # would skip the newest release and move `latest` back to an older
+          # one with the job green, which is a wrong publish rather than a
+          # recoverable no-op.
+          is_published() {
+            local ref="$1" out
+            if out="$(docker buildx imagetools inspect "$ref" 2>&1)"; then
+              return 0
+            fi
+            if grep -qiE 'not found|manifest unknown' <<<"$out"; then
+              return 1
+            fi
+            echo "::error::cannot tell whether $ref is published: $out"
+            exit 1
+          }
+
           for candidate in "${candidates[@]}"; do
             published=true
-            for image in mostrop2p/mostro mostrop2p/mostro-startos; do
-              docker buildx imagetools inspect "$image:$candidate" >/dev/null 2>&1 || {
+            for image in "${images[@]}"; do
+              is_published "$image:$candidate" || {
                 published=false
                 break
               }
             done
             [[ "$published" == true ]] || continue
-            for image in mostrop2p/mostro mostrop2p/mostro-startos; do
+            if [[ "$DRY_RUN" == "true" ]]; then
+              echo "dry run: latest would move to $candidate"
+              exit 0
+            fi
+            for image in "${images[@]}"; do
               docker buildx imagetools create -t "$image:latest" "$image:$candidate"
             done
             echo "latest -> $candidate"
             exit 0
           done
-          echo "::warning::no published version tag found, leaving latest untouched"
+
+          # This job is the only thing that moves `latest`, and on a release it
+          # runs after its own images were pushed, so an empty result is a
+          # broken state and not a normal outcome.
+          echo "::error::no published version tag among the newest $max_candidates, latest left untouched"
+          exit 1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,10 +146,11 @@ jobs:
   # This job will only run if both test and build jobs succeed.
   # With fail-fast: false, the build job fails if ANY matrix build fails,
   # ensuring all artifacts are built before publishing.
+  # Tag pushes only: workflow_dispatch must not publish an arbitrary branch to crates.io.
   publish:
     runs-on: ubuntu-latest
     needs: [test, build]
-    if: success()
+    if: success() && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
     steps:
@@ -165,10 +166,13 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
-  # Create release with all artifacts
+  # Create release with all artifacts for the pushed version tag (same guard as
+  # publish). Without it a workflow_dispatch would tag github.ref_name, which on
+  # a branch run means a release named after the branch.
   release:
     runs-on: ubuntu-latest
     needs: [changelog, build]
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -190,7 +190,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [changelog, build, version-tag]
-    if: needs.version-tag.outputs.is_release == 'true'
+    if: success() && needs.version-tag.outputs.is_release == 'true'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,11 +146,12 @@ jobs:
   # This job will only run if both test and build jobs succeed.
   # With fail-fast: false, the build job fails if ANY matrix build fails,
   # ensuring all artifacts are built before publishing.
-  # Tag pushes only: workflow_dispatch must not publish an arbitrary branch to crates.io.
+  # Tag pushes only: a workflow_dispatch can target a tag as well as a branch,
+  # so the event name is checked alongside the ref.
   publish:
     runs-on: ubuntu-latest
     needs: [test, build]
-    if: success() && startsWith(github.ref, 'refs/tags/v')
+    if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read
     steps:
@@ -172,7 +173,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [changelog, build]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,8 @@ name: Build and Test for all targets
 
 on:
   push:
-    tags: ['v*.*.*']          # run only when a tag like v1.2.3 is pushed
+    # Anchored filter pattern: only an exact vX.Y.Z tag push starts a run.
+    tags: ['v[0-9]+.[0-9]+.[0-9]+']
   workflow_dispatch:
 
 env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -142,16 +142,32 @@ jobs:
           name: artifact-${{ matrix.target }}
           path: artifacts/*
 
+  # Decides whether this run is a release. Actions expressions have no regex, so
+  # the exact tag check lives in a job the release jobs gate on. A
+  # workflow_dispatch can target a tag as well as a branch, hence the event name.
+  version-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      is_release: ${{ steps.check.outputs.is_release }}
+    steps:
+      - id: check
+        run: |
+          set -euo pipefail
+          release_re='^refs/tags/v[0-9]+\.[0-9]+\.[0-9]+$'
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" =~ $release_re ]]; then
+            echo "is_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
   # Publish to crates.io (only if all builds succeed)
   # This job will only run if both test and build jobs succeed.
   # With fail-fast: false, the build job fails if ANY matrix build fails,
   # ensuring all artifacts are built before publishing.
-  # Tag pushes only: a workflow_dispatch can target a tag as well as a branch,
-  # so the event name is checked alongside the ref.
   publish:
     runs-on: ubuntu-latest
-    needs: [test, build]
-    if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [test, build, version-tag]
+    if: success() && needs.version-tag.outputs.is_release == 'true'
     permissions:
       contents: read
     steps:
@@ -172,8 +188,8 @@ jobs:
   # a branch run means a release named after the branch.
   release:
     runs-on: ubuntu-latest
-    needs: [changelog, build]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    needs: [changelog, build, version-tag]
+    if: needs.version-tag.outputs.is_release == 'true'
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Both release workflows run on tag pushes and on `workflow_dispatch`, but neither distinguished the two. A manual run on any branch reached `cargo publish`, created a GitHub Release named after the branch, and overwrote the `latest` Docker tag.

Actions expressions have no regex, so "an exact `vX.Y.Z` tag push" cannot be written in an `if:` on its own. Both workflows resolve it in a job instead, and the tag filters are anchored (`v[0-9]+.[0-9]+.[0-9]+`) so a pre-release no longer starts a run at all.

**rust.yml** — a `version-tag` job publishes `is_release`, true only for a push of an exact `vX.Y.Z` tag, and `publish` and `release` gate on it. A `workflow_dispatch` can target a tag as well as a branch, hence the event check. The build jobs stay reachable from `workflow_dispatch`, so a manual run is still a way to check the cross-compilation before tagging. `release` keeps running independently of `publish`; the only change to its `needs` is `version-tag`. Both gates are now spelled the same way, `success() && ...`: the status function was already implied on `release`, but only one of the two said so.

**docker-build-startOs.yml** — the dispatch input defaulted to `latest`, so any manual run replaced the published image. A `resolve-tag` job now resolves the tag once for the whole run: a tag push publishes its exact `vX.Y.Z`, and everything else, a dispatch aimed at a tag included, defaults to `dev-<short-sha>` and rejects `latest` or `vX.Y.Z` as an explicit override. #610 added `check_stable` for this, but it only gated the second `latest` tag, not the input default.

`latest` is moved in a separate `promote-latest` job once both images are pushed. Deciding at build time froze the answer for the length of a multi-arch build, so a release tagged during that window could be overwritten by the older run finishing later. The promotion is independent of the tag that triggered it: it moves `latest` to the highest version tag whose images are already published. GitHub keeps one pending job per concurrency group, so a burst of releases can have its queued promotion replaced by a later one; because a promotion is only queued once its own images exist, whichever job survives the queue repairs `latest` for the ones that were dropped. It also never regresses on a backport run, and a failed build of the highest tag no longer freezes it.

That job answers "is this version published?" with `imagetools inspect`, so it has to be careful about what a non-zero exit means:

- **Only a missing manifest counts as "not published".** Reading every failure as absence let a rate limit, a 5xx or an expired token skip the newest release and move `latest` *back* to an older one, with the job green. That is a wrong publish, whereas failing to promote is recoverable, so `not found` / `manifest unknown` advances to the next candidate and anything else fails the job.
- **The scan is bounded to the five newest version tags.** `latest` belongs to one of them; walking all 85 costs two registry calls each and is also the path that ends with an old version being promoted.
- **A failing `git ls-remote` fails the step.** `set -euo pipefail` does not cover a process substitution, so an unreachable remote produced an empty tag list and the step ended on the "nothing to promote" path with a green check. The list is assigned before it is filtered, so `set -e` sees it.
- **An empty result is an error, not a warning.** This job is the only thing that moves `latest`, and on a release it runs after its own images were pushed, so finding nothing to promote is a broken state rather than a no-op.

Same file, while in there:

- Workflow context (`github.ref`, `github.event_name`, the dispatch input) read from environment variables instead of being interpolated into the `run:` scripts, plus `set -euo pipefail`. The tag reaches `$GITHUB_OUTPUT` only after an OCI charset check, so a newline cannot append a second `tag=` line.
- A `contents: read` permissions block. It was the only workflow handling secrets without one.
- A per-ref concurrency group for the builds, so two runs of the same ref cannot push at once. Per-ref rather than global, because a single group would drop an intermediate version tag when several tag pushes arrive together.
- The two build jobs, which differed only in the image and the Dockerfile, are a matrix.
- A `dry_run` dispatch input. The workflow does not run on pull requests and `promote-latest` is gated on a push, so the first real execution of any of this would otherwise be a release, with `latest` at stake. A dry run builds both images without pushing and prints the promotion target without writing it. Its `promote-latest` uses a separate concurrency group, since taking a slot in the real queue would cancel a pending promotion.
- The `type=gha` cache is scoped per image. With a single shared scope the two matrix jobs evicted each other's cache on every run.

`actionlint` 1.7.12 with `shellcheck` 0.11.0 is clean on the Docker workflow, and the four pre-existing SC2193 warnings there are gone. It still reports one SC2012 in `rust.yml`, in the checksums step this PR does not touch.

The `promote-latest` script was also exercised outside CI, by extracting the `run:` block and running it against stubbed `git` and `docker`: all images published promotes the newest; a 404 on the newest falls through to the next; a rate limit fails the job without writing any tag; a failing `git ls-remote` exits non-zero; a dry run resolves the target and writes nothing; and `v0.19.0-rc.1`, `v0.19.0foo` and `foo/v9.9.9` are all rejected as candidates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Improvements**
  - Manual and non-release Docker builds now use guarded development tags instead of release tags.
  - Docker publishing is queued per branch or tag, preventing unrelated builds from blocking one another.
  - Stable releases are recognized only for exact `vX.Y.Z` version tags, with `latest` assigned only to the highest version.
  - Docker image tags are validated against OCI naming rules.

- **Bug Fixes**
  - Crate, release, and Docker publishing no longer run for branches or invalid tag formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
