### PR TITLE
fix(price): bound relayed price staleness at one TTL, not two

### DIFF
--- a/docs/PRICE_PROVIDERS.md
+++ b/docs/PRICE_PROVIDERS.md
@@ -341,7 +341,18 @@ El Toque's CUP/MLC need at least one direct USD source to be live.
 Each currency's stored `AggregatedPrice` carries `as_of` = the timestamp
 of the last tick that produced a fresh aggregate for it.
 
-- A tick that yields a fresh value overwrites the entry with `as_of = now`.
+- A tick that yields a fresh value overwrites the entry with `as_of` = when
+  the value was **observed**. For a directly-fetched rate that is the tick's
+  `now` (the HTTP request returns the rate as of now). For a rate relayed
+  over Nostr it is the source event's own `created_at`, so the provider's
+  acceptance window and this serving window do not stack: a relayed price is
+  bounded at one `max_price_staleness_seconds` from observation, whatever age
+  the event arrived with (issue #860). The same applies to a fiat-cross
+  currency resolved against a Nostr-sourced anchor
+  (`nostr_anchor_dependent`, §6.3), which is no fresher than that anchor.
+- `as_of` never moves backwards: a write carrying an observation older than
+  the one already stored is dropped, so a relayed rate predating a direct
+  fetch cannot shorten a currency's remaining serving window.
 - A tick with zero contributors for a currency leaves the prior entry
   untouched (old `as_of`).
 - `PriceManager::get_price(ccy)`:

--- a/docs/PRICE_PROVIDERS.md
+++ b/docs/PRICE_PROVIDERS.md
@@ -170,7 +170,9 @@ parallel
  1. collect PerBtc quotes  → per-currency candidate lists (the "anchors")
  2. resolve PerBase quotes → currency/BTC = value × aggregate(base/BTC)   (§6.3)
  3. aggregate per currency → median + outlier guard / mean / single       (§6.2)
- 4. write store: { currency -> AggregatedPrice { value, as_of: now, sources } }
+ 4. write store: { currency -> AggregatedPrice { value, as_of: observed_at, sources } }
+    - `observed_at` is the tick's `now` for a directly-fetched rate, and the
+      source event's own `created_at` for one relayed over Nostr (§6.4).
     - currencies with zero fresh contributors this tick keep their prior
       AggregatedPrice (last-known-good, old `as_of`).
         │
@@ -351,17 +353,27 @@ that stored it (see the first bullet).
   the event arrived with (issue #860). The same applies to a fiat-cross
   currency resolved against a Nostr-sourced anchor
   (`nostr_anchor_dependent`, §6.3), which is no fresher than that anchor.
-- `as_of` never moves backwards: a write carrying an observation older than
-  the one already stored is dropped, so a relayed rate predating a direct
-  fetch cannot shorten a currency's remaining serving window.
+- A **backdated** write never moves `as_of` backwards: one carrying an
+  observation older than the one already stored is dropped, so a relayed rate
+  predating a direct fetch cannot shorten a currency's remaining serving
+  window. A **directly-fetched** write is not guarded this way on purpose —
+  it is this node's own authoritative observation and must land even when the
+  wall clock has stepped backwards behind a stamp already held, since
+  dropping it would freeze the price while still serving it as fresh.
 - A tick with zero contributors for a currency leaves the prior entry
   untouched (old `as_of`).
 - Because `as_of` can predate the tick, a fresh aggregate is **not** the same
   thing as a servable one: a relayed event admitted at the edge of the
   provider's acceptance window can already be past the TTL when it is
-  written. The tick report's `fresh_currencies` therefore counts entries the
-  store would actually serve, not entries the tick produced — it is the
-  number the partial-outage warning shows the operator.
+  written. The tick report therefore carries `servable_currencies` — every
+  stored entry inside the TTL, which is what `get_price` would serve right
+  now. It is deliberately not "fresh": an entry counted there may be old
+  enough to trigger the stale warning while still being served, and it may
+  come from an earlier tick. Both narrower counts mislead the operator, in
+  opposite directions — the size of the tick's aggregate map names
+  currencies the tick just stamped past the TTL, while restricting to the
+  tick's own currencies omits the last-known-good values a partial outage
+  leaves behind.
 - `PriceManager::get_price(ccy)`:
   - entry missing → `Err(NoCurrency)`.
   - `now - as_of <= max_price_staleness_seconds` → `Ok(value)` (a `warn!`

--- a/docs/PRICE_PROVIDERS.md
+++ b/docs/PRICE_PROVIDERS.md
@@ -338,8 +338,9 @@ El Toque's CUP/MLC need at least one direct USD source to be live.
 
 ### 6.4 Staleness (last-known-good + TTL)
 
-Each currency's stored `AggregatedPrice` carries `as_of` = the timestamp
-of the last tick that produced a fresh aggregate for it.
+Each currency's stored `AggregatedPrice` carries `as_of` = the time the
+served value was **observed**, which is not in general the time of the tick
+that stored it (see the first bullet).
 
 - A tick that yields a fresh value overwrites the entry with `as_of` = when
   the value was **observed**. For a directly-fetched rate that is the tick's
@@ -355,6 +356,12 @@ of the last tick that produced a fresh aggregate for it.
   fetch cannot shorten a currency's remaining serving window.
 - A tick with zero contributors for a currency leaves the prior entry
   untouched (old `as_of`).
+- Because `as_of` can predate the tick, a fresh aggregate is **not** the same
+  thing as a servable one: a relayed event admitted at the edge of the
+  provider's acceptance window can already be past the TTL when it is
+  written. The tick report's `fresh_currencies` therefore counts entries the
+  store would actually serve, not entries the tick produced — it is the
+  number the partial-outage warning shows the operator.
 - `PriceManager::get_price(ccy)`:
   - entry missing → `Err(NoCurrency)`.
   - `now - as_of <= max_price_staleness_seconds` → `Ok(value)` (a `warn!`

--- a/docs/PRICE_PROVIDERS.md
+++ b/docs/PRICE_PROVIDERS.md
@@ -170,9 +170,12 @@ parallel
  1. collect PerBtc quotes  → per-currency candidate lists (the "anchors")
  2. resolve PerBase quotes → currency/BTC = value × aggregate(base/BTC)   (§6.3)
  3. aggregate per currency → median + outlier guard / mean / single       (§6.2)
- 4. write store: { currency -> AggregatedPrice { value, as_of: observed_at, sources } }
+ 4. write store: { currency -> AggregatedPrice { value, as_of: observed_at, written_at, sources } }
     - `observed_at` is the tick's `now` for a directly-fetched rate, and the
       source event's own `created_at` for one relayed over Nostr (§6.4).
+    - `written_at` is always the tick's `now`, even for a relayed rate — it
+      answers "did our tick refresh it?" (the freshness warning), while
+      `as_of` answers "how old is this price?" (the TTL).
     - currencies with zero fresh contributors this tick keep their prior
       AggregatedPrice (last-known-good, old `as_of`).
         │
@@ -377,7 +380,10 @@ that stored it (see the first bullet).
 - `PriceManager::get_price(ccy)`:
   - entry missing → `Err(NoCurrency)`.
   - `now - as_of <= max_price_staleness_seconds` → `Ok(value)` (a `warn!`
-    is logged once the value is older than one update interval).
+    is logged once the value is older than one update interval, measured
+    from `written_at` — when this node last wrote it — so a relayed rate
+    whose backdated `as_of` is already older than one interval does not warn
+    on a healthy node every tick).
   - else → `Err(PriceTooStale)` (§10.2). Market-priced create/take for
     that currency is refused with a clear message.
 
@@ -532,7 +538,7 @@ Phases 3 and 4 both depend on Phase 2 and can land in either order.
   `resolve_per_base(quotes, anchors) -> per_currency_candidates` (§6.3),
   `aggregate_tick(provider_results, cfg) -> HashMap<String, f64>` (steps
   1–3 of §5.3). No I/O, no globals.
-- `src/price/store.rs`: `AggregatedPrice { value, as_of, source_count }`,
+- `src/price/store.rs`: `AggregatedPrice { value, as_of, written_at, source_count }`,
   the `RwLock<HashMap<String, AggregatedPrice>>` store, and
   staleness-checked `get` (§6.4).
 - `src/price/config.rs`: `PriceSettings` + `ProviderConfig` serde types

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -321,7 +321,7 @@ impl PriceManager {
 
         let now = Utc::now().timestamp();
         self.observe_warnings(&aggregates);
-        self.store.update(aggregates.clone(), now);
+        self.store_with_observation_time(aggregates.clone(), now);
         report.fresh_currencies = aggregates.len();
         report.contributors = contributors;
 
@@ -330,6 +330,49 @@ impl PriceManager {
         }
 
         report
+    }
+
+    /// Write the tick's aggregates, stamping relayed ones from when they
+    /// were **observed** rather than when we ingested them (issue #860).
+    ///
+    /// Without this the two staleness windows stack: the Nostr provider
+    /// accepts an event up to `max_price_staleness_seconds` old, and the
+    /// store would then serve it for another full window from `now` — total
+    /// age up to twice the configured TTL, against a setting whose name
+    /// implies one. Stamping `as_of` with the event's own `created_at`
+    /// bounds it at exactly one TTL, whatever age the event arrived with,
+    /// and needs no configuration.
+    ///
+    /// Two groups get the earlier stamp:
+    /// - currencies whose only surviving contributor is Nostr — a non-Nostr
+    ///   provider covering the currency drops Nostr's quote before
+    ///   aggregation (`restrict_nostr_to_fallback`), so a mixed contributor
+    ///   list containing Nostr cannot occur here;
+    /// - `nostr_anchor_dependent` ones, whose value embeds a relayed rate
+    ///   through a fiat-cross anchor even though `contributors` names only
+    ///   the cross provider (`aggregate.rs`) — the figure is no fresher
+    ///   than the anchor it was built from.
+    fn store_with_observation_time(&self, aggregates: HashMap<String, AggregateResult>, now: i64) {
+        let observed_at = self
+            .providers
+            .iter()
+            .find(|p| p.id == ProviderId::Nostr)
+            .and_then(|p| p.provider.last_observed_at());
+
+        // A future-dated or absent stamp falls through to the existing
+        // behaviour: never move `as_of` forward, that would *extend* the
+        // serving window rather than bound it.
+        let Some(observed_at) = observed_at.filter(|ts| *ts < now) else {
+            self.store.update(aggregates, now);
+            return;
+        };
+
+        let (relayed, direct): (HashMap<_, _>, HashMap<_, _>) = aggregates
+            .into_iter()
+            .partition(|(_, a)| a.contributors == [ProviderId::Nostr] || a.nostr_anchor_dependent);
+
+        self.store.update(direct, now);
+        self.store.update(relayed, observed_at);
     }
 
     /// Wall-clock budget for one provider's poll: `provider_timeout_seconds`
@@ -832,6 +875,9 @@ mod tests {
     struct ScriptedProvider {
         id: ProviderId,
         outcomes: std::sync::Mutex<Vec<Result<ProviderQuotes, ProviderError>>>,
+        /// Stands in for the Nostr provider's relayed-event `created_at`;
+        /// `None` reproduces every HTTP provider's default.
+        observed_at: Option<i64>,
     }
 
     impl ScriptedProvider {
@@ -839,7 +885,13 @@ mod tests {
             Self {
                 id,
                 outcomes: std::sync::Mutex::new(outcomes),
+                observed_at: None,
             }
+        }
+
+        fn observed_at(mut self, ts: i64) -> Self {
+            self.observed_at = Some(ts);
+            self
         }
     }
 
@@ -855,6 +907,10 @@ mod tests {
                 return Ok(ProviderQuotes::new());
             }
             q.remove(0)
+        }
+
+        fn last_observed_at(&self) -> Option<i64> {
+            self.observed_at
         }
     }
 
@@ -901,6 +957,109 @@ mod tests {
 
     fn manager_with(scripted: ScriptedProvider) -> PriceManager {
         manager_with_many(vec![scripted])
+    }
+
+    /// Regression for issue #860. A relayed rate must be stamped from when
+    /// the trusted node observed it, not from when we ingested it —
+    /// otherwise the provider's acceptance window and the store's serving
+    /// window stack, and a price outlives the configured TTL.
+    ///
+    /// One tick, two stamps: Yadio's USD is observed at fetch time and keeps
+    /// `now`; Nostr's ARS carries the age its event already had.
+    #[tokio::test]
+    async fn relayed_currency_is_stamped_from_observation_not_ingestion() {
+        const TTL: i64 = 1_800;
+        const EVENT_AGE: i64 = 900;
+
+        let tick_start = Utc::now().timestamp();
+        let observed_at = tick_start - EVENT_AGE;
+
+        let mut yadio_quotes = ProviderQuotes::new();
+        yadio_quotes.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let mut nostr_quotes = ProviderQuotes::new();
+        // Uncovered by Yadio, so it survives `restrict_nostr_to_fallback`.
+        nostr_quotes.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
+
+        let manager = manager_with_many(vec![
+            ScriptedProvider::new(ProviderId::Yadio, vec![Ok(yadio_quotes)]),
+            ScriptedProvider::new(ProviderId::Nostr, vec![Ok(nostr_quotes)])
+                .observed_at(observed_at),
+        ]);
+        manager.update_all().await;
+
+        // The relayed currency is bounded at exactly one TTL from
+        // observation: servable at the boundary, refused one second past it.
+        assert!(
+            manager.store.get("ARS", TTL, observed_at + TTL).is_ok(),
+            "relayed price must be servable up to one TTL after observation"
+        );
+        assert!(
+            manager
+                .store
+                .get("ARS", TTL, observed_at + TTL + 1)
+                .is_err(),
+            "relayed price must be refused past one TTL from observation"
+        );
+        // Pre-fix, `as_of = now` would have kept it alive until
+        // `observed_at + EVENT_AGE + TTL`. That window is now closed.
+        assert!(
+            manager
+                .store
+                .get("ARS", TTL, observed_at + EVENT_AGE + TTL)
+                .is_err(),
+            "the stacked ingestion + serving window must no longer be reachable"
+        );
+
+        // The directly-observed currency is untouched: still good for a full
+        // TTL measured from this tick.
+        assert!(
+            manager.store.get("USD", TTL, tick_start + TTL).is_ok(),
+            "an HTTP-sourced price must keep the full serving window"
+        );
+    }
+
+    /// A fiat-cross currency whose anchor came from Nostr is no fresher than
+    /// that anchor, even though `contributors` names only the cross provider
+    /// — so it must be backdated too. This is the case
+    /// `contributors == [Nostr]` alone does not catch.
+    #[tokio::test]
+    async fn nostr_anchor_dependent_currency_is_also_backdated() {
+        const TTL: i64 = 1_800;
+        const EVENT_AGE: i64 = 900;
+
+        let observed_at = Utc::now().timestamp() - EVENT_AGE;
+
+        // El Toque quotes CUP per USD; only Nostr supplies the USD anchor,
+        // so CUP resolves through a relayed rate.
+        let mut eltoque_quotes = ProviderQuotes::new();
+        eltoque_quotes.insert(
+            "CUP".into(),
+            Quote::PerBase {
+                base: "USD".into(),
+                value: 400.0,
+            },
+        );
+        let mut nostr_quotes = ProviderQuotes::new();
+        nostr_quotes.insert("USD".into(), Quote::PerBtc(50_000.0));
+
+        let manager = manager_with_many(vec![
+            ScriptedProvider::new(ProviderId::ElToque, vec![Ok(eltoque_quotes)]),
+            ScriptedProvider::new(ProviderId::Nostr, vec![Ok(nostr_quotes)])
+                .observed_at(observed_at),
+        ]);
+        manager.update_all().await;
+
+        assert!(
+            manager.store.get("CUP", TTL, observed_at + TTL).is_ok(),
+            "the cross currency must be servable up to one TTL from the anchor's observation"
+        );
+        assert!(
+            manager
+                .store
+                .get("CUP", TTL, observed_at + TTL + 1)
+                .is_err(),
+            "a cross currency built on a relayed anchor is no fresher than that anchor"
+        );
     }
 
     #[tokio::test]

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -344,14 +344,31 @@ impl PriceManager {
     /// and needs no configuration.
     ///
     /// Two groups get the earlier stamp:
-    /// - currencies whose only surviving contributor is Nostr — a non-Nostr
-    ///   provider covering the currency drops Nostr's quote before
-    ///   aggregation (`restrict_nostr_to_fallback`), so a mixed contributor
-    ///   list containing Nostr cannot occur here;
+    /// - currencies Nostr contributed to at all. Today
+    ///   `restrict_nostr_to_fallback` drops Nostr's quote for any currency
+    ///   another provider covers, so in practice this means "sole
+    ///   contributor" — but the test is `contains`, not equality, so if that
+    ///   invariant ever relaxes a partly-relayed value is stamped early
+    ///   (stale sooner) rather than stamped `now` (served past its true age,
+    ///   silently restoring this bug);
     /// - `nostr_anchor_dependent` ones, whose value embeds a relayed rate
     ///   through a fiat-cross anchor even though `contributors` names only
     ///   the cross provider (`aggregate.rs`) — the figure is no fresher
     ///   than the anchor it was built from.
+    ///
+    /// The second group is deliberately coarse: the flag is set when *any*
+    /// surviving contributor resolved through a Nostr-touched anchor, so a
+    /// currency that also has an independent, directly-observed contributor
+    /// is backdated as a whole. That over-refuses rather than over-serves,
+    /// which is the right way to be wrong on a price that quotes trades;
+    /// distinguishing the two would need per-contributor provenance that
+    /// `AggregateResult` does not carry.
+    ///
+    /// Note this is **not** the same predicate as `republishable_rates`,
+    /// which deliberately republishes a value Nostr merely helped
+    /// corroborate. "May I re-stamp this as my own observation" and "how old
+    /// is this really" are different questions, so the two must not be
+    /// merged into one helper.
     fn store_with_observation_time(&self, aggregates: HashMap<String, AggregateResult>, now: i64) {
         let observed_at = self
             .providers
@@ -367,9 +384,10 @@ impl PriceManager {
             return;
         };
 
-        let (relayed, direct): (HashMap<_, _>, HashMap<_, _>) = aggregates
-            .into_iter()
-            .partition(|(_, a)| a.contributors == [ProviderId::Nostr] || a.nostr_anchor_dependent);
+        let (relayed, direct): (HashMap<_, _>, HashMap<_, _>) =
+            aggregates.into_iter().partition(|(_, a)| {
+                a.contributors.contains(&ProviderId::Nostr) || a.nostr_anchor_dependent
+            });
 
         self.store.update(direct, now);
         self.store.update(relayed, observed_at);
@@ -504,13 +522,18 @@ impl PriceManager {
         };
         let age = now.saturating_sub(entry.as_of);
         let one_interval = self.settings.update_interval_seconds as i64;
+        // Reaching here means `get_price` served the value, so it is inside
+        // the TTL by definition — re-arm the past-TTL refusal flag on any
+        // served read, not only on a fully fresh one. A relayed currency's
+        // age is measured from when the trusted node observed the rate
+        // (issue #860), so it can sit above one interval for its entire
+        // servable life; gating this on `age <= one_interval` would let the
+        // refusal warning fire exactly once per process.
+        self.clear_warned(&self.warned_refused, key);
         if age <= one_interval {
-            // Fully fresh — also wipe both stale flags so a future slide
-            // past one interval (within-TTL warning) or past
-            // `max_price_staleness_seconds` (refusal warning) warns once
-            // more.
+            // Fully fresh — also wipe the within-TTL stale flag so a future
+            // slide past one interval warns once more.
             self.clear_warned(&self.warned_stale, key);
-            self.clear_warned(&self.warned_refused, key);
             return;
         }
         if self.mark_warned(&self.warned_stale, key) {
@@ -1015,6 +1038,78 @@ mod tests {
         assert!(
             manager.store.get("USD", TTL, tick_start + TTL).is_ok(),
             "an HTTP-sourced price must keep the full serving window"
+        );
+    }
+
+    /// Backdating must never *shorten* a currency's serving window. A
+    /// relayed event older than a value this node already fetched directly
+    /// is not news, and applying it would refuse a currency that was
+    /// perfectly servable a moment earlier.
+    #[tokio::test]
+    async fn a_relayed_event_older_than_the_stored_value_does_not_regress_as_of() {
+        const TTL: i64 = 1_800;
+
+        let direct_at = Utc::now().timestamp();
+        // The relayed event predates what we already hold for ARS.
+        let observed_at = direct_at - 600;
+
+        let mut direct = HashMap::new();
+        direct.insert(
+            "ARS".to_string(),
+            AggregateResult {
+                value: 105_000_000.0,
+                sources: 1,
+                contributors: vec![ProviderId::Yadio],
+                nostr_anchor_dependent: false,
+            },
+        );
+
+        let mut nostr_quotes = ProviderQuotes::new();
+        nostr_quotes.insert("ARS".into(), Quote::PerBtc(104_000_000.0));
+        let manager = manager_with(
+            ScriptedProvider::new(ProviderId::Nostr, vec![Ok(nostr_quotes)])
+                .observed_at(observed_at),
+        );
+        // Seed the store as if a healthy direct tick had just landed.
+        manager.store.update(direct, direct_at);
+
+        manager.update_all().await;
+
+        assert!(
+            manager.store.get("ARS", TTL, direct_at + TTL).is_ok(),
+            "an older relayed observation must not shorten the window the \
+             direct fetch already earned"
+        );
+    }
+
+    /// The observation time is read from provider state that survives across
+    /// ticks, so a tick where Nostr contributed nothing must not backdate
+    /// anything with a leftover timestamp.
+    #[tokio::test]
+    async fn a_tick_without_a_nostr_contribution_is_not_backdated() {
+        const TTL: i64 = 1_800;
+
+        let tick_start = Utc::now().timestamp();
+        let stale_leftover = tick_start - 1_700;
+
+        let mut yadio_quotes = ProviderQuotes::new();
+        yadio_quotes.insert("USD".into(), Quote::PerBtc(50_000.0));
+
+        // Nostr reports a (leftover) observation time but fails this tick,
+        // so it contributes to no aggregate.
+        let manager = manager_with_many(vec![
+            ScriptedProvider::new(ProviderId::Yadio, vec![Ok(yadio_quotes)]),
+            ScriptedProvider::new(
+                ProviderId::Nostr,
+                vec![Err(ProviderError::Http("nostr: no event".into()))],
+            )
+            .observed_at(stale_leftover),
+        ]);
+        manager.update_all().await;
+
+        assert!(
+            manager.store.get("USD", TTL, tick_start + TTL).is_ok(),
+            "a currency Nostr did not contribute to keeps the full window"
         );
     }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -322,7 +322,20 @@ impl PriceManager {
         let now = Utc::now().timestamp();
         self.observe_warnings(&aggregates);
         self.store_with_observation_time(aggregates.clone(), now);
-        report.fresh_currencies = aggregates.len();
+        // Count what the store will actually **serve**, not what the tick
+        // produced. `as_of` is no longer always `now` (issue #860), so a
+        // relayed event admitted at the `max_age` boundary — the gate is the
+        // full TTL and inclusive (`nostr.rs`), and the tick's `now` is taken
+        // after every remaining provider's poll budget — can be past the TTL
+        // the instant it is written. This number reaches the operator in the
+        // partial-outage warning (`scheduler.rs`), which is precisely the
+        // tick a relayed rate lands in: `restrict_nostr_to_fallback` only
+        // lets Nostr through for a currency nobody else covered.
+        report.fresh_currencies = self.store.servable_count(
+            aggregates.keys().map(String::as_str),
+            self.settings.max_price_staleness_seconds,
+            now,
+        );
         report.contributors = contributors;
 
         if self.settings.publish_to_nostr {
@@ -356,6 +369,14 @@ impl PriceManager {
     ///   the cross provider (`aggregate.rs`) — the figure is no fresher
     ///   than the anchor it was built from.
     ///
+    /// Both halves rest on the same guarantee, which is why reading the
+    /// stamp from provider state *after* the tick is sound for both. The
+    /// flag is set from `anchor_uses_nostr`, i.e. `kept_contributors` over
+    /// **this tick's** direct quotes after `restrict_nostr_to_fallback`
+    /// (`aggregate.rs`), so it cannot be true unless Nostr's quote survived
+    /// this tick — exactly the condition `contributors.contains(&Nostr)`
+    /// states outright.
+    ///
     /// The second group is deliberately coarse: the flag is set when *any*
     /// surviving contributor resolved through a Nostr-touched anchor, so a
     /// currency that also has an independent, directly-observed contributor
@@ -370,6 +391,7 @@ impl PriceManager {
     /// is this really" are different questions, so the two must not be
     /// merged into one helper.
     fn store_with_observation_time(&self, aggregates: HashMap<String, AggregateResult>, now: i64) {
+        let requested = aggregates.len();
         let observed_at = self
             .providers
             .iter()
@@ -379,18 +401,29 @@ impl PriceManager {
         // A future-dated or absent stamp falls through to the existing
         // behaviour: never move `as_of` forward, that would *extend* the
         // serving window rather than bound it.
-        let Some(observed_at) = observed_at.filter(|ts| *ts < now) else {
-            self.store.update(aggregates, now);
-            return;
+        let applied = match observed_at.filter(|ts| *ts < now) {
+            None => self.store.update(aggregates, now),
+            Some(observed_at) => {
+                let (relayed, direct): (HashMap<_, _>, HashMap<_, _>) =
+                    aggregates.into_iter().partition(|(_, a)| {
+                        a.contributors.contains(&ProviderId::Nostr) || a.nostr_anchor_dependent
+                    });
+
+                self.store.update(direct, now) + self.store.update_observed(relayed, observed_at)
+            }
         };
 
-        let (relayed, direct): (HashMap<_, _>, HashMap<_, _>) =
-            aggregates.into_iter().partition(|(_, a)| {
-                a.contributors.contains(&ProviderId::Nostr) || a.nostr_anchor_dependent
-            });
-
-        self.store.update(direct, now);
-        self.store.update(relayed, observed_at);
+        // The monotonicity guard discards a backwards write by design, but
+        // discarding it in silence left a vanished rate with no trace
+        // anywhere (review on PR #925). Expected behaviour, not an
+        // anomaly — hence `debug`, and once per tick rather than per key.
+        if applied < requested {
+            debug!(
+                "price: {}/{} tick writes dropped — observation older than the stored one",
+                requested - applied,
+                requested
+            );
+        }
     }
 
     /// Wall-clock budget for one provider's poll: `provider_timeout_seconds`
@@ -849,7 +882,13 @@ pub struct TickReport {
     /// Distinct from `successes`: a scoped-out provider lands in
     /// `successes` (it did poll OK) but **not** in `contributors`.
     pub contributors: Vec<ProviderId>,
-    /// Number of currencies the tick produced a fresh aggregate for.
+    /// Number of currencies the store would actually **serve** after this
+    /// tick. Not the size of the aggregate map: `as_of` can predate the
+    /// tick (issue #860), so a relayed rate admitted at the edge of the
+    /// provider's acceptance window can be past the TTL the instant it is
+    /// written. This is the number the partial-outage warning in
+    /// `scheduler.rs` shows the operator, so it must not name a currency
+    /// `get_price` refuses in the same second.
     pub fresh_currencies: usize,
 }
 
@@ -1154,6 +1193,58 @@ mod tests {
                 .get("CUP", TTL, observed_at + TTL + 1)
                 .is_err(),
             "a cross currency built on a relayed anchor is no fresher than that anchor"
+        );
+    }
+
+    /// Review finding on PR #925: `report.fresh_currencies` was sized from
+    /// the aggregate map, so a tick could report a currency as fresh in the
+    /// same second `get_price` refused it — and that number reaches the
+    /// operator through the partial-outage warning in `scheduler.rs`.
+    ///
+    /// Reachable, not theoretical: the Nostr `max_age` gate is the full TTL
+    /// and its boundary is deliberately inclusive
+    /// (`rank_candidates_keeps_event_exactly_at_max_age_boundary`), it runs
+    /// at fetch time, and the tick's `now` is only taken once every
+    /// remaining provider's poll budget has burned down.
+    #[tokio::test]
+    async fn a_relayed_rate_stamped_past_the_ttl_is_not_reported_fresh() {
+        const TTL: i64 = 1_800;
+
+        // Admitted at the boundary, then the tick's clock moved on.
+        let observed_at = Utc::now().timestamp() - TTL - 5;
+
+        let mut yadio_quotes = ProviderQuotes::new();
+        yadio_quotes.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let mut nostr_quotes = ProviderQuotes::new();
+        // Uncovered by Yadio, so it survives `restrict_nostr_to_fallback`.
+        nostr_quotes.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
+
+        let mut manager = manager_with_many(vec![
+            ScriptedProvider::new(ProviderId::Yadio, vec![Ok(yadio_quotes)]),
+            ScriptedProvider::new(ProviderId::Nostr, vec![Ok(nostr_quotes)])
+                .observed_at(observed_at),
+        ]);
+        manager.settings.max_price_staleness_seconds = TTL;
+
+        let report = manager.update_all().await;
+
+        // The tick aggregated both currencies, and Nostr did contribute.
+        assert!(
+            report.contributors.contains(&ProviderId::Nostr),
+            "the relayed quote reached aggregation"
+        );
+        assert!(
+            manager.get_price("USD").is_ok(),
+            "the directly-fetched currency is servable"
+        );
+        // But ARS is unservable the instant it is written.
+        assert!(
+            manager.get_price("ARS").is_err(),
+            "a rate stamped past the TTL cannot be served"
+        );
+        assert_eq!(
+            report.fresh_currencies, 1,
+            "the count must exclude a currency this tick just made unservable"
         );
     }
 
@@ -2100,6 +2191,63 @@ mod tests {
             manager.warned_refused.read().unwrap().len(),
             1,
             "past-TTL refusal warning must not be suppressed by the within-TTL flag"
+        );
+    }
+
+    /// Review finding on PR #925: moving the `warned_refused` re-arm out of
+    /// `observe_freshness`'s `age <= one_interval` branch changed behaviour
+    /// for **every** currency, not only relayed ones, and no test covered
+    /// it — both existing warning tests stay green with the line in either
+    /// position.
+    ///
+    /// The change is needed because a backdated currency's age is measured
+    /// from observation, so it sits above one poll interval for its entire
+    /// servable life; gating the re-arm on "fully fresh" would let the
+    /// refusal warning fire exactly once per process. This pins the new
+    /// semantics — *once per staleness episode* — for the ordinary
+    /// directly-fetched case too.
+    #[tokio::test]
+    async fn a_served_but_stale_read_re_arms_the_refusal_warning() {
+        let mut quotes = ProviderQuotes::new();
+        quotes.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let scripted = ScriptedProvider::new(ProviderId::Yadio, vec![Ok(quotes)]);
+        let mut manager = manager_with(scripted);
+        manager.settings.update_interval_seconds = 1;
+        manager.settings.max_price_staleness_seconds = 30;
+
+        // 60s old: past a 30s TTL, so the read is refused and arms the flag.
+        let mut agg = HashMap::new();
+        agg.insert(
+            "USD".to_string(),
+            AggregateResult {
+                value: 50_000.0,
+                sources: 1,
+                contributors: vec![ProviderId::Yadio],
+                nostr_anchor_dependent: false,
+            },
+        );
+        let now = Utc::now().timestamp();
+        manager.store.update(agg, now - 60);
+
+        assert!(manager.get_price("USD").is_err());
+        assert_eq!(
+            manager.warned_refused.read().unwrap().len(),
+            1,
+            "the refusal armed the flag"
+        );
+
+        // Widen the TTL: the same entry is served again, but it is still
+        // 60s old against a 1s interval — stale, never "fully fresh". The
+        // flag must re-arm anyway, or the next slide past the TTL is
+        // silent for the rest of the process.
+        manager.settings.max_price_staleness_seconds = 1_800;
+        assert!(
+            manager.get_price("USD").is_ok(),
+            "inside the widened TTL the stale value is served"
+        );
+        assert!(
+            manager.warned_refused.read().unwrap().is_empty(),
+            "a served read re-arms the refusal warning even when the value is stale"
         );
     }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -1457,6 +1457,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_past_ttl_relayed_single_source_does_not_latch_the_warning() {
+        // A relayed rate stamped past the TTL is stored but not served; its
+        // single source must not set warned_single_source, or the one-shot flag
+        // would swallow a later genuine within-TTL single-source transition.
+        const TTL: i64 = 1_800;
+        let observed_at = Utc::now().timestamp() - TTL - 5;
+
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let mut nostr = ProviderQuotes::new();
+        nostr.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
+
+        let mut manager = manager_with_many(vec![
+            ScriptedProvider::new(ProviderId::Yadio, vec![Ok(yadio)]),
+            ScriptedProvider::new(ProviderId::Nostr, vec![Ok(nostr)]).observed_at(observed_at),
+        ]);
+        manager.settings.max_price_staleness_seconds = TTL;
+
+        manager.update_all().await;
+        assert!(
+            manager.get_price("ARS").is_err(),
+            "ARS is past the TTL — not served"
+        );
+        assert!(
+            !manager.warned_single_source.read().unwrap().contains("ARS"),
+            "a past-TTL, non-served relayed rate must not set the single-source flag"
+        );
+    }
+
+    #[tokio::test]
     async fn single_yadio_tick_matches_today() {
         // Spec §9 Phase 1 acceptance: with only Yadio enabled, the manager
         // produces the same values as the legacy single-source path for a
@@ -2739,35 +2769,5 @@ mod coverage_tests {
         let report = manager.update_all().await;
         assert_eq!(report.servable_currencies, 1);
         assert_eq!(report.contributors, vec![ProviderId::Yadio]);
-    }
-
-    #[tokio::test]
-    async fn a_past_ttl_relayed_single_source_does_not_latch_the_warning() {
-        // A relayed rate stamped past the TTL is stored but not served; its
-        // single source must not set warned_single_source, or the one-shot flag
-        // would swallow a later genuine within-TTL single-source transition.
-        const TTL: i64 = 1_800;
-        let observed_at = Utc::now().timestamp() - TTL - 5;
-
-        let mut yadio = ProviderQuotes::new();
-        yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
-        let mut nostr = ProviderQuotes::new();
-        nostr.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
-
-        let mut manager = manager_with_many(vec![
-            ScriptedProvider::new(ProviderId::Yadio, vec![Ok(yadio)]),
-            ScriptedProvider::new(ProviderId::Nostr, vec![Ok(nostr)]).observed_at(observed_at),
-        ]);
-        manager.settings.max_price_staleness_seconds = TTL;
-
-        manager.update_all().await;
-        assert!(
-            manager.get_price("ARS").is_err(),
-            "ARS is past the TTL — not served"
-        );
-        assert!(
-            !manager.warned_single_source.read().unwrap().contains("ARS"),
-            "a past-TTL, non-served relayed rate must not set the single-source flag"
-        );
     }
 }

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -329,8 +329,10 @@ impl PriceManager {
         let contributors: Vec<ProviderId> = contributor_set.into_iter().collect();
 
         let now = Utc::now().timestamp();
-        self.observe_warnings(&aggregates);
         self.store_with_observation_time(aggregates.clone(), now);
+        // Warn *after* the write, so the warnings describe what is being
+        // served rather than what the tick computed — see `observe_warnings`.
+        self.observe_warnings(&aggregates);
         // What the store will actually **serve**, over the whole store —
         // not the size of this tick's aggregate map, and not the tick's own
         // currencies either. Both narrower counts lie, in opposite
@@ -478,13 +480,40 @@ impl PriceManager {
             .collect()
     }
 
-    /// Emit one-shot warnings on the single-source transition: a currency
-    /// with one contributor warns once; gaining a second contributor
-    /// clears the flag so a later regression warns again (spec §10.4).
+    /// Emit one-shot warnings on the single-source transition (spec §10.4):
+    /// a currency drops to one source and warns once; regaining a second
+    /// clears the flag so a later regression warns again.
+    ///
+    /// The source count comes from the **store**, and this runs **after**
+    /// the tick's write, because the two can disagree:
+    /// [`PriceStore::update_observed`]'s monotonicity guard drops a write
+    /// whose observation predates what is already held, and then the
+    /// aggregate describes a value the node is not serving. A relayed
+    /// single-source quote older than a two-source direct fetch would
+    /// otherwise latch "now has a single source" while two sources are
+    /// being served — and because the flag is one-shot, that latch then
+    /// swallows the genuine transition when the currency really does drop
+    /// to one source. The warning is a claim about what is served, so it is
+    /// computed from what is served.
+    ///
+    /// (Found by `/code-review` on PR #925. The guard that made it
+    /// reachable is this PR's own, so it is fixed here rather than filed:
+    /// before it, every write landed and the aggregate could not disagree
+    /// with the store.)
+    ///
+    /// The iteration set is still the tick's currencies. One absent from
+    /// the tick keeps its last-known-good value untouched, so its flag must
+    /// not move either.
     fn observe_warnings(&self, aggregates: &HashMap<String, AggregateResult>) {
-        for (currency, agg) in aggregates {
+        for currency in aggregates.keys() {
             let key = currency.to_uppercase();
-            if agg.sources <= 1 {
+            // Unreachable in practice: the guard only drops a write when a
+            // prior entry exists, and every other write lands. Skip rather
+            // than guess a source count for a currency we cannot serve.
+            let Some(sources) = self.store.snapshot(currency).map(|e| e.source_count) else {
+                continue;
+            };
+            if sources <= 1 {
                 if self.mark_warned(&self.warned_single_source, &key) {
                     warn!("price: {} now has a single source", currency);
                 }
@@ -1342,6 +1371,81 @@ mod tests {
         assert_eq!(
             r.servable_currencies, 1,
             "the early return must report last-known-good, not zero"
+        );
+    }
+
+    /// Review finding on PR #925, and a regression from this PR's own
+    /// monotonicity guard: `observe_warnings` ran on the tick's aggregate
+    /// *before* the write, so a dropped write left it describing a value the
+    /// node was not serving. Both halves are pinned here — the false warning
+    /// and, because the flag is one-shot, the genuine warning it swallowed.
+    #[tokio::test]
+    async fn a_dropped_write_neither_warns_nor_swallows_the_real_single_source() {
+        let old = Utc::now().timestamp() - 600;
+
+        let mut y1 = ProviderQuotes::new();
+        y1.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
+        let mut c1 = ProviderQuotes::new();
+        c1.insert("ARS".into(), Quote::PerBtc(105_100_000.0));
+        let mut n2 = ProviderQuotes::new();
+        n2.insert("ARS".into(), Quote::PerBtc(104_000_000.0));
+        let mut y3 = ProviderQuotes::new();
+        y3.insert("ARS".into(), Quote::PerBtc(106_000_000.0));
+
+        let manager = manager_with_many(vec![
+            ScriptedProvider::new(
+                ProviderId::Yadio,
+                vec![Ok(y1), Err(ProviderError::Http("down".into())), Ok(y3)],
+            ),
+            ScriptedProvider::new(
+                ProviderId::CoinGecko,
+                vec![
+                    Ok(c1),
+                    Err(ProviderError::Http("down".into())),
+                    Err(ProviderError::Http("down".into())),
+                ],
+            ),
+            ScriptedProvider::new(
+                ProviderId::Nostr,
+                vec![
+                    Err(ProviderError::Http("n/a".into())),
+                    Ok(n2),
+                    Err(ProviderError::Http("n/a".into())),
+                ],
+            )
+            .observed_at(old),
+        ]);
+
+        // Tick 1 — two HTTP sources agree. Nostr is dropped by
+        // `restrict_nostr_to_fallback` because ARS is already covered.
+        manager.update_all().await;
+        assert_eq!(manager.store.snapshot("ARS").unwrap().source_count, 2);
+        assert!(
+            !manager.warned_single_source.read().unwrap().contains("ARS"),
+            "two sources: nothing to warn about"
+        );
+
+        // Tick 2 — both HTTP providers fail, so Nostr survives as the sole
+        // contributor, but its event predates what we already hold. The
+        // guard drops the write: the served value still has two sources.
+        manager.update_all().await;
+        assert_eq!(
+            manager.store.snapshot("ARS").unwrap().source_count,
+            2,
+            "the backdated single-source write must not land"
+        );
+        assert!(
+            !manager.warned_single_source.read().unwrap().contains("ARS"),
+            "must not warn about a single source while serving two"
+        );
+
+        // Tick 3 — a genuine drop to one source, this time landing. The
+        // warning must fire, which it cannot if tick 2 latched the flag.
+        manager.update_all().await;
+        assert_eq!(manager.store.snapshot("ARS").unwrap().source_count, 1);
+        assert!(
+            manager.warned_single_source.read().unwrap().contains("ARS"),
+            "the real transition must still be reportable"
         );
     }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -400,7 +400,6 @@ impl PriceManager {
     /// is this really" are different questions, so the two must not be
     /// merged into one helper.
     fn store_with_observation_time(&self, aggregates: HashMap<String, AggregateResult>, now: i64) {
-        let requested = aggregates.len();
         let observed_at = self
             .providers
             .iter()
@@ -410,27 +409,30 @@ impl PriceManager {
         // A future-dated or absent stamp falls through to the existing
         // behaviour: never move `as_of` forward, that would *extend* the
         // serving window rather than bound it.
-        let applied = match observed_at.filter(|ts| *ts < now) {
-            None => self.store.update(aggregates, now),
-            Some(observed_at) => {
-                let (relayed, direct): (HashMap<_, _>, HashMap<_, _>) =
-                    aggregates.into_iter().partition(|(_, a)| {
-                        a.contributors.contains(&ProviderId::Nostr) || a.nostr_anchor_dependent
-                    });
-
-                self.store.update(direct, now) + self.store.update_observed(relayed, observed_at)
-            }
+        let Some(observed_at) = observed_at.filter(|ts| *ts < now) else {
+            self.store.update(aggregates, now);
+            return;
         };
+
+        let (relayed, direct): (HashMap<_, _>, HashMap<_, _>) =
+            aggregates.into_iter().partition(|(_, a)| {
+                a.contributors.contains(&ProviderId::Nostr) || a.nostr_anchor_dependent
+            });
+
+        self.store.update(direct, now);
+        let dropped = self.store.update_observed(relayed, observed_at);
 
         // The monotonicity guard discards a backwards write by design, but
         // discarding it in silence left a vanished rate with no trace
-        // anywhere (review on PR #925). Expected behaviour, not an
-        // anomaly — hence `debug`, and once per tick rather than per key.
-        if applied < requested {
+        // anywhere (review on PR #925). Name the currencies: a bare count
+        // records that *something* went missing without saying what, which
+        // cannot diagnose the rate that stopped moving. Expected behaviour,
+        // not an anomaly — hence `debug`.
+        if !dropped.is_empty() {
             debug!(
-                "price: {}/{} tick writes dropped — observation older than the stored one",
-                requested - applied,
-                requested
+                "price: dropped {} relayed write(s) older than the stored observation: {}",
+                dropped.len(),
+                dropped.join(", ")
             );
         }
     }
@@ -513,14 +515,20 @@ impl PriceManager {
             let Some(entry) = self.store.snapshot(currency) else {
                 continue;
             };
-            // A value past the TTL is stored but not served (issue #860 lets a
-            // relayed rate be stamped past it the instant it lands), so its
-            // source count must not warn — nor latch the one-shot flag and
-            // swallow a later genuine within-TTL single-source transition.
-            if now.saturating_sub(entry.as_of) > self.settings.max_price_staleness_seconds {
-                continue;
-            }
-            if entry.source_count <= 1 {
+            // A value past the TTL is stored but not served (issue #860 lets
+            // a relayed rate be stamped past it the instant it lands), so its
+            // source count must not raise the warning (@arkanoider).
+            //
+            // It must still **clear** the flag rather than skip the currency
+            // outright. `warned_single_source` means "we have already warned
+            // that this is down to one source"; a currency we cannot serve at
+            // all is not one we are warning about, and leaving the flag
+            // latched across an unservable stretch would swallow the genuine
+            // transition when it comes back inside the window — the same
+            // one-shot swallow this path exists to prevent.
+            let servable =
+                now.saturating_sub(entry.as_of) <= self.settings.max_price_staleness_seconds;
+            if servable && entry.source_count <= 1 {
                 if self.mark_warned(&self.warned_single_source, &key) {
                     warn!("price: {} now has a single source", currency);
                 }
@@ -1483,6 +1491,58 @@ mod tests {
         assert!(
             !manager.warned_single_source.read().unwrap().contains("ARS"),
             "a past-TTL, non-served relayed rate must not set the single-source flag"
+        );
+    }
+
+    /// `/code-review` on the round that added the past-TTL skip: skipping
+    /// the currency outright also skipped the `clear_warned` branch, so a
+    /// latched flag survived an unservable stretch and then swallowed the
+    /// genuine transition — the same one-shot swallow the skip was added to
+    /// prevent, one layer up.
+    #[tokio::test]
+    async fn an_unservable_currency_re_arms_the_single_source_warning() {
+        let mut quotes = ProviderQuotes::new();
+        quotes.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let scripted = ScriptedProvider::new(ProviderId::Yadio, vec![Ok(quotes)]);
+        let mut manager = manager_with(scripted);
+        manager.settings.max_price_staleness_seconds = 1_800;
+
+        let now = Utc::now().timestamp();
+        let agg = |sources: u8, contributors: Vec<ProviderId>| {
+            let mut m = HashMap::new();
+            m.insert(
+                "USD".to_string(),
+                AggregateResult {
+                    value: 50_000.0,
+                    sources,
+                    contributors,
+                    nostr_anchor_dependent: false,
+                },
+            );
+            m
+        };
+
+        // Latch the flag the ordinary way: one source, inside the TTL.
+        let single = agg(1, vec![ProviderId::Yadio]);
+        manager.store.update(single.clone(), now);
+        manager.observe_warnings(&single, now);
+        assert!(
+            manager.warned_single_source.read().unwrap().contains("USD"),
+            "a served single-source value warns once"
+        );
+
+        // The stored value is now past the TTL — unservable, so no warning.
+        // But the flag must not survive it.
+        let two = agg(2, vec![ProviderId::Yadio, ProviderId::CoinGecko]);
+        manager.store.update(two.clone(), now - 5_000);
+        assert!(
+            manager.get_price("USD").is_err(),
+            "past the TTL, so not served"
+        );
+        manager.observe_warnings(&two, now);
+        assert!(
+            manager.warned_single_source.read().unwrap().is_empty(),
+            "an unservable currency must re-arm, not stay latched"
         );
     }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -431,7 +431,7 @@ impl PriceManager {
             });
 
         self.store.update(direct, now);
-        let dropped = self.store.update_observed(relayed, observed_at);
+        let dropped = self.store.update_observed(relayed, now, observed_at);
 
         // The monotonicity guard discards a backwards write by design, but
         // discarding it in silence left a vanished rate with no trace
@@ -611,23 +611,28 @@ impl PriceManager {
     /// to emit the "stale but within TTL" warning at most once, and to
     /// clear the past-TTL flag once a fresh enough value lands so the
     /// next slide past the TTL warns again.
+    ///
+    /// The within-TTL "is stale" warning asks "did our tick refresh it?", so
+    /// it measures age from `written_at` (when this node last wrote the
+    /// value), **not** from `as_of` (which the #860 fix backdates to a
+    /// relayed event's `created_at`). Measuring from `as_of` would fire this
+    /// warning on a healthy node for every relayed currency whose event
+    /// arrives older than one interval, even though our own tick just wrote
+    /// it (issue #860 review, PR #925).
     fn observe_freshness(&self, currency: &str, key: &str, now: i64) {
         let Some(entry) = self.store.snapshot(currency) else {
             return;
         };
-        let age = now.saturating_sub(entry.as_of);
+        let age = now.saturating_sub(entry.written_at);
         let one_interval = self.settings.update_interval_seconds as i64;
         // Reaching here means `get_price` served the value, so it is inside
         // the TTL by definition — re-arm the past-TTL refusal flag on any
-        // served read, not only on a fully fresh one. A relayed currency's
-        // age is measured from when the trusted node observed the rate
-        // (issue #860), so it can sit above one interval for its entire
-        // servable life; gating this on `age <= one_interval` would let the
-        // refusal warning fire exactly once per process.
+        // served read, not only on a fully fresh one, so the next slide past
+        // the TTL warns again.
         self.clear_warned(&self.warned_refused, key);
         if age <= one_interval {
-            // Fully fresh — also wipe the within-TTL stale flag so a future
-            // slide past one interval warns once more.
+            // Refreshed within an interval — also wipe the within-TTL stale
+            // flag so a future slide past one interval warns once more.
             self.clear_warned(&self.warned_stale, key);
             return;
         }
@@ -2557,6 +2562,42 @@ mod tests {
         assert!(
             manager.warned_refused.read().unwrap().is_empty(),
             "a served read re-arms the refusal warning even when the value is stale"
+        );
+    }
+
+    /// Review finding on PR #925 (@Catrya): the within-TTL "is stale"
+    /// warning must measure from `written_at`, not `as_of`. Post-#860 a
+    /// relayed currency's `as_of` is its source event's `created_at`, so an
+    /// event arriving older than one interval tripped this warning on a
+    /// healthy node every tick — even though our own tick had just written
+    /// it. It must stay quiet: `written_at` is this tick's clock.
+    #[tokio::test]
+    async fn a_healthy_relayed_tick_does_not_warn_is_stale() {
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let mut nostr = ProviderQuotes::new();
+        // Uncovered by Yadio, so it survives `restrict_nostr_to_fallback`.
+        nostr.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
+
+        // Event is 400s old; interval is 300s — older than one interval but
+        // well inside the TTL.
+        let observed_at = Utc::now().timestamp() - 400;
+        let mut manager = manager_with_many(vec![
+            ScriptedProvider::new(ProviderId::Yadio, vec![Ok(yadio)]),
+            ScriptedProvider::new(ProviderId::Nostr, vec![Ok(nostr)]).observed_at(observed_at),
+        ]);
+        manager.settings.update_interval_seconds = 300;
+        manager.settings.max_price_staleness_seconds = 1_800;
+
+        manager.update_all().await;
+
+        assert!(
+            manager.get_price("ARS").is_ok(),
+            "the relayed rate is inside the TTL and served"
+        );
+        assert!(
+            manager.warned_stale.read().unwrap().is_empty(),
+            "a freshly-written relayed currency must not warn 'is stale' on a healthy node"
         );
     }
 

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -619,6 +619,10 @@ impl PriceManager {
     /// warning on a healthy node for every relayed currency whose event
     /// arrives older than one interval, even though our own tick just wrote
     /// it (issue #860 review, PR #925).
+    ///
+    /// Its blind spot: a relay stuck on one event is re-delivered and
+    /// re-written every tick, so this warning stays quiet for it, and the
+    /// first signal is the TTL refusal in `get_price`.
     fn observe_freshness(&self, currency: &str, key: &str, now: i64) {
         let Some(entry) = self.store.snapshot(currency) else {
             return;

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -332,7 +332,7 @@ impl PriceManager {
         self.store_with_observation_time(aggregates.clone(), now);
         // Warn *after* the write, so the warnings describe what is being
         // served rather than what the tick computed — see `observe_warnings`.
-        self.observe_warnings(&aggregates);
+        self.observe_warnings(&aggregates, now);
         // What the store will actually **serve**, over the whole store —
         // not the size of this tick's aggregate map, and not the tick's own
         // currencies either. Both narrower counts lie, in opposite
@@ -504,16 +504,23 @@ impl PriceManager {
     /// The iteration set is still the tick's currencies. One absent from
     /// the tick keeps its last-known-good value untouched, so its flag must
     /// not move either.
-    fn observe_warnings(&self, aggregates: &HashMap<String, AggregateResult>) {
+    fn observe_warnings(&self, aggregates: &HashMap<String, AggregateResult>, now: i64) {
         for currency in aggregates.keys() {
             let key = currency.to_uppercase();
             // Unreachable in practice: the guard only drops a write when a
             // prior entry exists, and every other write lands. Skip rather
             // than guess a source count for a currency we cannot serve.
-            let Some(sources) = self.store.snapshot(currency).map(|e| e.source_count) else {
+            let Some(entry) = self.store.snapshot(currency) else {
                 continue;
             };
-            if sources <= 1 {
+            // A value past the TTL is stored but not served (issue #860 lets a
+            // relayed rate be stamped past it the instant it lands), so its
+            // source count must not warn — nor latch the one-shot flag and
+            // swallow a later genuine within-TTL single-source transition.
+            if now.saturating_sub(entry.as_of) > self.settings.max_price_staleness_seconds {
+                continue;
+            }
+            if entry.source_count <= 1 {
                 if self.mark_warned(&self.warned_single_source, &key) {
                     warn!("price: {} now has a single source", currency);
                 }
@@ -2732,5 +2739,35 @@ mod coverage_tests {
         let report = manager.update_all().await;
         assert_eq!(report.servable_currencies, 1);
         assert_eq!(report.contributors, vec![ProviderId::Yadio]);
+    }
+
+    #[tokio::test]
+    async fn a_past_ttl_relayed_single_source_does_not_latch_the_warning() {
+        // A relayed rate stamped past the TTL is stored but not served; its
+        // single source must not set warned_single_source, or the one-shot flag
+        // would swallow a later genuine within-TTL single-source transition.
+        const TTL: i64 = 1_800;
+        let observed_at = Utc::now().timestamp() - TTL - 5;
+
+        let mut yadio = ProviderQuotes::new();
+        yadio.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let mut nostr = ProviderQuotes::new();
+        nostr.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
+
+        let mut manager = manager_with_many(vec![
+            ScriptedProvider::new(ProviderId::Yadio, vec![Ok(yadio)]),
+            ScriptedProvider::new(ProviderId::Nostr, vec![Ok(nostr)]).observed_at(observed_at),
+        ]);
+        manager.settings.max_price_staleness_seconds = TTL;
+
+        manager.update_all().await;
+        assert!(
+            manager.get_price("ARS").is_err(),
+            "ARS is past the TTL — not served"
+        );
+        assert!(
+            !manager.warned_single_source.read().unwrap().contains("ARS"),
+            "a past-TTL, non-served relayed rate must not set the single-source flag"
+        );
     }
 }

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -303,6 +303,15 @@ impl PriceManager {
         let aggregates = aggregate_tick(&filtered_with_ids, self.settings.outlier_threshold_pct);
         if aggregates.is_empty() {
             warn!("price: tick produced no fresh aggregates — keeping last-known-good");
+            // Last-known-good is exactly what this path preserves, so report
+            // it rather than zero. Reachable in a *partial* outage — every
+            // provider answered but every quote was scoped out or lost the
+            // outlier filter — where the operator warning would otherwise
+            // read "still 0" while the store serves everything it holds.
+            report.servable_currencies = self.store.servable_count(
+                self.settings.max_price_staleness_seconds,
+                Utc::now().timestamp(),
+            );
             return report;
         }
 
@@ -322,20 +331,18 @@ impl PriceManager {
         let now = Utc::now().timestamp();
         self.observe_warnings(&aggregates);
         self.store_with_observation_time(aggregates.clone(), now);
-        // Count what the store will actually **serve**, not what the tick
-        // produced. `as_of` is no longer always `now` (issue #860), so a
-        // relayed event admitted at the `max_age` boundary — the gate is the
-        // full TTL and inclusive (`nostr.rs`), and the tick's `now` is taken
-        // after every remaining provider's poll budget — can be past the TTL
-        // the instant it is written. This number reaches the operator in the
-        // partial-outage warning (`scheduler.rs`), which is precisely the
-        // tick a relayed rate lands in: `restrict_nostr_to_fallback` only
-        // lets Nostr through for a currency nobody else covered.
-        report.fresh_currencies = self.store.servable_count(
-            aggregates.keys().map(String::as_str),
-            self.settings.max_price_staleness_seconds,
-            now,
-        );
+        // What the store will actually **serve**, over the whole store —
+        // not the size of this tick's aggregate map, and not the tick's own
+        // currencies either. Both narrower counts lie, in opposite
+        // directions: the map counts a currency this tick just stamped past
+        // the TTL (`as_of` is no longer always `now`, issue #860), while
+        // restricting to the tick's currencies drops every last-known-good
+        // value still inside its window — which is precisely what a partial
+        // outage leaves behind, and a partial outage is exactly when
+        // `scheduler.rs` shows this number to the operator.
+        report.servable_currencies = self
+            .store
+            .servable_count(self.settings.max_price_staleness_seconds, now);
         report.contributors = contributors;
 
         if self.settings.publish_to_nostr {
@@ -882,14 +889,23 @@ pub struct TickReport {
     /// Distinct from `successes`: a scoped-out provider lands in
     /// `successes` (it did poll OK) but **not** in `contributors`.
     pub contributors: Vec<ProviderId>,
-    /// Number of currencies the store would actually **serve** after this
-    /// tick. Not the size of the aggregate map: `as_of` can predate the
-    /// tick (issue #860), so a relayed rate admitted at the edge of the
+    /// How many currencies [`PriceManager::get_price`] would serve right
+    /// now — every stored entry inside the TTL, not only the ones this tick
+    /// refreshed.
+    ///
+    /// Deliberately **not** named `fresh`: an entry counted here may be
+    /// stale in this codebase's own sense, old enough that
+    /// `observe_freshness` warns "is stale ({}s old)" while still serving
+    /// it. Servable and fresh are different things, and the operator asking
+    /// "what survived this outage" wants the first.
+    ///
+    /// It is not the size of the aggregate map either: `as_of` can predate
+    /// the tick (issue #860), so a relayed rate admitted at the edge of the
     /// provider's acceptance window can be past the TTL the instant it is
-    /// written. This is the number the partial-outage warning in
-    /// `scheduler.rs` shows the operator, so it must not name a currency
-    /// `get_price` refuses in the same second.
-    pub fresh_currencies: usize,
+    /// written. This number reaches the operator through the partial-outage
+    /// warning in `scheduler.rs`, so it must neither name a currency
+    /// `get_price` refuses in the same second nor omit one it would serve.
+    pub servable_currencies: usize,
 }
 
 /// Synthesise the legacy single-source config from the top-level
@@ -1196,7 +1212,7 @@ mod tests {
         );
     }
 
-    /// Review finding on PR #925: `report.fresh_currencies` was sized from
+    /// Review finding on PR #925: `report.servable_currencies` was sized from
     /// the aggregate map, so a tick could report a currency as fresh in the
     /// same second `get_price` refused it — and that number reaches the
     /// operator through the partial-outage warning in `scheduler.rs`.
@@ -1243,8 +1259,89 @@ mod tests {
             "a rate stamped past the TTL cannot be served"
         );
         assert_eq!(
-            report.fresh_currencies, 1,
+            report.servable_currencies, 1,
             "the count must exclude a currency this tick just made unservable"
+        );
+    }
+
+    /// CodeRabbit on PR #925, and it was right: restricting the count to the
+    /// tick's own currencies makes it lie *downward*. Every last-known-good
+    /// value still inside its window is servable and goes uncounted — and a
+    /// partial outage is exactly what leaves those behind, which is exactly
+    /// when `scheduler.rs` shows the number to the operator.
+    #[tokio::test]
+    async fn a_partial_outage_counts_last_known_good_not_just_this_tick() {
+        let mut t1 = ProviderQuotes::new();
+        t1.insert("USD".into(), Quote::PerBtc(50_000.0));
+        t1.insert("EUR".into(), Quote::PerBtc(45_000.0));
+        t1.insert("ARS".into(), Quote::PerBtc(105_000_000.0));
+        let mut t2 = ProviderQuotes::new();
+        t2.insert("USD".into(), Quote::PerBtc(50_100.0));
+
+        let manager = manager_with_many(vec![
+            ScriptedProvider::new(
+                ProviderId::Yadio,
+                vec![Ok(t1), Err(ProviderError::Http("down".into()))],
+            ),
+            ScriptedProvider::new(
+                ProviderId::CoinGecko,
+                vec![Err(ProviderError::Http("cold".into())), Ok(t2)],
+            ),
+        ]);
+
+        assert_eq!(manager.update_all().await.servable_currencies, 3);
+
+        // Tick 2: Yadio is down, CoinGecko covers USD alone. EUR and ARS
+        // still hold tick 1's values, well inside the TTL.
+        let r = manager.update_all().await;
+        assert_eq!(r.failures.len(), 1, "this is the partial-outage tick");
+        for c in ["USD", "EUR", "ARS"] {
+            assert!(
+                manager.get_price(c).is_ok(),
+                "{c} is servable, so the operator's count must include it"
+            );
+        }
+        assert_eq!(
+            r.servable_currencies, 3,
+            "counting only the tick's own currencies would report 1 of 3"
+        );
+    }
+
+    /// The `aggregates.is_empty()` early return used to leave the count at
+    /// its default zero. That path is not only the all-providers-down case:
+    /// every provider can answer and still contribute nothing (scoped out,
+    /// or every quote lost the outlier filter), and then the operator's
+    /// partial-outage warning read "still 0" while the store served
+    /// everything it held.
+    #[tokio::test]
+    async fn a_tick_with_no_aggregates_still_reports_last_known_good() {
+        let mut quotes = ProviderQuotes::new();
+        quotes.insert("USD".into(), Quote::PerBtc(50_000.0));
+        let scripted =
+            ScriptedProvider::new(ProviderId::Yadio, vec![Ok(quotes.clone()), Ok(quotes)]);
+        let mut manager = manager_with(scripted);
+
+        assert_eq!(manager.update_all().await.servable_currencies, 1);
+
+        // Now scope Yadio to a currency it never quotes: it still polls OK,
+        // so this is not an all-failed tick, but the aggregate map is empty.
+        manager
+            .settings
+            .providers
+            .get_mut(&ProviderId::Yadio.to_string())
+            .unwrap()
+            .only = Some(vec!["MLC".into()]);
+
+        let r = manager.update_all().await;
+        assert_eq!(
+            r.successes,
+            vec![ProviderId::Yadio],
+            "the provider answered — this is the empty-aggregate path, not an outage"
+        );
+        assert!(manager.get_price("USD").is_ok(), "USD is still servable");
+        assert_eq!(
+            r.servable_currencies, 1,
+            "the early return must report last-known-good, not zero"
         );
     }
 
@@ -1269,7 +1366,7 @@ mod tests {
             "yadio's quotes all survived scoping, so it contributes"
         );
         assert!(report.failures.is_empty());
-        assert_eq!(report.fresh_currencies, 3);
+        assert_eq!(report.servable_currencies, 3);
 
         assert!(
             (manager.get_price("USD").unwrap() - 75_899.55).abs() < 1e-6,
@@ -1317,7 +1414,7 @@ mod tests {
             warned_single_source: RwLock::new(HashSet::new()),
         };
         let r = manager.update_all().await;
-        assert_eq!(r.fresh_currencies, 0);
+        assert_eq!(r.servable_currencies, 0);
         assert!(manager.get_price("USD").is_err());
     }
 
@@ -1825,7 +1922,7 @@ mod tests {
             report.contributors.is_empty(),
             "scoped-out provider must not appear in the Nostr source tag"
         );
-        assert_eq!(report.fresh_currencies, 0);
+        assert_eq!(report.servable_currencies, 0);
     }
 
     fn quotes_of(pairs: &[(&str, f64)]) -> ProviderQuotes {
@@ -1921,7 +2018,7 @@ mod tests {
         let manager = manager_with_many(providers);
         let report = manager.update_all().await;
         assert_eq!(
-            report.fresh_currencies, 1,
+            report.servable_currencies, 1,
             "only USD survives the allowlist"
         );
         assert!(manager.get_price("USD").is_ok());
@@ -2529,7 +2626,7 @@ mod coverage_tests {
             }],
         );
         let report = manager.update_all().await;
-        assert_eq!(report.fresh_currencies, 1);
+        assert_eq!(report.servable_currencies, 1);
         assert_eq!(report.contributors, vec![ProviderId::Yadio]);
     }
 }

--- a/src/price/manager.rs
+++ b/src/price/manager.rs
@@ -389,10 +389,21 @@ impl PriceManager {
     /// The second group is deliberately coarse: the flag is set when *any*
     /// surviving contributor resolved through a Nostr-touched anchor, so a
     /// currency that also has an independent, directly-observed contributor
-    /// is backdated as a whole. That over-refuses rather than over-serves,
-    /// which is the right way to be wrong on a price that quotes trades;
-    /// distinguishing the two would need per-contributor provenance that
-    /// `AggregateResult` does not carry.
+    /// is backdated as a whole. Distinguishing the two needs per-contributor
+    /// provenance that `AggregateResult` does not carry — tracked in #959.
+    ///
+    /// **The cost is larger than "stamped early", and worth stating plainly**
+    /// (`/code-review`, measured). Because the backdated write also meets the
+    /// monotonicity guard, a tainted aggregate whose observation predates the
+    /// stored stamp is dropped **whole** — the fresh, independently-observed
+    /// direct half with it. If a relay stays pinned on one old-but-accepted
+    /// event while the currency keeps being cross-quoted, every subsequent
+    /// tick is discarded the same way, and the currency ages out to a refusal
+    /// while a good direct quote arrived on every one of those ticks.
+    ///
+    /// It is still the right trade for a price that quotes trades — refusing
+    /// beats serving a figure staler than it claims — but it is a refusal
+    /// this node could have avoided, not merely a shorter window.
     ///
     /// Note this is **not** the same predicate as `republishable_rates`,
     /// which deliberately republishes a value Nostr merely helped

--- a/src/price/provider.rs
+++ b/src/price/provider.rs
@@ -110,6 +110,19 @@ pub trait PriceProvider: Send + Sync {
     /// reports; any network/parse failure is an `Err` so the provider is
     /// skipped for this tick.
     async fn fetch(&self, http: &reqwest::Client) -> Result<ProviderQuotes, ProviderError>;
+
+    /// Unix timestamp of the *observation* behind the last successful
+    /// [`Self::fetch`], for a provider that relays a figure it did not
+    /// observe itself.
+    ///
+    /// `None` — the default, and correct for every HTTP provider — means
+    /// ingestion time is observation time: the request returns the rate as
+    /// of now. Only the Nostr provider differs, since a trusted node's rate
+    /// event was created before we read it, and that gap must not be
+    /// discarded when the store stamps `as_of` (issue #860).
+    fn last_observed_at(&self) -> Option<i64> {
+        None
+    }
 }
 
 /// Per-provider circuit-breaker state (spec §6.5).

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -214,6 +214,7 @@ impl NostrProvider {
     /// even though a usable redundant trusted node is right there. Split out
     /// from [`Self::fetch`] so the fallback behavior is unit-testable
     /// without a relay.
+    ///
     /// Returns the winning event alongside its quotes: the caller needs its
     /// `created_at` to stamp `as_of` from when the rate was observed rather
     /// than when we ingested it (issue #860).

--- a/src/price/providers/nostr.rs
+++ b/src/price/providers/nostr.rs
@@ -20,6 +20,7 @@
 //! (hermeme, PR #841).
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -63,6 +64,14 @@ pub struct NostrProvider {
     /// the shared `[price].max_price_staleness_seconds` so upstream Nostr
     /// freshness uses the same TTL the store enforces on cached quotes.
     max_age: Duration,
+    /// `created_at` of the event that sourced the last successful
+    /// [`PriceProvider::fetch`], surfaced through
+    /// [`PriceProvider::last_observed_at`]. `0` ⇒ never set.
+    ///
+    /// Atomic rather than a lock because `fetch` takes `&self` and this is a
+    /// single `i64` written once per tick by one scheduler task; `Relaxed`
+    /// is sufficient as no other state is ordered against it.
+    last_observed_at: AtomicI64,
 }
 
 impl NostrProvider {
@@ -113,6 +122,7 @@ impl NostrProvider {
             // `PriceSettings::validate` already rejects non-positive values;
             // clamp here so a zero can never make every event look fresh.
             max_age: Duration::from_secs(max_price_staleness_seconds.max(1) as u64),
+            last_observed_at: AtomicI64::new(0),
         })
     }
 
@@ -204,12 +214,15 @@ impl NostrProvider {
     /// even though a usable redundant trusted node is right there. Split out
     /// from [`Self::fetch`] so the fallback behavior is unit-testable
     /// without a relay.
-    pub(crate) fn pick_first_usable(
-        candidates: &[&Event],
-    ) -> Result<ProviderQuotes, ProviderError> {
+    /// Returns the winning event alongside its quotes: the caller needs its
+    /// `created_at` to stamp `as_of` from when the rate was observed rather
+    /// than when we ingested it (issue #860).
+    pub(crate) fn pick_first_usable<'a>(
+        candidates: &[&'a Event],
+    ) -> Result<(&'a Event, ProviderQuotes), ProviderError> {
         for event in candidates {
             match Self::parse_content(&event.content) {
-                Ok(quotes) if !quotes.is_empty() => return Ok(quotes),
+                Ok(quotes) if !quotes.is_empty() => return Ok((event, quotes)),
                 Ok(_) => debug!(
                     "price: nostr: candidate event {} parsed to zero usable rates, trying next",
                     event.id
@@ -309,7 +322,21 @@ impl PriceProvider for NostrProvider {
             ));
         }
 
-        Self::pick_first_usable(&candidates)
+        let (event, quotes) = Self::pick_first_usable(&candidates)?;
+        // Record when the rate was *observed* by the trusted node, not when
+        // we read it. `PriceManager::update_all` stamps `as_of` from this so
+        // the store's serving window is not stacked on top of the age the
+        // event already had (issue #860).
+        self.last_observed_at
+            .store(event.created_at.as_secs() as i64, Ordering::Relaxed);
+        Ok(quotes)
+    }
+
+    fn last_observed_at(&self) -> Option<i64> {
+        match self.last_observed_at.load(Ordering::Relaxed) {
+            0 => None,
+            ts => Some(ts),
+        }
     }
 }
 
@@ -565,8 +592,12 @@ mod tests {
         let valid = signed_event(&keys, SAMPLE_CONTENT, NOW - 2_000);
         let candidates = vec![&malformed, &valid];
 
-        let quotes = NostrProvider::pick_first_usable(&candidates).unwrap();
+        let (event, quotes) = NostrProvider::pick_first_usable(&candidates).unwrap();
         assert_eq!(quotes.get("USD"), Some(&Quote::PerBtc(50_000.0)));
+        // The returned event must be the one that actually parsed — its
+        // `created_at` is what stamps `as_of` (issue #860), so returning the
+        // skipped newest candidate would backdate by the wrong amount.
+        assert_eq!(event.id, valid.id);
     }
 
     #[test]
@@ -576,8 +607,9 @@ mod tests {
         let valid = signed_event(&keys, SAMPLE_CONTENT, NOW - 2_000);
         let candidates = vec![&empty, &valid];
 
-        let quotes = NostrProvider::pick_first_usable(&candidates).unwrap();
+        let (event, quotes) = NostrProvider::pick_first_usable(&candidates).unwrap();
         assert_eq!(quotes.get("USD"), Some(&Quote::PerBtc(50_000.0)));
+        assert_eq!(event.id, valid.id);
     }
 
     #[test]

--- a/src/price/store.rs
+++ b/src/price/store.rs
@@ -61,21 +61,36 @@ impl PriceStore {
         Self::default()
     }
 
-    /// Overwrite the currencies present in `aggregates` with `as_of = now`.
+    /// Overwrite the currencies present in `aggregates`, stamping each with
+    /// `as_of` — the time the value was **observed**, which is the tick's
+    /// `now` for a directly-fetched rate but the source event's own
+    /// timestamp for a relayed one (issue #860).
+    ///
     /// Currencies **absent** from `aggregates` are left untouched, so their
     /// last-known-good value (and its older `as_of`) is preserved (spec
     /// §6.4). Currency codes are upper-cased to match read lookups.
-    pub fn update(&self, aggregates: HashMap<String, AggregateResult>, now: i64) {
+    ///
+    /// **`as_of` never moves backwards.** A write carrying an observation
+    /// older than the one already stored is dropped: a relayed rate whose
+    /// event predates a value this node fetched directly is not news, and
+    /// applying it would *shorten* the serving window below what writing
+    /// nothing at all would have left — refusing a currency that was
+    /// perfectly servable a moment earlier.
+    pub fn update(&self, aggregates: HashMap<String, AggregateResult>, as_of: i64) {
         if aggregates.is_empty() {
             return;
         }
         let mut w = self.inner.write().expect("price store lock poisoned");
         for (currency, agg) in aggregates {
+            let key = currency.to_uppercase();
+            if w.get(&key).is_some_and(|prior| prior.as_of > as_of) {
+                continue;
+            }
             w.insert(
-                currency.to_uppercase(),
+                key,
                 AggregatedPrice {
                     value: agg.value,
-                    as_of: now,
+                    as_of,
                     source_count: agg.sources,
                 },
             );

--- a/src/price/store.rs
+++ b/src/price/store.rs
@@ -74,11 +74,10 @@ impl PriceStore {
     /// last-known-good value (and its older `as_of`) is preserved (spec
     /// §6.4). Currency codes are upper-cased to match read lookups.
     ///
-    /// Returns **how many writes were applied** — always every entry here,
-    /// but the shape matches [`Self::update_observed`] so a caller can
-    /// account for both halves of a tick the same way.
-    pub fn update(&self, aggregates: HashMap<String, AggregateResult>, as_of: i64) -> usize {
-        self.write(aggregates, as_of, false)
+    /// Every entry lands: a wall-clock write is unconditional (see
+    /// [`Self::update_observed`] for why the guard is not here).
+    pub fn update(&self, aggregates: HashMap<String, AggregateResult>, as_of: i64) {
+        self.write(aggregates, as_of, false);
     }
 
     /// Like [`Self::update`], but for a **backdated** write: `observed_at`
@@ -89,9 +88,9 @@ impl PriceStore {
     /// event predates a value this node fetched directly is not news, and
     /// applying it would *shorten* the serving window below what writing
     /// nothing at all would have left — refusing a currency that was
-    /// perfectly servable a moment earlier. Dropped entries are excluded
-    /// from the returned count, so a silently discarded rate leaves a trace
-    /// (review on PR #925).
+    /// perfectly servable a moment earlier. **Returns the currency codes it
+    /// dropped**, so a discarded rate leaves a trace naming itself rather
+    /// than a bare count nothing can be diagnosed from (review on PR #925).
     ///
     /// The guard is deliberately **not** on [`Self::update`]. A wall-clock
     /// write is this node's own authoritative observation and must land even
@@ -104,7 +103,7 @@ impl PriceStore {
         &self,
         aggregates: HashMap<String, AggregateResult>,
         observed_at: i64,
-    ) -> usize {
+    ) -> Vec<String> {
         self.write(aggregates, observed_at, true)
     }
 
@@ -113,15 +112,16 @@ impl PriceStore {
         aggregates: HashMap<String, AggregateResult>,
         as_of: i64,
         monotonic: bool,
-    ) -> usize {
+    ) -> Vec<String> {
+        let mut dropped = Vec::new();
         if aggregates.is_empty() {
-            return 0;
+            return dropped;
         }
-        let mut applied = 0usize;
         let mut w = self.inner.write().expect("price store lock poisoned");
         for (currency, agg) in aggregates {
             let key = currency.to_uppercase();
             if monotonic && w.get(&key).is_some_and(|prior| prior.as_of > as_of) {
+                dropped.push(key);
                 continue;
             }
             w.insert(
@@ -132,9 +132,8 @@ impl PriceStore {
                     source_count: agg.sources,
                 },
             );
-            applied += 1;
         }
-        applied
+        dropped
     }
 
     /// How many stored currencies [`Self::get`] would serve at `now` — the
@@ -279,7 +278,7 @@ mod tests {
     fn empty_update_is_noop() {
         let store = PriceStore::new();
         store.update(results(&[("USD", 50_000.0, 1)]), 1_000);
-        assert_eq!(store.update(HashMap::new(), 9_999), 0);
+        store.update(HashMap::new(), 9_999);
         // USD untouched.
         assert_eq!(store.snapshot("USD").unwrap().as_of, 1_000);
     }
@@ -292,13 +291,14 @@ mod tests {
     #[test]
     fn update_never_regresses_as_of_and_drops_the_value_with_it() {
         let store = PriceStore::new();
-        assert_eq!(store.update(results(&[("USD", 50_000.0, 2)]), 2_000), 1);
+        store.update(results(&[("USD", 50_000.0, 2)]), 2_000);
 
-        // An older observation for the same currency is not news.
+        // An older observation for the same currency is not news, and the
+        // drop names itself so the trace can diagnose which rate stopped.
         assert_eq!(
             store.update_observed(results(&[("USD", 41_000.0, 1)]), 1_000),
-            0,
-            "a backwards write must report itself as dropped"
+            vec!["USD".to_string()],
+            "a backwards write must name itself as dropped"
         );
 
         let entry = store.snapshot("USD").unwrap();
@@ -311,10 +311,9 @@ mod tests {
 
         // Equal stamps still apply: a re-observation at the same instant is
         // not a regression, and the guard is `>`, not `>=`.
-        assert_eq!(
-            store.update_observed(results(&[("USD", 52_000.0, 3)]), 2_000),
-            1
-        );
+        assert!(store
+            .update_observed(results(&[("USD", 52_000.0, 3)]), 2_000)
+            .is_empty());
         assert_eq!(store.snapshot("USD").unwrap().value, 52_000.0);
     }
 
@@ -333,11 +332,7 @@ mod tests {
         store.update(results(&[("USD", 50_000.0, 2)]), 10_000);
 
         // The clock steps back an hour. This write is authoritative.
-        assert_eq!(
-            store.update(results(&[("USD", 60_000.0, 2)]), 6_400),
-            1,
-            "a wall-clock write must land even behind the stored stamp"
-        );
+        store.update(results(&[("USD", 60_000.0, 2)]), 6_400);
 
         let entry = store.snapshot("USD").unwrap();
         assert_eq!(entry.value, 60_000.0, "the new price must be served");

--- a/src/price/store.rs
+++ b/src/price/store.rs
@@ -309,8 +309,10 @@ mod tests {
 
         // An older observation for the same currency is not news, and the
         // drop names itself so the trace can diagnose which rate stopped.
+        // The tick clock (3_000) differs from the stored `written_at` (2_000)
+        // on purpose, so a dropped write that still stamped it would show.
         assert_eq!(
-            store.update_observed(results(&[("USD", 41_000.0, 1)]), 2_000, 1_000),
+            store.update_observed(results(&[("USD", 41_000.0, 1)]), 3_000, 1_000),
             vec!["USD".to_string()],
             "a backwards write must name itself as dropped"
         );
@@ -322,13 +324,25 @@ mod tests {
             "the value is dropped along with the stamp"
         );
         assert_eq!(entry.source_count, 2, "and so is its source count");
+        assert_eq!(
+            entry.written_at, 2_000,
+            "a dropped write did not refresh the value, so the freshness clock stays"
+        );
 
         // Equal stamps still apply: a re-observation at the same instant is
         // not a regression, and the guard is `>`, not `>=`.
         assert!(store
-            .update_observed(results(&[("USD", 52_000.0, 3)]), 2_000, 2_000)
+            .update_observed(results(&[("USD", 52_000.0, 3)]), 3_000, 2_000)
             .is_empty());
-        assert_eq!(store.snapshot("USD").unwrap().value, 52_000.0);
+        // A re-observation of the same event lands too, so it stamps the tick
+        // clock: a relay stuck on one event reads as refreshed every tick, and
+        // is caught by the TTL rather than by the freshness warning.
+        let entry = store.snapshot("USD").unwrap();
+        assert_eq!(entry.value, 52_000.0);
+        assert_eq!(
+            entry.written_at, 3_000,
+            "a landed write stamps the tick clock, re-observations included"
+        );
     }
 
     /// A backdated write records `written_at` from the tick clock, not from

--- a/src/price/store.rs
+++ b/src/price/store.rs
@@ -137,30 +137,28 @@ impl PriceStore {
         applied
     }
 
-    /// How many of `currencies` currently hold an entry [`Self::get`] would
-    /// serve at `now` — the same `now - as_of <= max_staleness_secs`
-    /// predicate, evaluated under one read lock.
+    /// How many stored currencies [`Self::get`] would serve at `now` — the
+    /// same `now - as_of <= max_staleness_secs` predicate, over **every**
+    /// entry, under one read lock.
     ///
-    /// This is the honest count for the tick report. Sizing it from the
-    /// aggregate map instead would count a currency the tick has just
-    /// stamped **past** the TTL: `as_of` is no longer always the wall clock
-    /// (issue #860), so a relayed event admitted at the `max_age` boundary
-    /// can be unservable the instant it is written. Counting applied writes
-    /// would be wrong the other way — a write dropped by the monotonicity
-    /// guard leaves a *fresher* value in place, so that currency is still
-    /// servable. Only the stored entry knows.
-    pub fn servable_count<'a>(
-        &self,
-        currencies: impl Iterator<Item = &'a str>,
-        max_staleness_secs: i64,
-        now: i64,
-    ) -> usize {
+    /// This answers "what can this node serve right now", which is the only
+    /// question the operator-facing tick report is actually asking. Two
+    /// narrower counts were both wrong, in opposite directions:
+    ///
+    /// - the size of the tick's aggregate map counts a currency the tick has
+    ///   just stamped **past** the TTL, since `as_of` is no longer always the
+    ///   wall clock (issue #860) — it lies upward;
+    /// - restricting this count to the tick's own currencies omits every
+    ///   last-known-good value still inside its window, which is precisely
+    ///   what a partial outage leaves behind — it lies downward.
+    ///
+    /// Counting *applied writes* is wrong too: a write dropped by
+    /// [`Self::update_observed`]'s guard leaves a **fresher** value in place,
+    /// so that currency is still servable. Only the stored entry knows.
+    pub fn servable_count(&self, max_staleness_secs: i64, now: i64) -> usize {
         let r = self.inner.read().expect("price store lock poisoned");
-        currencies
-            .filter(|c| {
-                r.get(&c.to_uppercase())
-                    .is_some_and(|e| now.saturating_sub(e.as_of) <= max_staleness_secs)
-            })
+        r.values()
+            .filter(|e| now.saturating_sub(e.as_of) <= max_staleness_secs)
             .count()
     }
 
@@ -348,33 +346,33 @@ mod tests {
     }
 
     /// `servable_count` must agree with [`PriceStore::get`] entry by entry,
-    /// including the two cases the aggregate map cannot see: an entry
-    /// stamped past the TTL, and a currency that was never stored.
+    /// over the whole store — including the entry a tick's aggregate map
+    /// cannot see (a last-known-good value from an earlier tick) and the one
+    /// it would wrongly include (an entry stamped past the TTL).
     #[test]
     fn servable_count_agrees_with_get() {
         let store = PriceStore::new();
         store.update(results(&[("USD", 50_000.0, 2)]), 1_000);
         // Inside a 500s TTL at now = 2_000; USD, at 1_000, is not.
         store.update(results(&[("ARS", 105_000_000.0, 1)]), 1_600);
+        store.update(results(&[("EUR", 45_000.0, 1)]), 1_700);
 
-        let keys = ["USD", "ARS", "EUR"];
         assert_eq!(
-            store.servable_count(keys.iter().copied(), 500, 2_000),
-            1,
-            "only ARS is inside the window; USD aged out and EUR was never stored"
+            store.servable_count(500, 2_000),
+            2,
+            "ARS and EUR are inside the window; USD aged out"
         );
         // Entry by entry, the same predicate as `get`.
         assert!(store.get("ARS", 500, 2_000).is_ok());
+        assert!(store.get("EUR", 500, 2_000).is_ok());
         assert_eq!(
             store.get("USD", 500, 2_000).unwrap_err(),
             PriceError::TooStale
         );
-        assert_eq!(
-            store.get("EUR", 500, 2_000).unwrap_err(),
-            PriceError::NoCurrency
-        );
 
-        // Case-insensitive, like every other read path.
-        assert_eq!(store.servable_count(["ars"].into_iter(), 500, 2_000), 1);
+        // Widening the window brings the aged-out entry back into the count.
+        assert_eq!(store.servable_count(1_500, 2_000), 3);
+        // An empty store counts zero rather than panicking on the lock.
+        assert_eq!(PriceStore::new().servable_count(1_800, 2_000), 0);
     }
 }

--- a/src/price/store.rs
+++ b/src/price/store.rs
@@ -5,8 +5,10 @@
 //! Phase 1 on): the scheduler writes a fresh aggregate each tick, and
 //! consumers read a currency's price through the staleness check. A
 //! currency with no fresh contributors this tick simply keeps its prior
-//! entry (last-known-good) — [`PriceStore::update`] only overwrites the
-//! currencies present in the new aggregate.
+//! entry (last-known-good) — a write only touches the currencies present
+//! in the new aggregate, and [`PriceStore::update_observed`] may leave even
+//! one of those alone when the incoming observation is the older of the
+//! two.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -20,8 +22,10 @@ use super::aggregate::AggregateResult;
 pub struct AggregatedPrice {
     /// Fiat units per 1 BTC.
     pub value: f64,
-    /// Unix timestamp of the last tick that produced a fresh aggregate for
-    /// this currency. Anchors the staleness window.
+    /// Unix timestamp of when the value was **observed** — the storing
+    /// tick's own clock for a directly-fetched rate, the source event's
+    /// `created_at` for one relayed over Nostr (issue #860). Anchors the
+    /// staleness window.
     pub as_of: i64,
     /// How many sources contributed the value (observability / "down to one
     /// source" warnings).
@@ -70,20 +74,54 @@ impl PriceStore {
     /// last-known-good value (and its older `as_of`) is preserved (spec
     /// §6.4). Currency codes are upper-cased to match read lookups.
     ///
-    /// **`as_of` never moves backwards.** A write carrying an observation
-    /// older than the one already stored is dropped: a relayed rate whose
+    /// Returns **how many writes were applied** — always every entry here,
+    /// but the shape matches [`Self::update_observed`] so a caller can
+    /// account for both halves of a tick the same way.
+    pub fn update(&self, aggregates: HashMap<String, AggregateResult>, as_of: i64) -> usize {
+        self.write(aggregates, as_of, false)
+    }
+
+    /// Like [`Self::update`], but for a **backdated** write: `observed_at`
+    /// is a timestamp this node did not generate (a relayed event's own
+    /// `created_at`), so it may predate what is already stored.
+    ///
+    /// **Such a write never moves `as_of` backwards.** A relayed rate whose
     /// event predates a value this node fetched directly is not news, and
     /// applying it would *shorten* the serving window below what writing
     /// nothing at all would have left — refusing a currency that was
-    /// perfectly servable a moment earlier.
-    pub fn update(&self, aggregates: HashMap<String, AggregateResult>, as_of: i64) {
+    /// perfectly servable a moment earlier. Dropped entries are excluded
+    /// from the returned count, so a silently discarded rate leaves a trace
+    /// (review on PR #925).
+    ///
+    /// The guard is deliberately **not** on [`Self::update`]. A wall-clock
+    /// write is this node's own authoritative observation and must land even
+    /// when `now` sits behind a stamp we already hold — which a backwards
+    /// clock step (NTP step after a bad-RTC boot, a resumed VM snapshot)
+    /// makes possible. Guarding it there froze every currency at its
+    /// pre-jump price while `get` still reported it fresh, since
+    /// `now - as_of` goes negative and negative is inside any TTL.
+    pub fn update_observed(
+        &self,
+        aggregates: HashMap<String, AggregateResult>,
+        observed_at: i64,
+    ) -> usize {
+        self.write(aggregates, observed_at, true)
+    }
+
+    fn write(
+        &self,
+        aggregates: HashMap<String, AggregateResult>,
+        as_of: i64,
+        monotonic: bool,
+    ) -> usize {
         if aggregates.is_empty() {
-            return;
+            return 0;
         }
+        let mut applied = 0usize;
         let mut w = self.inner.write().expect("price store lock poisoned");
         for (currency, agg) in aggregates {
             let key = currency.to_uppercase();
-            if w.get(&key).is_some_and(|prior| prior.as_of > as_of) {
+            if monotonic && w.get(&key).is_some_and(|prior| prior.as_of > as_of) {
                 continue;
             }
             w.insert(
@@ -94,7 +132,36 @@ impl PriceStore {
                     source_count: agg.sources,
                 },
             );
+            applied += 1;
         }
+        applied
+    }
+
+    /// How many of `currencies` currently hold an entry [`Self::get`] would
+    /// serve at `now` — the same `now - as_of <= max_staleness_secs`
+    /// predicate, evaluated under one read lock.
+    ///
+    /// This is the honest count for the tick report. Sizing it from the
+    /// aggregate map instead would count a currency the tick has just
+    /// stamped **past** the TTL: `as_of` is no longer always the wall clock
+    /// (issue #860), so a relayed event admitted at the `max_age` boundary
+    /// can be unservable the instant it is written. Counting applied writes
+    /// would be wrong the other way — a write dropped by the monotonicity
+    /// guard leaves a *fresher* value in place, so that currency is still
+    /// servable. Only the stored entry knows.
+    pub fn servable_count<'a>(
+        &self,
+        currencies: impl Iterator<Item = &'a str>,
+        max_staleness_secs: i64,
+        now: i64,
+    ) -> usize {
+        let r = self.inner.read().expect("price store lock poisoned");
+        currencies
+            .filter(|c| {
+                r.get(&c.to_uppercase())
+                    .is_some_and(|e| now.saturating_sub(e.as_of) <= max_staleness_secs)
+            })
+            .count()
     }
 
     /// Read a currency's price, enforcing the staleness window.
@@ -214,8 +281,100 @@ mod tests {
     fn empty_update_is_noop() {
         let store = PriceStore::new();
         store.update(results(&[("USD", 50_000.0, 1)]), 1_000);
-        store.update(HashMap::new(), 9_999);
+        assert_eq!(store.update(HashMap::new(), 9_999), 0);
         // USD untouched.
         assert_eq!(store.snapshot("USD").unwrap().as_of, 1_000);
+    }
+
+    /// The monotonicity guard, at the layer that owns it. Review on PR #925:
+    /// the only coverage ran through the whole manager, and none of it
+    /// asserted that the **value** is dropped along with the stamp — a
+    /// backdated write must be discarded whole, not split into a new price
+    /// wearing an old timestamp.
+    #[test]
+    fn update_never_regresses_as_of_and_drops_the_value_with_it() {
+        let store = PriceStore::new();
+        assert_eq!(store.update(results(&[("USD", 50_000.0, 2)]), 2_000), 1);
+
+        // An older observation for the same currency is not news.
+        assert_eq!(
+            store.update_observed(results(&[("USD", 41_000.0, 1)]), 1_000),
+            0,
+            "a backwards write must report itself as dropped"
+        );
+
+        let entry = store.snapshot("USD").unwrap();
+        assert_eq!(entry.as_of, 2_000, "as_of must never move backwards");
+        assert_eq!(
+            entry.value, 50_000.0,
+            "the value is dropped along with the stamp"
+        );
+        assert_eq!(entry.source_count, 2, "and so is its source count");
+
+        // Equal stamps still apply: a re-observation at the same instant is
+        // not a regression, and the guard is `>`, not `>=`.
+        assert_eq!(
+            store.update_observed(results(&[("USD", 52_000.0, 3)]), 2_000),
+            1
+        );
+        assert_eq!(store.snapshot("USD").unwrap().value, 52_000.0);
+    }
+
+    /// The monotonicity guard must not reach a wall-clock write. Found by
+    /// `/code-review` on this PR: with the guard on `update` too, a
+    /// backwards clock step (NTP step after a bad-RTC boot, a resumed VM
+    /// snapshot) made `now` fall behind the stored `as_of`, so **every**
+    /// direct write for **every** currency was silently dropped — and
+    /// `get` kept serving the frozen pre-jump price as fresh, because
+    /// `now - as_of` goes negative and negative is inside any TTL. An hour
+    /// of a stale price presented as current, with only a `debug!` line
+    /// blaming a stale observation.
+    #[test]
+    fn a_backwards_clock_step_does_not_freeze_direct_writes() {
+        let store = PriceStore::new();
+        store.update(results(&[("USD", 50_000.0, 2)]), 10_000);
+
+        // The clock steps back an hour. This write is authoritative.
+        assert_eq!(
+            store.update(results(&[("USD", 60_000.0, 2)]), 6_400),
+            1,
+            "a wall-clock write must land even behind the stored stamp"
+        );
+
+        let entry = store.snapshot("USD").unwrap();
+        assert_eq!(entry.value, 60_000.0, "the new price must be served");
+        assert_eq!(entry.as_of, 6_400, "and stamped at the clock we now have");
+        assert_eq!(store.get("USD", 1_800, 6_400).unwrap(), 60_000.0);
+    }
+
+    /// `servable_count` must agree with [`PriceStore::get`] entry by entry,
+    /// including the two cases the aggregate map cannot see: an entry
+    /// stamped past the TTL, and a currency that was never stored.
+    #[test]
+    fn servable_count_agrees_with_get() {
+        let store = PriceStore::new();
+        store.update(results(&[("USD", 50_000.0, 2)]), 1_000);
+        // Inside a 500s TTL at now = 2_000; USD, at 1_000, is not.
+        store.update(results(&[("ARS", 105_000_000.0, 1)]), 1_600);
+
+        let keys = ["USD", "ARS", "EUR"];
+        assert_eq!(
+            store.servable_count(keys.iter().copied(), 500, 2_000),
+            1,
+            "only ARS is inside the window; USD aged out and EUR was never stored"
+        );
+        // Entry by entry, the same predicate as `get`.
+        assert!(store.get("ARS", 500, 2_000).is_ok());
+        assert_eq!(
+            store.get("USD", 500, 2_000).unwrap_err(),
+            PriceError::TooStale
+        );
+        assert_eq!(
+            store.get("EUR", 500, 2_000).unwrap_err(),
+            PriceError::NoCurrency
+        );
+
+        // Case-insensitive, like every other read path.
+        assert_eq!(store.servable_count(["ars"].into_iter(), 500, 2_000), 1);
     }
 }

--- a/src/price/store.rs
+++ b/src/price/store.rs
@@ -27,6 +27,14 @@ pub struct AggregatedPrice {
     /// `created_at` for one relayed over Nostr (issue #860). Anchors the
     /// staleness window.
     pub as_of: i64,
+    /// Unix timestamp of when **this node** last wrote the value — always
+    /// the storing tick's clock, even for a relayed rate whose `as_of` is
+    /// backdated to the source event. Answers "did our tick refresh it?",
+    /// which is a different question from `as_of`'s "how old is this price?"
+    /// — the `observe_freshness` warning measures its interval from here so
+    /// a relayed event that arrives already older than one interval doesn't
+    /// trip it on a healthy node (issue #860 review, PR #925).
+    pub written_at: i64,
     /// How many sources contributed the value (observability / "down to one
     /// source" warnings).
     pub source_count: u8,
@@ -77,12 +85,15 @@ impl PriceStore {
     /// Every entry lands: a wall-clock write is unconditional (see
     /// [`Self::update_observed`] for why the guard is not here).
     pub fn update(&self, aggregates: HashMap<String, AggregateResult>, as_of: i64) {
-        self.write(aggregates, as_of, false);
+        // A direct write is observed and written at the same instant.
+        self.write(aggregates, as_of, as_of, false);
     }
 
     /// Like [`Self::update`], but for a **backdated** write: `observed_at`
     /// is a timestamp this node did not generate (a relayed event's own
-    /// `created_at`), so it may predate what is already stored.
+    /// `created_at`), so it may predate what is already stored. `now` is
+    /// this node's own clock, recorded as `written_at` so the freshness
+    /// warning still measures from when we wrote the value.
     ///
     /// **Such a write never moves `as_of` backwards.** A relayed rate whose
     /// event predates a value this node fetched directly is not news, and
@@ -102,14 +113,16 @@ impl PriceStore {
     pub fn update_observed(
         &self,
         aggregates: HashMap<String, AggregateResult>,
+        now: i64,
         observed_at: i64,
     ) -> Vec<String> {
-        self.write(aggregates, observed_at, true)
+        self.write(aggregates, now, observed_at, true)
     }
 
     fn write(
         &self,
         aggregates: HashMap<String, AggregateResult>,
+        written_at: i64,
         as_of: i64,
         monotonic: bool,
     ) -> Vec<String> {
@@ -129,6 +142,7 @@ impl PriceStore {
                 AggregatedPrice {
                     value: agg.value,
                     as_of,
+                    written_at,
                     source_count: agg.sources,
                 },
             );
@@ -296,7 +310,7 @@ mod tests {
         // An older observation for the same currency is not news, and the
         // drop names itself so the trace can diagnose which rate stopped.
         assert_eq!(
-            store.update_observed(results(&[("USD", 41_000.0, 1)]), 1_000),
+            store.update_observed(results(&[("USD", 41_000.0, 1)]), 2_000, 1_000),
             vec!["USD".to_string()],
             "a backwards write must name itself as dropped"
         );
@@ -312,9 +326,27 @@ mod tests {
         // Equal stamps still apply: a re-observation at the same instant is
         // not a regression, and the guard is `>`, not `>=`.
         assert!(store
-            .update_observed(results(&[("USD", 52_000.0, 3)]), 2_000)
+            .update_observed(results(&[("USD", 52_000.0, 3)]), 2_000, 2_000)
             .is_empty());
         assert_eq!(store.snapshot("USD").unwrap().value, 52_000.0);
+    }
+
+    /// A backdated write records `written_at` from the tick clock, not from
+    /// the backdated `as_of` — so the freshness warning measures from when
+    /// we wrote it, while the TTL keeps measuring from the observation
+    /// (issue #860 review, PR #925).
+    #[test]
+    fn update_observed_stamps_written_at_from_the_tick_clock() {
+        let store = PriceStore::new();
+        // Tick at now = 5_000 stores a rate observed 900s earlier.
+        store.update_observed(results(&[("ARS", 105_000_000.0, 1)]), 5_000, 4_100);
+
+        let entry = store.snapshot("ARS").unwrap();
+        assert_eq!(entry.as_of, 4_100, "the TTL clock is the observation time");
+        assert_eq!(
+            entry.written_at, 5_000,
+            "the freshness clock is when this node wrote it"
+        );
     }
 
     /// The monotonicity guard must not reach a wall-clock write. Found by

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1392,10 +1392,10 @@ async fn job_update_bitcoin_prices() {
                 // covered. A summary at warn is enough; per-provider info
                 // is already in the manager's per-provider logs.
                 warn!(
-                    "price: {}/{} providers failed this tick (still {} fresh currencies)",
+                    "price: {}/{} providers failed this tick ({} currencies still servable)",
                     report.failures.len(),
                     report.failures.len() + report.successes.len(),
-                    report.fresh_currencies
+                    report.servable_currencies
                 );
             }
             tokio::time::sleep(tokio::time::Duration::from_secs(update_interval)).await;


### PR DESCRIPTION
Closes #860. Replaces #886, which I withdrew — its premise did not survive
@Catrya's review, and the correction is [on the issue][correction].

[correction]: https://github.com/MostroP2P/mostro/issues/860#issuecomment-5434066338

## The bug, restated correctly

The Nostr provider accepts a trusted-node rate event that is already some
age, and `PriceStore` then stamped it `as_of = now` and served it for another
full `max_price_staleness_seconds`. The two windows stack, so a relayed price
outlives the configured TTL.

The size, corrected — the original issue said ~2x, which was wrong because it
missed the NIP-40 gate at `nostr.rs:194`:

| Publisher | Binding ingestion gate | + store window | Total | vs TTL |
|---|---|---|---|---|
| Runs this code | 600s (`is_expired_at`) | 1800s | 2400s | 1.33x |
| Omits the expiration tag | 1800s (`max_age`) | 1800s | 3600s | 2.0x |

Both exceed the setting. This bounds both at exactly **1.0x**.

## The fix

This is the approach @arkanoider endorsed in the first reply on #860 ("carry
the event's own `created_at` through to `as_of`") and @Catrya arrived at
independently in the #886 review. It turned out not to need the architecture
change I claimed it did.

Stamp `as_of` from when the rate was **observed** rather than when we ingested
it. Total age is then bounded at one TTL whatever age the event arrived with,
and **no new configuration** is involved.

- `PriceProvider` gains a defaulted `last_observed_at() -> Option<i64>`.
  `None` is correct for every HTTP provider — ingestion time *is* observation
  time — so the five HTTP adapters are untouched.
- `NostrProvider` overrides it, recording the `created_at` of the event that
  sourced the tick. `pick_first_usable` now returns the winning event so the
  timestamp comes from the candidate that actually parsed, not the newest one.
- `PriceManager` stamps relayed currencies from that timestamp and everything
  else from `now`.
- `PriceStore::update_observed` — the backdated write — **never moves `as_of`
  backwards**: a write carrying an older observation is dropped. Without this
  a relayed event predating a direct fetch would move `as_of` back and refuse
  a currency that was servable a moment earlier, worse than writing nothing.
  It returns how many writes landed, so a discarded rate leaves a trace
  instead of vanishing; the manager logs the shortfall once per tick at
  debug, since the guard doing its job is expected rather than an anomaly.
- `report.servable_currencies` (renamed from `fresh_currencies`) counts what
  the store will actually **serve** — `PriceStore::servable_count` applying
  `get`'s own predicate over the whole store. This field lied in *both*
  directions before: sizing it from the aggregate map named a currency fresh
  in the same second `get_price` refused it (@Catrya), and restricting it to
  the tick's own currencies dropped every last-known-good value still inside
  its window (CodeRabbit). Both reach the operator through the partial-outage
  warning in `scheduler.rs`, which is precisely the tick a relayed rate lands
  in, since `restrict_nostr_to_fallback` only lets Nostr through for a
  currency nobody else covered. Counting *applied writes* is wrong too: a
  write the guard drops leaves a fresher value in place, so that currency is
  still servable.
- The rename is deliberate. An entry counted there can be old enough that
  `observe_freshness` warns `"is stale ({}s old)"` while still being served,
  so *fresh* contradicts the vocabulary the module next door uses. The
  operator line is now `"{} currencies still servable"`.
- `observe_warnings` now reads its source count from the **store**, after the
  write. It ran on the tick's aggregate map beforehand, which was safe while
  every write landed — the monotonicity guard ended that, and a dropped
  backdated write left it warning "single source" about a value the node was
  not serving, latching a one-shot flag that then swallowed the genuine
  transition.

`nostr_anchor_dependent` currencies are backdated too: a fiat-cross value
built on a relayed anchor is no fresher than that anchor, even though
`contributors` names only the cross provider. That case is the one a
`contributors == [Nostr]` test alone does not catch.

## Deliberate choices worth reviewing

- **The relayed test is `contains`, not equality.** Today
  `restrict_nostr_to_fallback` drops Nostr's quote for any currency another
  provider covers, so the two are equivalent. `contains` fails safe (stale
  sooner) if that invariant ever relaxes, rather than failing open (served
  past its true age).
- **Not merged with `republishable_rates`**, whose predicate is the apparent
  inverse. They answer different questions: that one deliberately republishes
  a value Nostr merely corroborated (pinned by
  `republishable_rates_keeps_a_currency_nostr_only_partly_helped_with`), while
  backdating must trigger on any Nostr involvement. Sharing a helper would
  break one of them.
- **The monotonicity guard is on `update_observed` only, never on `update`.**
  Applying it to both was a freeze, and my own `/code-review` caught it in the
  first version of this branch: a backwards clock step (an NTP step after a
  bad-RTC boot, a resumed VM snapshot) puts `now` behind the stored `as_of`,
  so every direct write for every currency is silently dropped and `get` keeps
  serving the pre-jump price as fresh — `now - as_of` goes negative, and
  negative is inside any TTL. A wall-clock write is this node's own
  authoritative observation and must always land; only a stamp we did not
  generate needs the guard.
- **`nostr_anchor_dependent` is coarse, and the cost is bigger than "stamped
  early".** The flag is set when *any* surviving contributor resolved through
  a Nostr-touched anchor, so a currency that also has an independent direct
  contributor is backdated as a whole. Because the backdated write also meets
  the monotonicity guard, such an aggregate is dropped **whole** when its
  observation predates the stored stamp — the fresh, independently-observed
  direct half with it. Measured: tick 1 stores CUP from a direct Yadio quote;
  tick 2 has Yadio quoting CUP fresh again while El Toque cross-quotes it
  against a USD anchor only Nostr supplies, from an older event — and the
  write is discarded, CUP keeping tick 1's value and stamp. With a relay
  pinned on that event it repeats every tick, and the currency ages out to a
  refusal with a good direct quote arriving throughout.

  Still the right trade here — refusing beats serving a figure staler than it
  claims — but it is a refusal this node could have avoided, not merely a
  shorter window, and the rustdoc now says that rather than the milder
  version. Separating the halves needs per-contributor provenance
  `AggregateResult` does not carry: **#959**, where this consequence is
  recorded.
- **Two clocks, because the store is asked two questions** (round 5). The TTL
  asks "how old is this price?" and reads `as_of`, which this PR backdates for
  a relayed rate. The within-TTL "is stale" warning asks "did our tick refresh
  it?", and reading `as_of` there made it fire on a healthy node for every
  relayed currency whose event arrived older than one interval (@Catrya,
  reproduced with a 400 s event and a 300 s interval). `AggregatedPrice` now
  carries `written_at`, the storing tick's clock on every write that lands;
  `observe_freshness` measures from it, and the TTL is unchanged. @arkanoider
  pushed this as `a28536c`, the shape she proposed. A write the guard drops
  leaves `written_at` alone, so a currency no tick refreshed — the
  `nostr_anchor_dependent` case above — still warns, then ages out.

## Known limitations, not fixed here

- **A relay stuck on one event gets no early warning.** `nostr-sdk` re-delivers
  an already-seen event to each tick's query, so the same `created_at` passes
  the guard (equal stamps apply) and `written_at` moves every tick. The
  within-TTL warning stays quiet, and the first signal is the TTL refusal with
  its own warning. That matches the warning's behaviour on `main`, where the
  same relay was also served forever; here it is at least refused at one TTL.
  Not refreshing `written_at` on a re-observation of the same event would bring
  the early warning back, at the cost of intermittent warnings whenever the
  upstream publishes slightly slower than our tick — the false alarm this round
  removed. Left as it is, and open to the reviewers.

- `max_age` is still the full TTL, so an event arriving at nearly TTL age is
  accepted and stamped effectively dead-on-arrival. Tightening the acceptance
  window is a separate decision from fixing the double-count, and I would
  rather it be settled on the issue than smuggled in here. What *is* fixed is
  the observability half @Catrya flagged: such a currency is no longer
  **counted** as fresh while `get_price` refuses it.
- Observation time is read from provider state after the tick rather than
  travelling with the quotes. Safe today, and — as @Catrya pointed out, this
  note undersold it — for **both** halves of the partition, on the same
  guarantee. `contributors.contains(&Nostr)` states it outright;
  `nostr_anchor_dependent` comes from `anchor_uses_nostr`, i.e.
  `kept_contributors` over **this tick's** direct quotes after
  `restrict_nostr_to_fallback`, so it cannot be true unless Nostr's quote
  survived this tick either. The doc comment now says so.

  Threading the stamp through `fetch` — or onto `AggregateResult` — would
  still remove the coupling, drop the map split (and with it the two
  per-tick `HashMap`s), and let the store write from one borrowed map. Filed as **#959**
  rather than left as a comment nobody would find.

## Test plan

The previous version of this section claimed every new test fails against the
pre-fix code. **That was false for two of the four.** @Catrya ran them rather
than take my word for it and was right; I reproduced her table before writing
anything, and each test now names the state it actually fails against.

| Test | Fails against | What it pins |
|---|---|---|
| `relayed_currency_is_stamped_from_observation_not_ingestion` | pre-PR | commit 1's premise — regression |
| `nostr_anchor_dependent_currency_is_also_backdated` | pre-PR | commit 1's premise — regression |
| `a_relayed_event_older_than_the_stored_value_does_not_regress_as_of` | commit 1 alone — **passes** pre-PR | commit 2's premise — regression |
| `a_tick_without_a_nostr_contribution_is_not_backdated` | **nothing** | the design choice: partition on `contributors`, not on `observed_at.is_some()`. Worth having, but not a regression test |
| `a_relayed_rate_stamped_past_the_ttl_is_not_reported_fresh` | the count sized from `aggregates.len()` | round 2 — regression |
| `a_backwards_clock_step_does_not_freeze_direct_writes` | the guard applied to `update` too | this round — regression |
| `update_never_regresses_as_of_and_drops_the_value_with_it` | the guard removed; since round 5 also a mutant that stamps `written_at` on the drop path | commit 2's guard, at the layer that owns it, incl. that the *value* is dropped with the stamp and that a dropped write leaves `written_at` alone |
| `a_served_but_stale_read_re_arms_the_refusal_warning` | the re-arm moved back inside `age <= one_interval` | commit 2's re-arm. Both pre-existing warning tests stay green with the line in **either** position, which is why this was uncovered |
| `servable_count_agrees_with_get` | **nothing** — the function is new | a unit test, not a regression test |
| `a_partial_outage_counts_last_known_good_not_just_this_tick` | the count restricted to the tick's own currencies | round 3 — regression (3 servable, reported as 1) |
| `a_tick_with_no_aggregates_still_reports_last_known_good` | the bare `return report` on the empty-aggregate path | round 3 — regression |
| `a_dropped_write_neither_warns_nor_swallows_the_real_single_source` | `observe_warnings` running before the write, off the aggregate's own count | round 3 — regression, and both halves: the false warning and the genuine one it swallowed |
| `a_past_ttl_relayed_single_source_does_not_latch_the_warning` | the past-TTL entry not being skipped | round 4 — @arkanoider's, regression |
| `an_unservable_currency_re_arms_the_single_source_warning` | that skip being a bare `continue`, which also bypassed `clear_warned` | round 4 — regression |
| `a_healthy_relayed_tick_does_not_warn_is_stale` | the warning measured from `as_of` — applied alone to `3862c81`, it fails | round 5 — @arkanoider's, regression |
| `update_observed_stamps_written_at_from_the_tick_clock` | **nothing** — the field is new | a unit test, not a regression test |

- [x] Verified on **`main` @ `e5ea779` (0.18.7, mostro-core 0.14.6, #825
      included) merged with this branch**: `cargo fmt --all --check` clean,
      `cargo clippy --all-targets --all-features -- -D warnings` clean,
      `cargo test` **1354 passed / 0 failed / 3 ignored**. On the branch
      alone, 1260 passed. No CI ran on this head — #929, which is also how a
      commit that did not compile reached an approval on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price freshness tracking for relayed rates by using their original observation time.
  * Prevented older observations from replacing newer rates or shortening their serving window.
  * Ensured directly fetched rates remain available when the system clock moves backward.
  * Applied consistent freshness rules to fiat conversions based on relayed reference rates.
  * Improved freshness recovery after successfully serving a price.
  * Updated availability reporting to include all currently servable rates, including retained last-known-good values, while excluding expired rates.
  * Improved partial-outage and refusal warnings to reflect current rate availability accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



