### PR TITLE
fix: notify solver when dispute closes after user resolution

### DIFF
--- a/src/app/dispute.rs
+++ b/src/app/dispute.rs
@@ -8,6 +8,7 @@ use crate::nip33::{create_dispute_event_tags, new_dispute_event};
 use crate::util::{enqueue_order_msg, get_order};
 use mostro_core::prelude::*;
 use nostr_sdk::prelude::*;
+use std::str::FromStr;
 
 use mostro_core::db::Crud;
 use uuid::Uuid;
@@ -226,14 +227,15 @@ pub async fn dispute_action(
 ///
 /// This is a best-effort operation: if the dispute update or event publishing fails,
 /// errors are logged but not propagated, since the primary order operation has already
-/// succeeded.
+/// succeeded. The solver is notified via DM when one is assigned and the dispute
+/// reaches a terminal status. Non-terminal statuses do not trigger a notification.
 ///
 /// # Arguments
-/// * `pool` - Database connection pool
+/// * `ctx` - Application context containing the database pool and Nostr client
 /// * `order` - The order associated with the dispute
 /// * `new_status` - The new dispute status (e.g., SellerRefunded or Settled)
 /// * `my_keys` - Mostro's keys for signing the dispute event
-/// * `context` - Description of the resolution context for logging (e.g., "cooperative cancel")
+/// * `context` - Description of the resolution context for logging (e.g., "cooperative cancel", "release")
 pub async fn close_dispute_after_user_resolution(
     ctx: &AppContext,
     order: &Order,
@@ -245,6 +247,10 @@ pub async fn close_dispute_after_user_resolution(
     if let Ok(mut dispute) = find_dispute_by_order_id(pool, order.id).await {
         let dispute_id = dispute.id;
         let opened_at = dispute.created_at;
+
+        // Clone solver_pubkey before update, as dispute.update() consumes the struct
+        let solver_pubkey_opt = dispute.solver_pubkey.clone();
+
         dispute.status = new_status.to_string();
 
         if let Err(e) = dispute.update(pool).await {
@@ -273,7 +279,7 @@ pub async fn close_dispute_after_user_resolution(
                         dispute_id,
                         order.id,
                         order.seller_dispute,
-                        order.buyer_dispute,
+                        order.buyer_dispute
                     );
                     "unknown"
                 }
@@ -301,6 +307,37 @@ pub async fn close_dispute_after_user_resolution(
                         dispute_id,
                         e
                     );
+                }
+            }
+
+            // --- NOTIFY SOLVER ---
+            let solver_action = match new_status {
+                DisputeStatus::SellerRefunded => Some(Action::CooperativeCancelAccepted),
+                DisputeStatus::Settled | DisputeStatus::Released => Some(Action::Released),
+                DisputeStatus::Initiated | DisputeStatus::InProgress => None,
+            };
+
+            if let (Some(action), Some(pk_str)) = (solver_action, solver_pubkey_opt.as_ref()) {
+                match PublicKey::from_str(pk_str) {
+                    Ok(solver_pubkey) => {
+                        enqueue_order_msg(
+                            None,
+                            Some(order.id),
+                            action,
+                            Some(Payload::Dispute(dispute_id, None)),
+                            solver_pubkey,
+                            None,
+                        )
+                        .await;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Failed to parse solver pubkey for dispute {} on order {}: {}",
+                            dispute_id,
+                            order.id,
+                            e
+                        );
+                    }
                 }
             }
         }
