### PR TITLE
feat: maintenance (drain) mode — persistent flag + escrow gate (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2386,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "mostro-core"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5c310ad08889f8a142e6d31be4318ec7b45404e7de027ff80a852250efc8b0"
+checksum = "ad0df29fd70a740c32cfefdf975e5499925e24d820dc95c8c016dc2f94435d7a"
 dependencies = [
  "bitcoin",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ reqwest = { version = "0.12.1", default-features = false, features = [
   "json",
   "rustls-tls",
 ] }
-mostro-core = { version = "0.14.5", features = ["sqlx"] }
+mostro-core = { version = "0.14.6", features = ["sqlx"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 async-trait = "0.1.83"

--- a/migrations/20260901120000_daemon_state.sql
+++ b/migrations/20260901120000_daemon_state.sql
@@ -1,0 +1,11 @@
+-- Small key/value store for operator-controlled daemon state that must
+-- survive a restart but is flipped at runtime (not from settings.toml).
+--
+-- First user: maintenance mode (docs/MAINTENANCE_MODE_LN_MIGRATION.md).
+-- `maintenance_mode` = "0" | "1", `maintenance_reason`, `maintenance_since`
+-- (unix seconds). Later phases add `ln_node_pubkey` for the boot guard.
+CREATE TABLE IF NOT EXISTS daemon_state (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,6 +3,8 @@
 
 // Application context (dependency injection)
 pub mod context;
+pub mod daemon_state; // key/value operator state (maintenance mode)
+pub mod maintenance; // maintenance (drain) mode flag + drain counters
 
 // Submodules for different trading actions
 pub mod add_cashu_escrow; // Cashu escrow lock handler (Track A / CF-5 stub)
@@ -424,6 +426,26 @@ async fn accept_event(
 
     // Get inner message kind
     let inner_message = message.get_inner_message_kind();
+    // Maintenance (drain) mode: refuse to open new escrow. This runs BEFORE
+    // `check_trade_index` on purpose — that check registers a first-time
+    // identity and persists its trade index, so gating after it would burn
+    // the index of a request we are about to reject. Nothing is persisted on
+    // this path; the sender only gets a `CantDo(MaintenanceMode)`.
+    if ctx.maintenance().blocks(&inner_message.action) {
+        tracing::info!(
+            "Maintenance mode: rejecting {:?} from {}",
+            inner_message.action,
+            unwrapped.sender
+        );
+        manage_errors(
+            MostroError::MostroCantDo(CantDoReason::MaintenanceMode),
+            message.clone(),
+            unwrapped.clone(),
+            &inner_message.action,
+        )
+        .await;
+        return None;
+    }
     // Check if message is message with trade index
     if let Err(e) = check_trade_index(ctx, &unwrapped, &message).await {
         tracing::warn!("Error checking trade index: {}", e);
@@ -912,6 +934,204 @@ mod tests {
             // `SpamGate::global()` is `None` unless `install_spam_gate` ran, so
             // the v2 arm can only be pinned against the installed state.
             assert_eq!(gate_for(true).is_some(), SpamGate::global().is_some());
+        }
+    }
+
+    /// Maintenance (drain) mode gate in [`accept_event`]: the three actions
+    /// that open new escrow are answered with `CantDo(MaintenanceMode)` and
+    /// persist nothing; everything else passes through unchanged.
+    mod maintenance_gate_tests {
+        use super::*;
+        use crate::config::MESSAGE_QUEUES;
+        use crate::db::is_user_present;
+        use mostro_core::nip59::WrapOptions;
+        use mostro_core::prelude::Payload;
+        use mostro_core::transport::wrap_message_nip44;
+
+        /// A kind-14 event in full-privacy mode (trade key doubles as
+        /// identity) so no inner signature is needed.
+        fn v2_event(
+            mostro: &Keys,
+            trade: &Keys,
+            action: Action,
+            trade_index: Option<u32>,
+        ) -> Event {
+            let message = create_test_message(action, trade_index);
+            wrap_message_nip44(
+                &message,
+                trade,
+                trade,
+                mostro.public_key(),
+                WrapOptions::default(),
+            )
+            .expect("wrap kind-14 event")
+        }
+
+        async fn accept(ctx: &AppContext, event: &Event, mostro: &Keys) -> bool {
+            accept_event(
+                ctx,
+                event,
+                mostro,
+                0,
+                0,
+                NostrKind::from(crate::config::constants::DM_EVENT_KIND),
+                None,
+            )
+            .await
+            .is_some()
+        }
+
+        /// The `CantDo` reasons queued for `to` (the queue is process-global,
+        /// so filter by destination).
+        async fn cant_do_reasons_for(to: &PublicKey) -> Vec<CantDoReason> {
+            MESSAGE_QUEUES
+                .queue_order_cantdo
+                .read()
+                .await
+                .iter()
+                .filter(|(_, dest)| dest == to)
+                .filter_map(|(m, _)| match &m.get_inner_message_kind().payload {
+                    Some(Payload::CantDo(Some(r))) => Some(r.clone()),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        async fn enabled_ctx() -> AppContext {
+            let ctx = create_migrated_ctx().await;
+            ctx.maintenance()
+                .set(ctx.pool(), true, Some("test"))
+                .await
+                .unwrap();
+            ctx
+        }
+
+        #[tokio::test]
+        async fn gate_rejects_new_order_take_buy_and_take_sell_when_enabled() {
+            let ctx = enabled_ctx().await;
+            let mostro = create_test_keys();
+            for action in [Action::NewOrder, Action::TakeBuy, Action::TakeSell] {
+                let trade = create_test_keys();
+                let event = v2_event(&mostro, &trade, action.clone(), None);
+                assert!(
+                    !accept(&ctx, &event, &mostro).await,
+                    "{action:?} must be rejected"
+                );
+                assert_eq!(
+                    cant_do_reasons_for(&trade.public_key()).await,
+                    vec![CantDoReason::MaintenanceMode],
+                    "{action:?} must be answered with MaintenanceMode"
+                );
+            }
+        }
+
+        /// Payload-less test messages only pass `inner_message.verify()` for
+        /// some actions (`FiatSent` does), so the positive acceptance is
+        /// pinned on that one and the rest are checked for the absence of a
+        /// `CantDo` — which is all the gate can produce.
+        #[tokio::test]
+        async fn gate_passes_actions_on_existing_orders_when_enabled() {
+            let ctx = enabled_ctx().await;
+            let mostro = create_test_keys();
+            let trade = create_test_keys();
+            let event = v2_event(&mostro, &trade, Action::FiatSent, None);
+            assert!(
+                accept(&ctx, &event, &mostro).await,
+                "FiatSent must be accepted"
+            );
+            assert!(cant_do_reasons_for(&trade.public_key()).await.is_empty());
+
+            for action in [
+                Action::Release,
+                Action::Cancel,
+                Action::AddInvoice,
+                Action::AddBondInvoice,
+                Action::Dispute,
+                Action::RateUser,
+                Action::Orders,
+                Action::RestoreSession,
+                Action::TradePubkey,
+                Action::LastTradeIndex,
+                Action::AdminCancel,
+                Action::AdminSettle,
+            ] {
+                let trade = create_test_keys();
+                let event = v2_event(&mostro, &trade, action.clone(), None);
+                accept(&ctx, &event, &mostro).await;
+                assert!(
+                    cant_do_reasons_for(&trade.public_key()).await.is_empty(),
+                    "{action:?} must not be answered by the gate"
+                );
+            }
+        }
+
+        #[tokio::test]
+        async fn gate_is_noop_when_disabled() {
+            let ctx = create_migrated_ctx().await;
+            assert!(!ctx.maintenance().is_enabled());
+            let mostro = create_test_keys();
+            for action in [Action::NewOrder, Action::TakeBuy, Action::TakeSell] {
+                let trade = create_test_keys();
+                let event = v2_event(&mostro, &trade, action.clone(), None);
+                accept(&ctx, &event, &mostro).await;
+                assert!(
+                    cant_do_reasons_for(&trade.public_key()).await.is_empty(),
+                    "{action:?} must not be gated while disabled"
+                );
+            }
+        }
+
+        /// Dual-key event (identity signs the inner tuple, trade key authors
+        /// the event): the shape in which `check_trade_index` registers a
+        /// first-time identity.
+        fn dual_key_event(mostro: &Keys, identity: &Keys, trade: &Keys) -> Event {
+            let message = create_test_message(Action::NewOrder, Some(1));
+            let opts = WrapOptions {
+                signed: true,
+                ..WrapOptions::default()
+            };
+            wrap_message_nip44(&message, identity, trade, mostro.public_key(), opts)
+                .expect("wrap signed kind-14 event")
+        }
+
+        /// `check_trade_index` registers an unknown identity and persists its
+        /// trade index. The gate runs first so a rejected first-time user is
+        /// never created — otherwise the same request retried after
+        /// maintenance would fail with `InvalidTradeIndex`.
+        #[tokio::test]
+        async fn gate_rejects_first_time_user_without_creating_it() {
+            let mostro = create_test_keys();
+
+            // Control: with the gate off the same request registers the user
+            // (`check_trade_index` runs before the payload shape check, so
+            // the registration happens whether or not the message is later
+            // accepted — which is exactly why the gate must come first).
+            let open = create_migrated_ctx().await;
+            let (identity, trade) = (create_test_keys(), create_test_keys());
+            let event = dual_key_event(&mostro, &identity, &trade);
+            accept(&open, &event, &mostro).await;
+            assert!(
+                is_user_present(open.pool(), identity.public_key().to_string())
+                    .await
+                    .is_ok(),
+                "control: check_trade_index registers a first-time user"
+            );
+
+            // Under maintenance nothing is persisted.
+            let closed = enabled_ctx().await;
+            let (identity, trade) = (create_test_keys(), create_test_keys());
+            let event = dual_key_event(&mostro, &identity, &trade);
+            assert!(!accept(&closed, &event, &mostro).await);
+            assert!(
+                is_user_present(closed.pool(), identity.public_key().to_string())
+                    .await
+                    .is_err(),
+                "a rejected first-time user must not be registered"
+            );
+            assert_eq!(
+                cant_do_reasons_for(&trade.public_key()).await,
+                vec![CantDoReason::MaintenanceMode]
+            );
         }
     }
 

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -6,6 +6,7 @@
 //!
 //! This enables unit testing with mock implementations — see `TestContextBuilder`.
 
+use crate::app::maintenance::MaintenanceState;
 use crate::cashu::CashuClient;
 use crate::config::settings::Settings;
 use mostro_core::prelude::Message;
@@ -44,6 +45,10 @@ pub struct AppContext {
     /// it here; `None` in the default Lightning mode. Track A's lock handler
     /// reads it through [`AppContext::cashu_client`].
     cashu_client: Option<Arc<CashuClient>>,
+    /// Maintenance (drain) mode flag. Defaults to a disabled, unpersisted
+    /// flag; `main.rs` attaches the one loaded from `daemon_state` with
+    /// [`AppContext::with_maintenance`].
+    maintenance: MaintenanceState,
 }
 
 impl AppContext {
@@ -65,7 +70,20 @@ impl AppContext {
             order_msg_queue,
             keys,
             cashu_client: None,
+            maintenance: MaintenanceState::new(),
         }
+    }
+
+    /// Attach the maintenance flag loaded from the database. The same clone
+    /// must be handed to the admin RPC so both sides observe one flag.
+    pub fn with_maintenance(mut self, maintenance: MaintenanceState) -> Self {
+        self.maintenance = maintenance;
+        self
+    }
+
+    /// Maintenance (drain) mode flag.
+    pub fn maintenance(&self) -> &MaintenanceState {
+        &self.maintenance
     }
 
     /// Attach a connected Cashu mint client (Cashu mode, CF-5). Returns a new

--- a/src/app/daemon_state.rs
+++ b/src/app/daemon_state.rs
@@ -18,20 +18,36 @@ pub async fn get(pool: &SqlitePool, key: &str) -> Result<Option<String>, MostroE
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
 }
 
+const UPSERT: &str = "INSERT INTO daemon_state (key, value, updated_at) VALUES (?1, ?2, ?3) \
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at";
+
 /// Upsert one key with the current unix timestamp.
 pub async fn set(pool: &SqlitePool, key: &str, value: &str) -> Result<(), MostroError> {
-    let now = chrono::Utc::now().timestamp();
-    sqlx::query(
-        "INSERT INTO daemon_state (key, value, updated_at) VALUES (?1, ?2, ?3) \
-         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
-    )
-    .bind(key)
-    .bind(value)
-    .bind(now)
-    .execute(pool)
-    .await
-    .map(|_| ())
-    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+    sqlx::query(UPSERT)
+        .bind(key)
+        .bind(value)
+        .bind(chrono::Utc::now().timestamp())
+        .execute(pool)
+        .await
+        .map(|_| ())
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
+/// Same upsert inside a caller-owned transaction, so several keys can be
+/// written atomically.
+pub async fn set_in(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    key: &str,
+    value: &str,
+) -> Result<(), MostroError> {
+    sqlx::query(UPSERT)
+        .bind(key)
+        .bind(value)
+        .bind(chrono::Utc::now().timestamp())
+        .execute(&mut **tx)
+        .await
+        .map(|_| ())
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
 }
 
 #[cfg(test)]
@@ -48,6 +64,24 @@ mod tests {
     async fn get_returns_none_for_an_unknown_key() {
         let pool = pool().await;
         assert_eq!(get(&pool, "nope").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn set_in_is_atomic_across_keys() {
+        let pool = pool().await;
+        let mut tx = pool.begin().await.unwrap();
+        set_in(&mut tx, "a", "1").await.unwrap();
+        set_in(&mut tx, "b", "2").await.unwrap();
+        tx.rollback().await.unwrap();
+        assert_eq!(get(&pool, "a").await.unwrap(), None, "rolled back");
+        assert_eq!(get(&pool, "b").await.unwrap(), None, "rolled back");
+
+        let mut tx = pool.begin().await.unwrap();
+        set_in(&mut tx, "a", "1").await.unwrap();
+        set_in(&mut tx, "b", "2").await.unwrap();
+        tx.commit().await.unwrap();
+        assert_eq!(get(&pool, "a").await.unwrap().as_deref(), Some("1"));
+        assert_eq!(get(&pool, "b").await.unwrap().as_deref(), Some("2"));
     }
 
     #[tokio::test]

--- a/src/app/daemon_state.rs
+++ b/src/app/daemon_state.rs
@@ -1,0 +1,61 @@
+//! Key/value accessors for the `daemon_state` table.
+//!
+//! Operator-controlled state that is flipped at runtime over the admin RPC and
+//! must survive a restart — unlike `settings.toml`, which is read once at boot
+//! into an immutable `Arc<Settings>`. See
+//! `docs/MAINTENANCE_MODE_LN_MIGRATION.md` §3.1.
+
+use mostro_core::error::MostroError::{self, MostroInternalErr};
+use mostro_core::error::ServiceError;
+use sqlx::SqlitePool;
+
+/// Read one key. `Ok(None)` when the key was never written.
+pub async fn get(pool: &SqlitePool, key: &str) -> Result<Option<String>, MostroError> {
+    sqlx::query_scalar::<_, String>("SELECT value FROM daemon_state WHERE key = ?1")
+        .bind(key)
+        .fetch_optional(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
+/// Upsert one key with the current unix timestamp.
+pub async fn set(pool: &SqlitePool, key: &str, value: &str) -> Result<(), MostroError> {
+    let now = chrono::Utc::now().timestamp();
+    sqlx::query(
+        "INSERT INTO daemon_state (key, value, updated_at) VALUES (?1, ?2, ?3) \
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+    )
+    .bind(key)
+    .bind(value)
+    .bind(now)
+    .execute(pool)
+    .await
+    .map(|_| ())
+    .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_an_unknown_key() {
+        let pool = pool().await;
+        assert_eq!(get(&pool, "nope").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn set_then_get_round_trips_and_overwrites() {
+        let pool = pool().await;
+        set(&pool, "k", "1").await.unwrap();
+        assert_eq!(get(&pool, "k").await.unwrap().as_deref(), Some("1"));
+        set(&pool, "k", "0").await.unwrap();
+        assert_eq!(get(&pool, "k").await.unwrap().as_deref(), Some("0"));
+    }
+}

--- a/src/app/maintenance.rs
+++ b/src/app/maintenance.rs
@@ -14,6 +14,7 @@ use mostro_core::prelude::{Action, Status};
 use sqlx::SqlitePool;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use tokio::sync::Mutex;
 
 pub const KEY_ENABLED: &str = "maintenance_mode";
 pub const KEY_REASON: &str = "maintenance_reason";
@@ -23,10 +24,13 @@ pub const KEY_SINCE: &str = "maintenance_since";
 ///
 /// Cheap to clone; every clone observes the same flag. The persisted value is
 /// authoritative: `set` writes the DB first and flips the atomic second, so a
-/// crash in between is resolved by the next `load`.
+/// crash in between is resolved by the next `load`. Writers are serialised by
+/// `write_lock` for the whole DB-then-atomic sequence, so two concurrent
+/// `set` calls cannot leave the row reflecting one and the flag the other.
 #[derive(Clone, Debug, Default)]
 pub struct MaintenanceState {
     enabled: Arc<AtomicBool>,
+    write_lock: Arc<Mutex<()>>,
 }
 
 impl MaintenanceState {
@@ -44,6 +48,7 @@ impl MaintenanceState {
             .unwrap_or(false);
         Ok(Self {
             enabled: Arc::new(AtomicBool::new(enabled)),
+            write_lock: Arc::default(),
         })
     }
 
@@ -63,20 +68,32 @@ impl MaintenanceState {
 
     /// Persist and apply a new value. `reason` is stored verbatim (or cleared)
     /// and `maintenance_since` is stamped on every enable.
+    ///
+    /// The three rows are written in one transaction and the in-memory flag
+    /// flips only after it commits, all under `write_lock`. A failed commit
+    /// leaves both the rows and the flag untouched.
     pub async fn set(
         &self,
         pool: &SqlitePool,
         enabled: bool,
         reason: Option<&str>,
     ) -> Result<(), MostroError> {
-        daemon_state::set(pool, KEY_ENABLED, if enabled { "1" } else { "0" }).await?;
-        daemon_state::set(pool, KEY_REASON, reason.unwrap_or_default()).await?;
+        let _guard = self.write_lock.lock().await;
         let since = if enabled {
             chrono::Utc::now().timestamp().to_string()
         } else {
             String::new()
         };
-        daemon_state::set(pool, KEY_SINCE, &since).await?;
+        let mut tx = pool
+            .begin()
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
+        daemon_state::set_in(&mut tx, KEY_ENABLED, if enabled { "1" } else { "0" }).await?;
+        daemon_state::set_in(&mut tx, KEY_REASON, reason.unwrap_or_default()).await?;
+        daemon_state::set_in(&mut tx, KEY_SINCE, &since).await?;
+        tx.commit()
+            .await
+            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
         self.enabled.store(enabled, Ordering::Release);
         Ok(())
     }
@@ -271,6 +288,43 @@ mod tests {
                 .unwrap()
                 .as_deref(),
             Some("")
+        );
+    }
+
+    #[tokio::test]
+    async fn set_leaves_flag_and_rows_untouched_when_the_write_fails() {
+        let pool = pool().await;
+        let state = MaintenanceState::load(&pool).await.unwrap();
+        pool.close().await;
+        assert!(state.set(&pool, true, Some("x")).await.is_err());
+        assert!(!state.is_enabled(), "a failed write must not flip the flag");
+    }
+
+    /// Concurrent writers: whatever order they land in, the persisted row and
+    /// the in-memory flag must agree at the end.
+    #[tokio::test]
+    async fn concurrent_sets_keep_row_and_flag_consistent() {
+        let pool = pool().await;
+        let state = MaintenanceState::load(&pool).await.unwrap();
+        let mut tasks = tokio::task::JoinSet::new();
+        for i in 0..32u32 {
+            let (state, pool) = (state.clone(), pool.clone());
+            tasks.spawn(async move { state.set(&pool, i % 2 == 0, None).await.unwrap() });
+        }
+        while let Some(r) = tasks.join_next().await {
+            r.unwrap();
+        }
+        let persisted = daemon_state::get(&pool, KEY_ENABLED)
+            .await
+            .unwrap()
+            .unwrap()
+            == "1";
+        assert_eq!(state.is_enabled(), persisted);
+        let since = daemon_state::get(&pool, KEY_SINCE).await.unwrap().unwrap();
+        assert_eq!(
+            since.is_empty(),
+            !persisted,
+            "since must match the final mode"
         );
     }
 

--- a/src/app/maintenance.rs
+++ b/src/app/maintenance.rs
@@ -1,0 +1,374 @@
+//! Maintenance ("drain") mode.
+//!
+//! While enabled the daemon refuses to open new escrow — `NewOrder`, `TakeBuy`
+//! and `TakeSell` are answered with `CantDo(MaintenanceMode)` — but every
+//! action that closes escrow keeps working, so open trades can finish on the
+//! current Lightning node before the operator switches to a different one.
+//! `drain_counters` reports what is still bound to that node.
+//! Spec: `docs/MAINTENANCE_MODE_LN_MIGRATION.md` §3.2 / §3.4.
+
+use crate::app::daemon_state;
+use mostro_core::error::MostroError::{self, MostroInternalErr};
+use mostro_core::error::ServiceError;
+use mostro_core::prelude::{Action, Status};
+use sqlx::SqlitePool;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+pub const KEY_ENABLED: &str = "maintenance_mode";
+pub const KEY_REASON: &str = "maintenance_reason";
+pub const KEY_SINCE: &str = "maintenance_since";
+
+/// Process-wide maintenance flag, backed by `daemon_state`.
+///
+/// Cheap to clone; every clone observes the same flag. The persisted value is
+/// authoritative: `set` writes the DB first and flips the atomic second, so a
+/// crash in between is resolved by the next `load`.
+#[derive(Clone, Debug, Default)]
+pub struct MaintenanceState {
+    enabled: Arc<AtomicBool>,
+}
+
+impl MaintenanceState {
+    /// A disabled flag not backed by any row yet (tests, and the default for
+    /// contexts that never load one).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build the flag from the persisted `daemon_state` row.
+    pub async fn load(pool: &SqlitePool) -> Result<Self, MostroError> {
+        let enabled = daemon_state::get(pool, KEY_ENABLED)
+            .await?
+            .map(|v| v == "1")
+            .unwrap_or(false);
+        Ok(Self {
+            enabled: Arc::new(AtomicBool::new(enabled)),
+        })
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Acquire)
+    }
+
+    /// Does the flag block this action? Only the three actions that open new
+    /// escrow; everything on an existing order stays allowed (spec R4).
+    pub fn blocks(&self, action: &Action) -> bool {
+        self.is_enabled()
+            && matches!(
+                action,
+                Action::NewOrder | Action::TakeBuy | Action::TakeSell
+            )
+    }
+
+    /// Persist and apply a new value. `reason` is stored verbatim (or cleared)
+    /// and `maintenance_since` is stamped on every enable.
+    pub async fn set(
+        &self,
+        pool: &SqlitePool,
+        enabled: bool,
+        reason: Option<&str>,
+    ) -> Result<(), MostroError> {
+        daemon_state::set(pool, KEY_ENABLED, if enabled { "1" } else { "0" }).await?;
+        daemon_state::set(pool, KEY_REASON, reason.unwrap_or_default()).await?;
+        let since = if enabled {
+            chrono::Utc::now().timestamp().to_string()
+        } else {
+            String::new()
+        };
+        daemon_state::set(pool, KEY_SINCE, &since).await?;
+        self.enabled.store(enabled, Ordering::Release);
+        Ok(())
+    }
+}
+
+/// What is still bound to the connected Lightning node (spec §1.3).
+/// `drained()` is true when the node can be switched.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DrainCounters {
+    /// A — orders with a hold invoice in a non-terminal status.
+    pub escrowed_orders: u32,
+    /// B — buyer payouts in flight (`settled-hold-invoice` + payout hash).
+    pub inflight_payouts: u32,
+    /// C — successful orders whose dev fee is still unpaid.
+    pub unpaid_dev_fees: u32,
+    /// D — bond hold invoices still open (`requested` / `locked`).
+    pub open_bonds: u32,
+    /// E — bonds waiting for (or in the middle of) their payout.
+    pub pending_bond_payouts: u32,
+    /// Informational: pending orders hold no escrow and do not block a switch.
+    pub pending_orders: u32,
+}
+
+impl DrainCounters {
+    pub fn drained(&self) -> bool {
+        self.escrowed_orders == 0
+            && self.inflight_payouts == 0
+            && self.unpaid_dev_fees == 0
+            && self.open_bonds == 0
+            && self.pending_bond_payouts == 0
+    }
+}
+
+/// Order statuses that no longer need the node that issued their hold invoice.
+fn terminal_statuses() -> [String; 7] {
+    [
+        Status::Canceled,
+        Status::CanceledByAdmin,
+        Status::SettledByAdmin,
+        Status::CompletedByAdmin,
+        Status::Expired,
+        Status::Success,
+        Status::CooperativelyCanceled,
+    ]
+    .map(|s| s.to_string())
+}
+
+async fn count(pool: &SqlitePool, sql: &'static str, binds: &[String]) -> Result<u32, MostroError> {
+    let mut q = sqlx::query_scalar::<_, i64>(sql);
+    for b in binds {
+        q = q.bind(b.clone());
+    }
+    q.fetch_one(pool)
+        .await
+        .map(|n| n.max(0) as u32)
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))
+}
+
+/// Compute the counters with the exact predicates of spec §1.3.
+pub async fn drain_counters(pool: &SqlitePool) -> Result<DrainCounters, MostroError> {
+    let terminal = terminal_statuses();
+    Ok(DrainCounters {
+        // One placeholder per entry of `terminal_statuses()`.
+        escrowed_orders: count(
+            pool,
+            "SELECT COUNT(*) FROM orders WHERE hash IS NOT NULL \
+             AND status NOT IN (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            &terminal,
+        )
+        .await?,
+        inflight_payouts: count(
+            pool,
+            "SELECT COUNT(*) FROM orders WHERE payout_payment_hash IS NOT NULL AND status = ?1",
+            &[Status::SettledHoldInvoice.to_string()],
+        )
+        .await?,
+        unpaid_dev_fees: count(
+            pool,
+            "SELECT COUNT(*) FROM orders WHERE dev_fee > 0 AND dev_fee_paid = 0 AND status = ?1",
+            &[Status::Success.to_string()],
+        )
+        .await?,
+        open_bonds: count(
+            pool,
+            "SELECT COUNT(*) FROM bonds WHERE hash IS NOT NULL AND state IN (?1, ?2)",
+            &["requested".to_string(), "locked".to_string()],
+        )
+        .await?,
+        pending_bond_payouts: count(
+            pool,
+            "SELECT COUNT(*) FROM bonds WHERE state = ?1",
+            &["pending-payout".to_string()],
+        )
+        .await?,
+        pending_orders: count(
+            pool,
+            "SELECT COUNT(*) FROM orders WHERE status = ?1",
+            &[Status::Pending.to_string()],
+        )
+        .await?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::bond::db::create_bond;
+    use crate::app::bond::model::Bond;
+    use crate::app::bond::types::BondRole;
+    use uuid::Uuid;
+
+    async fn pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    async fn insert_order(
+        pool: &SqlitePool,
+        status: &str,
+        hash: Option<&str>,
+        payout_hash: Option<&str>,
+        dev_fee: i64,
+        dev_fee_paid: bool,
+    ) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
+                                   amount, fiat_code, fiat_amount, created_at, expires_at,
+                                   failed_payment, payment_attempts, hash, payout_payment_hash,
+                                   dev_fee, dev_fee_paid)
+               VALUES (?1, 'sell', 'ev', ?2, 0, 'lightning', 100000, 'USD', 100,
+                       1700000000, 1700086400, 0, 0, ?3, ?4, ?5, ?6)"#,
+        )
+        .bind(id)
+        .bind(status)
+        .bind(hash)
+        .bind(payout_hash)
+        .bind(dev_fee)
+        .bind(dev_fee_paid)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    /// Bonds carry a FK to `orders`, so each one gets its own parent order
+    /// in a status that contributes nothing to the counters.
+    async fn insert_bond(pool: &SqlitePool, state: &str, hash: Option<&str>, payout: Option<&str>) {
+        let order_id = insert_order(pool, "canceled", None, None, 0, false).await;
+        let mut b = Bond::new_requested(order_id, "ab".repeat(32), BondRole::Maker, 1000);
+        b.state = state.to_string();
+        b.hash = hash.map(str::to_string);
+        b.payout_payment_hash = payout.map(str::to_string);
+        create_bond(pool, b).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn maintenance_state_defaults_to_disabled_without_a_row() {
+        let pool = pool().await;
+        let state = MaintenanceState::load(&pool).await.unwrap();
+        assert!(!state.is_enabled());
+    }
+
+    #[tokio::test]
+    async fn maintenance_state_round_trips_through_daemon_state() {
+        let pool = pool().await;
+        let state = MaintenanceState::load(&pool).await.unwrap();
+        state.set(&pool, true, Some("ln migration")).await.unwrap();
+        assert!(state.is_enabled(), "atomic flips with the write");
+
+        let fresh = MaintenanceState::load(&pool).await.unwrap();
+        assert!(fresh.is_enabled(), "a fresh load sees the persisted value");
+        assert_eq!(
+            daemon_state::get(&pool, KEY_REASON)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("ln migration")
+        );
+        assert!(!daemon_state::get(&pool, KEY_SINCE)
+            .await
+            .unwrap()
+            .unwrap()
+            .is_empty());
+
+        state.set(&pool, false, None).await.unwrap();
+        assert!(!MaintenanceState::load(&pool).await.unwrap().is_enabled());
+        assert_eq!(
+            daemon_state::get(&pool, KEY_SINCE)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("")
+        );
+    }
+
+    #[tokio::test]
+    async fn clones_share_one_flag() {
+        let pool = pool().await;
+        let a = MaintenanceState::load(&pool).await.unwrap();
+        let b = a.clone();
+        a.set(&pool, true, None).await.unwrap();
+        assert!(b.is_enabled());
+    }
+
+    #[test]
+    fn blocks_only_the_escrow_opening_actions() {
+        let state = MaintenanceState::new();
+        assert!(!state.blocks(&Action::NewOrder), "disabled blocks nothing");
+        state.enabled.store(true, Ordering::Release);
+        for a in [Action::NewOrder, Action::TakeBuy, Action::TakeSell] {
+            assert!(state.blocks(&a), "{a:?} must be blocked");
+        }
+        for a in [
+            Action::Release,
+            Action::Cancel,
+            Action::FiatSent,
+            Action::AddInvoice,
+            Action::AddBondInvoice,
+            Action::PayBondInvoice,
+            Action::Dispute,
+            Action::RateUser,
+            Action::AdminCancel,
+            Action::AdminSettle,
+            Action::AdminTakeDispute,
+            Action::AdminAddSolver,
+            Action::Orders,
+            Action::RestoreSession,
+            Action::TradePubkey,
+            Action::LastTradeIndex,
+            Action::AddCashuEscrow,
+        ] {
+            assert!(!state.blocks(&a), "{a:?} must stay allowed");
+        }
+    }
+
+    #[tokio::test]
+    async fn drain_counters_are_zero_on_an_empty_database() {
+        let pool = pool().await;
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!(c, DrainCounters::default());
+        assert!(c.drained());
+    }
+
+    #[tokio::test]
+    async fn drain_counters_reflects_each_predicate() {
+        let pool = pool().await;
+        let h = "aa".repeat(32);
+
+        // A: escrowed, non-terminal.
+        insert_order(&pool, "active", Some(&h), None, 0, false).await;
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!((c.escrowed_orders, c.inflight_payouts), (1, 0));
+        assert!(!c.drained());
+
+        // B: in-flight buyer payout (also counted under A, non-terminal).
+        insert_order(&pool, "settled-hold-invoice", Some(&h), Some(&h), 0, false).await;
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!((c.escrowed_orders, c.inflight_payouts), (2, 1));
+
+        // C: unpaid dev fee on a successful order.
+        insert_order(&pool, "success", Some(&h), None, 50, false).await;
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!((c.escrowed_orders, c.unpaid_dev_fees), (2, 1));
+
+        // D / E: bonds.
+        insert_bond(&pool, "locked", Some(&h), None).await;
+        insert_bond(&pool, "pending-payout", Some(&h), Some(&h)).await;
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!((c.open_bonds, c.pending_bond_payouts), (1, 1));
+
+        // Informational only.
+        insert_order(&pool, "pending", None, None, 0, false).await;
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!(c.pending_orders, 1);
+        assert_eq!(c.escrowed_orders, 2, "pending without hash is not escrow");
+    }
+
+    #[tokio::test]
+    async fn drain_counters_ignore_terminal_residue() {
+        let pool = pool().await;
+        let h = "bb".repeat(32);
+        // Terminal order that kept both hashes (post-finalisation clear lost).
+        insert_order(&pool, "canceled-by-admin", Some(&h), Some(&h), 0, false).await;
+        insert_order(&pool, "success", Some(&h), Some(&h), 50, true).await;
+        // Slashed bond keeps payout_payment_hash as its idempotency record.
+        insert_bond(&pool, "slashed", Some(&h), Some(&h)).await;
+        insert_bond(&pool, "released", Some(&h), None).await;
+
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!(c, DrainCounters::default());
+        assert!(c.drained());
+    }
+}

--- a/src/app/maintenance.rs
+++ b/src/app/maintenance.rs
@@ -7,6 +7,7 @@
 //! `drain_counters` reports what is still bound to that node.
 //! Spec: `docs/MAINTENANCE_MODE_LN_MIGRATION.md` §3.2 / §3.4.
 
+use crate::app::bond::types::BondState;
 use crate::app::daemon_state;
 use mostro_core::error::MostroError::{self, MostroInternalErr};
 use mostro_core::error::ServiceError;
@@ -176,16 +177,20 @@ pub async fn drain_counters(pool: &SqlitePool) -> Result<DrainCounters, MostroEr
             &[Status::Success.to_string()],
         )
         .await?,
+        // D is exactly `BondState::is_active()`; keep the two in sync.
         open_bonds: count(
             pool,
             "SELECT COUNT(*) FROM bonds WHERE hash IS NOT NULL AND state IN (?1, ?2)",
-            &["requested".to_string(), "locked".to_string()],
+            &[
+                BondState::Requested.to_string(),
+                BondState::Locked.to_string(),
+            ],
         )
         .await?,
         pending_bond_payouts: count(
             pool,
             "SELECT COUNT(*) FROM bonds WHERE state = ?1",
-            &["pending-payout".to_string()],
+            &[BondState::PendingPayout.to_string()],
         )
         .await?,
         pending_orders: count(
@@ -242,7 +247,12 @@ mod tests {
 
     /// Bonds carry a FK to `orders`, so each one gets its own parent order
     /// in a status that contributes nothing to the counters.
-    async fn insert_bond(pool: &SqlitePool, state: &str, hash: Option<&str>, payout: Option<&str>) {
+    async fn insert_bond(
+        pool: &SqlitePool,
+        state: BondState,
+        hash: Option<&str>,
+        payout: Option<&str>,
+    ) {
         let order_id = insert_order(pool, "canceled", None, None, 0, false).await;
         let mut b = Bond::new_requested(order_id, "ab".repeat(32), BondRole::Maker, 1000);
         b.state = state.to_string();
@@ -368,6 +378,23 @@ mod tests {
         }
     }
 
+    /// Predicate D must stay the SQL twin of `BondState::is_active()`.
+    #[test]
+    fn open_bond_predicate_matches_bond_state_is_active() {
+        let counted = [BondState::Requested, BondState::Locked];
+        for state in [
+            BondState::Requested,
+            BondState::Locked,
+            BondState::Released,
+            BondState::PendingPayout,
+            BondState::Slashed,
+            BondState::Forfeited,
+            BondState::Failed,
+        ] {
+            assert_eq!(counted.contains(&state), state.is_active(), "{state}");
+        }
+    }
+
     #[tokio::test]
     async fn drain_counters_are_zero_on_an_empty_database() {
         let pool = pool().await;
@@ -398,8 +425,8 @@ mod tests {
         assert_eq!((c.escrowed_orders, c.unpaid_dev_fees), (2, 1));
 
         // D / E: bonds.
-        insert_bond(&pool, "locked", Some(&h), None).await;
-        insert_bond(&pool, "pending-payout", Some(&h), Some(&h)).await;
+        insert_bond(&pool, BondState::Locked, Some(&h), None).await;
+        insert_bond(&pool, BondState::PendingPayout, Some(&h), Some(&h)).await;
         let c = drain_counters(&pool).await.unwrap();
         assert_eq!((c.open_bonds, c.pending_bond_payouts), (1, 1));
 
@@ -418,8 +445,8 @@ mod tests {
         insert_order(&pool, "canceled-by-admin", Some(&h), Some(&h), 0, false).await;
         insert_order(&pool, "success", Some(&h), Some(&h), 50, true).await;
         // Slashed bond keeps payout_payment_hash as its idempotency record.
-        insert_bond(&pool, "slashed", Some(&h), Some(&h)).await;
-        insert_bond(&pool, "released", Some(&h), None).await;
+        insert_bond(&pool, BondState::Slashed, Some(&h), Some(&h)).await;
+        insert_bond(&pool, BondState::Released, Some(&h), None).await;
 
         let c = drain_counters(&pool).await.unwrap();
         assert_eq!(c, DrainCounters::default());

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ pub mod util;
 pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 
 use crate::app::context::AppContext;
+use crate::app::maintenance::MaintenanceState;
 use crate::app::{run, run_cashu};
 use crate::cli::settings_init;
 use crate::config::{
@@ -206,6 +207,10 @@ async fn main() -> Result<()> {
                 .expect("MOSTRO_CONFIG not initialized")
                 .clone(),
         );
+        let maintenance = MaintenanceState::load(get_db_pool().as_ref()).await?;
+        if maintenance.is_enabled() {
+            tracing::warn!("Maintenance mode is ON: new orders and takes are rejected");
+        }
         let ctx = AppContext::new(
             get_db_pool(),
             client.clone(),
@@ -213,7 +218,8 @@ async fn main() -> Result<()> {
             MESSAGE_QUEUES.queue_order_msg.clone(),
             mostro_keys.clone(),
         )
-        .with_cashu_client(cashu_client);
+        .with_cashu_client(cashu_client)
+        .with_maintenance(maintenance);
 
         start_scheduler(ctx.clone()).await;
 
@@ -295,13 +301,18 @@ async fn main() -> Result<()> {
             .expect("MOSTRO_CONFIG not initialized")
             .clone(),
     );
+    let maintenance = MaintenanceState::load(get_db_pool().as_ref()).await?;
+    if maintenance.is_enabled() {
+        tracing::warn!("Maintenance mode is ON: new orders and takes are rejected");
+    }
     let ctx = AppContext::new(
         get_db_pool(),
         client.clone(),
         settings,
         MESSAGE_QUEUES.queue_order_msg.clone(),
         mostro_keys.clone(),
-    );
+    )
+    .with_maintenance(maintenance);
 
     // Start scheduler for tasks
     start_scheduler(ctx.clone()).await;


### PR DESCRIPTION
## Summary

Phase 1 of the maintenance-mode / Lightning node migration spec (#932): the persistent flag and the escrow gate. No operator surface yet — the RPC to flip the flag is Phase 2; until then the flag can only be set through the `daemon_state` table.

- **`daemon_state`** key/value table (`migrations/20260901120000_daemon_state.sql`) + `src/app/daemon_state.rs` accessors. Runtime operator state that must survive a restart, unlike `settings.toml`.
- **`MaintenanceState`** (`src/app/maintenance.rs`): `Arc<AtomicBool>` backed by `daemon_state`; `load` / `is_enabled` / `blocks(action)` / `set`. DB is written before the atomic flips, so the persisted value is authoritative after a crash. Attached to `AppContext` via `with_maintenance` in both boot paths of `main.rs`; a warning is logged at boot when it is on.
- **Gate** in `accept_event`, **before** `check_trade_index`: `NewOrder` / `TakeBuy` / `TakeSell` get `CantDo(MaintenanceMode)` and nothing is persisted. Placement matters: `check_trade_index` registers a first-time identity and stores its trade index, so gating after it would burn the index of a request we reject (Codex P2 on #932).
- **`drain_counters`**: the five §1.3 predicates plus informational `pending_orders`, and `drained()`. Uses the real `bonds.state` column, aligns in-flight buyer payouts with `find_inflight_payouts`, and keys pending bond payouts on state because `payout_payment_hash` is a never-cleared idempotency record (Codex P1s on #932). Consumed by the Phase 2 RPC and the Phase 4 boot guard.
- `mostro-core` 0.14.5 → 0.14.6 (`CantDoReason::MaintenanceMode`, `Unknown` catch-all).

## Test plan

TDD: tests written first (failed on missing variants/modules), then implementation.

- [x] `daemon_state`: unknown key → `None`; set/get round trip + overwrite
- [x] `MaintenanceState`: defaults to disabled without a row; round trip through `daemon_state` (`enabled`, `reason`, `since`); clones share one flag; `blocks` only the three escrow-opening actions, table-driven over 17 allowed actions
- [x] `drain_counters`: empty DB → all zero / drained; one fixture per predicate (A–E + pending); terminal residue (order keeping both hashes, `slashed` bond keeping `payout_payment_hash`, `released` bond) is **not** counted
- [x] Gate through the real `accept_event` with kind-14 events: rejects the three actions with a `MaintenanceMode` `CantDo` to the trade key; does not gate 13 other actions; no-op when disabled; **first-time dual-key user is not registered** when rejected (with a control run showing it is registered when the gate is off)
- [x] `cargo test`: 1257 passed · `cargo clippy --all-targets --all-features` clean · `cargo fmt --check`
- [x] Coverage (`cargo llvm-cov`): `daemon_state.rs` 95.7 %, `maintenance.rs` 99.6 %

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ZQvcc8LfrsTYx9VAiSxS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent maintenance mode that survives daemon restarts.
  * New orders and trade-taking actions are blocked while maintenance mode is active; existing trades can continue.
  * Added maintenance reasons, timestamps, and operational drain-status counters.
  * Maintenance mode is restored automatically when the daemon starts.

* **Bug Fixes**
  * Prevented users from being registered when their initial requests are rejected during maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->