### PR TITLE
fix: drain counter E counts only in-flight bond payouts

### DIFF
--- a/docs/LIGHTNING_OPS.md
+++ b/docs/LIGHTNING_OPS.md
@@ -331,7 +331,7 @@ The daemon ships a **maintenance (drain) mode** for this. Full design in
 | `inflight_payouts` | buyer payouts in flight (`settled-hold-invoice` with a payout hash) |
 | `inflight_dev_fees` | dev-fee payouts claimed or in flight; a merely unpaid dev fee is paid by whichever node is connected and does not count |
 | `open_bonds` | bond hold invoices still open (`requested` / `locked`) |
-| `pending_bond_payouts` | bonds waiting for, or in the middle of, their payout |
+| `pending_bond_payouts` | slashed-bond payouts already dispatched and being tracked on the node; one still waiting for the winner's invoice does not count |
 | `pending_orders` | informational only: no escrow, does not block the switch |
 
 `drained` is `true` when every counter except `pending_orders` is zero.

--- a/docs/MAINTENANCE_MODE_LN_MIGRATION.md
+++ b/docs/MAINTENANCE_MODE_LN_MIGRATION.md
@@ -60,7 +60,7 @@ the switch:
 | B. In‑flight buyer payouts | `orders.payout_payment_hash IS NOT NULL AND status = 'settled-hold-invoice'` | `job_reconcile_inflight_payouts` tracks the hash on the node that sent it. Same predicate as `find_inflight_payouts` (`src/db.rs`); a subset of A, reported separately for visibility |
 | C. In‑flight dev fees | `orders.dev_fee_paid = 0 AND dev_fee_payment_hash IS NOT NULL` | `job_process_dev_fee_payment` sets the marker while it claims/sends and clears it on failure; only that window tracks a payment on the node. A merely unpaid dev fee is an outgoing payment to a Lightning address the new node makes just as well, so it is **not** counted (found in the regtest dry run: the address is mainnet‑only, the fee can never be paid there, and counting it blocked `drained` forever) |
 | D. Open bond hold invoices | `bonds.hash IS NOT NULL AND state IN ('requested','locked')` | maker/taker bond hold invoices (`src/app/bond/flow.rs`) |
-| E. Pending bond payouts | `bonds.state = 'pending-payout'` | payout not yet sent or in flight; `bonds.payout_payment_hash` is the idempotency record for it |
+| E. In‑flight bond payouts | `bonds.state = 'pending-payout' AND payout_payment_hash IS NOT NULL` | `run_bond_payout_cycle` (`src/app/bond/payout.rs`) reconciles the hash with `track_payment_v2` on the node that sent it. A `pending-payout` bond still waiting for the winner's invoice is out: its HTLC was settled at slash time and the payout can be sent from any node (the bond twin of B) |
 
 Predicate notes, verified against the schema and jobs:
 

--- a/proto/admin.proto
+++ b/proto/admin.proto
@@ -123,7 +123,7 @@ message DrainCounters {
   uint32 inflight_dev_fees = 3;
   // D: bond hold invoices still open (requested / locked)
   uint32 open_bonds = 4;
-  // E: bonds waiting for, or in the middle of, their payout
+  // E: slashed-bond payouts in flight (pending-payout + payout hash)
   uint32 pending_bond_payouts = 5;
   // Informational: pending orders hold no escrow and do not block a switch
   uint32 pending_orders = 6;

--- a/src/app/maintenance.rs
+++ b/src/app/maintenance.rs
@@ -137,7 +137,12 @@ pub struct DrainCounters {
     pub inflight_dev_fees: u32,
     /// D — bond hold invoices still open (`requested` / `locked`).
     pub open_bonds: u32,
-    /// E — bonds waiting for (or in the middle of) their payout.
+    /// E — slashed-bond payouts in flight (`pending-payout` with a
+    /// `payout_payment_hash`): `run_bond_payout_cycle` reconciles that hash
+    /// with `track_payment_v2` on the node that sent it. A `pending-payout`
+    /// bond still waiting for the winner's invoice is not node-bound — its
+    /// HTLC was settled at slash time and the payout can go out from any
+    /// node — so it does not block the switch.
     pub pending_bond_payouts: u32,
     /// Informational: pending orders hold no escrow and do not block a switch.
     pub pending_orders: u32,
@@ -307,9 +312,11 @@ pub async fn drain_counters(pool: &SqlitePool) -> Result<DrainCounters, MostroEr
             ],
         )
         .await?,
+        // E is the bond twin of B: only a payout already dispatched is
+        // tracked on the old node.
         pending_bond_payouts: count(
             pool,
-            "SELECT COUNT(*) FROM bonds WHERE state = ?1",
+            "SELECT COUNT(*) FROM bonds WHERE state = ?1 AND payout_payment_hash IS NOT NULL",
             &[BondState::PendingPayout.to_string()],
         )
         .await?,
@@ -768,6 +775,12 @@ mod tests {
         // D / E: bonds.
         insert_bond(&pool, BondState::Locked, Some(&h), None).await;
         insert_bond(&pool, BondState::PendingPayout, Some(&h), Some(&h)).await;
+        let c = drain_counters(&pool).await.unwrap();
+        assert_eq!((c.open_bonds, c.pending_bond_payouts), (1, 1));
+
+        // A slashed bond still waiting for the winner's invoice: HTLC already
+        // settled, payout not dispatched — payable from any node, not E.
+        insert_bond(&pool, BondState::PendingPayout, Some(&h), None).await;
         let c = drain_counters(&pool).await.unwrap();
         assert_eq!((c.open_bonds, c.pending_bond_payouts), (1, 1));
 


### PR DESCRIPTION
## Summary

Follow-up to #940 (counter A) with the same reasoning applied to counter E.

A `pending-payout` bond is a slashed bond: its HTLC was **settled into Mostro's wallet at slash time**. Until the winner sends a payout invoice nothing has left the node, and once they do the payout can be sent from any node. Counting every `pending-payout` row blocked `drained` for up to `payout_claim_window_days` (15 days). A production node was held by a single 416-sat payout whose winner never answered 2166 invoice requests.

What *is* node-bound is a payout already dispatched: `run_bond_payout_cycle` reconciles `payout_payment_hash` with `track_payment_v2` on the node that sent it.

## Change

- `drain_counters`: E = `bonds.state = 'pending-payout' AND payout_payment_hash IS NOT NULL` — the bond twin of counter B (`inflight_payouts`).
- Docs: §1.3 inventory row E in `MAINTENANCE_MODE_LN_MIGRATION.md`, counter table in `LIGHTNING_OPS.md`, comment on `pending_bond_payouts` in `proto/admin.proto` (field number and name unchanged, wire-compatible).
- Test `drain_counters_reflects_each_predicate`: a `pending-payout` bond without a payout hash is not counted; one with a hash still is.

Full suite green (1290 passed), clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWN1jHfoZxfjusDVB9n3GW


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Maintenance mode now excludes bond payouts still awaiting the winner’s invoice from node-switching blockers.
  - Pending bond payouts are counted only after payout processing has been dispatched and a payment hash is available.
  - Added coverage to verify that undispatched payouts do not prevent switching nodes.

- **Documentation**
  - Updated maintenance-mode guidance and field descriptions to clarify which bond payouts remain tied to the old node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->