### PR TITLE
fix: advertise the plain invoice_expiration_window

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -446,11 +446,13 @@ pub struct LightningSettings {
     pub lnd_macaroon_file: String,
     /// LND gRPC host
     pub lnd_grpc_host: String,
-    /// Invoice expiration window in seconds
+    /// Minimum remaining lifetime, in seconds, a buyer payout invoice must
+    /// have to be accepted. Enforced in `lightning::invoice`.
     pub invoice_expiration_window: u32,
     /// Hold invoice CLTV delta
     pub hold_invoice_cltv_delta: u32,
-    /// Hold invoice expiration window in seconds
+    /// Lifetime, in seconds, of the hold invoice the seller pays. Distinct
+    /// from `invoice_expiration_window`, which governs the buyer's payout.
     pub hold_invoice_expiration_window: u32,
     /// Number of payment attempts
     pub payment_attempts: u32,

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -1,6 +1,6 @@
 use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
 use crate::config::settings::Settings;
-use crate::config::types::{BondApplyTo, MostroSettings};
+use crate::config::types::{BondApplyTo, LightningSettings, MostroSettings};
 use crate::lightning::LnStatus;
 use crate::util::{get_expiration_timestamp_for_kind, get_keys, monotonic_dispute_event_timestamp};
 use crate::LN_STATUS;
@@ -631,18 +631,13 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
         // `transport` setting so clients pick the right wire format before
         // sending anything. See docs/TRANSPORT_V2_SPEC.md.
         Tag::custom("protocol_version", vec![protocol_version.to_string()]),
-        Tag::custom(
-            "hold_invoice_expiration_window",
-            vec![ln_settings.hold_invoice_expiration_window.to_string()],
-        ),
-        Tag::custom(
-            "hold_invoice_cltv_delta",
-            vec![ln_settings.hold_invoice_cltv_delta.to_string()],
-        ),
-        Tag::custom(
-            "invoice_expiration_window",
-            vec![ln_settings.hold_invoice_expiration_window.to_string()],
-        ),
+    ];
+
+    // Spliced in at its original position: the extraction leaves the wire
+    // order of the info event unchanged.
+    tags_vec.extend(ln_policy_tags(ln_settings));
+
+    tags_vec.extend([
         Tag::custom("lnd_version", vec![ln_status.version.to_string()]),
         Tag::custom("lnd_node_pubkey", vec![ln_status.node_pubkey.to_string()]),
         Tag::custom("lnd_commit_hash", vec![ln_status.commit_hash.to_string()]),
@@ -655,11 +650,33 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
             create_platform_tag_values(mostro_settings.name.as_deref()),
         ),
         Tag::custom("z", vec!["info".to_string()]),
-    ];
+    ]);
 
     tags_vec.extend(bond_policy_tags(bond_settings));
 
     Tags::from_list(tags_vec)
+}
+
+/// Build the Lightning policy tag block for the info event.
+///
+/// Split out from [`info_to_tags`] so unit tests can pin each window against
+/// a *distinct* value without mutating the `MOSTRO_CONFIG` OnceLock the
+/// parent reads from; the shared test settings leave both at `0`.
+fn ln_policy_tags(ln_settings: &LightningSettings) -> Vec<Tag> {
+    vec![
+        Tag::custom(
+            "hold_invoice_expiration_window",
+            vec![ln_settings.hold_invoice_expiration_window.to_string()],
+        ),
+        Tag::custom(
+            "hold_invoice_cltv_delta",
+            vec![ln_settings.hold_invoice_cltv_delta.to_string()],
+        ),
+        Tag::custom(
+            "invoice_expiration_window",
+            vec![ln_settings.invoice_expiration_window.to_string()],
+        ),
+    ]
 }
 
 /// Build the bond policy tag block for the info event.
@@ -720,6 +737,7 @@ mod tests {
     use super::create_status_tags;
     use super::{info_to_tags, order_to_tags};
     use crate::app::context::test_utils::test_settings;
+    use crate::config::types::LightningSettings;
     use crate::config::MOSTRO_CONFIG;
     use crate::lightning::LnStatus;
     use mostro_core::prelude::*;
@@ -1113,6 +1131,31 @@ mod tests {
                 None
             }
         })
+    }
+
+    #[test]
+    fn ln_policy_tags_reports_each_window_from_its_own_field() {
+        // Regression for #895, where one window was published under the
+        // other's tag. The two values must differ for this to prove
+        // anything: driven by the global config, both would be `0`.
+        let ln_settings = LightningSettings {
+            invoice_expiration_window: 600,
+            hold_invoice_expiration_window: 120,
+            ..Default::default()
+        };
+
+        let tags = Tags::from_list(super::ln_policy_tags(&ln_settings));
+
+        assert_eq!(
+            get_tag_value(&tags, "invoice_expiration_window").as_deref(),
+            Some("600"),
+            "invoice_expiration_window must report the buyer payout window"
+        );
+        assert_eq!(
+            get_tag_value(&tags, "hold_invoice_expiration_window").as_deref(),
+            Some("120"),
+            "hold_invoice_expiration_window must report the hold invoice window"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #895.

## The bug

The kind-38385 info event filled the `invoice_expiration_window` tag from
`ln_settings.hold_invoice_expiration_window` — a copy-paste from the tag two
entries above, so both tags published the same number.

The two are independent settings: the hold invoice window is the lifetime of
the invoice the seller pays, while `invoice_expiration_window` is the minimum
remaining lifetime a buyer payout invoice must have, enforced in
`src/lightning/invoice.rs`. So the one number a client needs in order to build
an acceptable payout invoice was precisely the one the daemon misreported. A
client that trusted the info event got a `cant-do` back, and the order sat in
`waiting-buyer-invoice` until it was reaped.

## The change

- Read the field each tag names — the fix itself.
- Extract the three `ln_settings`-derived tags into `ln_policy_tags`, mirroring
  the existing `bond_policy_tags`. The helper is spliced in at the original
  position, so the wire order of the info event's tags is unchanged.
- Document what separates the two windows on the settings fields themselves
  (`src/config/types.rs`), where the doc comments only paraphrased the names.

## Why the extraction

Without it the regression test would be vacuous. `test_settings()` builds
`LightningSettings::default()`, which leaves *both* windows at `0`, and
`MOSTRO_CONFIG` is a process-wide OnceLock no test can mutate — so a test
driven through `info_to_tags()` passes just as happily with the fields swapped.
Testing the pure helper allows pinning each window against a distinct value.
This is the same reason `bond_policy_tags` was split out, and its doc comment
says so.

## Verification

The regression test was confirmed to fail against the original bug before the
fix was applied:

```text
---- nip33::tests::ln_policy_tags_reports_each_window_from_its_own_field stdout ----
assertion `left == right` failed: invoice_expiration_window must report the buyer payout window
  left: Some("120")
 right: Some("600")
```

With the fix, the full suite is green:

```text
test result: ok. 1234 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 16.44s
```

`cargo clippy --all-targets --all-features -- -D warnings` is clean and
`cargo fmt` has been applied. No schema or config changes: the tag name and the
settings keys are untouched, only the value the tag is filled from. Clients
pick up the corrected value on the next info event.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Lightning policy information so buyer invoice expiration windows are reported separately from seller-paid hold invoice lifetimes.
  - Ensured hold-invoice, hold-CLTV, and invoice-expiration settings are each represented accurately.

- **Documentation**
  - Clarified the distinction between buyer payout invoice expiration and seller-paid hold invoice lifetime in Lightning settings documentation.

- **Tests**
  - Added coverage to verify the two expiration values remain independent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->