### PR TITLE
fix: admin cancel tolerates a hold invoice LND already canceled or does not know

### DIFF
--- a/docs/LIGHTNING_OPS.md
+++ b/docs/LIGHTNING_OPS.md
@@ -390,9 +390,12 @@ re-opens the book against the old node; nothing else changed.
 ### Disaster recovery: old node lost with open escrow
 
 `[lightning].allow_node_change = true` exists for exactly one case: the old
-node is gone for good. The daemon **cannot** close the affected rows —
-`AdminCancel` / `AdminSettle` talk to the *configured* node and would hit an
-unknown invoice. With the daemon stopped:
+node is gone for good. `AdminSettle`, payouts and bond releases talk to the
+*configured* node and hit an unknown invoice, so the daemon **cannot** close
+those rows. `AdminCancel` on a disputed order is the exception: it treats an
+unknown invoice as already gone and closes the dispute (`canceled-by-admin`,
+`seller-refunded`); the seller is refunded by the old node's HTLC timeout,
+not by the call. With the daemon stopped:
 
 1. Export the rows behind the non-zero counters; these are the trades to
    reconcile by hand.
@@ -403,9 +406,12 @@ unknown invoice. With the daemon stopped:
    be paid from the new node manually.
 3. Database: mark the orders terminal by hand (`canceled-by-admin` for
    unsettled escrow, `completed-by-admin` after a manual payout) and the
-   bonds `failed`, so the counters reach zero.
-4. Notify the users involved; the daemon sends nothing for rows changed this
-   way.
+   bonds `failed`, so the counters reach zero. Disputed orders can instead
+   be closed with `AdminCancel` once the daemon runs against the new node
+   with `allow_node_change = true`; that path also resolves the dispute and
+   the bonds and notifies both parties.
+4. Notify the users involved; the daemon sends nothing for rows changed by
+   hand.
 5. Start against the new node. With the counters at zero the guard accepts
    the change without the override; set `allow_node_change = true` only if a
    row could not be closed and you knowingly leave it unresolved. Turn it

--- a/docs/LIGHTNING_OPS.md
+++ b/docs/LIGHTNING_OPS.md
@@ -408,8 +408,12 @@ not by the call. With the daemon stopped:
    unsettled escrow, `completed-by-admin` after a manual payout) and the
    bonds `failed`, so the counters reach zero. Disputed orders can instead
    be closed with `AdminCancel` once the daemon runs against the new node
-   with `allow_node_change = true`; that path also resolves the dispute and
-   the bonds and notifies both parties.
+   with `allow_node_change = true`; that path also closes the dispute,
+   releases the bonds (their old-node HTLCs refund the users at expiry) and
+   notifies both parties. A `slash_*` in the `BondResolution`, and the
+   range maker bond close, need a settle on the old node and cannot run:
+   those bonds stay `locked`, keep `open_bonds` non-zero and must be
+   marked `failed` by hand as above.
 4. Notify the users involved; the daemon sends nothing for rows changed by
    hand.
 5. Start against the new node. With the counters at zero the guard accepts

--- a/docs/MAINTENANCE_MODE_LN_MIGRATION.md
+++ b/docs/MAINTENANCE_MODE_LN_MIGRATION.md
@@ -567,8 +567,10 @@ done **before** enabling `allow_node_change`, with the daemon stopped:
    the counters reach zero and the guard accepts the new node. Disputed
    orders with unsettled escrow may instead be closed with `AdminCancel`
    after starting against the new node with `allow_node_change = true`: it
-   treats the unknown invoice as gone, resolves the dispute and bonds and
-   notifies both parties.
+   treats the unknown invoice as gone, closes the dispute, releases the
+   bonds and notifies both parties. A `slash_*` and the range maker bond
+   close need a settle on the old node and cannot run there: the bond stays
+   `locked`, keeps `open_bonds` non-zero and is marked `failed` by hand.
 4. Notify the users involved through the usual admin channel; the daemon
    sends no message for rows changed by hand.
 5. Start the daemon with the new `[lightning]` block. With the counters at

