### PR TITLE
feat: advertise maintenance mode in the info event, republish on change (Phase 3)

### DIFF
--- a/src/app/maintenance.rs
+++ b/src/app/maintenance.rs
@@ -15,7 +15,7 @@ use mostro_core::prelude::{Action, Status};
 use sqlx::SqlitePool;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 pub const KEY_ENABLED: &str = "maintenance_mode";
 pub const KEY_REASON: &str = "maintenance_reason";
@@ -34,6 +34,11 @@ pub const KEY_LN_NODE_PUBKEY: &str = "ln_node_pubkey";
 pub struct MaintenanceState {
     enabled: Arc<AtomicBool>,
     write_lock: Arc<Mutex<()>>,
+    /// Signalled after every successful `set`, so the info-event job can
+    /// republish the `maintenance_mode` tag at once instead of waiting a
+    /// full `publish_mostro_info_interval`. One consumer, so `notify_one`
+    /// (which stores a permit) is used rather than `notify_waiters`.
+    changed: Arc<Notify>,
 }
 
 impl MaintenanceState {
@@ -52,6 +57,7 @@ impl MaintenanceState {
         Ok(Self {
             enabled: Arc::new(AtomicBool::new(enabled)),
             write_lock: Arc::default(),
+            changed: Arc::default(),
         })
     }
 
@@ -98,7 +104,14 @@ impl MaintenanceState {
             .await
             .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
         self.enabled.store(enabled, Ordering::Release);
+        self.changed.notify_one();
         Ok(())
+    }
+
+    /// Resolves after the next successful `set` (or immediately if one
+    /// happened since the last call). Used by the info-event job.
+    pub async fn changed(&self) {
+        self.changed.notified().await
     }
 }
 
