### PR TITLE
fix: info event advertised the hold window as invoice_expiration_window

### DIFF
--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -579,6 +579,32 @@ fn advertised_first_contact_pow(mostro_settings: &MostroSettings) -> u8 {
 ///
 /// `maintenance` is the current maintenance (drain) flag; the tag is always
 /// emitted so clients can tell "maintenance off" from "older daemon".
+/// The two invoice windows the info event advertises, each under its own name.
+///
+/// They are different settings with different jobs and clients act on both:
+/// `invoice_expiration_window` is the remaining lifetime a payout invoice must
+/// still have for `validate_bolt11_invoice` to accept it, while
+/// `hold_invoice_expiration_window` is how long a taker has to pay or supply
+/// an invoice. Advertising one under the other's name makes clients build
+/// invoices mostrod then rejects.
+///
+/// Takes the settings and reads them by field name, so there is no argument
+/// order to get wrong at the call site, and a test can hand it distinct values
+/// instead of depending on which module wins the global-settings race in the
+/// test binary.
+fn invoice_window_tags(ln_settings: &crate::config::LightningSettings) -> [Tag; 2] {
+    [
+        Tag::custom(
+            "invoice_expiration_window",
+            vec![ln_settings.invoice_expiration_window.to_string()],
+        ),
+        Tag::custom(
+            "hold_invoice_expiration_window",
+            vec![ln_settings.hold_invoice_expiration_window.to_string()],
+        ),
+    ]
+}
+
 pub fn info_to_tags(ln_status: &LnStatus, maintenance: bool) -> Tags {
     let mostro_settings = Settings::get_mostro();
     let ln_settings = Settings::get_ln();
@@ -642,16 +668,8 @@ pub fn info_to_tags(ln_status: &LnStatus, maintenance: bool) -> Tags {
         // sending anything. See docs/TRANSPORT_V2_SPEC.md.
         Tag::custom("protocol_version", vec![protocol_version.to_string()]),
         Tag::custom(
-            "hold_invoice_expiration_window",
-            vec![ln_settings.hold_invoice_expiration_window.to_string()],
-        ),
-        Tag::custom(
             "hold_invoice_cltv_delta",
             vec![ln_settings.hold_invoice_cltv_delta.to_string()],
-        ),
-        Tag::custom(
-            "invoice_expiration_window",
-            vec![ln_settings.hold_invoice_expiration_window.to_string()],
         ),
         Tag::custom("lnd_version", vec![ln_status.version.to_string()]),
         Tag::custom("lnd_node_pubkey", vec![ln_status.node_pubkey.to_string()]),
@@ -667,6 +685,7 @@ pub fn info_to_tags(ln_status: &LnStatus, maintenance: bool) -> Tags {
         Tag::custom("z", vec!["info".to_string()]),
     ];
 
+    tags_vec.extend(invoice_window_tags(ln_settings));
     tags_vec.extend(bond_policy_tags(bond_settings));
     tags_vec.push(Tag::custom(
         "maintenance_mode",
@@ -974,6 +993,49 @@ mod tests {
     }
 
     // ── info_to_tags: end-to-end y-tag emission (kind 38385) ────────────────────
+
+    /// `invoice_expiration_window` and `hold_invoice_expiration_window` are
+    /// different settings with different jobs, and clients act on both: the
+    /// first is the remaining lifetime a payout invoice must still have for
+    /// `validate_bolt11_invoice` to accept it, the second is how long a taker
+    /// has to pay or supply an invoice. Publishing one under the other's name
+    /// makes clients build invoices mostrod then rejects — which is exactly
+    /// what the info event did, advertising the hold window under both names.
+    ///
+    /// Distinct values on purpose: equal ones would let a swapped mapping
+    /// pass.
+    #[test]
+    fn invoice_window_tags_publish_each_window_under_its_own_name() {
+        let ln_settings = crate::config::LightningSettings {
+            invoice_expiration_window: 3600,
+            hold_invoice_expiration_window: 300,
+            ..Default::default()
+        };
+
+        let tags = Tags::from_list(super::invoice_window_tags(&ln_settings).to_vec());
+
+        assert_eq!(
+            get_tag_value(&tags, "invoice_expiration_window"),
+            Some("3600".to_string()),
+        );
+        assert_eq!(
+            get_tag_value(&tags, "hold_invoice_expiration_window"),
+            Some("300".to_string()),
+        );
+    }
+
+    /// The end-to-end event must still carry both names, so a refactor that
+    /// drops one is caught even though the mapping is guarded above.
+    #[test]
+    fn info_to_tags_emits_both_invoice_window_tags() {
+        init_test_settings();
+        let ln_status = make_ln_status();
+
+        let tags = info_to_tags(&ln_status, false);
+
+        assert!(get_tag_value(&tags, "invoice_expiration_window").is_some());
+        assert!(get_tag_value(&tags, "hold_invoice_expiration_window").is_some());
+    }
 
     #[test]
     fn info_to_tags_emits_y_tag_with_mostro_as_first_value() {

--- a/src/nip33.rs
+++ b/src/nip33.rs
@@ -572,13 +572,6 @@ fn advertised_first_contact_pow(mostro_settings: &MostroSettings) -> u8 {
     }
 }
 
-/// Transform mostro info fields to tags
-///
-/// # Arguments
-///
-///
-/// `maintenance` is the current maintenance (drain) flag; the tag is always
-/// emitted so clients can tell "maintenance off" from "older daemon".
 /// The two invoice windows the info event advertises, each under its own name.
 ///
 /// They are different settings with different jobs and clients act on both:
@@ -605,6 +598,13 @@ fn invoice_window_tags(ln_settings: &crate::config::LightningSettings) -> [Tag; 
     ]
 }
 
+/// Transform mostro info fields to tags
+///
+/// # Arguments
+///
+///
+/// `maintenance` is the current maintenance (drain) flag; the tag is always
+/// emitted so clients can tell "maintenance off" from "older daemon".
 pub fn info_to_tags(ln_status: &LnStatus, maintenance: bool) -> Tags {
     let mostro_settings = Settings::get_mostro();
     let ln_settings = Settings::get_ln();


### PR DESCRIPTION
## Problem

The info event (kind 38385) publishes both invoice windows so clients can
build an invoice mostrod will accept. The `invoice_expiration_window` tag was
carrying `ln_settings.hold_invoice_expiration_window` — the very value the
`hold_invoice_expiration_window` tag a few lines above already carried. The
real `invoice_expiration_window` was never advertised at all.

These are different settings with different jobs, and clients act on both:

- `invoice_expiration_window` is the remaining lifetime a payout invoice must
  still have for `validate_bolt11_invoice` to accept it.
- `hold_invoice_expiration_window` is how long a taker has to pay or supply an
  invoice.

On the shipped template they are 3600 and 300. So a client that reads the
advertised value builds an invoice with five minutes of remaining lifetime,
and mostrod rejects it for having under an hour left. The client has no way to
discover the real requirement.

The bug predates the nostr-sdk 0.45.1 migration (#867), which only reformatted
the line.

## Change

Both window tags now come from one `invoice_window_tags` helper.

It takes `&LightningSettings` rather than two bare `u32`s, deliberately: with
two same-typed arguments the call site can silently swap them, and taking the
struct means the mapping lives in exactly one place, read by field name.

## About the test

The first version of this test was worthless and I only caught it by checking.
It asserted the tags against `Settings::get_ln()`, and `MOSTRO_CONFIG` is a
global `OnceLock` that whichever module reaches first wins. Under
`LightningSettings::default()` both windows are `0`, so the assertions passed
with the bug still in place.

Taking the settings as an argument is what makes the test deterministic: it
constructs settings with distinct values (3600 / 300) and does not touch the
global at all. Verified red before green — restoring the original mapping fails
with `left: Some("300"), right: Some("3600")`.

A second test keeps the end-to-end event honest by asserting both tag names are
present, so a refactor that drops one is still caught.

## Compatibility

Tag order changes: the two windows now sit together, appended after the
`z` tag and before the bond-policy and `maintenance_mode` tags, instead of
being separated by `hold_invoice_cltv_delta`. Nostr tags are looked up by name
and no consumer depends on their position, so this is not a wire-compat
concern. (An earlier revision of this description said "after the maintenance
tag", which was simply wrong about where the code puts them.)

Clients that were reading `invoice_expiration_window` will start seeing the
correct, larger value. Any client that worked around this by using the hold
window will now get accurate data.

## Test plan

- [x] `cargo test` — 1300 passed, 0 failed
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt`
- [x] Verified red before green with the original mapping restored
- [x] End-to-end event still emits both tag names
- [ ] Confirm against a live relay that the published info event carries
      `invoice_expiration_window = 3600` and
      `hold_invoice_expiration_window = 300` on default settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hCU6QgN1zup7LEHm49SGM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Information events now include separate expiration windows for regular invoices and hold invoices.
  - Lightning configuration details are reported more accurately, including the existing CLTV delta setting.

- **Bug Fixes**
  - Corrected invoice metadata publishing so each expiration window reflects its corresponding Lightning setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
