### PR TITLE
test: cover the CantDo(DisputeCreationError) arm

### DIFF
--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -168,7 +168,8 @@ pub async fn dispute_action(
     // Create new dispute record
     let dispute = Dispute::new(order_id, order.status.clone());
 
-    // Setup dispute
+    // Setup dispute. `setup_dispute` leaves `order.status` dirty on `Err`;
+    // returning here keeps that out of the database.
     order
         .setup_dispute(is_buyer_dispute)
         .map_err(MostroCantDo)?;
@@ -435,6 +436,55 @@ mod tests {
             result,
             Err(MostroInternalErr(ServiceError::DisputeAlreadyExists))
         ));
+    }
+
+    #[tokio::test]
+    async fn dispute_action_rejects_order_with_dispute_flag_but_no_dispute_row() {
+        // #848 made a `setup_dispute` failure reach the client instead of
+        // being swallowed. That arm needs an order whose dispute flag is
+        // already set with no matching `disputes` row: the normal
+        // double-dispute path trips the `DisputeAlreadyExists` guard above
+        // and never reaches `setup_dispute`.
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let order = create_order(Some(buyer), Some(seller), Status::Active)
+            .create(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE orders SET buyer_dispute = 1 WHERE id = ?1")
+            .bind(order.id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let event = create_event(buyer);
+        let err = dispute_action(
+            &ctx,
+            dispute_msg_for(Some(order.id)),
+            &event,
+            &Keys::generate(),
+        )
+        .await
+        .expect_err("inconsistent dispute state must be rejected");
+
+        assert!(matches!(
+            err,
+            MostroCantDo(CantDoReason::DisputeCreationError)
+        ));
+
+        // The behaviour #848 changed: the old code created the row anyway.
+        // `find_dispute_by_order_id` uses `fetch_one`, so a missing row is
+        // `Err`, not `Ok(None)`.
+        assert!(find_dispute_by_order_id(&pool, order.id).await.is_err());
+
+        // Nothing was persisted before the early return.
+        let stored = Order::by_id(&pool, order.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, Status::Active.to_string());
+        assert!(stored.buyer_dispute);
+        assert!(!stored.seller_dispute);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #907.

#848 changed `dispute_action` so a `setup_dispute` failure reaches the client
instead of being swallowed, but nothing pinned that behaviour —
`DisputeCreationError` appeared nowhere under `src/`.

## The state the test builds

The arm is unreachable through the ordinary flow: a second dispute on the same
order trips the `DisputeAlreadyExists` guard long before `setup_dispute` runs
twice. It needs an inconsistent database — an order with `buyer_dispute` set
and no matching row in `disputes` — so the test writes that flag directly with
`sqlx::query` and inserts no dispute row, then sends the dispute as the buyer.

## What it asserts

- `dispute_action` returns `CantDo(DisputeCreationError)`.
- **No dispute row is created** — the behaviour that actually changed in #848,
  since the old code created it anyway. As @ToRyVand noted on the issue,
  `find_dispute_by_order_id` uses `fetch_one`, so a missing row is `Err` rather
  than `Ok(None)`, which makes `is_err()` the right assertion here.
- Nothing was persisted before the early return: status still `active`,
  `seller_dispute` still unset.

Verified it fails against the pre-#848 behaviour: restoring the old
`if order.setup_dispute(..).is_ok() { .. }` makes it fail on the
`DisputeCreationError` assertion.

## Also

One comment at the call site recording the invariant from the issue:
`setup_dispute` sets `order.status` before its error return, so the local order
is left dirty on `Err` — harmless only because the early return happens before
any persist.

## Verification

```text
test result: ok. 1234 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

`cargo clippy --all-targets --all-features -- -D warnings` is clean and
`cargo fmt` has been applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented failed dispute setup attempts from persisting unintended order changes.
  * Added validation for orders with an existing dispute flag but no corresponding dispute record.
  * Confirmed that failed dispute creation returns the appropriate error without creating a dispute record.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->