### PR TITLE
fix: keep amt and fa tags consistent during the taker-bond window

### DIFF
--- a/src/app/bond/db.rs
+++ b/src/app/bond/db.rs
@@ -134,6 +134,45 @@ pub async fn find_active_bonds_for_order(
     .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
 }
 
+/// Orders parked at `Status::WaitingTakerBond` whose taker-bond window
+/// has demonstrably closed: every `Requested` taker bond on them was
+/// created before `stale_cutoff`, and none is `Locked`.
+///
+/// `Locked` taker bonds are excluded on purpose — a locked bond means a
+/// taker's sats are held and `on_bond_invoice_accepted` owns the next
+/// transition (promotion into the trade, not a drop back to `Pending`);
+/// sweeping such an order would strand the winner. Orders with no taker
+/// bond rows at all DO match: that is a pure stranded status and the
+/// drop is exactly the recovery needed.
+///
+/// Used by the scheduler sweep (`reconcile_stranded_taker_bonds`, issue
+/// #927 part 2) to bound the bond window when the LND cancel signal
+/// that normally drives `maybe_drop_waiting_taker_bond` was missed
+/// (daemon restart before resubscribe, dropped subscription, LND
+/// unreachable at cancel time).
+pub async fn find_stale_waiting_taker_bond_orders(
+    pool: &Pool<Sqlite>,
+    stale_cutoff: i64,
+) -> Result<Vec<Order>, mostro_core::error::MostroError> {
+    sqlx::query_as::<_, Order>(
+        "SELECT o.* FROM orders o \
+         WHERE o.status = ? \
+           AND NOT EXISTS ( \
+             SELECT 1 FROM bonds b \
+             WHERE b.order_id = o.id AND b.role = ? \
+               AND (b.state = ? OR (b.state = ? AND b.created_at >= ?)) \
+           )",
+    )
+    .bind(Status::WaitingTakerBond.to_string())
+    .bind(BondRole::Taker.to_string())
+    .bind(BondState::Locked.to_string())
+    .bind(BondState::Requested.to_string())
+    .bind(stale_cutoff)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
 /// Look up the active (`Requested` or `Locked`) bond row for a given
 /// `(order_id, taker_pubkey)` pair. Used by the take handlers'
 /// idempotent-retry check (a taker re-emitting `take-buy` / `take-sell`

--- a/src/app/bond/flow.rs
+++ b/src/app/bond/flow.rs
@@ -1285,6 +1285,98 @@ pub(crate) async fn maybe_drop_waiting_taker_bond(
     Ok(())
 }
 
+/// Scheduler sweep (issue #927 part 2): bound the taker-bond window
+/// independently of the LND cancel callback.
+///
+/// Normally LND's cancel of an expired bond hold invoice drives
+/// `on_bond_invoice_canceled` → [`maybe_drop_waiting_taker_bond`]
+/// within `hold_invoice_expiration_window` seconds. If that signal is
+/// missed (daemon restart before `resubscribe_active_bonds` re-attaches,
+/// dropped subscription, LND unreachable during the cancel), the order
+/// sits at `WaitingTakerBond` — publishing as `pending` — until the
+/// 24 h expiry sweep. This sweep releases the demonstrably stale
+/// `Requested` taker bonds and drops the order back to `Pending`. Safe
+/// to run redundantly with the LND path: every step no-ops when the
+/// order or bond has already moved on.
+pub async fn reconcile_stranded_taker_bonds(pool: &Pool<Sqlite>) {
+    // Margin past `hold_invoice_expiration_window` before a `Requested`
+    // bond counts as stale, so the sweep never races LND's own
+    // expiration cancel on a healthy subscription.
+    const STALE_GRACE_SECONDS: i64 = 60;
+    let window = Settings::get_ln().hold_invoice_expiration_window as i64;
+    let stale_cutoff = Utc::now().timestamp() - window - STALE_GRACE_SECONDS;
+    reconcile_stranded_taker_bonds_at(pool, stale_cutoff).await;
+}
+
+/// Testable core of [`reconcile_stranded_taker_bonds`]: the cutoff is
+/// injected so tests don't depend on global LN settings.
+pub(crate) async fn reconcile_stranded_taker_bonds_at(pool: &Pool<Sqlite>, stale_cutoff: i64) {
+    let stale = match super::db::find_stale_waiting_taker_bond_orders(pool, stale_cutoff).await {
+        Ok(orders) => orders,
+        Err(e) => {
+            warn!("reconcile_taker_bonds: scan for stranded WaitingTakerBond orders failed: {e}");
+            return;
+        }
+    };
+    for order in stale {
+        sweep_stranded_taker_bond_order(pool, order.id, stale_cutoff).await;
+    }
+}
+
+/// Per-order sweep step of [`reconcile_stranded_taker_bonds_at`].
+///
+/// Re-checks each bond's state and age at action time. The finder's
+/// exclusions only hold at SELECT time, and a `WaitingTakerBond` order
+/// is still takeable — so between the scan and this point a concurrent
+/// take can add a fresh `Requested` bond, or one can lock. Releasing
+/// either would cancel a live hold invoice (in the locked case: refund
+/// the winner's bond mid-promotion). Only bonds matching the finder's
+/// own stale predicate — `Requested`, taker role, created before the
+/// cutoff — are released; anything fresher is skipped here and makes
+/// `maybe_drop_waiting_taker_bond`'s CAS no-op below.
+///
+/// The inverse race (a stale `Requested` bond locking between the fetch
+/// and the release) cannot happen: its hold invoice expired at least
+/// the grace margin ago, so LND no longer accepts payment on it. A
+/// transient LND failure during the cancel leaves the bond active and
+/// the CAS no-ops until the next tick — never a false release of a
+/// possibly-encumbered HTLC.
+async fn sweep_stranded_taker_bond_order(pool: &Pool<Sqlite>, order_id: Uuid, stale_cutoff: i64) {
+    match find_active_bonds_for_order(pool, order_id).await {
+        Ok(bonds) => {
+            let taker_role = BondRole::Taker.to_string();
+            let requested = BondState::Requested.to_string();
+            for bond in bonds.iter().filter(|b| {
+                b.role == taker_role && b.state == requested && b.created_at < stale_cutoff
+            }) {
+                if let Err(e) = release_bond(pool, bond).await {
+                    warn!(
+                        bond_id = %bond.id,
+                        order_id = %order_id,
+                        "reconcile_taker_bonds: could not release stale taker bond: {e}"
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            warn!(
+                order_id = %order_id,
+                "reconcile_taker_bonds: bond lookup failed: {e}"
+            );
+            return;
+        }
+    }
+    // Republishes from a fresh DB read, so the orderbook gets correct
+    // tags — not the taker-mutated in-memory struct the
+    // `WaitingTakerBond` event was built from at take-time.
+    if let Err(e) = maybe_drop_waiting_taker_bond(pool, order_id).await {
+        warn!(
+            order_id = %order_id,
+            "reconcile_taker_bonds: drop back to Pending failed: {e}"
+        );
+    }
+}
+
 /// Resume the take flow after the winning bond locks.
 ///
 /// The take handler deferred the trade hold-invoice step under
@@ -1898,6 +1990,213 @@ mod tests {
 
         let order = Order::by_id(&pool, order_id).await.unwrap().unwrap();
         assert_eq!(order.status, Status::Pending.to_string());
+    }
+
+    async fn insert_waiting_taker_bond_order(pool: &Pool<Sqlite>) -> Uuid {
+        let id = Uuid::new_v4();
+        insert_order(pool, id).await;
+        sqlx::query("UPDATE orders SET status = ? WHERE id = ?")
+            .bind(Status::WaitingTakerBond.to_string())
+            .bind(id)
+            .execute(pool)
+            .await
+            .unwrap();
+        id
+    }
+
+    /// Issue #927 part 2: the stale-order finder must select exactly the
+    /// orders whose taker-bond window has demonstrably closed — and
+    /// nothing else.
+    #[tokio::test]
+    async fn find_stale_waiting_taker_bond_orders_scopes_to_closed_windows() {
+        let pool = setup_pool().await;
+        let now = Utc::now().timestamp();
+        let stale_cutoff = now - 360;
+
+        // (a) Stale Requested taker bond → returned.
+        let stale_requested = insert_waiting_taker_bond_order(&pool).await;
+        let mut b = make_bond(stale_requested, BondState::Requested);
+        b.created_at = stale_cutoff - 100;
+        create_bond(&pool, b).await.unwrap();
+
+        // (b) Fresh Requested taker bond (window still open) → not returned.
+        let fresh_requested = insert_waiting_taker_bond_order(&pool).await;
+        let mut b = make_bond(fresh_requested, BondState::Requested);
+        b.created_at = now;
+        create_bond(&pool, b).await.unwrap();
+
+        // (c) Locked taker bond, however old → not returned. The winner's
+        // sats are held; `on_bond_invoice_accepted` owns that transition.
+        let locked = insert_waiting_taker_bond_order(&pool).await;
+        let mut b = make_bond(locked, BondState::Locked);
+        b.created_at = stale_cutoff - 100;
+        create_bond(&pool, b).await.unwrap();
+
+        // (d) No bond rows at all → returned (pure stranded status).
+        let bondless = insert_waiting_taker_bond_order(&pool).await;
+
+        // (e) Stale Requested taker bond + Locked MAKER bond (apply_to =
+        // both) → returned: the role filter must ignore the maker bond.
+        let with_maker = insert_waiting_taker_bond_order(&pool).await;
+        let mut t = make_bond(with_maker, BondState::Requested);
+        t.created_at = stale_cutoff - 100;
+        create_bond(&pool, t).await.unwrap();
+        let mut m = Bond::new_requested(with_maker, "m".repeat(64), BondRole::Maker, 1_000);
+        m.state = BondState::Locked.to_string();
+        m.created_at = now;
+        create_bond(&pool, m).await.unwrap();
+
+        // (f) Pending order with a stale Requested bond → not returned
+        // (status filter).
+        let pending = Uuid::new_v4();
+        insert_order(&pool, pending).await;
+        let mut b = make_bond(pending, BondState::Requested);
+        b.created_at = stale_cutoff - 100;
+        create_bond(&pool, b).await.unwrap();
+
+        let found = super::super::db::find_stale_waiting_taker_bond_orders(&pool, stale_cutoff)
+            .await
+            .unwrap();
+        let ids: std::collections::HashSet<Uuid> = found.iter().map(|o| o.id).collect();
+        assert!(ids.contains(&stale_requested), "stale Requested must match");
+        assert!(
+            ids.contains(&bondless),
+            "bondless stranded order must match"
+        );
+        assert!(
+            ids.contains(&with_maker),
+            "maker bond must not pin the order"
+        );
+        assert!(
+            !ids.contains(&fresh_requested),
+            "open window must not match"
+        );
+        assert!(!ids.contains(&locked), "Locked taker bond must not match");
+        assert!(
+            !ids.contains(&pending),
+            "non-WaitingTakerBond must not match"
+        );
+    }
+
+    /// Issue #927 part 2: the sweep releases the stale `Requested` taker
+    /// bond and drops the order back to `Pending` with no LND callback
+    /// involved. Uses a bond without a hash (the `request_taker_bond`
+    /// bailed-early shape) so `release_bond` skips the LND connection;
+    /// the NIP-33 republish inside `maybe_drop_waiting_taker_bond` may
+    /// fail without Nostr globals, but the status CAS commits before it
+    /// and the sweep swallows that error.
+    #[tokio::test]
+    async fn reconcile_stranded_taker_bonds_releases_stale_and_drops_order() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let now = Utc::now().timestamp();
+
+        let order_id = insert_waiting_taker_bond_order(&pool).await;
+        let mut bond = make_bond(order_id, BondState::Requested);
+        bond.hash = None;
+        bond.created_at = now - 1_000;
+        let bond_id = bond.id;
+        create_bond(&pool, bond).await.unwrap();
+
+        reconcile_stranded_taker_bonds_at(&pool, now - 360).await;
+
+        let state: String = sqlx::query_scalar("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(state, BondState::Released.to_string());
+        let order = Order::by_id(&pool, order_id).await.unwrap().unwrap();
+        assert_eq!(order.status, Status::Pending.to_string());
+    }
+
+    /// Race regression (issue #927 part 2 review): the finder's
+    /// exclusions only hold at SELECT time, and a `WaitingTakerBond`
+    /// order is still takeable — a concurrent take can add a fresh
+    /// `Requested` bond (or a bond can lock) between the scan and the
+    /// release loop. The per-order sweep step must re-check state and
+    /// age at action time, or it would cancel a live hold invoice — in
+    /// the locked case refunding the winner's bond mid-promotion.
+    /// Simulates the post-scan state by invoking the step directly.
+    #[tokio::test]
+    async fn sweep_step_rechecks_bond_state_and_age_at_action_time() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let now = Utc::now().timestamp();
+        let order_id = insert_waiting_taker_bond_order(&pool).await;
+
+        // Fresh `Requested` taker bond: a concurrent take that landed
+        // after the scan. Must NOT be released.
+        let mut fresh = make_bond(order_id, BondState::Requested);
+        fresh.hash = None;
+        fresh.created_at = now;
+        let fresh_id = fresh.id;
+        create_bond(&pool, fresh).await.unwrap();
+
+        // Taker bond that locked after the scan (winner mid-promotion,
+        // stale by age). Must NOT be released either — state, not just
+        // age, gates the release. `hash = None` so a broken filter would
+        // actually mark it Released (with a hash, `release_bond` merely
+        // errors on the absent LND and the assert passes vacuously).
+        let mut locked = make_bond(order_id, BondState::Locked);
+        locked.hash = None;
+        locked.pubkey = "w".repeat(64);
+        locked.created_at = now - 1_000;
+        let locked_id = locked.id;
+        create_bond(&pool, locked).await.unwrap();
+
+        sweep_stranded_taker_bond_order(&pool, order_id, now - 360).await;
+
+        let fresh_state: String = sqlx::query_scalar("SELECT state FROM bonds WHERE id = ?")
+            .bind(fresh_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            fresh_state,
+            BondState::Requested.to_string(),
+            "a fresh Requested bond must survive the sweep"
+        );
+        let locked_state: String = sqlx::query_scalar("SELECT state FROM bonds WHERE id = ?")
+            .bind(locked_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            locked_state,
+            BondState::Locked.to_string(),
+            "a Locked bond must survive the sweep regardless of age"
+        );
+        // And the drop CAS must no-op: the surviving bonds pin the order.
+        let order = Order::by_id(&pool, order_id).await.unwrap().unwrap();
+        assert_eq!(order.status, Status::WaitingTakerBond.to_string());
+    }
+
+    /// A fresh `Requested` bond keeps its order out of the sweep — the
+    /// racing taker still has time to pay the bond invoice.
+    #[tokio::test]
+    async fn reconcile_stranded_taker_bonds_leaves_open_windows_alone() {
+        init_test_settings();
+        let pool = setup_pool().await;
+        let now = Utc::now().timestamp();
+
+        let order_id = insert_waiting_taker_bond_order(&pool).await;
+        let mut bond = make_bond(order_id, BondState::Requested);
+        bond.hash = None;
+        bond.created_at = now;
+        let bond_id = bond.id;
+        create_bond(&pool, bond).await.unwrap();
+
+        reconcile_stranded_taker_bonds_at(&pool, now - 360).await;
+
+        let state: String = sqlx::query_scalar("SELECT state FROM bonds WHERE id = ?")
+            .bind(bond_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(state, BondState::Requested.to_string());
+        let order = Order::by_id(&pool, order_id).await.unwrap().unwrap();
+        assert_eq!(order.status, Status::WaitingTakerBond.to_string());
     }
 
     /// Phase 1.5 P2 regression: `maybe_drop_waiting_taker_bond` must

--- a/src/app/bond/mod.rs
+++ b/src/app/bond/mod.rs
@@ -19,10 +19,10 @@ pub mod slash;
 pub mod types;
 
 pub use flow::{
-    maker_bond_required, release_bond, release_bonds_for_order, release_bonds_for_order_or_warn,
-    release_taker_bonds_for_order_or_warn, request_maker_bond, request_taker_bond,
-    resubscribe_active_bonds, taker_bond_required, trade_committed_by_locked_taker_bond,
-    TakerContext,
+    maker_bond_required, reconcile_stranded_taker_bonds, release_bond, release_bonds_for_order,
+    release_bonds_for_order_or_warn, release_taker_bonds_for_order_or_warn, request_maker_bond,
+    request_taker_bond, resubscribe_active_bonds, taker_bond_required,
+    trade_committed_by_locked_taker_bond, TakerContext,
 };
 pub use math::{compute_bond_amount, compute_node_share};
 pub use model::Bond;

--- a/src/app/order.rs
+++ b/src/app/order.rs
@@ -100,6 +100,16 @@ pub async fn order_action(
             return Err(MostroCantDo(cause));
         }
 
+        // A half-specified range is not a thing: reject it explicitly.
+        // Otherwise it slips past both `check_fiat_amount` (skipped below
+        // when either bound is set) and `check_range_order_limits` (which
+        // only enforces the amount == 0 rule when both bounds are set),
+        // and gets persisted with a fixed sats price and no fiat amount
+        // (issue #927, part 3).
+        if order.min_amount.is_some() != order.max_amount.is_some() {
+            return Err(MostroCantDo(CantDoReason::InvalidAmount));
+        }
+
         // `check_fiat_amount` in mostro-core requires fiat_amount > 0. Range orders set
         // min/max and use fiat_amount == 0, so only run it for single-amount orders.
         if order.min_amount.is_none() && order.max_amount.is_none() {
@@ -306,6 +316,56 @@ mod tests {
             "expected InvalidAmount, got: {:?}",
             err
         );
+    }
+
+    /// Issue #927 part 3: a half-specified range (only one of
+    /// `min_amount` / `max_amount`) used to slip past every validation —
+    /// `check_fiat_amount` is skipped when either bound is set, while
+    /// `check_range_order_limits` only enforces its rules when both are —
+    /// so an order with a fixed sats price and no fiat amount got
+    /// persisted. It must be rejected outright.
+    #[tokio::test]
+    async fn test_order_action_rejects_partial_range() {
+        let pool = create_test_pool().await;
+        use crate::app::context::test_utils::{test_settings, TestContextBuilder};
+        let ctx = TestContextBuilder::new()
+            .with_pool(std::sync::Arc::new(pool.clone()))
+            .with_settings(test_settings())
+            .build();
+        let keys = create_test_keys();
+        let event = create_test_unwrapped_message();
+
+        for (min, max) in [(Some(100), None), (None, Some(500))] {
+            let order = mostro_core::order::SmallOrder::new(
+                Some(uuid::Uuid::new_v4()),
+                Some(mostro_core::order::Kind::Sell),
+                Some(mostro_core::order::Status::Pending),
+                1_000, // fixed sats price
+                "USD".to_string(),
+                min,
+                max,
+                0, // no fiat amount
+                "BANK".to_string(),
+                0,
+                None,
+                None,
+                None,
+                None,
+                None,
+            );
+            let msg = Message::new_order(
+                Some(uuid::Uuid::new_v4()),
+                Some(1),
+                None,
+                Action::NewOrder,
+                Some(Payload::Order(order)),
+            );
+            let err = order_action(&ctx, msg, &event, &keys).await.unwrap_err();
+            assert!(
+                matches!(err, MostroCantDo(CantDoReason::InvalidAmount)),
+                "partial range (min={min:?}, max={max:?}) must be InvalidAmount, got: {err:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -283,27 +283,43 @@ fn create_rating_tag(reputation_data: Option<(f64, i64, i64)>) -> String {
     }
 }
 
-fn create_fiat_amt_array(order: &Order) -> Vec<String> {
-    // `WaitingTakerBond` is the daemon-internal "matched, awaiting bond"
-    // state (Phase 1.5). On the wire it publishes as `pending` (per
-    // `create_status_tags`), so range-order min/max advertising must
-    // mirror the `Pending` branch — otherwise the bond window would
-    // expose a single `fiat_amount` and clients would think the order
-    // had moved out of the range-takeable state.
-    if order.status == Status::Pending.to_string()
+/// `WaitingTakerBond` is the daemon-internal "matched, awaiting bond"
+/// state (Phase 1.5). On the wire it publishes as `pending` (per
+/// `create_status_tags`), so every tag whose value depends on "is this
+/// order still openly takeable?" must treat it exactly like `Pending`.
+/// Encoding the predicate once keeps `fa` and `amt` from disagreeing
+/// about it — a range in `fa` next to a taker-specific quote in `amt`
+/// is the contradiction reported in issue #927.
+fn publishes_as_pending(order: &Order) -> bool {
+    order.status == Status::Pending.to_string()
         || order.status == Status::WaitingTakerBond.to_string()
-    {
-        match (order.min_amount, order.max_amount) {
-            (Some(min), Some(max)) => {
-                vec![min.to_string(), max.to_string()]
-            }
-            _ => {
-                vec![order.fiat_amount.to_string()]
-            }
+}
+
+fn create_fiat_amt_array(order: &Order) -> Vec<String> {
+    // While the order publishes as `pending`, a range order advertises
+    // its [min, max] — otherwise the bond window would expose a single
+    // `fiat_amount` and clients would think the order had moved out of
+    // the range-takeable state.
+    if publishes_as_pending(order) {
+        if let (Some(min), Some(max)) = (order.min_amount, order.max_amount) {
+            return vec![min.to_string(), max.to_string()];
         }
-    } else {
-        vec![order.fiat_amount.to_string()]
     }
+    vec![order.fiat_amount.to_string()]
+}
+
+/// Sats amount as advertised in the `amt` tag. A range order that still
+/// publishes as `pending` has no agreed sats amount — the in-memory
+/// `Order` may already carry a prospective taker's quote (`take_sell` /
+/// `take_buy` mutate `amount` before `request_taker_bond` republishes),
+/// but that price is not binding until the taker's bond locks. `"0"` is
+/// what the DB row still holds and what the `Pending` event this one
+/// replaces already advertised (issue #927).
+fn create_amt_value(order: &Order) -> String {
+    if publishes_as_pending(order) && order.is_range_order() {
+        return "0".to_string();
+    }
+    order.amount.to_string()
 }
 
 pub(crate) fn create_platform_tag_values(instance_name: Option<&str>) -> Vec<String> {
@@ -497,7 +513,7 @@ pub fn order_to_tags(
             Tag::custom("k", vec![order.kind.to_string()]),
             Tag::custom("f", vec![order.fiat_code.to_string()]),
             Tag::custom("s", vec![status.to_string()]),
-            Tag::custom("amt", vec![order.amount.to_string()]),
+            Tag::custom("amt", vec![create_amt_value(order)]),
             Tag::custom("fa", create_fiat_amt_array(order)),
             Tag::custom("pm", payment_method),
             Tag::custom("premium", vec![order.premium.to_string()]),
@@ -1548,6 +1564,45 @@ mod tests {
         order.status = Status::Active.to_string();
         order.fiat_amount = 55;
         assert_eq!(super::create_fiat_amt_array(&order), vec!["55".to_string()]);
+    }
+
+    // ── create_amt_value ─────────────────────────────────────────────────
+
+    /// Regression for issue #927: taking a range order mutates the
+    /// in-memory `amount` with the taker's quote before the
+    /// `WaitingTakerBond` republish. The `amt` tag must keep publishing
+    /// `"0"` (like the `Pending` event it replaces) for the whole bond
+    /// window, or the event carries a range in `fa` next to a fixed sats
+    /// price in `amt` — a combination order creation explicitly forbids.
+    #[test]
+    fn amt_value_is_zero_while_range_order_publishes_as_pending() {
+        // Pending range order → "0".
+        let mut order = make_pending_order();
+        order.min_amount = Some(500_000);
+        order.max_amount = Some(2_000_000);
+        assert_eq!(super::create_amt_value(&order), "0");
+
+        // The reported bug: range order in `WaitingTakerBond` with the
+        // taker's quote already on the struct → still "0", and `fa`
+        // still advertises the range, so the two tags agree.
+        order.status = Status::WaitingTakerBond.to_string();
+        order.amount = 199_399;
+        assert_eq!(super::create_amt_value(&order), "0");
+        assert_eq!(
+            super::create_fiat_amt_array(&order),
+            vec!["500000".to_string(), "2000000".to_string()]
+        );
+
+        // Single-amount order in `WaitingTakerBond` → real amount.
+        let mut single = make_pending_order();
+        single.status = Status::WaitingTakerBond.to_string();
+        single.amount = 1_000;
+        single.fiat_amount = 42;
+        assert_eq!(super::create_amt_value(&single), "1000");
+
+        // Range order once the trade is on → the price is real.
+        order.status = Status::Active.to_string();
+        assert_eq!(super::create_amt_value(&order), "199399");
     }
 
     // ── create_status_tags remaining arms ────────────────────────────────

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -45,6 +45,7 @@ pub async fn start_scheduler(ctx: AppContext) {
         job_process_dev_fee_payment(ctx.clone()).await;
         job_process_bond_payouts(ctx.clone()).await;
         job_reconcile_stranded_maker_bonds(ctx.clone()).await;
+        job_reconcile_stranded_taker_bonds(ctx.clone()).await;
     }
 
     // Mode-agnostic jobs (the info event self-skips when LN status is absent).
@@ -1332,6 +1333,25 @@ async fn job_reconcile_stranded_maker_bonds(ctx: AppContext) {
         let pool = ctx.pool();
         loop {
             bond::reconcile_stranded_range_maker_bonds(pool).await;
+            tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
+        }
+    });
+}
+
+/// Belt-and-braces bound on the taker-bond window (issue #927 part 2).
+/// Normally LND's cancel of the expired bond hold invoice drops a
+/// `WaitingTakerBond` order back to `Pending`; if that signal is missed
+/// (daemon restart before resubscribe, dropped subscription, LND
+/// unreachable during the cancel), the order — and its published
+/// `pending` event — would otherwise linger until the 24 h expiry
+/// sweep. This job sweeps such orders within ~10 minutes instead.
+async fn job_reconcile_stranded_taker_bonds(ctx: AppContext) {
+    let interval = 300u64;
+
+    tokio::spawn(async move {
+        let pool = ctx.pool();
+        loop {
+            bond::reconcile_stranded_taker_bonds(pool).await;
             tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
         }
     });


### PR DESCRIPTION
Closes #927

A range order being taken published a contradictory event: the range in `fa` next to the taker's quote in `amt`, while still showing `s: pending`. The order was fine in the DB — the event was built from the in-memory struct that `take_sell`/`take_buy` mutate before the `WaitingTakerBond` republish.

**Part 1 nip33:** `fa` and `amt` now share a single `publishes_as_pending()` predicate. While a range order publishes as pending, `amt` stays `"0"` — byte-identical to the Pending event it replaces, so no client changes needed.

**Part 2 scheduler sweep:** if the LND cancel signal is missed, the order no longer sits at `WaitingTakerBond` for up to 24 h. A job runs every 300 s, releases demonstrably stale `Requested` taker bonds and drops the order back to `Pending`. One deviation from the issue: calling only `maybe_drop_waiting_taker_bond` would never fire (its CAS no-ops while a `requested` bond exists — exactly the stranded state), so the sweep releases those bonds first via the existing `release_bond`. The per-order step re-checks bond state and age at action time, since a concurrent take can land between the scan and the release.

**Part 3 order creation:** half-specified ranges (min xor max) are now rejected with `InvalidAmount`. They used to slip past both `check_fiat_amount` and `check_range_order_limits` and get persisted with a fixed sats price and no fiat amount.

**Tested manually on regtest** (Polar with a real LND node): took a range order of 5000-10000 CUP and let the bond expire without paying. The event kept `amt: "0"` and the full range in `fa` during the whole bond window, and since LND's cancel signal genuinely never arrived, the sweep recovered the order back to `Pending` in about 6 minutes. Also adds 6 new unit tests; full suite passes (1250 tests) and clippy is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatic Lightning-only recovery sweep for orders stuck waiting for a taker bond.
  * Eligible orders are returned to pending status and republished when the bond window expires without a cancellation signal.

* **Bug Fixes**
  * Orders with incomplete amount ranges are now rejected.
  * Range orders now display consistent amount information while awaiting a taker bond.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->