### PR TITLE
feat: boot node-identity guard for Lightning node changes (Phase 4)

### DIFF
--- a/docs/STARTUP_AND_CONFIG.md
+++ b/docs/STARTUP_AND_CONFIG.md
@@ -110,6 +110,7 @@ Configuration is loaded from `~/.mostro/settings.toml` (template: `settings.tpl.
 - `hold_invoice_expiration_window` (u32): Hold invoice expiration in seconds (default: 300)
 - `payment_attempts` (u32): Max payment retry attempts (default: 3)
 - `payment_retries_interval` (u32): Retry interval in seconds (default: 60)
+- `allow_node_change` (bool): Disaster-recovery override for the boot node-identity guard. By default mostrod refuses to start when the connected LND's identity pubkey differs from the one it last ran with and escrow is still open on the old node; `true` downgrades that to a warning and knowingly leaves those trades unresolved (default: false; see `docs/MAINTENANCE_MODE_LN_MIGRATION.md` §3.6/§5.1)
 - `escrow_deadline_margin_blocks` (u32): Safety margin in blocks before the hold invoice's CLTV horizon; at `hold_invoice_cltv_delta - escrow_deadline_margin_blocks` blocks after the escrow was paid, mostrod cancels the trade (Active) or opens a dispute (FiatSent) before LND auto-refunds the escrow. Must exceed the LND node's `invoices.holdexpirydelta` (LND default: 12) (default: 24)
 
 **Mostro** (`src/config/types.rs:76-108`):

--- a/settings.tpl.toml
+++ b/settings.tpl.toml
@@ -29,6 +29,13 @@ max_final_cltv_expiry_delta = 432
 # dispute (FiatSent) while the escrow still exists. Must comfortably
 # exceed your node's holdexpirydelta.
 escrow_deadline_margin_blocks = 24
+# Boot guard: mostrod refuses to start against a Lightning node whose
+# identity pubkey differs from the one it last ran with while escrow
+# (hold invoices, bonds, in-flight payouts) is still open on the old
+# node. Drain first (see docs/MAINTENANCE_MODE_LN_MIGRATION.md). Set to
+# true ONLY for disaster recovery when the old node is gone for good; it
+# knowingly leaves the affected trades unresolved.
+allow_node_change = false
 
 [nostr]
 nsec_privkey = 'nsec1...'

--- a/src/app/maintenance.rs
+++ b/src/app/maintenance.rs
@@ -143,6 +143,84 @@ impl DrainCounters {
     }
 }
 
+/// Outcome of the boot node-identity guard (spec §3.6).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NodeIdentityDecision {
+    /// No pubkey stored yet: recorded, continue.
+    FirstBoot,
+    /// Same node as last run: continue.
+    Same,
+    /// Different node but nothing bound to the old one: recorded, continue.
+    ChangedDrained { previous: String },
+    /// Different node with escrow still open on the old one and no
+    /// override: the caller must refuse to start.
+    ChangedWithOpenEscrow {
+        previous: String,
+        counters: DrainCounters,
+    },
+    /// Different node with open escrow, but `allow_node_change = true`:
+    /// recorded, continue, affected rows knowingly left unresolved.
+    ChangedOverridden {
+        previous: String,
+        counters: DrainCounters,
+    },
+}
+
+impl NodeIdentityDecision {
+    /// Whether the daemon may proceed with boot.
+    pub fn allows_boot(&self) -> bool {
+        !matches!(self, Self::ChangedWithOpenEscrow { .. })
+    }
+}
+
+/// Pure decision rule of the guard, separated from IO so it can be tested
+/// without LND. `stored` is the pubkey from the last run (if any), `current`
+/// the connected node's, `counters` what is still bound to the old node.
+pub fn check_node_identity(
+    stored: Option<&str>,
+    current: &str,
+    counters: &DrainCounters,
+    allow_override: bool,
+) -> NodeIdentityDecision {
+    match stored {
+        None => NodeIdentityDecision::FirstBoot,
+        Some(prev) if prev == current => NodeIdentityDecision::Same,
+        Some(prev) if counters.drained() => NodeIdentityDecision::ChangedDrained {
+            previous: prev.to_owned(),
+        },
+        Some(prev) if allow_override => NodeIdentityDecision::ChangedOverridden {
+            previous: prev.to_owned(),
+            counters: counters.clone(),
+        },
+        Some(prev) => NodeIdentityDecision::ChangedWithOpenEscrow {
+            previous: prev.to_owned(),
+            counters: counters.clone(),
+        },
+    }
+}
+
+/// Run the guard against the database: compare the connected node's pubkey
+/// with the one persisted under `ln_node_pubkey`, compute the drain
+/// counters only when they differ, and persist the new pubkey in every
+/// case that allows boot. Never persists on refusal, so a later boot
+/// against the old node still sees its own pubkey.
+pub async fn node_identity_guard(
+    pool: &SqlitePool,
+    current: &str,
+    allow_override: bool,
+) -> Result<NodeIdentityDecision, MostroError> {
+    let stored = daemon_state::get(pool, KEY_LN_NODE_PUBKEY).await?;
+    let counters = match stored.as_deref() {
+        Some(prev) if prev != current => drain_counters(pool).await?,
+        _ => DrainCounters::default(),
+    };
+    let decision = check_node_identity(stored.as_deref(), current, &counters, allow_override);
+    if decision.allows_boot() && !matches!(decision, NodeIdentityDecision::Same) {
+        daemon_state::set(pool, KEY_LN_NODE_PUBKEY, current).await?;
+    }
+    Ok(decision)
+}
+
 /// Order statuses that no longer need the node that issued their hold invoice.
 fn terminal_statuses() -> [String; 7] {
     [
@@ -441,6 +519,139 @@ mod tests {
         ] {
             assert_eq!(counted.contains(&state), state.is_active(), "{state}");
         }
+    }
+
+    fn open() -> DrainCounters {
+        DrainCounters {
+            escrowed_orders: 2,
+            ..DrainCounters::default()
+        }
+    }
+
+    #[test]
+    fn node_guard_rule_covers_every_branch() {
+        let none = DrainCounters::default();
+        assert_eq!(
+            check_node_identity(None, "02aa", &none, false),
+            NodeIdentityDecision::FirstBoot
+        );
+        assert_eq!(
+            check_node_identity(Some("02aa"), "02aa", &open(), false),
+            NodeIdentityDecision::Same,
+            "same node never refuses, whatever the counters"
+        );
+        assert_eq!(
+            check_node_identity(Some("02aa"), "02bb", &none, false),
+            NodeIdentityDecision::ChangedDrained {
+                previous: "02aa".into()
+            }
+        );
+        let refused = check_node_identity(Some("02aa"), "02bb", &open(), false);
+        assert_eq!(
+            refused,
+            NodeIdentityDecision::ChangedWithOpenEscrow {
+                previous: "02aa".into(),
+                counters: open()
+            }
+        );
+        assert!(!refused.allows_boot());
+        let overridden = check_node_identity(Some("02aa"), "02bb", &open(), true);
+        assert_eq!(
+            overridden,
+            NodeIdentityDecision::ChangedOverridden {
+                previous: "02aa".into(),
+                counters: open()
+            }
+        );
+        assert!(overridden.allows_boot());
+    }
+
+    #[tokio::test]
+    async fn node_guard_stores_pubkey_on_first_boot_and_accepts_same() {
+        let pool = pool().await;
+        assert_eq!(
+            node_identity_guard(&pool, "02aa", false).await.unwrap(),
+            NodeIdentityDecision::FirstBoot
+        );
+        assert_eq!(
+            daemon_state::get(&pool, KEY_LN_NODE_PUBKEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("02aa")
+        );
+        // Open escrow does not matter while the node is the same.
+        insert_order(&pool, "active", Some(&"aa".repeat(32)), None, 0, false).await;
+        assert_eq!(
+            node_identity_guard(&pool, "02aa", false).await.unwrap(),
+            NodeIdentityDecision::Same
+        );
+    }
+
+    #[tokio::test]
+    async fn node_guard_rejects_new_pubkey_with_open_escrow_and_keeps_old_one() {
+        let pool = pool().await;
+        node_identity_guard(&pool, "02aa", false).await.unwrap();
+        insert_order(&pool, "active", Some(&"aa".repeat(32)), None, 0, false).await;
+
+        let decision = node_identity_guard(&pool, "02bb", false).await.unwrap();
+        assert!(matches!(
+            &decision,
+            NodeIdentityDecision::ChangedWithOpenEscrow { previous, counters }
+                if previous == "02aa" && counters.escrowed_orders == 1
+        ));
+        assert!(!decision.allows_boot());
+        assert_eq!(
+            daemon_state::get(&pool, KEY_LN_NODE_PUBKEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("02aa"),
+            "a refused boot must not overwrite the stored pubkey"
+        );
+    }
+
+    #[tokio::test]
+    async fn node_guard_allows_new_pubkey_when_drained() {
+        let pool = pool().await;
+        node_identity_guard(&pool, "02aa", false).await.unwrap();
+        insert_order(&pool, "success", Some(&"aa".repeat(32)), None, 0, true).await;
+
+        let decision = node_identity_guard(&pool, "02bb", false).await.unwrap();
+        assert_eq!(
+            decision,
+            NodeIdentityDecision::ChangedDrained {
+                previous: "02aa".into()
+            }
+        );
+        assert_eq!(
+            daemon_state::get(&pool, KEY_LN_NODE_PUBKEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("02bb")
+        );
+    }
+
+    #[tokio::test]
+    async fn node_guard_override_records_new_pubkey_despite_open_escrow() {
+        let pool = pool().await;
+        node_identity_guard(&pool, "02aa", false).await.unwrap();
+        insert_order(&pool, "active", Some(&"aa".repeat(32)), None, 0, false).await;
+
+        let decision = node_identity_guard(&pool, "02bb", true).await.unwrap();
+        assert!(matches!(
+            decision,
+            NodeIdentityDecision::ChangedOverridden { .. }
+        ));
+        assert!(decision.allows_boot());
+        assert_eq!(
+            daemon_state::get(&pool, KEY_LN_NODE_PUBKEY)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("02bb")
+        );
     }
 
     #[tokio::test]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -477,6 +477,15 @@ pub struct LightningSettings {
     /// `invoices.holdexpirydelta` (LND default: 12) with room to spare.
     #[serde(default = "default_escrow_deadline_margin_blocks")]
     pub escrow_deadline_margin_blocks: u32,
+    /// Disaster-recovery override for the boot node-identity guard. By
+    /// default the daemon refuses to start against a Lightning node whose
+    /// identity pubkey differs from the one it last ran with while escrow
+    /// is still open on the old node (hold invoices cannot move between
+    /// nodes). `true` turns that refusal into a warning and knowingly
+    /// leaves the affected rows unresolved. See
+    /// docs/MAINTENANCE_MODE_LN_MIGRATION.md §3.6 / §5.1.
+    #[serde(default)]
+    pub allow_node_change: bool,
 }
 
 /// ~3 days of blocks. High enough for every wallet we know of (18 to 144 is
@@ -508,6 +517,7 @@ impl Default for LightningSettings {
             payment_retries_interval: 0,
             max_final_cltv_expiry_delta: default_max_final_cltv_expiry_delta(),
             escrow_deadline_margin_blocks: default_escrow_deadline_margin_blocks(),
+            allow_node_change: false,
         }
     }
 }

--- a/src/config/wizard.rs
+++ b/src/config/wizard.rs
@@ -147,6 +147,7 @@ fn prompt_lightning_settings() -> Result<LightningSettings, MostroError> {
         payment_retries_interval: 60,
         max_final_cltv_expiry_delta: 432,
         escrow_deadline_margin_blocks: 24,
+        allow_node_change: false,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ pub mod util;
 pub type Result<T, E = Box<dyn std::error::Error>> = std::result::Result<T, E>;
 
 use crate::app::context::AppContext;
-use crate::app::maintenance::MaintenanceState;
+use crate::app::maintenance::{node_identity_guard, MaintenanceState, NodeIdentityDecision};
 use crate::app::{run, run_cashu};
 use crate::cli::settings_init;
 use crate::config::{
@@ -230,9 +230,45 @@ async fn main() -> Result<()> {
     let mut ln_client = LndConnector::new().await?;
     let ln_status = ln_client.get_node_info().await?;
     let ln_status = LnStatus::from_get_info_response(ln_status);
+    let node_pubkey = ln_status.node_pubkey.clone();
     if LN_STATUS.set(ln_status).is_err() {
         panic!("No connection to LND node - shutting down Mostro!");
     };
+
+    // Node-identity guard: hold invoices live only in the node that issued
+    // them, so starting against a different node while escrow is still open
+    // on the old one would strand every release/cancel. Refuse loudly here
+    // instead of failing one order at a time (spec §3.6).
+    let allow_node_change = Settings::get_ln().allow_node_change;
+    match node_identity_guard(get_db_pool().as_ref(), &node_pubkey, allow_node_change).await? {
+        NodeIdentityDecision::FirstBoot => {
+            tracing::info!("Recorded Lightning node identity {node_pubkey}");
+        }
+        NodeIdentityDecision::Same => {}
+        NodeIdentityDecision::ChangedDrained { previous } => {
+            tracing::warn!(
+                "Lightning node changed from {previous} to {node_pubkey} with no open escrow; recorded"
+            );
+        }
+        NodeIdentityDecision::ChangedOverridden { previous, counters } => {
+            tracing::warn!(
+                "Lightning node changed from {previous} to {node_pubkey} with open escrow \
+                 ({counters:?}) — [lightning].allow_node_change = true, continuing; the affected \
+                 rows CANNOT be resolved by the daemon, see \
+                 docs/MAINTENANCE_MODE_LN_MIGRATION.md §5.1"
+            );
+        }
+        NodeIdentityDecision::ChangedWithOpenEscrow { previous, counters } => {
+            tracing::error!(
+                "REFUSING TO START: Lightning node changed from {previous} to {node_pubkey} but \
+                 escrow is still bound to the old node: {counters:?}. Reconnect the old node and \
+                 drain it (SetMaintenanceMode + GetMaintenanceStatus until drained == true), or \
+                 if it is gone for good follow docs/MAINTENANCE_MODE_LN_MIGRATION.md §5.1 and set \
+                 [lightning].allow_node_change = true."
+            );
+            std::process::exit(1);
+        }
+    }
 
     // A failure here means no in-flight hold invoice is resubscribed for the
     // whole run, which is indistinguishable from "there were none" unless it is


### PR DESCRIPTION
## Summary

Phase 4 of the maintenance-mode / Lightning node migration spec (#932, §3.6): the boot node-identity guard.

- At boot, after `LN_STATUS` is set, `node_identity_guard` compares the connected node's `identity_pubkey` with `daemon_state.ln_node_pubkey` from the last run:
  - **first boot** → record, continue;
  - **same node** → continue (open escrow is fine, it lives on this node);
  - **different node, `drain_counters` drained** → record with a warning, continue;
  - **different node, escrow still bound to the old one** → `REFUSING TO START` error naming the counters and both pubkeys, `exit(1)`, stored pubkey **not** overwritten so a boot against the old node still matches;
  - **same, but `[lightning].allow_node_change = true`** → warning, record, continue; the log states the affected rows cannot be resolved by the daemon and points to §5.1.
- `[lightning].allow_node_change` (bool, `#[serde(default)]` = `false`, so existing `settings.toml` files keep loading). Added to `settings.tpl.toml`, the wizard, `Default`, and `docs/STARTUP_AND_CONFIG.md`.
- The decision is a pure function `check_node_identity(stored, current, counters, allow_override) -> NodeIdentityDecision`; `node_identity_guard` does the IO and only computes counters when the pubkey actually changed.
- `GetMaintenanceStatus.stored_ln_node_pubkey` (Phase 2) is now populated.

**Rollback note:** this phase can prevent the daemon from starting. If that happens unexpectedly, either point `[lightning]` back at the previous node, or set `allow_node_change = true` after reading §5.1.

## Test plan

- [x] `node_guard_rule_covers_every_branch` — pure rule over all five outcomes + `allows_boot`
- [x] `node_guard_stores_pubkey_on_first_boot_and_accepts_same` — same node with open escrow never refuses
- [x] `node_guard_rejects_new_pubkey_with_open_escrow_and_keeps_old_one` — refusal, counters reported, stored pubkey untouched
- [x] `node_guard_allows_new_pubkey_when_drained` — recorded
- [x] `node_guard_override_records_new_pubkey_despite_open_escrow`
- [x] `cargo test`: 1283 passed · `cargo clippy --all-targets --all-features` clean · `cargo fmt --check` · markdownlint clean
- [ ] Manual: regtest with two LND nodes, open an order, switch `[lightning]`, confirm the refusal message; drain, switch, confirm the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ZQvcc8LfrsTYx9VAiSxS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added startup protection against connecting to a different Lightning node while escrowed trades remain open.
  * Added an optional disaster-recovery override to continue startup with a changed node identity.
  * Node identity is recorded automatically on first use and after approved migrations.

* **Documentation**
  * Documented the new `allow_node_change` configuration setting, including its default behavior and recovery guidance.
  * Updated configuration templates and setup wizard defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->