--- a/docs/MAINTENANCE_MODE_LN_MIGRATION.md
+++ b/docs/MAINTENANCE_MODE_LN_MIGRATION.md
@@ -339,11 +339,12 @@ Override: `[lightning].allow_node_change = true` (default `false`, added to
 `settings.tpl.toml` and `LightningSettings`) skips step 4's exit and only
 logs. It exists for disaster recovery only: the old node is gone for good and
 the operator accepts that the affected rows **cannot be resolved by the
-daemon**. `AdminCancel` and `AdminSettle` are not a recovery path here: both
-call `cancel_hold_invoice` / `settle_hold_invoice` on the *currently
-configured* node before touching the order, so they fail with an
-unknown‑invoice error against the new node. See §5.1 for the manual
-procedure. The flag must never be left on in normal operation; the wizard
+daemon**. `AdminSettle` is not a recovery path here: it calls
+`settle_hold_invoice` on the *currently configured* node before touching the
+order, so it fails with an unknown‑invoice error against the new node.
+`AdminCancel` on a disputed order tolerates that error (the HTLC is refunded
+by the old node at CLTV expiry) and closes the dispute. See §5.1 for the
+manual procedure. The flag must never be left on in normal operation; the wizard
 does not ask for it.
 
 ### 3.7 Behaviour matrix while enabled
@@ -563,9 +564,13 @@ done **before** enabling `allow_node_change`, with the daemon stopped:
 3. Database: mark the affected orders terminal by hand
    (`status = 'canceled-by-admin'` for unsettled escrow,
    `'completed-by-admin'` after a manual payout) and the bonds `failed`, so
-   the counters reach zero and the guard accepts the new node.
+   the counters reach zero and the guard accepts the new node. Disputed
+   orders with unsettled escrow may instead be closed with `AdminCancel`
+   after starting against the new node with `allow_node_change = true`: it
+   treats the unknown invoice as gone, resolves the dispute and bonds and
+   notifies both parties.
 4. Notify the users involved through the usual admin channel; the daemon
-   sends no message for rows changed this way.
+   sends no message for rows changed by hand.
 5. Start the daemon with the new `[lightning]` block. With the counters at
    zero the guard accepts the change without the override; set
    `allow_node_change = true` only if a row could not be closed and the

--- a/docs/RPC.md
+++ b/docs/RPC.md
@@ -37,8 +37,11 @@ Cancel an order as an admin. Two cases are accepted:
   `seller-refunded`, both parties are notified, and the optional
   `BondResolution` is applied. A hold invoice LND already canceled (CLTV
   expiry refunded the seller) or does not know (the daemon now runs against a
-  different node) is treated as done, so stale disputes can still be closed;
-  only a transient LND failure aborts the cancel.
+  different node, `[lightning].allow_node_change = true`) is treated as done,
+  so stale disputes can still be closed; only a transient LND failure aborts
+  the cancel. In the different-node case the seller's HTLC is still held by
+  the old node and is refunded there when it expires, not by this call; the
+  daemon logs a warning saying so.
 - An order still pre-trade — `pending`, or `waiting-taker-bond` while a
   taker is mid-bond — with no escrow: an **operator** cancel.
   The row flips to `canceled-by-admin`, the maker and any bonded prospective

--- a/docs/RPC.md
+++ b/docs/RPC.md
@@ -41,7 +41,10 @@ Cancel an order as an admin. Two cases are accepted:
   so stale disputes can still be closed; only a transient LND failure aborts
   the cancel. In the different-node case the seller's HTLC is still held by
   the old node and is refunded there when it expires, not by this call; the
-  daemon logs a warning saying so.
+  daemon logs a warning saying so. Bond releases tolerate the unknown invoice
+  the same way, but a `slash_*` (a settle) cannot be executed on a different
+  node: the bond stays `locked`, is counted by `GetMaintenanceStatus`
+  (`open_bonds`) and has to be marked `failed` by hand.
 - An order still pre-trade — `pending`, or `waiting-taker-bond` while a
   taker is mid-bond — with no escrow: an **operator** cancel.
   The row flips to `canceled-by-admin`, the maker and any bonded prospective

