### PR TITLE
test: pin the v2 arm of gate_applies_to_v2_only

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -784,14 +784,17 @@ mod tests {
             forged
         }
 
+        /// Drive `accept_event` over a v2 (kind-14) event with an explicit
+        /// gate, the shape both ordering tests below need.
         async fn accept(
             ctx: &AppContext,
             event: &Event,
             mostro: &Keys,
             gate: &SpamGate,
         ) -> Option<(Action, Message, UnwrappedMessage)> {
-            // Same constant the event loops derive `is_v2` from, so the test
-            // fails if it ever drifts from `Transport::Nip44Direct`'s kind.
+            // Same kind constant the event loops use to identify v2 before
+            // calling `gate_for`, so the test fails if it drifts from
+            // `Transport::Nip44Direct`'s kind.
             accept_event(
                 ctx,
                 event,
@@ -909,9 +912,16 @@ mod tests {
         #[test]
         fn gate_applies_to_v2_only() {
             assert!(gate_for(false).is_none(), "v1 must fail open");
-            // `SpamGate::global()` is `None` unless `install_spam_gate` ran, so
-            // the v2 arm can only be pinned against the installed state.
-            assert_eq!(gate_for(true).is_some(), SpamGate::global().is_some());
+            // Force the installed state rather than reading it: asserting
+            // against `SpamGate::global()` compares `gate_for` with itself and
+            // passes vacuously while nothing has installed yet. Install wins
+            // here or another test's already did; either way a second one is
+            // refused, not a panic.
+            let _ = SpamGate::new(REPLAY_WINDOW_SECS).install_global();
+            assert!(
+                gate_for(true).is_some(),
+                "v2 must resolve the installed gate"
+            );
         }
     }
 

--- a/src/spam_gate.rs
+++ b/src/spam_gate.rs
@@ -226,12 +226,13 @@ mod tests {
         assert!(guard.check_and_record(id, 1_000 + 61));
     }
 
+    /// The `OnceLock` is process-wide and other tests install it too, so this
+    /// one cannot claim the first install (same reason as
+    /// `PriceManager::install_global_accepts_once_then_refuses`). The contract
+    /// asserted below holds either way.
     #[test]
     fn install_global_then_second_install_is_rejected() {
-        // The OnceLock is process-wide, so this single test owns both the
-        // first (successful) install and the AlreadyInstalled rejection.
-        let first = SpamGate::new(REPLAY_WINDOW_SECS).install_global();
-        assert!(first.is_ok(), "first install must succeed");
+        let _ = SpamGate::new(REPLAY_WINDOW_SECS).install_global();
         assert!(
             SpamGate::global().is_some(),
             "global() must expose the installed gate"


### PR DESCRIPTION
Closes #913.

Two non-blocking nits from the review of #892. Tests and comments only, no
runtime change.

## The v2 arm was not pinned

```rust
assert_eq!(gate_for(true).is_some(), SpamGate::global().is_some());
```

`gate_for(true)` *returns* that global, so the assert compares the function
with itself. Until something installs a gate in the process both sides are
`None` and it passes without checking anything. The two sides are also read at
different instants while tests run in parallel, so an install landing between
them yields a spurious `false == true`.

Confirmed empirically: with `gate_for` rewritten to return `None`
unconditionally — the v2-only policy disabled outright — the old test still
passed. With this change it fails on `v2 must resolve the installed gate`.

The fix installs the gate and asserts `is_some()` directly.

## Why `spam_gate.rs` changes too

`install_global_then_second_install_is_rejected` required being the process's
first install (`assert!(first.is_ok(), "first install must succeed")`), which
only held while it was the sole installer of this `OnceLock`. Once the test
above installs as well, whichever loses the race fails — under
`--test-threads=1` tests run alphabetically, so `app::…` installs first and
that test breaks. Verified: applying only the `app.rs` change fails there with
`first install must succeed`.

So it adopts what `PriceManager`'s equivalent test already does
(`price/manager.rs`, `install_global_accepts_once_then_refuses`): ignore the
install result and pin the contract that survives any ordering — a gate is
exposed, and a second install is refused rather than panicking. What is given
up, "the process's first install returns `Ok`", is not deterministically
testable in a binary with parallel tests, and the `price` module already made
that trade.

## Stale comment

A comment named `is_v2`, a variable the event loops no longer have since #892;
they pass the condition to `gate_for`.

## Verification

```text
test result: ok. 1233 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

Green both in parallel and under `--test-threads=1`, and each of the two tests
passes in isolation. `cargo clippy --all-targets --all-features -- -D warnings`
is clean and `cargo fmt` has been applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened validation that transport gating applies correctly to version 2 paths.
  * Improved test reliability when handling process-wide gate initialization.
  * Standardized test references to shared transport configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->