### PR TITLE
fix: count only in-flight dev fees in the drain counters

### DIFF
--- a/docs/LIGHTNING_OPS.md
+++ b/docs/LIGHTNING_OPS.md
@@ -329,7 +329,7 @@ The daemon ships a **maintenance (drain) mode** for this. Full design in
 |---|---|
 | `escrowed_orders` | orders with a hold invoice in a non-terminal status |
 | `inflight_payouts` | buyer payouts in flight (`settled-hold-invoice` with a payout hash) |
-| `unpaid_dev_fees` | successful orders whose dev fee is still unpaid |
+| `inflight_dev_fees` | dev-fee payouts claimed or in flight; a merely unpaid dev fee is paid by whichever node is connected and does not count |
 | `open_bonds` | bond hold invoices still open (`requested` / `locked`) |
 | `pending_bond_payouts` | bonds waiting for, or in the middle of, their payout |
 | `pending_orders` | informational only: no escrow, does not block the switch |

--- a/docs/MAINTENANCE_MODE_LN_MIGRATION.md
+++ b/docs/MAINTENANCE_MODE_LN_MIGRATION.md
@@ -58,7 +58,7 @@ the switch:
 |---|---|---|
 | A. Escrowed orders | `orders.hash IS NOT NULL AND status NOT IN (terminal)` | hold invoice must be settled or canceled on the node that issued it |
 | B. In‑flight buyer payouts | `orders.payout_payment_hash IS NOT NULL AND status = 'settled-hold-invoice'` | `job_reconcile_inflight_payouts` tracks the hash on the node that sent it. Same predicate as `find_inflight_payouts` (`src/db.rs`); a subset of A, reported separately for visibility |
-| C. Unpaid dev fees | `orders.dev_fee > 0 AND dev_fee_paid = 0 AND status = 'success'` | `job_process_dev_fee_payment` pays from the node; harmless to re‑run on the new node but cleaner to drain |
+| C. In‑flight dev fees | `orders.dev_fee_paid = 0 AND dev_fee_payment_hash IS NOT NULL` | `job_process_dev_fee_payment` sets the marker while it claims/sends and clears it on failure; only that window tracks a payment on the node. A merely unpaid dev fee is an outgoing payment to a Lightning address the new node makes just as well, so it is **not** counted (found in the regtest dry run: the address is mainnet‑only, the fee can never be paid there, and counting it blocked `drained` forever) |
 | D. Open bond hold invoices | `bonds.hash IS NOT NULL AND state IN ('requested','locked')` | maker/taker bond hold invoices (`src/app/bond/flow.rs`) |
 | E. Pending bond payouts | `bonds.state = 'pending-payout'` | payout not yet sent or in flight; `bonds.payout_payment_hash` is the idempotency record for it |
 