--- a/docs/RPC.md
+++ b/docs/RPC.md
@@ -35,7 +35,10 @@ Cancel an order as an admin. Two cases are accepted:
 - An order in `dispute`: the assigned solver's resolution. The escrow hold
   invoice is cancelled (funds return to the seller), the dispute is closed as
   `seller-refunded`, both parties are notified, and the optional
-  `BondResolution` is applied.
+  `BondResolution` is applied. A hold invoice LND already canceled (CLTV
+  expiry refunded the seller) or does not know (the daemon now runs against a
+  different node) is treated as done, so stale disputes can still be closed;
+  only a transient LND failure aborts the cancel.
 - An order still pre-trade — `pending`, or `waiting-taker-bond` while a
   taker is mid-bond — with no escrow: an **operator** cancel.
   The row flips to `canceled-by-admin`, the maker and any bonded prospective

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -12,7 +12,7 @@ use crate::util::{enqueue_order_msg, get_order, send_dm, update_order_event};
 use mostro_core::db::Crud;
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 /// Admin-initiated order cancellation.
 ///
@@ -145,8 +145,9 @@ pub async fn admin_cancel_action(
         // know at all (the daemon now runs against a different node) is
         // not an error: the HTLC is verifiably gone and the dispute can
         // still be closed. Only a transient LND failure aborts the cancel.
-        tolerate_gone_hold_invoice(&order.id, ln_client.cancel_hold_invoice(hash).await)?;
-        info!("Order Id {}: Funds returned to seller", &order.id);
+        if tolerate_gone_hold_invoice(&order.id, ln_client.cancel_hold_invoice(hash).await)? {
+            info!("Order Id {}: Funds returned to seller", &order.id);
+        }
     }
 
     // we check if there is a dispute
