### PR TITLE
fix: keep dev fee audit events (kind 8383) for one year

### DIFF
--- a/src/config/constants.rs
+++ b/src/config/constants.rs
@@ -13,6 +13,12 @@ pub const DEV_FEE_LIGHTNING_ADDRESS: &str = "pivotaldeborah52@walletofsatoshi.co
 /// This ensures events are NOT replaceable, maintaining complete audit history
 pub const DEV_FEE_AUDIT_EVENT_KIND: u16 = 8383;
 
+/// NIP-40 retention for dev fee audit events (kind 8383), in days.
+/// Audit events document fee payments for third-party verification, so they
+/// are kept for a full year — not for the much shorter order-expiration
+/// window (`max_expiration_days`).
+pub const DEV_FEE_AUDIT_EXPIRATION_DAYS: u32 = 365;
+
 /// Nostr event kind for protocol-v2 direct messages (NIP-44 direct transport)
 /// Kind 14 carries Mostro protocol messages as signed events with NIP-44
 /// encrypted content when `transport = "nip44"` (see docs/TRANSPORT_V2_SPEC.md)

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -1,6 +1,8 @@
 // File with the types for the configuration settings
 // Initialize the types for the configuration settings
-use crate::config::constants::{DEV_FEE_AUDIT_EVENT_KIND, DM_EVENT_KIND};
+use crate::config::constants::{
+    DEV_FEE_AUDIT_EVENT_KIND, DEV_FEE_AUDIT_EXPIRATION_DAYS, DM_EVENT_KIND,
+};
 use crate::config::MOSTRO_CONFIG;
 use mostro_core::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -229,9 +231,9 @@ impl ExpirationSettings {
             NOSTR_ORDER_EVENT_KIND => self.order_days.or(Some(30)), // orders
             NOSTR_RATING_EVENT_KIND => self.rating_days.or(Some(90)), // ratings
             NOSTR_DISPUTE_EVENT_KIND => self.dispute_days.or(Some(90)), // disputes
-            DEV_FEE_AUDIT_EVENT_KIND => self.fee_audit_days.or(Some(365)), // fee audits
-            DM_EVENT_KIND => self.dm_days.or(Some(30)),             // protocol-v2 direct messages
-            _ => None, // unknown kinds don't get expiration
+            DEV_FEE_AUDIT_EVENT_KIND => self.fee_audit_days.or(Some(DEV_FEE_AUDIT_EXPIRATION_DAYS)), // fee audits
+            DM_EVENT_KIND => self.dm_days.or(Some(30)), // protocol-v2 direct messages
+            _ => None,                                  // unknown kinds don't get expiration
         }
     }
 }
@@ -258,6 +260,15 @@ mod tests {
         assert_eq!(
             settings.get_expiration_for_kind(NOSTR_RATING_EVENT_KIND),
             Some(90)
+        );
+    }
+
+    #[test]
+    fn fee_audit_kind_falls_back_to_one_year_when_unconfigured() {
+        let settings = ExpirationSettings::default();
+        assert_eq!(
+            settings.get_expiration_for_kind(DEV_FEE_AUDIT_EVENT_KIND),
+            Some(DEV_FEE_AUDIT_EXPIRATION_DAYS)
         );
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use crate::config::constants::{
-    DEV_FEE_AUDIT_EVENT_KIND, DEV_FEE_LIGHTNING_ADDRESS, DM_EVENT_KIND,
+    DEV_FEE_AUDIT_EVENT_KIND, DEV_FEE_AUDIT_EXPIRATION_DAYS, DEV_FEE_LIGHTNING_ADDRESS,
+    DM_EVENT_KIND,
 };
 use crate::config::settings::{get_db_pool, Settings};
 use crate::config::*;
@@ -182,20 +183,28 @@ pub fn get_expiration_timestamp_for_kind(kind: u16) -> Option<i64> {
         }
     }
 