@@ -732,5 +769,137 @@ mod tests {
 
         let dispute = find_dispute_by_order_id(&pool, order.id).await.unwrap();
         assert_eq!(dispute.status, DisputeStatus::Settled.to_string());
+    }
+
+    /// When a dispute has a solver assigned and users resolve it via
+    /// cooperative cancel (SellerRefunded), the solver must receive
+    /// Action::CooperativeCancelAccepted so their client knows the case is closed.
+    #[tokio::test]
+    async fn close_dispute_after_user_resolution_notifies_solver() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+        let solver = Keys::generate();
+
+        let mut order = create_order(Some(buyer), Some(seller), Status::Dispute);
+        order.seller_dispute = true;
+        let order = order.create(&pool).await.unwrap();
+
+        let mut dispute = Dispute::new(order.id, Status::Active.to_string());
+        dispute.solver_pubkey = Some(solver.public_key().to_string());
+        dispute.create(&pool).await.unwrap();
+
+        close_dispute_after_user_resolution(
+            &ctx,
+            &order,
+            DisputeStatus::SellerRefunded,
+            &Keys::generate(),
+            "cooperative cancel",
+        )
+        .await;
+
+        let queue = MESSAGE_QUEUES.queue_order_msg.read().await;
+        let solver_msgs: Vec<_> = queue
+            .iter()
+            .filter(|(msg, dest)| {
+                *dest == solver.public_key()
+                    && msg.get_inner_message_kind().action == Action::CooperativeCancelAccepted
+                    && msg.get_inner_message_kind().id == Some(order.id)
+            })
+            .collect();
+
+        assert_eq!(solver_msgs.len(), 1);
+
+        // Verify the payload contains the dispute_id
+        let dispute = find_dispute_by_order_id(&pool, order.id).await.unwrap();
+        let (msg, _) = solver_msgs[0];
+        assert!(matches!(
+            msg.get_inner_message_kind().payload,
+            Some(Payload::Dispute(id, None)) if id == dispute.id
+        ));
+    }
+
+    /// When a dispute has a solver assigned and users resolve it via
+    /// release (Settled), the solver must receive Action::Released
+    /// so their client knows the case is closed.
+    #[tokio::test]
+    async fn close_dispute_after_user_resolution_notifies_solver_on_settled() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+        let solver = Keys::generate();
+
+        let mut order = create_order(Some(buyer), Some(seller), Status::Dispute);
+        order.seller_dispute = true;
+        let order = order.create(&pool).await.unwrap();
+
+        let mut dispute = Dispute::new(order.id, Status::Active.to_string());
+        dispute.solver_pubkey = Some(solver.public_key().to_string());
+        dispute.create(&pool).await.unwrap();
+
+        close_dispute_after_user_resolution(
+            &ctx,
+            &order,
+            DisputeStatus::Settled,
+            &Keys::generate(),
+            "release",
+        )
+        .await;
+
+        let queue = MESSAGE_QUEUES.queue_order_msg.read().await;
+        let solver_msgs: Vec<_> = queue
+            .iter()
+            .filter(|(msg, dest)| {
+                *dest == solver.public_key()
+                    && msg.get_inner_message_kind().action == Action::Released
+                    && msg.get_inner_message_kind().id == Some(order.id)
+            })
+            .collect();
+
+        assert_eq!(solver_msgs.len(), 1);
+
+        // Verify the payload contains the dispute_id
+        let dispute = find_dispute_by_order_id(&pool, order.id).await.unwrap();
+        let (msg, _) = solver_msgs[0];
+        assert!(matches!(
+            msg.get_inner_message_kind().payload,
+            Some(Payload::Dispute(id, None)) if id == dispute.id
+        ));
+    }
+
+    /// When no solver is assigned (solver_pubkey is None), no DM is queued.
+    #[tokio::test]
+    async fn close_dispute_after_user_resolution_skips_notification_without_solver() {
+        let pool = create_test_pool().await;
+        let ctx = build_ctx(&pool);
+        let buyer = Keys::generate().public_key();
+        let seller = Keys::generate().public_key();
+
+        let mut order = create_order(Some(buyer), Some(seller), Status::Dispute);
+        order.seller_dispute = true;
+        let order = order.create(&pool).await.unwrap();
+        Dispute::new(order.id, Status::Active.to_string())
+            .create(&pool)
+            .await
+            .unwrap();
+
+        close_dispute_after_user_resolution(
+            &ctx,
+            &order,
+            DisputeStatus::SellerRefunded,
+            &Keys::generate(),
+            "cooperative cancel",
+        )
+        .await;
+
+        let queue = MESSAGE_QUEUES.queue_order_msg.read().await;
+        assert!(
+            queue
+                .iter()
+                .all(|(msg, _)| msg.get_inner_message_kind().id != Some(order.id)),
+            "No message should be queued when solver is not assigned"
+        );
     }
 }


### PR DESCRIPTION
**Fixes #918**

**Problem:**
When users resolve a dispute themselves (cooperative cancel or release), the assigned solver was never notified. Their client only discovered the closure by passively watching replaceable kind-38386 events.

**Solution:**
This PR sends a direct notification to `dispute.solver_pubkey` inside `close_dispute_after_user_resolution` when a solver is assigned. The solver's client receives a direct message and can remove the case from its work queue.

The notification uses appropriate actions based on how the dispute was resolved:
- `Action::CooperativeCancelAccepted` for cooperative cancellations (`SellerRefunded`)
- `Action::Released` for settlements (`Settled` or `Released`)

The notification includes the `dispute_id` in the payload so solvers can precisely identify which case was closed. No notification is sent for non-terminal dispute statuses (`Initiated`, `InProgress`).

**Testing:**
- ✅ Test verifying solver receives `CooperativeCancelAccepted` on cooperative cancel
- ✅ Test verifying solver receives `Released` on settlement
- ✅ Test verifying no notification is sent when no solver is assigned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dispute resolution now notifies the assigned solver when a cooperative cancellation is accepted or an order is released.
  * Notifications include the related order and dispute details.
  * Notifications are sent only for applicable resolution outcomes.

* **Bug Fixes**
  * Prevented solver notifications when no solver is assigned or the solver’s address cannot be parsed.
  * Added safeguards to ensure each applicable resolution sends a single notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->