@@ -283,20 +284,28 @@ pub async fn admin_cancel_action(
 /// not encumbered), the same classification the bond release uses
 /// (`bond::flow::classify_cancel_error`). Transient failures propagate so
 /// the solver retries once LND is back.
+///
+/// Returns `true` when this call actually canceled the invoice and `false`
+/// when it was already gone. In the unknown-invoice case after a node
+/// change ([lightning].allow_node_change = true) the seller's HTLC is still
+/// ACCEPTED on the old node and is refunded there at CLTV expiry, so the
+/// caller must not log "funds returned" as if it happened now.
 fn tolerate_gone_hold_invoice<T>(
     order_id: &uuid::Uuid,
     result: Result<T, MostroError>,
-) -> Result<(), MostroError> {
+) -> Result<bool, MostroError> {
     use crate::app::bond::flow::{classify_cancel_error, CancelOutcome};
     match result {
-        Ok(_) => Ok(()),
+        Ok(_) => Ok(true),
         Err(e) => match classify_cancel_error(&e) {
             CancelOutcome::AlreadyDone => {
-                info!(
-                    "Order Id {}: hold invoice already canceled or unknown to LND ({}); closing anyway",
+                warn!(
+                    "Order Id {}: hold invoice already canceled or unknown to LND ({}); closing \
+                     anyway. If this daemon was moved to a different node the seller is refunded \
+                     by the old node at CLTV expiry, not now",
                     order_id, e
                 );
-                Ok(())
+                Ok(false)
             }
             CancelOutcome::Transient => Err(e),
         },
@@ -992,14 +1001,15 @@ mod tests {
     #[test]
     fn gone_hold_invoice_is_not_an_error() {
         let id = uuid::Uuid::new_v4();
-        assert!(tolerate_gone_hold_invoice(&id, Ok::<(), _>(())).is_ok());
+        assert_eq!(tolerate_gone_hold_invoice(&id, Ok::<(), _>(())), Ok(true));
         for msg in [
             "code=NotFound message=unable to locate invoice",
             "code=Unknown message=invoice already canceled",
             "code=AlreadyExists message=duplicate",
         ] {
-            assert!(
-                tolerate_gone_hold_invoice(&id, Err::<(), _>(ln_err(msg))).is_ok(),
+            assert_eq!(
+                tolerate_gone_hold_invoice(&id, Err::<(), _>(ln_err(msg))),
+                Ok(false),
                 "{msg} must be tolerated"
             );
         }

--- a/src/app/admin_cancel.rs
+++ b/src/app/admin_cancel.rs
@@ -139,12 +139,14 @@ pub async fn admin_cancel_action(
     let bond_resolution = bond::extract_bond_resolution(&msg);
     bond::validate_bond_resolution(pool, &order, &bond_resolution).await?;
 
-    if order.hash.is_some() {
-        // We return funds to seller
-        if let Some(hash) = order.hash.as_ref() {
-            ln_client.cancel_hold_invoice(hash).await?;
-            info!("Order Id {}: Funds returned to seller", &order.id);
-        }
+    if let Some(hash) = order.hash.as_ref() {
+        // We return funds to seller. A hold invoice that LND already
+        // canceled (CLTV expiry refunded the seller long ago) or does not
+        // know at all (the daemon now runs against a different node) is
+        // not an error: the HTLC is verifiably gone and the dispute can
+        // still be closed. Only a transient LND failure aborts the cancel.
+        tolerate_gone_hold_invoice(&order.id, ln_client.cancel_hold_invoice(hash).await)?;
+        info!("Order Id {}: Funds returned to seller", &order.id);
     }
 
     // we check if there is a dispute
@@ -274,6 +276,31 @@ pub async fn admin_cancel_action(
     }
 
     Ok(())
+}
+
+/// Map the result of `cancel_hold_invoice` on the escrow: an invoice that
+/// is already canceled / unknown to the node counts as done (the HTLC is
+/// not encumbered), the same classification the bond release uses
+/// (`bond::flow::classify_cancel_error`). Transient failures propagate so
+/// the solver retries once LND is back.
+fn tolerate_gone_hold_invoice<T>(
+    order_id: &uuid::Uuid,
+    result: Result<T, MostroError>,
+) -> Result<(), MostroError> {
+    use crate::app::bond::flow::{classify_cancel_error, CancelOutcome};
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => match classify_cancel_error(&e) {
+            CancelOutcome::AlreadyDone => {
+                info!(
+                    "Order Id {}: hold invoice already canceled or unknown to LND ({}); closing anyway",
+                    order_id, e
+                );
+                Ok(())
+            }
+            CancelOutcome::Transient => Err(e),
+        },
+    }
 }
 
 /// Operator cancel of a pre-trade (`Pending` / `WaitingTakerBond`) order
@@ -952,5 +979,48 @@ mod tests {
             .unwrap();
         assert_eq!(stored.status, Status::WaitingPayment.to_string());
         assert!(queued_actions_for(maker).await.is_empty());
+    }
+
+    // ── tolerate_gone_hold_invoice ───────────────────────────────────────
+
+    fn ln_err(msg: &str) -> MostroError {
+        MostroInternalErr(ServiceError::LnNodeError(msg.to_string()))
+    }
+
+    /// An escrow whose HTLC is already gone must not block the dispute
+    /// close: LND "not found" / "already canceled" are treated as done.
+    #[test]
+    fn gone_hold_invoice_is_not_an_error() {
+        let id = uuid::Uuid::new_v4();
+        assert!(tolerate_gone_hold_invoice(&id, Ok::<(), _>(())).is_ok());
+        for msg in [
+            "code=NotFound message=unable to locate invoice",
+            "code=Unknown message=invoice already canceled",
+            "code=AlreadyExists message=duplicate",
+        ] {
+            assert!(
+                tolerate_gone_hold_invoice(&id, Err::<(), _>(ln_err(msg))).is_ok(),
+                "{msg} must be tolerated"
+            );
+        }
+    }
+
+    /// Anything that may leave the HTLC encumbered still aborts the cancel.
+    #[test]
+    fn transient_ln_failure_still_aborts() {
+        let id = uuid::Uuid::new_v4();
+        for msg in [
+            "code=Unavailable message=transport error",
+            "code=DeadlineExceeded message=timeout",
+            "code=Internal message=something broke",
+        ] {
+            assert!(
+                matches!(
+                    tolerate_gone_hold_invoice(&id, Err::<(), _>(ln_err(msg))),
+                    Err(MostroInternalErr(ServiceError::LnNodeError(_)))
+                ),
+                "{msg} must propagate"
+            );
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,8 +255,9 @@ async fn main() -> Result<()> {
                 "Lightning node changed from {previous} to {node_pubkey} with open escrow \
                  ({counters:?}) — [lightning].allow_node_change = true, continuing. Disputed \
                  escrow can still be closed with AdminCancel (the old-node HTLC refunds the \
-                 seller at CLTV expiry); settled escrow and bonds bound to the old node CANNOT \
-                 be resolved by the daemon, see docs/MAINTENANCE_MODE_LN_MIGRATION.md §5.1"
+                 seller at CLTV expiry) and its bonds released; settled escrow, bond slashes \
+                 and range maker bond closes bound to the old node CANNOT be executed by the \
+                 daemon and stay Locked, see docs/MAINTENANCE_MODE_LN_MIGRATION.md §5.1"
             );
         }
         NodeIdentityDecision::ChangedWithOpenEscrow { previous, counters } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,9 +253,10 @@ async fn main() -> Result<()> {
         NodeIdentityDecision::ChangedOverridden { previous, counters } => {
             tracing::warn!(
                 "Lightning node changed from {previous} to {node_pubkey} with open escrow \
-                 ({counters:?}) — [lightning].allow_node_change = true, continuing; the affected \
-                 rows CANNOT be resolved by the daemon, see \
-                 docs/MAINTENANCE_MODE_LN_MIGRATION.md §5.1"
+                 ({counters:?}) — [lightning].allow_node_change = true, continuing. Disputed \
+                 escrow can still be closed with AdminCancel (the old-node HTLC refunds the \
+                 seller at CLTV expiry); settled escrow and bonds bound to the old node CANNOT \
+                 be resolved by the daemon, see docs/MAINTENANCE_MODE_LN_MIGRATION.md §5.1"
             );
         }
         NodeIdentityDecision::ChangedWithOpenEscrow { previous, counters } => {


### PR DESCRIPTION
## Summary

`admin_cancel_action` aborted on any `cancel_hold_invoice` error. Two real cases made stale disputes impossible to close:

- the escrow HTLC already expired by CLTV: LND canceled it and refunded the seller long ago, and now answers "invoice already canceled";
- after a Lightning node migration the new node has never seen the hash and answers "unable to locate invoice".

A production node has 38 open disputes, most 11 days to over a year old, while LND holds only 9 ACCEPTED hold invoices; every one of those disputes counts toward the maintenance drain and needs `AdminCancel` to close.

## Change

`admin_cancel` classifies the LND error with the bond release's `classify_cancel_error`: `AlreadyDone` (NotFound / AlreadyExists / "already canceled" / "unable to locate invoice" …) is logged and the cancel proceeds — the HTLC is verifiably not encumbered; `Transient` (Unavailable, DeadlineExceeded, Internal, transport) still aborts so the solver retries once LND is back.

`docs/RPC.md` CancelOrder section states the behaviour.

## Tests

- `gone_hold_invoice_is_not_an_error`
- `transient_ln_failure_still_aborts`
- existing `dispute_with_hash_reaches_ln_cancel_seam` (dead node → transient → still refused) unchanged.

Full suite green (1292 passed), clippy clean.

## Test plan

- [ ] regtest: open a dispute, let the hold invoice expire by CLTV, `admcancel` → order `canceled-by-admin`, dispute `seller-refunded`
- [ ] regtest: `admcancel` with LND stopped → still refused with an LN error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWN1jHfoZxfjusDVB9n3GW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order cancellation now handles already-canceled or unknown Lightning invoices during node migration.
  * Disputed orders can be closed after recovery, with applicable refunds occurring at the Lightning timeout.

* **Documentation**
  * Updated disaster-recovery, maintenance, and RPC guidance for node changes, disputed escrow, cancellations, payouts, and bond handling.
  * Clarified which recovery actions remain unavailable when escrow or bonds are tied to the previous node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->