@@ -268,7 +268,7 @@ message GetMaintenanceStatusRequest { optional string request_id = 1; }
 message DrainCounters {
   uint32 escrowed_orders        = 1; // §1.3 A
   uint32 inflight_payouts       = 2; // §1.3 B
-  uint32 unpaid_dev_fees        = 3; // §1.3 C
+  uint32 inflight_dev_fees      = 3; // §1.3 C
   uint32 locked_bonds           = 4; // §1.3 D
   uint32 inflight_bond_payouts  = 5; // §1.3 E
   uint32 pending_orders         = 6; // informational: pending, no escrow

--- a/docs/RPC.md
+++ b/docs/RPC.md
@@ -142,7 +142,7 @@ The maintenance flag plus the counters of what is still bound to the connected L
 - `counters`:
   - `escrowed_orders`: orders with a hold invoice in a non-terminal status
   - `inflight_payouts`: buyer payouts in flight (`settled-hold-invoice` with a payout hash)
-  - `unpaid_dev_fees`: successful orders whose dev fee is still unpaid
+  - `inflight_dev_fees`: dev-fee payouts claimed or in flight (marker set, not yet paid); a merely unpaid dev fee is not node-bound and is not counted
   - `open_bonds`: bond hold invoices still open (`requested` / `locked`)
   - `pending_bond_payouts`: bonds waiting for, or in the middle of, their payout
   - `pending_orders`: informational — pending orders hold no escrow and do not block a switch

--- a/proto/admin.proto
+++ b/proto/admin.proto
@@ -118,8 +118,9 @@ message DrainCounters {
   uint32 escrowed_orders = 1;
   // B: buyer payouts in flight (settled-hold-invoice + payout hash)
   uint32 inflight_payouts = 2;
-  // C: successful orders whose dev fee is still unpaid
-  uint32 unpaid_dev_fees = 3;
+  // C: dev-fee payouts claimed or in flight (marker set, not yet paid);
+  // a merely unpaid dev fee is not node-bound and is not counted
+  uint32 inflight_dev_fees = 3;
   // D: bond hold invoices still open (requested / locked)
   uint32 open_bonds = 4;
   // E: bonds waiting for, or in the middle of, their payout

--- a/src/app/maintenance.rs
+++ b/src/app/maintenance.rs
@@ -123,8 +123,11 @@ pub struct DrainCounters {
     pub escrowed_orders: u32,
     /// B — buyer payouts in flight (`settled-hold-invoice` + payout hash).
     pub inflight_payouts: u32,
-    /// C — successful orders whose dev fee is still unpaid.
-    pub unpaid_dev_fees: u32,
+    /// C — dev-fee payouts the daemon has claimed or sent and not yet
+    /// finalised (`dev_fee_payment_hash` marker set, `dev_fee_paid = 0`).
+    /// A merely *unpaid* dev fee is not node-bound: it is an outgoing
+    /// payment to a Lightning address the new node can make just as well.
+    pub inflight_dev_fees: u32,
     /// D — bond hold invoices still open (`requested` / `locked`).
     pub open_bonds: u32,
     /// E — bonds waiting for (or in the middle of) their payout.
@@ -137,7 +140,7 @@ impl DrainCounters {
     pub fn drained(&self) -> bool {
         self.escrowed_orders == 0
             && self.inflight_payouts == 0
-            && self.unpaid_dev_fees == 0
+            && self.inflight_dev_fees == 0
             && self.open_bonds == 0
             && self.pending_bond_payouts == 0
     }
@@ -264,10 +267,13 @@ pub async fn drain_counters(pool: &SqlitePool) -> Result<DrainCounters, MostroEr
             &[Status::SettledHoldInvoice.to_string()],
         )
         .await?,
-        unpaid_dev_fees: count(
+        // `dev_fee_payment_hash` is the claim marker / payment hash the
+        // dev-fee job sets while it works an order and clears on failure
+        // (`src/app/dev_fee.rs`); only that window is bound to the node.
+        inflight_dev_fees: count(
             pool,
-            "SELECT COUNT(*) FROM orders WHERE dev_fee > 0 AND dev_fee_paid = 0 AND status = ?1",
-            &[Status::Success.to_string()],
+            "SELECT COUNT(*) FROM orders WHERE dev_fee_paid = 0 AND dev_fee_payment_hash IS NOT NULL",
+            &[],
         )
         .await?,
         // D is exactly `BondState::is_active()`; keep the two in sync.
@@ -317,14 +323,27 @@ mod tests {
         dev_fee: i64,
         dev_fee_paid: bool,
     ) -> Uuid {
+        insert_order_with_dev_fee_hash(pool, status, hash, payout_hash, dev_fee, dev_fee_paid, None)
+            .await
+    }
+
+    async fn insert_order_with_dev_fee_hash(
+        pool: &SqlitePool,
+        status: &str,
+        hash: Option<&str>,
+        payout_hash: Option<&str>,
+        dev_fee: i64,
+        dev_fee_paid: bool,
+        dev_fee_payment_hash: Option<&str>,
+    ) -> Uuid {
         let id = Uuid::new_v4();
         sqlx::query(
             r#"INSERT INTO orders (id, kind, event_id, status, premium, payment_method,
                                    amount, fiat_code, fiat_amount, created_at, expires_at,
                                    failed_payment, payment_attempts, hash, payout_payment_hash,
-                                   dev_fee, dev_fee_paid)
+                                   dev_fee, dev_fee_paid, dev_fee_payment_hash)
                VALUES (?1, 'sell', 'ev', ?2, 0, 'lightning', 100000, 'USD', 100,
-                       1700000000, 1700086400, 0, 0, ?3, ?4, ?5, ?6)"#,
+                       1700000000, 1700086400, 0, 0, ?3, ?4, ?5, ?6, ?7)"#,
         )
         .bind(id)
         .bind(status)
@@ -332,6 +351,7 @@ mod tests {
         .bind(payout_hash)
         .bind(dev_fee)
         .bind(dev_fee_paid)
+        .bind(dev_fee_payment_hash)
         .execute(pool)
         .await
         .unwrap();
@@ -678,10 +698,24 @@ mod tests {
         let c = drain_counters(&pool).await.unwrap();
         assert_eq!((c.escrowed_orders, c.inflight_payouts), (2, 1));
 
-        // C: unpaid dev fee on a successful order.
+        // C: dev fee claimed / in flight (marker set). A merely unpaid dev
+        // fee with no marker is NOT node-bound and must not count.
         insert_order(&pool, "success", Some(&h), None, 50, false).await;
         let c = drain_counters(&pool).await.unwrap();
-        assert_eq!((c.escrowed_orders, c.unpaid_dev_fees), (2, 1));
+        assert_eq!((c.escrowed_orders, c.inflight_dev_fees), (2, 0));
+        insert_order_with_dev_fee_hash(
+            &pool,
+            "success",
+            Some(&h),
+            None,
+            50,
+            false,
+            Some("PENDING-x"),
+        )
+        .await;
+        insert_order_with_dev_fee_hash(&pool, "success", Some(&h), None, 50, false, Some(&h)).await;
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!((c.escrowed_orders, c.inflight_dev_fees), (2, 2));
 
         // D / E: bonds.
         insert_bond(&pool, BondState::Locked, Some(&h), None).await;
@@ -702,7 +736,8 @@ mod tests {
         let h = "bb".repeat(32);
         // Terminal order that kept both hashes (post-finalisation clear lost).
         insert_order(&pool, "canceled-by-admin", Some(&h), Some(&h), 0, false).await;
-        insert_order(&pool, "success", Some(&h), Some(&h), 50, true).await;
+        insert_order_with_dev_fee_hash(&pool, "success", Some(&h), Some(&h), 50, true, Some(&h))
+            .await;
         // Slashed bond keeps payout_payment_hash as its idempotency record.
         insert_bond(&pool, BondState::Slashed, Some(&h), Some(&h)).await;
         insert_bond(&pool, BondState::Released, Some(&h), None).await;

--- a/src/rpc/service.rs
+++ b/src/rpc/service.rs
@@ -530,7 +530,7 @@ impl AdminService for AdminServiceImpl {
             counters: Some(DrainCounters {
                 escrowed_orders: counters.escrowed_orders,
                 inflight_payouts: counters.inflight_payouts,
-                unpaid_dev_fees: counters.unpaid_dev_fees,
+                inflight_dev_fees: counters.inflight_dev_fees,
                 open_bonds: counters.open_bonds,
                 pending_bond_payouts: counters.pending_bond_payouts,
                 pending_orders: counters.pending_orders,


### PR DESCRIPTION
## Summary

Found while running the maintenance-mode runbook end to end on Polar (carol = Mostro node, alice seller, bob buyer): after the only escrowed order settled and bob got paid, `GetMaintenanceStatus` kept reporting `drained = false` because predicate C counted the order's **unpaid dev fee**.

An unpaid dev fee is not bound to the old node: it is an outgoing payment to a Lightning address that whichever node is connected can make. Only the window in which the dev-fee job has **claimed or sent** the payment (`dev_fee_payment_hash` marker set, `dev_fee_paid = 0`, see `src/app/dev_fee.rs`) tracks a payment on the connected node. On regtest the mainnet-only dev-fee address can never be paid, so the old predicate blocked the switch forever; on mainnet it would have delayed it by a job tick for no reason.

- `DrainCounters.unpaid_dev_fees` → `inflight_dev_fees` with predicate `dev_fee_paid = 0 AND dev_fee_payment_hash IS NOT NULL`. Proto field number 3 unchanged, so existing clients keep decoding it.
- Spec §1.3, `docs/RPC.md`, `docs/LIGHTNING_OPS.md` updated with the reasoning.

## Test plan

- [x] `drain_counters_reflects_each_predicate`: an unpaid dev fee with no marker is **not** counted; a `PENDING-…` claim marker and a real payment hash both are
- [x] `drain_counters_ignore_terminal_residue`: paid dev fee with a leftover hash is not counted
- [x] `cargo test` full suite · clippy clean · fmt · markdownlint
- [x] Polar dry run continues on this build (results in the mostro-cli PR / session notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ZQvcc8LfrsTYx9VAiSxS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Maintenance status now reports developer-fee payouts that have been claimed or are in progress.
  * Merely unpaid developer fees are no longer included in node-drain counters.
  * The maintenance status API field has been renamed to `inflight_dev_fees`.
  * Updated maintenance migration and RPC documentation to clarify the revised counter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->