@@ -337,6 +350,39 @@ mod tests {
             since.is_empty(),
             !persisted,
             "since must match the final mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_wakes_a_changed_waiter_and_stores_a_permit() {
+        let pool = pool().await;
+        let state = MaintenanceState::load(&pool).await.unwrap();
+
+        // Waiter registered before the change.
+        let waiter = state.clone();
+        let woke = tokio::spawn(async move { waiter.changed().await });
+        tokio::task::yield_now().await;
+        state.set(&pool, true, None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), woke)
+            .await
+            .expect("changed() must resolve after set")
+            .unwrap();
+
+        // Change before anyone waits: the permit is kept.
+        state.set(&pool, false, None).await.unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), state.changed())
+            .await
+            .expect("a change before the wait must still be observed");
+
+        // A failed write does not signal.
+        let closed = MaintenanceState::load(&pool).await.unwrap();
+        pool.close().await;
+        assert!(closed.set(&pool, true, None).await.is_err());
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), closed.changed())
+                .await
+                .is_err(),
+            "no notification on a failed set"
         );
     }
 

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -569,7 +569,9 @@ fn advertised_first_contact_pow(mostro_settings: &MostroSettings) -> u8 {
 /// # Arguments
 ///
 ///
-pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
+/// `maintenance` is the current maintenance (drain) flag; the tag is always
+/// emitted so clients can tell "maintenance off" from "older daemon".
+pub fn info_to_tags(ln_status: &LnStatus, maintenance: bool) -> Tags {
     let mostro_settings = Settings::get_mostro();
     let ln_settings = Settings::get_ln();
     let bond_settings = Settings::get_bond();
@@ -658,6 +660,10 @@ pub fn info_to_tags(ln_status: &LnStatus) -> Tags {
     ];
 
     tags_vec.extend(bond_policy_tags(bond_settings));
+    tags_vec.push(Tag::custom(
+        "maintenance_mode",
+        vec![maintenance.to_string()],
+    ));
 
     Tags::from_list(tags_vec)
 }
@@ -966,7 +972,7 @@ mod tests {
         init_test_settings();
         let ln_status = make_ln_status();
 
-        let tags = info_to_tags(&ln_status);
+        let tags = info_to_tags(&ln_status, false);
 
         let y_values = get_y_tag_values(&tags).expect("info_to_tags must emit a y tag");
 
@@ -978,7 +984,7 @@ mod tests {
         init_test_settings();
         let ln_status = make_ln_status();
 
-        let tags = info_to_tags(&ln_status);
+        let tags = info_to_tags(&ln_status, false);
 
         let y_values = get_y_tag_values(&tags).expect("info_to_tags must emit a y tag");
 
@@ -986,6 +992,34 @@ mod tests {
         assert_eq!(
             y_values, expected,
             "info_to_tags must wire create_platform_tag_values correctly into the y tag"
+        );
+    }
+
+    fn tag_value(tags: &Tags, name: &str) -> Option<String> {
+        tags.iter()
+            .find(|t| t.kind() == name)
+            .and_then(|t| t.content().map(str::to_string))
+    }
+
+    #[test]
+    fn info_to_tags_emits_maintenance_mode_false_by_default() {
+        init_test_settings();
+        let ln_status = make_ln_status();
+        let tags = info_to_tags(&ln_status, false);
+        assert_eq!(
+            tag_value(&tags, "maintenance_mode").as_deref(),
+            Some("false")
+        );
+    }
+
+    #[test]
+    fn info_to_tags_emits_maintenance_mode_true_when_enabled() {
+        init_test_settings();
+        let ln_status = make_ln_status();
+        let tags = info_to_tags(&ln_status, true);
+        assert_eq!(
+            tag_value(&tags, "maintenance_mode").as_deref(),
+            Some("true")
         );
     }
 
@@ -1001,7 +1035,7 @@ mod tests {
         init_test_settings();
         let ln_status = make_ln_status();
 
-        let tags = info_to_tags(&ln_status);
+        let tags = info_to_tags(&ln_status, false);
 
         // Expectations come from the settings actually installed in
         // `MOSTRO_CONFIG`, never from this module's `test_settings()` copy:
@@ -1125,7 +1159,7 @@ mod tests {
         init_test_settings();
         let ln_status = make_ln_status();
 
-        let tags = info_to_tags(&ln_status);
+        let tags = info_to_tags(&ln_status, false);
 
         assert_eq!(
             get_tag_value(&tags, "bond_enabled").as_deref(),

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -2,7 +2,10 @@ use crate::config::constants::NOSTR_EXCHANGE_RATES_EVENT_KIND;
 use crate::config::settings::Settings;
 use crate::config::types::{BondApplyTo, MostroSettings};
 use crate::lightning::LnStatus;
-use crate::util::{get_expiration_timestamp_for_kind, get_keys, monotonic_dispute_event_timestamp};
+use crate::util::{
+    get_expiration_timestamp_for_kind, get_keys, monotonic_dispute_event_timestamp,
+    monotonic_info_event_timestamp,
+};
 use crate::LN_STATUS;
 use mostro_core::prelude::*;
 use nostr::error::Error;
@@ -140,13 +143,18 @@ pub fn new_info_event(
     identifier: String,
     extra_tags: Tags,
 ) -> Result<Event, Error> {
+    // Strictly increasing per `d` tag: a maintenance-mode flip republishes
+    // the info event at once, and a same-second tie with the previous
+    // publish would let the relay keep the stale revision (NIP-01 breaks
+    // ties by lowest event id).
+    let created_at = monotonic_info_event_timestamp(&identifier, Timestamp::now());
     create_event(
         keys,
         content,
         identifier,
         extra_tags,
         NOSTR_INFO_EVENT_KIND,
-        None,
+        Some(created_at),
     )
 }
 
@@ -1020,6 +1028,25 @@ mod tests {
         assert_eq!(
             tag_value(&tags, "maintenance_mode").as_deref(),
             Some("true")
+        );
+    }
+
+    /// Two info events built in the same second must not tie on
+    /// `created_at`, or a relay keeps whichever has the lower id.
+    #[test]
+    fn consecutive_info_events_have_strictly_increasing_created_at() {
+        init_test_settings();
+        let keys = Keys::generate();
+        let id = keys.public_key().to_string();
+        let ln_status = make_ln_status();
+        let first =
+            super::new_info_event(&keys, "", id.clone(), info_to_tags(&ln_status, false)).unwrap();
+        let second = super::new_info_event(&keys, "", id, info_to_tags(&ln_status, true)).unwrap();
+        assert!(
+            second.created_at > first.created_at,
+            "{} !> {}",
+            second.created_at,
+            first.created_at
         );
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -188,9 +188,31 @@ async fn job_relay_list(ctx: AppContext) {
     });
 }
 
+/// Why the info-event job woke up: the regular interval elapsed, or the
+/// maintenance flag changed and the `maintenance_mode` tag must go out now.
+#[derive(Debug, PartialEq, Eq)]
+enum InfoWake {
+    Interval,
+    MaintenanceChanged,
+}
+
+/// Wait for whichever comes first: the publish interval or a maintenance
+/// flag change. Split out of `job_info_event_send` so the wake-up rule is
+/// unit-testable without a nostr client.
+async fn wait_for_info_wake(
+    interval: tokio::time::Duration,
+    maintenance: &crate::app::maintenance::MaintenanceState,
+) -> InfoWake {
+    tokio::select! {
+        _ = tokio::time::sleep(interval) => InfoWake::Interval,
+        _ = maintenance.changed() => InfoWake::MaintenanceChanged,
+    }
+}
+
 async fn job_info_event_send(ctx: AppContext) {
     let mostro_keys = ctx.keys().clone();
     let client = ctx.nostr_client().clone();
+    let maintenance = ctx.maintenance().clone();
     let interval = ctx.settings().mostro.publish_mostro_info_interval as u64;
     // The info event embeds LN node stats (`info_to_tags`). In Cashu mode there
     // is no LND, so `LN_STATUS` is never set — skip the job rather than panic
@@ -201,9 +223,14 @@ async fn job_info_event_send(ctx: AppContext) {
     };
     tokio::spawn(async move {
         loop {
-            info!("Sending info about mostro");
+            let in_maintenance = maintenance.is_enabled();
+            if in_maintenance {
+                warn!("Sending info about mostro (maintenance mode ON: new orders and takes are rejected)");
+            } else {
+                info!("Sending info about mostro");
+            }
 
-            let tags = crate::nip33::info_to_tags(ln_status);
+            let tags = crate::nip33::info_to_tags(ln_status, in_maintenance);
             let id = mostro_keys.public_key().to_string();
 
             let info_ev = match crate::nip33::new_info_event(&mostro_keys, "", id, tags) {
@@ -213,7 +240,11 @@ async fn job_info_event_send(ctx: AppContext) {
 
             let _ = client.send_event(&info_ev).await;
 
-            tokio::time::sleep(tokio::time::Duration::from_secs(interval)).await;
+            if wait_for_info_wake(tokio::time::Duration::from_secs(interval), &maintenance).await
+                == InfoWake::MaintenanceChanged
+            {
+                info!("Maintenance flag changed: republishing mostro info now");
+            }
         }
     });
 }
@@ -2372,6 +2403,36 @@ mod tests {
                 .is_empty(),
             "undeliverable restore-session message must be dropped after retries"
         );
+    }
+
+    /// The info job must republish as soon as the maintenance flag flips,
+    /// not at the next interval tick.
+    #[tokio::test]
+    async fn info_wake_fires_on_maintenance_change_before_the_interval() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        let state = crate::app::maintenance::MaintenanceState::load(&pool)
+            .await
+            .unwrap();
+        let interval = tokio::time::Duration::from_secs(3600);
+
+        let waiter = state.clone();
+        let wake = tokio::spawn(async move { wait_for_info_wake(interval, &waiter).await });
+        tokio::task::yield_now().await;
+        state.set(&pool, true, None).await.unwrap();
+        let reason = tokio::time::timeout(tokio::time::Duration::from_secs(1), wake)
+            .await
+            .expect("must not wait for the interval")
+            .unwrap();
+        assert_eq!(reason, InfoWake::MaintenanceChanged);
+    }
+
+    #[tokio::test]
+    async fn info_wake_falls_back_to_the_interval() {
+        tokio::time::pause();
+        let state = crate::app::maintenance::MaintenanceState::new();
+        let reason = wait_for_info_wake(tokio::time::Duration::from_secs(10), &state).await;
+        assert_eq!(reason, InfoWake::Interval);
     }
 
     #[tokio::test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1147,6 +1147,29 @@ pub(crate) fn monotonic_dispute_event_timestamp(d_tag: &str, candidate: Timestam
     ))
 }
 
+/// Same registry for the kind-38385 Mostro info event, keyed by its `d`
+/// tag (the node pubkey). Normally one publish per
+/// `publish_mostro_info_interval`, but a maintenance-mode flip republishes
+/// immediately, and if that lands in the same second as the previous
+/// publish the two revisions would tie on `created_at` and the relay would
+/// keep the lower event id — possibly the stale `maintenance_mode` value.
+static INFO_EVENT_TIMESTAMPS: std::sync::LazyLock<std::sync::Mutex<HashMap<String, u64>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+/// Next `created_at` for a kind-38385 info event revision identified by
+/// `d_tag`: `candidate`, bumped to strictly after the last revision
+/// published under that tag when both land in the same second.
+pub(crate) fn monotonic_info_event_timestamp(d_tag: &str, candidate: Timestamp) -> Timestamp {
+    let mut last_ts = INFO_EVENT_TIMESTAMPS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    Timestamp::from(monotonic_created_at(
+        &mut last_ts,
+        d_tag.to_owned(),
+        candidate.as_secs(),
+    ))
+}
+
 /// Orders whose latest kind-38383 publish failed (a relay rejected the
 /// event, the send errored, or no Nostr client existed), so the DB state
 /// and the advertised orderbook diverged. The scheduler's orderbook
@@ -2363,6 +2386,18 @@ mod tests {
     /// Two revisions of the same order in the same Unix second must not tie:
     /// NIP-01 breaks same-timestamp ties by lowest event id, which can keep a
     /// dead `pending` revision as the winning state on relays.
+    #[test]
+    fn info_event_timestamp_bumps_same_second_republish() {
+        let d_tag = format!("info-{}", Uuid::new_v4());
+        let now = Timestamp::from(1_700_000_000);
+        let first = monotonic_info_event_timestamp(&d_tag, now);
+        let republish = monotonic_info_event_timestamp(&d_tag, now);
+        assert_eq!(first.as_secs(), 1_700_000_000);
+        assert_eq!(republish.as_secs(), 1_700_000_001, "must be strictly later");
+        let later = monotonic_info_event_timestamp(&d_tag, Timestamp::from(1_700_000_100));
+        assert_eq!(later.as_secs(), 1_700_000_100, "wall clock wins once ahead");
+    }
+
     #[test]
     fn monotonic_timestamp_bumps_same_second_revisions() {
         let order_id = Uuid::new_v4();


### PR DESCRIPTION
## Summary

Phase 3 of the maintenance-mode / Lightning node migration spec (#932, §3.5): client signalling.

- **`maintenance_mode` tag** in the NIP-33 info event (`info_to_tags(ln_status, maintenance)`), always emitted as `"true"`/`"false"` like `bond_enabled`, so clients can tell "maintenance off" from "older daemon" and warn the user before mining PoW for a `new-order`/`take` that will be rejected. Documented in the protocol book (MostroP2P/protocol#57).
- **Immediate republish.** `MaintenanceState` gains a `tokio::sync::Notify` signalled after every successful `set` (`changed()` resolves on it; a permit is kept if nobody is waiting yet; a failed write signals nothing). `job_info_event_send` reads the flag on every tick and waits on `select!(interval, changed())`, factored into `wait_for_info_wake` so the wake rule is unit-testable without a nostr client. Result: a `SetMaintenanceMode` is visible to clients right away instead of after `publish_mostro_info_interval`.
- Log line at each publish says whether maintenance is ON.

Independent of Phase 2 apart from sharing `MaintenanceState`; the RPC needs no change because `set` itself notifies.

## Test plan

- [x] `info_to_tags_emits_maintenance_mode_false_by_default` / `_true_when_enabled`
- [x] `set_wakes_a_changed_waiter_and_stores_a_permit` — waiter registered before the change wakes; a change before the wait is still observed; a failed `set` (closed pool) does not signal
- [x] `info_wake_fires_on_maintenance_change_before_the_interval` — 1 h interval, flag flips, helper returns `MaintenanceChanged` within 1 s
- [x] `info_wake_falls_back_to_the_interval` — paused clock, returns `Interval`
- [x] `cargo test`: 1276 passed · `cargo clippy --all-targets --all-features` clean · `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ZQvcc8LfrsTYx9VAiSxS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added maintenance-mode status to published service information.
  - Information updates are now republished immediately when maintenance mode changes, rather than waiting for the next scheduled update.
  - Maintenance status changes are reliably reflected in event metadata.

- **Bug Fixes**
  - Ensured rapidly successive information updates receive increasing timestamps, so newer updates are recognized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->