### PR TITLE
docs: document the y tag multi-value compatibility contract (#660)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -237,7 +237,7 @@ In few minutes you should see a nostr event with Mostro settings:
       ["hold_invoice_expiration_window", "900"],
       ["hold_invoice_cltv_delta", "298"],
       ["invoice_expiration_window", "900"],
-      ["y", "mostrop2p"],
+      ["y", "mostro", "<instance name>"],
       ["z", "info"]
     ],
     "content": "",

--- a/docs/DEV_FEE.md
+++ b/docs/DEV_FEE.md
@@ -1145,7 +1145,7 @@ Why kind 8383 (Regular Event)?
     "status": "success"
   },
   "tags": [
-    ["y", "mostro"],
+    ["y", "mostro", "<instance name>"],
     ["z", "dev-fee-payment"],
     ["order", "550e8400-e29b-..."],
     ["amount", "100"],

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Quick links to architecture and feature guides.
 - Maintenance Mode & LN Node Migration: MAINTENANCE_MODE_LN_MIGRATION.md (design spec; operator procedure lives in LIGHTNING_OPS.md)
 - RPC Interface Reference: RPC.md
 - NIP-01 Kind 0 Metadata: NIP01_KIND0_METADATA.md
+- `y` Tag Compatibility Contract: Y_TAG_COMPATIBILITY.md (platform identifier plus optional instance name; guidance for indexers and clients)
 
 Tips
 - Run tests and lints before pushing: `cargo test`, `cargo fmt`, `cargo clippy --all-targets --all-features`.

--- a/docs/SEPARATE_EVENT_KINDS_SPEC.md
+++ b/docs/SEPARATE_EVENT_KINDS_SPEC.md
@@ -272,6 +272,8 @@ client.send_event(&new_event).await?;
 
 ## Event Examples
 
+The `y` tag in the examples below shows the single-value form. Since #653 it may carry a second value with the configured instance name, `["y", "mostro", "<instance name>"]`. See `Y_TAG_COMPATIBILITY.md` for the contract.
+
 ### Order Event (Kind 38383 - Unchanged)
 
 ```json

--- a/docs/Y_TAG_COMPATIBILITY.md
+++ b/docs/Y_TAG_COMPATIBILITY.md
@@ -1,0 +1,69 @@
+# `y` Tag Compatibility Contract
+
+Mostro publishes a `y` tag on its public Nostr events to identify the platform. Since PR #653 the tag may carry a second value with the human-readable name of the Mostro instance, taken from `[mostro] name` in `settings.toml`. This document states the contract for that tag so indexers, aggregators, and clients can rely on it without breaking when the second value appears or disappears.
+
+## Tag shape
+
+This document talks about tag **values**. In a Nostr tag array, element `0` is the tag name (`"y"`) and the values start at index `1`.
+
+Before #653 the tag always had exactly one value:
+
+```json
+["y", "mostro"]
+```
+
+Since #653 the tag has one or two values, depending on the instance configuration:
+
+```json
+["y", "mostro"]
+["y", "mostro", "<instance name>"]
+```
+
+The second value is the `name` configured under `[mostro]` in `settings.toml`, trimmed of surrounding whitespace. When `name` is unset, empty, or whitespace only, the tag collapses back to the single-value form. The construction lives in `fn create_platform_tag_values` in `src/nip33.rs`.
+
+## Where it is emitted
+
+The `y` tag is present on every event built through the platform tag helper:
+
+| Event | Kind | `z` value |
+| --- | --- | --- |
+| Order (NIP-33 replaceable) | 38383 | `order` |
+| Instance info (NIP-33 replaceable) | 38385 | `info` |
+| Dispute (NIP-33 replaceable) | 38386 | `dispute` |
+| Dev fee audit | 8383 | `dev-fee-payment` |
+
+Rating events (kind 38384) do **not** carry a `y` tag. Their tags come from `Rating::to_tags` in `mostro-core` and only include the rating fields plus `z`.
+
+## Contract
+
+- The first value is always the string `mostro`. It is the platform identifier and is the only value a consumer should use to recognize Mostro events.
+- The second value is optional. It is present only when the instance operator configured a non-empty `[mostro] name`.
+- The second value is additive metadata. Its presence, absence, or content never changes the meaning of the event.
+- Consumers MUST NOT assume the tag has exactly one value.
+- Consumers MUST NOT depend on the second value being present. A given instance can add, change, or remove its name between releases of the same event.
+- Consumers that need to distinguish instances SHOULD key on the event `pubkey`, not on the instance name. The name is a display hint, not an identity.
+- Mostro will not remove the first value or insert values before it. Any future value is appended after the instance name.
+
+## Migration guidance for consumers
+
+**You read only the first value.** No change needed. `tag[1] == "mostro"` keeps working in both shapes.
+
+**You assume a fixed value count.** Code such as `if len(tag) != 2: reject` or a destructuring assignment that expects exactly `["y", platform]` fails on the two-value form. Relax the check to `len(tag) >= 2` and read `tag[1]` for the platform. Read `tag[2]` only if it exists:
+
+```python
+if len(tag) >= 2 and tag[0] == "y":
+    platform = tag[1]
+    instance_name = tag[2] if len(tag) >= 3 else None
+```
+
+**You filter with a relay `#y` filter.** NIP-01 states that relays index only the first value of a tag, so `{"#y": ["mostro"]}` matches both `["y", "mostro"]` and `["y", "mostro", "FreeSatoshi"]`. No change needed. The instance name is not indexed by relays, so `{"#y": ["<instance name>"]}` will not return that instance's events; use `authors` with the instance pubkey instead.
+
+**You display the platform to users.** Prefer the instance name when present and fall back to `mostro`. Never show the tag as a single joined string, since the two values have different meanings.
+
+## History
+
+- Issue #649 proposed appending the instance name so aggregators can tell nodes apart without a pubkey lookup.
+- PR #653 implemented it and added the platform tag helper with unit tests covering the empty, whitespace-only, and trimmed-name cases.
+- First shipped in `v0.16.5`.
+
+The public protocol specification documents the same shape in the [order event](https://github.com/MostroP2P/protocol/blob/main/src/order_event.md) and [other events](https://github.com/MostroP2P/protocol/blob/main/src/other_events.md) pages of the Mostro protocol book.


### PR DESCRIPTION
## Summary

- Adds `docs/Y_TAG_COMPATIBILITY.md` describing the `y` tag contract introduced by #653: the first value is always `mostro`, the second value is the optional `[mostro] name` from settings, additive and non-breaking.
- Fixes stale examples that still showed the pre-#653 shape or a wrong value.
- Documentation only. No protocol or code changes.

## Changes

- New `docs/Y_TAG_COMPATIBILITY.md`: tag shape with explicit indexing (element 0 is the tag name, values start at index 1), before/after examples, the four emitters (order 38383, info 38385, dispute 38386, dev-fee audit 8383; rating 38384 does not carry `y`), the contract, migration guidance for consumers that read one value, assume a fixed value count, or filter with `#y` (NIP-01 indexes only the first value, so `{"#y": ["mostro"]}` keeps working), and history (#649, #653, v0.16.5).
- `docs/README.md`: link to the new page.
- `INSTALL.md`: info event example showed `["y", "mostrop2p"]`.
- `docs/DEV_FEE.md`: audit event example now shows the two-value form.
- `docs/SEPARATE_EVENT_KINDS_SPEC.md`: one sentence before the examples pointing to the contract; examples left as historical.

## Notes for review

- The changelog entry lands through this PR title, since `CHANGELOG.md` is regenerated by git-cliff on release.
- The Contract section states that any future value would be appended after the instance name. That is a maintainer guarantee; please confirm or adjust the wording.
- The `protocol` book already documents the optional second value. A compatibility subsection can be mirrored there in a follow-up if wanted.

## Testing

- [x] `npx markdownlint-cli2@0.23.2`: 42 files, 0 issues (same command as `markdown.yml`).
- [x] Emitters and kinds checked against `src/nip33.rs`, `src/util.rs`, and `mostro-core` 0.14.6 `Rating::to_tags`.

Closes #660


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the optional Mostro instance name in Nostr event `y` tags.
  * Added compatibility guidance for clients, indexers, relay filters, and platform displays.
  * Updated event examples and developer-fee audit specifications to show the instance name format.
  * Added a quick link to the new `y` tag compatibility documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->