-    // Backward-compat fallback for known kinds only.
-    // Keep this list in sync with `ExpirationSettings::get_expiration_for_kind` in `src/config/types.rs`
-    // when adding/removing event kinds.
+    let max_expiration_days = Settings::get_mostro().max_expiration_days;
+    fallback_expiration_days_for_kind(kind, max_expiration_days)
+        .map(|days| now + Duration::days(days as i64).num_seconds())
+}
+
+/// Retention in days used when no `[expiration]` block is configured.
+///
+/// Backward-compat fallback for known kinds only. Keep this in sync with
+/// `ExpirationSettings::get_expiration_for_kind` in `src/config/types.rs`
+/// when adding/removing event kinds.
+fn fallback_expiration_days_for_kind(kind: u16, max_expiration_days: u32) -> Option<u32> {
     match kind {
-        NOSTR_ORDER_EVENT_KIND
-        | NOSTR_RATING_EVENT_KIND
-        | NOSTR_DISPUTE_EVENT_KIND
-        | DEV_FEE_AUDIT_EVENT_KIND => {
-            let mostro_settings = Settings::get_mostro();
-            Some(now + Duration::days(mostro_settings.max_expiration_days.into()).num_seconds())
+        // Fee audit events are a public payment record, not an order: they
+        // keep the same one-year retention as the configured path instead of
+        // the far shorter `max_expiration_days` order window.
+        DEV_FEE_AUDIT_EVENT_KIND => Some(DEV_FEE_AUDIT_EXPIRATION_DAYS),
+        NOSTR_ORDER_EVENT_KIND | NOSTR_RATING_EVENT_KIND | NOSTR_DISPUTE_EVENT_KIND => {
+            Some(max_expiration_days)
         }
         // Protocol-v2 direct messages: same 30-day default as
         // `ExpirationSettings::get_expiration_for_kind`.
-        DM_EVENT_KIND => Some(now + Duration::days(30).num_seconds()),
+        DM_EVENT_KIND => Some(30),
         _ => None,
     }
 }
@@ -3214,6 +3223,46 @@ mod tests {
         assert!(get_expiration_timestamp_for_kind(DM_EVENT_KIND).is_some());
         // Unknown kinds never get an expiration.
         assert!(get_expiration_timestamp_for_kind(12_345).is_none());
+    }
+
+    /// Dev fee audit events are a public payment record: they must carry a
+    /// one-year NIP-40 expiration, never the 15-day `max_expiration_days`
+    /// order window.
+    #[test]
+    fn dev_fee_audit_events_expire_after_one_year() {
+        init_globals();
+        let now = Timestamp::now().as_secs() as i64;
+        let audit_exp = get_expiration_timestamp_for_kind(DEV_FEE_AUDIT_EVENT_KIND)
+            .expect("fee audit events always expire");
+        let expected = now + Duration::days(DEV_FEE_AUDIT_EXPIRATION_DAYS.into()).num_seconds();
+        assert!(
+            (audit_exp - expected).abs() <= 2,
+            "fee audit events must expire ~365 days out, got {audit_exp} (expected {expected})"
+        );
+    }
+
+    /// The `[expiration]`-less fallback used to stamp fee audit events with
+    /// `max_expiration_days` (15 days). Orders still follow that window; fee
+    /// audits keep their full year.
+    #[test]
+    fn fallback_expiration_keeps_fee_audits_at_one_year() {
+        const MAX_EXPIRATION_DAYS: u32 = 15;
+        assert_eq!(
+            fallback_expiration_days_for_kind(DEV_FEE_AUDIT_EVENT_KIND, MAX_EXPIRATION_DAYS),
+            Some(DEV_FEE_AUDIT_EXPIRATION_DAYS)
+        );
+        assert_eq!(
+            fallback_expiration_days_for_kind(NOSTR_ORDER_EVENT_KIND, MAX_EXPIRATION_DAYS),
+            Some(MAX_EXPIRATION_DAYS)
+        );
+        assert_eq!(
+            fallback_expiration_days_for_kind(DM_EVENT_KIND, MAX_EXPIRATION_DAYS),
+            Some(30)
+        );
+        assert_eq!(
+            fallback_expiration_days_for_kind(12_345, MAX_EXPIRATION_DAYS),
+            None
+        );
     }
 
     // ───────────────────────── order tags & publication ─────────────────────────


### PR DESCRIPTION
## Problem

Dev fee audit events (kind `8383`) are being published with a NIP-40 `expiration` tag 15 days out. They are a public payment record intended for third-party verification and should be retained for a full year.

## Root cause

`ExpirationSettings::get_expiration_for_kind` already defaults kind 8383 to 365 days, and `settings.tpl.toml` ships `fee_audit_days = 365`. But `get_expiration_timestamp_for_kind` has a backward-compat fallback used when a node's `settings.toml` has no `[expiration]` block — and that fallback lumped fee audits in with orders/ratings/disputes:

```rust
NOSTR_ORDER_EVENT_KIND
| NOSTR_RATING_EVENT_KIND
| NOSTR_DISPUTE_EVENT_KIND
| DEV_FEE_AUDIT_EVENT_KIND => {
    let mostro_settings = Settings::get_mostro();
    Some(now + Duration::days(mostro_settings.max_expiration_days.into()).num_seconds())
}
```

`max_expiration_days` is the order-expiration window (15 in the shipped template), which is where the 15-day tag came from.

## Change

- New `DEV_FEE_AUDIT_EXPIRATION_DAYS: u32 = 365` constant in `src/config/constants.rs`, now the single source for both the configured path and the fallback.
- The fallback is extracted into a pure `fallback_expiration_days_for_kind(kind, max_expiration_days)`, with kind 8383 on its own arm returning one year.
- Orders, ratings, disputes and protocol-v2 DMs keep exactly their current retention. Nothing else changes.

## Test plan

- [x] `fallback_expiration_days_for_kind` unit test pins 8383 → 365 with `max_expiration_days = 15`, and asserts orders still get 15, DMs 30, unknown kinds `None`. Verified RED against the old behavior (`left: Some(15)`, `right: Some(365)`).
- [x] `dev_fee_audit_events_expire_after_one_year` covers the configured path end to end.
- [x] `fee_audit_kind_falls_back_to_one_year_when_unconfigured` in `config::types`.
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings` clean.
- [x] Full suite: 1236 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fee-audit events now consistently retain data for one year, including when custom expiration settings are used.
  * Preserved existing retention periods for orders and direct messages.
  * Added safeguards to prevent future expiration changes from affecting fee-audit records unintentionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->