### PR TITLE
docs: reputation portability design proposal

### DIFF
--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -1,0 +1,259 @@
+# Reputation Portability
+
+Design proposal for letting a user carry reputation earned in one trading venue
+(lnp2pBot, or another Mostro instance) into a Mostro instance, without giving
+any operator, or anyone who reads relays, a way to link the two identities.
+
+Status: **proposal**. Values marked *open decision* are defaults to be
+confirmed before implementation.
+
+## 1. Goals
+
+1. A user with reputation on lnp2pBot can claim it on a Mostro instance.
+2. The same mechanism lets a user copy reputation from one Mostro to another.
+3. No party can link the source identity (Telegram user, or identity pubkey on
+   the source Mostro) with the destination identity pubkey. This must hold
+   even when the source and destination operators are the same person, and
+   even if the source database leaks.
+4. Imported reputation is merged into the destination's ordinary reputation
+   fields, so a counterparty sees one rating, one review count and one age, and
+   never needs to know where it came from.
+5. The destination operator decides which issuers to trust; nothing else is
+   configurable per instance.
+
+## 2. Non-goals
+
+- Moving reputation. Portability is a **copy**: the source keeps it.
+- Exact numbers. Reputation travels as coarse bands (section 4).
+- Users in `full_privacy` mode. They have no identity-bound reputation by
+  design, so there is nothing to import into.
+
+## 3. Threat model
+
+| Adversary | Must not learn |
+|---|---|
+| Source operator (bot or Mostro) | The destination identity pubkey, or which token was redeemed where |
+| Destination operator | The source identity (`tg_id` or source pubkey), or exact source stats |
+| Source + destination colluding, or a leaked source database | Any join key between the two identities |
+| Relay observer / counterparty | Anything beyond the merged public rating |
+
+Two attacks decide the design:
+
+- **Fingerprinting by exact values.** "347 trades, 4.87 rating, 12.3 BTC" is
+  unique in the source database. Any design that publishes exact values on the
+  destination lets the source operator, or a past counterparty who saw those
+  numbers in the bot, identify the destination pubkey. Hence bands.
+- **Issuer sees what it signs.** If the issuer signs a plaintext containing the
+  destination pubkey, or even a hash of it, it can recognise the same value
+  when it is redeemed. Hence blind signatures.
+
+Residual risk: **timing correlation**. With few migrations per day, a
+colluding pair can match "issued at 14:02" with "redeemed at 14:05". The
+client mitigates this by delaying redemption by a random interval, and issuers
+store no issuance timestamps finer than the per-user flag in section 6.
+
+## 4. Reputation bands
+
+Reputation is quantised into a cell of a three-dimensional grid. The grid is a
+**protocol constant**: every issuer uses the same cuts, so a token means the
+same thing wherever it is redeemed. Operators choose whom to trust, not what a
+band means.
+
+| Dimension | Bands (*open decision*) | Seeds on the destination |
+|---|---|---|
+| Completed trades | `1-9`, `10-49`, `50-199`, `200+` | `total_reviews` = band floor |
+| Average rating | `<4.0`, `4.0-4.5`, `4.5+` | `total_rating` = band floor |
+| Account age | `<6m`, `6-24m`, `24m+` | `created_at` moved back to band floor |
+
+Rules:
+
+- Seeds always use the **floor** of the band. Nobody receives more than they
+  earned; the destination shows a conservative lower bound.
+- Cells are the leaves of the issuer keyset (section 5). An issuer must merge
+  any cell holding fewer than `K` users (*open decision*, default 50) into an
+  adjacent lower cell before publishing, so every cell is a real crowd.
+- The trades dimension on Mostro counts orders that reached `success` for the
+  identity; on lnp2pBot it is `trades_completed`.
+- Eligibility (*open decision*): at least 10 completed trades, not banned, and
+  disputes lost below 10% of completed trades. Below eligibility the issuer
+  refuses and there is nothing to migrate.
+
+## 5. Cryptography: blind signatures per cell
+
+The scheme is BDHKE, the blind Diffie-Hellman key exchange used by Cashu. The
+issuer plays the role of the mint, and each grid cell plays the role of a
+denomination. Mostro already depends on `cdk`, which implements it; the bot can
+use `@cashu/crypto`; the mobile app needs a few lines over secp256k1.
+
+### 5.1 Issuer keyset
+
+An issuer holds one secret scalar `k_cell` per grid cell and publishes the
+public points `K_cell = k_cell·G` as a parameterised replaceable Nostr event
+signed with the issuer's own key:
+
+```
+kind: 30xxx (open decision)
+tags: ["d", "reputation-keyset"], ["epoch", "2026"]
+content: {"cells": {"trades:200+|rating:4.5+|age:24m+": "<hex K>", ...}}
+```
+
+lnp2pBot publishes with its existing `NOSTR_SK`. A Mostro publishes with its
+daemon key. Keysets are rotated by **epoch** (yearly); a destination accepts
+the current and previous epoch only, so stale reputation cannot be imported
+years later and an issuer can retire keys.
+
+### 5.2 Issuance (export)
+
+Runs on the user's device; the issuer never sees the plaintext.
+
+1. Client builds `secret = "repv1:" || destination_identity_pubkey || nonce`.
+2. Client computes `Y = hash_to_curve(secret)`, picks random `r`, sends
+   `B_ = Y + r·G` to the issuer.
+3. Issuer looks up the user in its own database, picks the cell, checks
+   eligibility and the once-only flag, and returns `C_ = k_cell·B_` together
+   with the cell id and a DLEQ proof that `C_` was produced with the published
+   `K_cell`.
+4. Client verifies the DLEQ against the public keyset. This defeats a
+   **tagging attack** where an issuer signs one user with a private key to
+   recognise them later.
+5. Client unblinds `C = C_ - r·K_cell` and stores the token
+   `{issuer, epoch, cell, secret, C}`.
+
+Transport differs per issuer:
+
+- **lnp2pBot**: the app opens `t.me/lnp2pbot?start=migrate_<base64(B_)>`;
+  the bot answers with a deep link back into the app carrying `C_`, the cell
+  id and the DLEQ. The bot sets `reputation_exported_at` on the user and
+  stores nothing else.
+- **Mostro**: a new gift-wrapped action `export-reputation` with `B_` in the
+  payload, signed with the source identity key. The daemon answers with the
+  same fields and sets `reputation_exported_at` in `users`.
+
+### 5.3 Redemption (import)
+
+A new gift-wrapped action `import-reputation`, signed with the **destination
+identity key**, carrying the token. The destination daemon:
+
+1. Checks the issuer is in its trusted list and the epoch is accepted.
+2. Verifies `C == k_cell·hash_to_curve(secret)` using `K_cell` (i.e. verifies
+   the unblinded signature against the published keyset).
+3. Checks the pubkey embedded in `secret` equals the identity that signed the
+   message. This binds the token to one identity; selling it means handing
+   over the key, which is the same risk as selling the account today.
+4. Checks `hash(secret)` is not in `redeemed_reputation_tokens`, and that this
+   `(issuer, identity)` pair has not been redeemed before.
+5. Inserts the redemption and seeds the user row (section 6) in the same
+   transaction.
+
+Replies: `reputation-imported` on success; existing error payload with a new
+reason on failure (untrusted issuer, bad signature, already redeemed,
+identity mismatch, expired epoch).
+
+## 6. Merging on the destination
+
+Seeds are added to the user's existing values; nothing is overwritten.
+
+| `users` column | Effect |
+|---|---|
+| `total_reviews` | `+= trades_floor` |
+| `total_rating` | recomputed as the weighted average of the existing average and the seed floor |
+| `created_at` | `= min(created_at, now - age_floor)` |
+| `min_rating`, `max_rating`, `last_rating` | unchanged if non-zero, otherwise set to `round(rating_floor)` |
+| `seeded_reviews` (new) | `+= trades_floor`, internal only |
+| `seeded_rating_sum` (new) | `+= trades_floor * rating_floor`, internal only |
+
+The public `rating` tag on order events is unchanged in shape:
+`{"total_reviews", "total_rating", "days"}`. No `legacy` marker is published.
+The seeded review count acts as an anchor, so new ratings move the average
+slowly, exactly as they would for a long-standing Mostro user.
+
+Worked example. User with 10 days on Mostro and 2 reviews at 4.5 imports from
+lnp2pBot where they have 347 trades, 4.87 average, 3 years:
+
+| Field | Before | After |
+|---|---|---|
+| `total_reviews` | 2 | 202 |
+| `total_rating` | 4.5 | 4.5 |
+| `days` | 10 | 730 |
+
+Counterparties see "4.5 · 202 reviews · 2 years".
+
+## 7. Mostro-to-Mostro specifics
+
+- **Only native reputation is exportable.** When a Mostro acts as issuer it
+  computes the cell from `total_reviews - seeded_reviews` and the native
+  rating derived from `seeded_rating_sum`. Seeds never travel twice, which
+  rules out A→B→A doubling and A→B→C chains. A user who wants A and C on B
+  redeems one token from each; the destination records each issuer once per
+  identity.
+- **Fresh identity per instance.** The mobile app uses one identity key for
+  every instance by default, so A and B can already link a user. Because the
+  token binds to the *destination* pubkey, which the issuer never sees, the
+  app can offer "use a new identity on this Mostro" and carry reputation over
+  without the two identities being linkable. Without blinding this option
+  would not exist.
+- **Reputation is not publicly queryable by identity.** Mostro's rating events
+  are keyed by trade pubkey, so a destination cannot simply read the source's
+  relays; an issuer attestation is required even between Mostros.
+- **Trust list.** Each instance configures accepted issuers. The reference
+  instance ships with the lnp2pBot issuer pubkey enabled.
+
+```toml
+[reputation_import]
+enabled = true
+accepted_epochs = 2
+issuers = [
+  "<lnp2pbot issuer pubkey>",
+  "<another mostro daemon pubkey>",
+]
+```
+
+## 8. Multi-destination, Sybil and re-issuance
+
+- **One token per source account, bound to one destination identity,
+  redeemable on any number of Mostros.** Restricting the number of
+  destinations is unenforceable without a shared ledger, and issuing
+  per-destination tokens would tell the issuer which instances the user uses.
+  Since reputation is per-instance, redeeming on N instances grants exactly
+  what the user had, once each.
+- **Sybil on one instance** (several identities sharing one reputation) is
+  blocked by the identity binding plus the once-only issuance flag.
+- **No re-issuance in v1.** A lost seed means the token cannot be re-obtained.
+  Re-issuance would let one person hold two reputable identities on the same
+  instance. An admin override for support cases is acceptable; a public
+  re-issuance path is not (*open decision*).
+- **Selling reputation** cannot be prevented cryptographically, since the
+  issuer signs a pubkey it does not see. It is bounded by eligibility, by the
+  one-token rule, and by being equivalent to selling the account.
+
+## 9. Work breakdown
+
+**Protocol** (first, the others depend on it): actions `export-reputation`,
+`import-reputation`, `reputation-imported`; token payload; keyset event kind
+and schema; the band grid as a protocol constant; error reasons.
+
+**lnp2pBot**: module `bot/modules/reputation` with the `/migrate` deep-link
+handler, issuer key from a new `REPUTATION_ISSUER_SK`, keyset publication via
+the existing `nostr` module, eligibility rules, `reputation_exported_at` on
+`User`, cell population check for `K`-anonymity before publishing.
+
+**Mostro**: `[reputation_import]` settings; keyset fetch and cache per
+issuer; BDHKE verify with `cdk`; migration adding `seeded_reviews`,
+`seeded_rating_sum`, `reputation_exported_at` to `users` and the table
+`redeemed_reputation_tokens(secret_hash, issuer, identity_pubkey, cell,
+redeemed_at)`; issuer side (`export-reputation`) with its own keyset and DLEQ.
+
+**Mobile**: settings screen "Import reputation" listing available issuers;
+blinding, DLEQ verification and unblinding; Telegram deep-link round trip for
+the bot; random redemption delay; persisting the blinding state in Sembast so
+an interrupted flow can resume; optional "new identity on this instance"; the
+order-book rating filter already reads `total_rating`, so merged values pass
+through it unchanged.
+
+## 10. Open decisions
+
+1. Band cuts for the three dimensions (section 4).
+2. `K` minimum cell population (default 50).
+3. Eligibility minimums (default 10 trades, disputes lost < 10%).
+4. Keyset event kind number and epoch length (default yearly).
+5. Admin override for re-issuance: yes or no.

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -149,7 +149,7 @@ without extra framing.
 | Element | Encoding |
 |---|---|
 | Curve points | 33-byte compressed SEC1 (`0x02`/`0x03` prefix) |
-| Scalars | 32-byte big-endian, reduced mod `n`, rejected if zero |
+| Scalars | 32-byte big-endian integer in `1..n-1`; a parser rejects `0` and any value `≥ n` instead of reducing it, so each scalar has exactly one encoding. Reduction mod `n` happens only inside arithmetic (challenge, blinding, unblinding) |
 | Tagged hash | `H_tag(x) = SHA256(SHA256(tag) ‖ SHA256(tag) ‖ x)`, as in BIP-340 |
 | Challenge | `c = int(H_"mostro/reputation/challenge/v1"(R ‖ m)) mod n`, `R` compressed |
 | `m` | `"repv1:"` (6 ASCII bytes) ‖ 32-byte x-only destination identity pubkey ‖ 32-byte random nonce — 70 bytes exactly |
@@ -161,7 +161,7 @@ The token travels as the `ReputationToken` payload of `import-reputation`
 Binary fields are lowercase hex, and a parser rejects the token before any
 curve arithmetic when a field is missing, duplicated, of the wrong length,
 not lowercase hex, or when a point does not decode onto the curve or a scalar
-is zero or not below `n`:
+is zero or `≥ n` (never reduced):
 
 | Field | Type | Bytes | Meaning |
 |---|---|---|---|
@@ -197,6 +197,15 @@ content: {
   "merges": {"reviews:200+|rating:0-4.0|age:24m+": "reviews:50-200|rating:0-4.0|age:24m+", ...}
 }
 ```
+
+A consumer verifies the event before reading anything from it: the Nostr
+signature must be valid, `pubkey` must equal the trusted issuer key (the same
+32-byte x-only key that fills the token's `issuer` field), `kind` must be the
+reserved one, `d` must be `reputation-keyset:<epoch>` with the `epoch` tag
+equal to that `<epoch>`, and `content` must parse into `cells` and `merges`
+with every key a valid cell id and every value a valid compressed point. An
+event failing any of these is discarded and never cached, so a relay or a
+third party cannot substitute a `P_cell`.
 
 `cells` holds only the **effective** cells, the ones that actually have a key.
 `merges` is the published map from every raw cell that was folded away to the
@@ -518,7 +527,7 @@ reasoning.
 | 0.2 | protocol | Reputation band grid as a protocol constant: the three dimensions, cuts, floors, cell id string format (`reviews:200+\|rating:4.5+\|age:24m+`), the deterministic K-anonymity merge rule and its raw→effective map. | Open decisions 1-3 closed and written down. |
 | 0.3 | protocol | Issuer keyset event: kind number, `d` tag, `epoch` tag, content schema, accepted-epochs rule. | Kind number reserved. |
 | 0.4 | protocol | Actions `export-reputation`, `reputation-exported`, `import-reputation`, `reputation-imported` — those four kebab-case strings are the wire discriminators, used verbatim in the schema, the core enum serialization, the compatibility note and the vectors. Payload schemas; new `cant-do` reasons; the redemption checks in section 5.4 as normative text. | Spec merged; one name per action across every document. |
-| 0.5 | protocol | Test vectors for the section 5.1 encoding (tagged hashes, point and scalar bytes, a canonical `m`, a cell id and a token id); keyset with a `merges` map; a full clause-blind-Schnorr transcript (`x_cell`, `k_0`, `k_1`, `α_i`, `β_i`, `R_i`, `c'_i`, `b`, `s'_b`, `s`) for fixed randomness; a valid token; and a table of invalid tokens (wrong cell key, wrong identity, expired epoch, mauled `s`, mauled `R`). | Vectors file committed; every implementation below tests against it. |
+| 0.5 | protocol | Test vectors for the section 5.1 encoding (tagged hashes, point and scalar bytes, a canonical `m`, a cell id and a token id); keyset with a `merges` map; a full clause-blind-Schnorr transcript (`x_cell`, `k_0`, `k_1`, `α_i`, `β_i`, `R_i`, `c'_i`, `b`, `s'_b`, `s`) for fixed randomness; a valid token; and a table of invalid tokens (wrong cell key, wrong identity, expired epoch, mauled `s`, mauled `R`, `s = 0`, `s = n + v` for a valid `v` — must be rejected, not reduced to `v`); plus one per-cell derivation vector (secret key, epoch, cell id → `x_cell`, `P_cell`) for the 4.1 scheme. | Vectors file committed; every implementation below tests against it. |
 
 ### Phase 1: `since` rollout
 
@@ -547,9 +556,9 @@ Independent of the migration and worth shipping first.
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
 | 3.1 | mostro | Settings section `[reputation_import]` (`enabled`, `issuers`, `accepted_epochs`) with parsing, defaults and validation. No behaviour. | Bad config is rejected at startup with a clear error. |
-| 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `native_rating_sum` (backfilled as `total_rating * total_reviews`, the best available estimate for legacy rows), `native_created_at` (backfilled from `created_at`) and `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(token_id PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
+| 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `native_rating_sum` (backfilled as `total_rating * total_reviews`; no per-review history exists to replay, and this makes a legacy row's native rating equal its displayed `total_rating` exactly — with `seeded_reviews = 0` the division in section 7 returns `total_rating` bit for bit, so legacy users export the reputation they show today), `native_created_at` (backfilled from `created_at`) and `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(token_id PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
 | 3.3 | mostro | Crypto module `reputation::verify` over `k256` (new dependency), using `reputation::encoding` from core so the byte contract is shared: challenge hash and the `s·G == R + H(R‖m)·P_cell` check. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
-| 3.4 | mostro | Keyset fetcher: fetch and cache the issuer keyset event per trusted issuer, refresh on epoch change, reject unknown epochs. Tested with the `local-relay` feature. | Cache survives a relay outage. |
+| 3.4 | mostro | Keyset fetcher: fetch and cache the issuer keyset event per trusted issuer, applying the section 5.2 acceptance rules (event signature, `pubkey` equals the trusted issuer, kind, `d`/`epoch` agreement, content shape) before caching; refresh on epoch change, reject unknown epochs. Tested with the `local-relay` feature, including a keyset signed by the wrong key and one whose `d` and `epoch` disagree. | Cache survives a relay outage; a forged keyset is never cached. |
 | 3.5 | mostro | Handler `src/app/import_reputation.rs`: routing in `app.rs`, checks 1-5 of section 5.4 in one transaction, calls `User::apply_reputation_seed` from core, persists through a new `update_user_reputation_seed` in `db.rs`, replies `reputation-imported` or `cant-do`. Integration test end-to-end with a fixture issuer. | A second redemption of the same token is rejected. |
 | 3.6 | mostro | Publish the updated kind 38384 rating event after a successful import, reusing `update_user_rating_event`. | Event visible on the local relay. |
 
@@ -557,7 +566,7 @@ Independent of the migration and worth shipping first.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 4.1 | mostro | Settings `[reputation_export]` (`enabled`); per-cell key derivation `x_cell = HKDF(ikm = daemon secret key, salt = "mostro/reputation/keyset/v1", info = epoch label ‖ 0x00 ‖ cell id)` (deterministic, never stored), the cell id being the canonical section 5.1 string so each cell gets its own scalar. Unit tests: same inputs, same keys; a different epoch label yields different keys; a different cell id yields different keys; the derived `P_cell` set has no duplicates across the grid. | No publication yet. |
+| 4.1 | mostro | Settings `[reputation_export]` (`enabled`); per-cell key derivation with HKDF-SHA256 (RFC 5869): `ikm` = the daemon secret key as 32 big-endian bytes, `salt` = the ASCII bytes of `mostro/reputation/keyset/v1`, `info` = UTF-8 epoch label ‖ `0x00` ‖ UTF-8 canonical cell id (section 5.1) ‖ one counter byte starting at `0x00`, `L` = 32; `x_cell = int(okm)`, and if that is `0` or `≥ n` the counter byte is incremented and the expand step repeated (probability ≈ 2⁻¹²⁸, but defined). Deterministic, never stored. Unit tests: same inputs, same keys; a different epoch label yields different keys; a different cell id yields different keys; the derived `P_cell` set has no duplicates across the grid. | No publication yet. |
 | 4.2 | mostro | Publish the keyset event at startup and on epoch rollover. The merge is computed **once per epoch**: on first publication the daemon takes cell populations from the database, runs the deterministic merge from section 4, and persists the resulting raw→effective map in a new `reputation_keysets(epoch PK, merges JSON, published_at)` table. Every later startup within the same epoch republishes byte-identical `cells` and `merges` from that row, never from a fresh count, so the event replacing on `(kind, pubkey, d)` is always the same keyset. | Event validates against 2.2; a client applying `merges` reproduces the issuer's assignment for every raw cell; a restart after the population changes republishes the stored keyset unchanged. |
 | 4.3 | mostro | Native stats for the export cell come from `User::native_stats` in core (`total_reviews - seeded_reviews`, `native_rating_sum / native_reviews`, `native_created_at` for age, per section 7). `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` feeds eligibility only (full-privacy orders carry no master pubkey and are simply not counted). Tested. | Seeded values are excluded from the cell. |
 | 4.4 | mostro | Handler `export_reputation_action`: the two-round-trip clause protocol (open session with `R'_0`/`R'_1`, then answer one clause), session store with expiry, eligibility, once-only flag, `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons; an abandoned session expires without consuming the flag. |
@@ -589,7 +598,7 @@ Runs in parallel with phase 5; shares the UI copy and the localized strings.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation — this is the bot's issuer identity: it signs the keyset, appears in trusted lists and fills the token `issuer` field, and is deliberately not `NOSTR_SK`. Per-cell key derivation from it (same HKDF scheme as 4.1, epoch label and cell id in `info`); `@noble/curves` dependency for secp256k1 arithmetic. Unit tests on derivation. | No command yet; the derived pubkey matches what 6.2 publishes. |
+| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation — this is the bot's issuer identity: it signs the keyset, appears in trusted lists and fills the token `issuer` field, and is deliberately not `NOSTR_SK`. Per-cell key derivation from it with exactly the 4.1 contract (HKDF-SHA256, same salt, `info` layout, counter byte and range check); `@noble/curves` dependency for secp256k1 arithmetic. Unit tests on derivation, including the 0.5 derivation vector so the bot and mostrod agree byte for byte on the scheme even though each derives from its own secret. | No command yet; the derived pubkey matches what 6.2 publishes. |
 | 6.2 | bot | Publish the keyset event through the existing `nostr` module at startup, signed with `REPUTATION_ISSUER_SK`. As in 4.2 the merge is computed from Mongo once per epoch and stored in a `reputation_keysets` collection; later startups republish the stored `cells` and `merges` unchanged. | Event validates against 2.2; a restart republishes the stored keyset unchanged. |
 | 6.3 | bot | `User.reputation_exported_at` (day-truncated); `computeCell(user)` and `isEligible(user)` in `util/`, the cell from `total_reviews`, `total_rating` and `created_at`, eligibility from `trades_completed`, `disputes` and `banned`. Tests on band edges. | Pure functions only. |
 | 6.4 | bot | `/start migrate_...` handler: the two round trips (open session, then answer one clause), session store with expiry, eligibility, once-only, reply with the app deep link; error messages in every locale YAML. Tests with a mocked user. | Round trip with 5.5. |

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -12,9 +12,11 @@ confirmed before implementation.
 1. A user with reputation on lnp2pBot can claim it on a Mostro instance.
 2. The same mechanism lets a user copy reputation from one Mostro to another.
 3. No party can link the source identity (Telegram user, or identity pubkey on
-   the source Mostro) with the destination identity pubkey. This must hold
-   even when the source and destination operators are the same person, and
-   even if the source database leaks.
+   the source Mostro) with the destination identity pubkey **from the protocol
+   data itself** — not even when the source and destination operators are the
+   same person, or when the source database leaks. The guarantee is
+   cryptographic on the data; it is only probabilistic against traffic
+   analysis, and section 3 states the residual explicitly.
 4. Imported reputation is merged into the destination's ordinary reputation
    fields, so a counterparty sees one rating, one review count and one age, and
    never needs to know where it came from.
@@ -47,10 +49,22 @@ Two attacks decide the design:
   destination pubkey, or even a hash of it, it can recognise the same value
   when it is redeemed. Hence blind signatures.
 
-Residual risk: **timing correlation**. With few migrations per day, a
-colluding pair can match "issued at 14:02" with "redeemed at 14:05". The
-client mitigates this by delaying redemption by a random interval, and issuers
-store no issuance timestamps finer than the per-user flag in section 6.
+**Residual risk: timing correlation.** The cryptography makes the token
+itself unlinkable, but it cannot hide *when* things happen. With few
+migrations per day, a colluding pair can match "issued at 14:02" with
+"redeemed at 14:05" and defeat goal 3 statistically. This is accepted, not
+solved, and it is bounded rather than eliminated:
+
+- The client waits a random delay before redeeming, drawn from a window wide
+  enough that many issuances fall inside it (*open decision* 8, default 24h).
+  The effective anonymity set is the number of migrations from the same
+  issuer within that window, which is small on day one and grows with
+  adoption.
+- Issuers store no issuance timestamp finer than the per-user flag in
+  section 6, so the correlation must be done live; it cannot be reconstructed
+  later from the database alone.
+- Nothing here helps the very first migrant. Anyone for whom this matters
+  should wait until the issuer has processed a meaningful number of exports.
 
 ## 4. Reputation bands
 
@@ -59,43 +73,77 @@ Reputation is quantised into a cell of a three-dimensional grid. The grid is a
 same thing wherever it is redeemed. Operators choose whom to trust, not what a
 band means.
 
-| Dimension | Bands (*open decision*) | Seeds on the destination |
-|---|---|---|
-| Completed trades | `1-9`, `10-49`, `50-199`, `200+` | `total_reviews` = band floor |
-| Average rating | `<4.0`, `4.0-4.5`, `4.5+` | `total_rating` = band floor |
-| Account age | `<6m`, `6-24m`, `24m+` | `created_at` moved back to band floor |
+All intervals are **half-open**, `[low, high)`, so every value falls in
+exactly one band and two implementations cannot disagree on a boundary. A
+"month" is exactly 30 days of 86400 seconds; ages are computed from
+`day_truncate(created_at)` (section 6.1) so the band does not flip mid-day.
+
+| Dimension | Bands (*open decision*) | Floor | Seeds on the destination |
+|---|---|---|---|
+| Ratings received | `[1,10)`, `[10,50)`, `[50,200)`, `[200,∞)` | 1 / 10 / 50 / 200 | `total_reviews` += floor |
+| Average rating | `[0,4.0)`, `[4.0,4.5)`, `[4.5,5.0]` | 0.0 / 4.0 / 4.5 | `total_rating` weighted with floor |
+| Account age | `[0,6m)`, `[6m,24m)`, `[24m,∞)` | 0d / 180d / 720d | `created_at` moved back by floor |
+
+The top rating band is closed at 5.0 because that is the maximum a rating can
+take; every other band is half-open.
 
 Rules:
 
+- **The first dimension counts ratings received, not completed trades.** On
+  Mostro `total_reviews` only increments when a counterparty actually submits
+  a rating, and it is also the weight of the running average. Seeding it from
+  a trade count would publish a review count the user never earned and give a
+  single rating the weight of hundreds. On lnp2pBot the matching field is
+  `total_reviews`; completed trades are used for eligibility only.
 - Seeds always use the **floor** of the band. Nobody receives more than they
   earned; the destination shows a conservative lower bound.
 - Cells are the leaves of the issuer keyset (section 5). An issuer must merge
   any cell holding fewer than `K` users (*open decision*, default 50) into an
   adjacent lower cell before publishing, so every cell is a real crowd.
-- The trades dimension on Mostro counts orders that reached `success` for the
-  identity; on lnp2pBot it is `trades_completed`.
-- Eligibility (*open decision*): at least 10 completed trades, not banned, and
-  disputes lost below 10% of completed trades. Below eligibility the issuer
-  refuses and there is nothing to migrate.
+- Eligibility (*open decision*): at least 10 completed trades **and** at least
+  1 rating received, not banned, and disputes lost below 10% of completed
+  trades. Below eligibility the issuer refuses and there is nothing to
+  migrate.
 
-## 5. Cryptography: blind signatures per cell
+## 5. Cryptography: blind Schnorr signatures per cell
 
-The scheme is BDHKE, the blind Diffie-Hellman key exchange used by Cashu. The
-issuer plays the role of the mint, and each grid cell plays the role of a
-denomination. Mostro already depends on `cdk`, which implements it; the bot can
-use `@cashu/crypto`; the mobile app needs a few lines over secp256k1.
+The token must be verified by the **destination**, which is not the party that
+issued it. That rules out Cashu's BDHKE: there the mint verifies its own
+tokens with the private key `k`, and given only `K = k·G` deciding whether
+`C = k·Y` is the Decisional Diffie-Hellman problem, assumed hard on
+secp256k1. A third party simply cannot check a BDHKE token.
+
+The scheme is therefore **blind Schnorr on secp256k1**, which is blind at
+issuance and *publicly* verifiable at redemption: anyone holding the issuer's
+public key can check the signature. Each grid cell has its own keypair, so the
+key that verifies a token is what states its band.
+
+Concurrent blind Schnorr sessions are subject to the ROS attack, so issuers
+use the **clause variant** (Fuchsbauer–Kiltz–Loss): the issuer opens two
+nonce clauses, the client prepares a challenge for each, and the issuer
+answers only one, chosen at random. Issuers additionally allow one open
+session per user at a time.
+
+Implementations need scalar and point arithmetic on secp256k1, not a Cashu
+library: `k256` in mostro and in the 2.x app's Rust core, `@noble/curves` in
+the bot, and a small Dart implementation in the 1.x app.
 
 ### 5.1 Issuer keyset
 
-An issuer holds one secret scalar `k_cell` per grid cell and publishes the
-public points `K_cell = k_cell·G` as a parameterised replaceable Nostr event
+An issuer holds one secret scalar `x_cell` per grid cell and publishes the
+public points `P_cell = x_cell·G` as a parameterised replaceable Nostr event
 signed with the issuer's own key:
 
-```
+```text
 kind: 30xxx (open decision)
-tags: ["d", "reputation-keyset"], ["epoch", "2026"]
-content: {"cells": {"trades:200+|rating:4.5+|age:24m+": "<hex K>", ...}}
+tags: ["d", "reputation-keyset:2026"], ["epoch", "2026"]
+content: {"cells": {"reviews:200+|rating:4.5+|age:24m+": "<hex P>", ...}}
 ```
+
+The epoch is part of the `d` tag, not only a separate tag. Addressable events
+replace on `(kind, pubkey, d)`, so a fixed `d` would make each rotation
+**delete the previous keyset** from relays and leave the destination unable to
+verify tokens from the epoch it still accepts.
 
 lnp2pBot publishes with its existing `NOSTR_SK`. A Mostro publishes with its
 daemon key. Keysets are rotated by **epoch** (yearly); a destination accepts
@@ -104,30 +152,44 @@ years later and an issuer can retire keys.
 
 ### 5.2 Issuance (export)
 
-Runs on the user's device; the issuer never sees the plaintext.
+The blinding runs on the user's device; the issuer never sees the message it
+signs. Writing `m` for that message and `H` for the challenge hash:
 
-1. Client builds `secret = "repv1:" || destination_identity_pubkey || nonce`.
-2. Client computes `Y = hash_to_curve(secret)`, picks random `r`, sends
-   `B_ = Y + r·G` to the issuer.
-3. Issuer looks up the user in its own database, picks the cell, checks
-   eligibility and the once-only flag, and returns `C_ = k_cell·B_` together
-   with the cell id and a DLEQ proof that `C_` was produced with the published
-   `K_cell`.
-4. Client verifies the DLEQ against the public keyset. This defeats a
-   **tagging attack** where an issuer signs one user with a private key to
-   recognise them later.
-5. Client unblinds `C = C_ - r·K_cell` and stores the token
-   `{issuer, epoch, cell, secret, C}`.
+1. Client builds `m = "repv1:" || destination_identity_pubkey || nonce`.
+2. Issuer looks up the user, checks eligibility and the once-only flag, picks
+   the cell, and opens the session by sending the cell id and two nonce
+   points `R'_0 = k_0·G`, `R'_1 = k_1·G`.
+3. **Client validates the cell against its own statistics.** The user knows
+   their own review count, rating and account age, so the client recomputes
+   the cell and aborts if the issuer named a different one. Without this
+   check an adversarial issuer could tag a user by assigning a deliberately
+   rare cell and recognise it at redemption; no proof about the signature
+   itself would catch that, because the signature would be perfectly valid.
+4. Client picks random `α_i`, `β_i` for each clause, computes
+   `R_i = R'_i + α_i·G + β_i·P_cell` and `c'_i = H(R_i ‖ m) + β_i`, and sends
+   both `c'_i`.
+5. Issuer picks `b ∈ {0,1}` at random and returns `s'_b = k_b + c'_b·x_cell`
+   with `b`. Answering only one clause is what defeats ROS.
+6. Client unblinds `s = s'_b + α_b` and stores the token
+   `{issuer, epoch, cell, m, R_b, s}`.
+7. Client verifies `s·G == R_b + H(R_b ‖ m)·P_cell` against the published
+   keyset **before** storing. This is the same check the destination will run,
+   so a token that would be rejected later is caught immediately, and an
+   issuer that signed with an off-keyset key is detected at once.
 
 Transport differs per issuer:
 
-- **lnp2pBot**: the app opens `t.me/lnp2pbot?start=migrate_<base64(B_)>`;
-  the bot answers with a deep link back into the app carrying `C_`, the cell
-  id and the DLEQ. The bot sets `reputation_exported_at` on the user and
-  stores nothing else.
-- **Mostro**: a new gift-wrapped action `export-reputation` with `B_` in the
-  payload, signed with the source identity key. The daemon answers with the
-  same fields and sets `reputation_exported_at` in `users`.
+- **lnp2pBot**: two round trips over the Telegram deep link
+  (`t.me/lnp2pbot?start=migrate_...`), the bot answering into the app's deep
+  link scheme. The bot sets `reputation_exported_at` on the user and stores
+  nothing else.
+- **Mostro**: gift-wrapped `export-reputation` messages signed with the source
+  identity key, one per round trip. The daemon sets `reputation_exported_at`
+  in `users`.
+
+The session is stateful across the two round trips, so both the issuer and the
+client persist it; an abandoned session expires and does not consume the
+once-only flag.
 
 ### 5.3 Redemption (import)
 
@@ -135,27 +197,29 @@ A new gift-wrapped action `import-reputation`, signed with the **destination
 identity key**, carrying the token. The destination daemon:
 
 1. Checks the issuer is in its trusted list and the epoch is accepted.
-2. Verifies `C == k_cell·hash_to_curve(secret)` using `K_cell` (i.e. verifies
-   the unblinded signature against the published keyset).
-3. Checks the pubkey embedded in `secret` equals the identity that signed the
+2. Verifies `s·G == R + H(R ‖ m)·P_cell` with the `P_cell` published for the
+   token's cell and epoch. This needs only public data, which is the whole
+   reason for blind Schnorr; the cell whose key verifies is the band.
+3. Checks the pubkey embedded in `m` equals the identity that signed the
    message. This binds the token to one identity; selling it means handing
    over the key, which is the same risk as selling the account today.
-4. Checks `hash(secret)` is not in `redeemed_reputation_tokens`, and that this
+4. Checks `hash(m)` is not in `redeemed_reputation_tokens`, and that this
    `(issuer, identity)` pair has not been redeemed before.
 5. Inserts the redemption and seeds the user row (section 6) in the same
    transaction.
 
 Replies: `reputation-imported` on success; `cant-do` with one of the new
-`CantDoReason` variants on failure (section 9, PR 2.3). Older clients map
-unknown reasons to the `Unknown` catch-all that core 0.14.6 introduced, so
-the new variants do not break them.
+`CantDoReason` variants on failure (section 9, PR 2.3). `CantDoReason` is the
+one enum in core carrying `#[serde(other)]`, so an old client degrades a new
+reason to `Unknown` instead of failing. `Action` and `Payload` have no such
+fallback — see section 9 for why that is still safe.
 
 ## 6. Merging on the destination
 
 Each dimension has its own merge rule, because they measure different things:
 
-- **Completed trades add up.** A trade on A and a trade on B are distinct
-  trades, so the seed is added to the local count.
+- **Ratings received add up.** A rating on A and a rating on B are distinct
+  reviews by distinct counterparties, so the seed is added to the local count.
 - **Rating is a weighted average**, weighted by review count per origin. It is
   never summed and never maxed.
 - **Account age is a maximum, never a sum.** "Days operating" answers "since
@@ -177,12 +241,12 @@ effect.
 
 | `users` column | Effect |
 |---|---|
-| `total_reviews` | `+= trades_floor` |
+| `total_reviews` | `+= reviews_floor` |
 | `total_rating` | recomputed as the weighted average of the existing average and the seed floor |
 | `created_at` | `= min(created_at, now - age_floor)` |
 | `min_rating`, `max_rating`, `last_rating` | unchanged if non-zero, otherwise set to `round(rating_floor)` |
-| `seeded_reviews` (new) | `+= trades_floor`, internal only |
-| `seeded_rating_sum` (new) | `+= trades_floor * rating_floor`, internal only |
+| `seeded_reviews` (new) | `+= reviews_floor`, internal only |
+| `seeded_rating_sum` (new) | `+= reviews_floor * rating_floor`, internal only |
 
 The public `rating` tag on order events keeps its three-field shape:
 `{"total_reviews", "total_rating", "since"}` (see 6.1). No `legacy` marker is published.
@@ -190,7 +254,10 @@ The seeded review count acts as an anchor, so new ratings move the average
 slowly, exactly as they would for a long-standing Mostro user.
 
 Worked example. User with 10 days on Mostro and 2 reviews at 4.5 imports from
-lnp2pBot where they have 347 trades, 4.87 average, 3 years:
+lnp2pBot where they have 347 completed trades, **214 ratings received**, 4.87
+average and 3 years. The cell is `reviews:200+ | rating:4.5+ | age:24m+`, so
+the seed is 200 reviews at 4.5 and 720 days; the 347 trades only decided
+eligibility:
 
 | Field | Before | After |
 |---|---|---|
@@ -240,12 +307,16 @@ new peers interoperate during the window.
   rules out A→B→A doubling and A→B→C chains. A user who wants A and C on B
   redeems one token from each; the destination records each issuer once per
   identity.
-- **Fresh identity per instance.** The mobile app uses one identity key for
-  every instance by default, so A and B can already link a user. Because the
-  token binds to the *destination* pubkey, which the issuer never sees, the
-  app can offer "use a new identity on this Mostro" and carry reputation over
-  without the two identities being linkable. Without blinding this option
-  would not exist.
+- **One identity across instances.** A token binds the destination identity
+  pubkey inside `m`, and redemption requires that key to sign, so a single
+  token serves one identity — on as many instances as trust the issuer. The
+  app already uses one identity key for every instance, so this is the normal
+  case. Carrying reputation to a *fresh* identity per instance would need one
+  token per identity, and nothing could then stop a user from redeeming two of
+  them under two identities on the same instance: the destination cannot tell
+  they are the same person, which is precisely the property the design
+  provides. Fresh identity per instance and Sybil resistance are mutually
+  exclusive here, and Sybil resistance wins.
 - **Reputation is not publicly queryable by identity.** Mostro's rating events
   are keyed by trade pubkey, so a destination cannot simply read the source's
   relays; an issuer attestation is required even between Mostros.
@@ -265,13 +336,16 @@ issuers = [
 ## 8. Multi-destination, Sybil and re-issuance
 
 - **One token per source account, bound to one destination identity,
-  redeemable on any number of Mostros.** Restricting the number of
-  destinations is unenforceable without a shared ledger, and issuing
-  per-destination tokens would tell the issuer which instances the user uses.
+  redeemable on any number of Mostros.** The binding is to the identity, not
+  to the instance: the issuer never learns where the token is spent, and the
+  same identity can redeem it on every instance that trusts the issuer.
   Since reputation is per-instance, redeeming on N instances grants exactly
-  what the user had, once each.
+  what the user had, once each. Restricting the number of destinations is
+  unenforceable without a shared ledger anyway, and issuing per-destination
+  tokens would tell the issuer which instances the user uses.
 - **Sybil on one instance** (several identities sharing one reputation) is
-  blocked by the identity binding plus the once-only issuance flag.
+  blocked by the identity binding plus the once-only issuance flag. This is
+  what rules out fresh identity per instance (section 7).
 - **No re-issuance in v1.** A lost seed means the token cannot be re-obtained.
   Re-issuance would let one person hold two reputable identities on the same
   instance. An admin override for support cases is acceptable; a public
@@ -292,23 +366,33 @@ published.
 Repositories: `protocol` (spec), `mostro-core` (shared types, crates.io),
 `mostro` (daemon), `mobile` (app 1.x, pure Dart), `app` (app 2.x, Flutter UI
 over a Rust core through flutter_rust_bridge, already on mostro-core, nostr-sdk
-0.45 and cdk), `lnp2pbot/bot`.
+0.45 and `k256`), `lnp2pbot/bot`.
 
 Both apps must support the migration. They differ in where the work lands:
-the 1.x app needs its own Dart implementation of everything (BDHKE, models,
-parsing), while the 2.x app gets the types from mostro-core and the BDHKE
-primitives from cdk inside its Rust core, and only adds bridge functions and
-UI on the Dart side.
+the 1.x app needs its own Dart implementation of everything (blind Schnorr,
+models, parsing), while the 2.x app gets the types from mostro-core and does
+the curve arithmetic with `k256` inside its Rust core, adding only bridge
+functions and UI on the Dart side.
+
+**Protocol compatibility.** `PROTOCOL_VER` stays at 2 and the new actions do
+not gate on it. In core 0.14.6 only `CantDoReason` carries `#[serde(other)]`;
+`Action` and `Payload` would fail to deserialise an unknown variant. That is
+safe here because these messages are strictly request/response over targeted
+gift wraps: `export-reputation` and `import-reputation` are only ever sent by
+a client that implements them, and `reputation-exported` / `reputation-imported`
+only ever come back to the client that asked. No new variant is broadcast, so
+no old client is ever handed one. PR 2.3 carries a test that pins this
+reasoning.
 
 ### Phase 0: specification
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
 | 0.1 | protocol | Add `since` to the `rating` tag and to the kind 38384 event, day-truncated Unix timestamp. Mark `days` deprecated with a removal version. | Spec merged, example events updated. |
-| 0.2 | protocol | Reputation band grid as a protocol constant: the three dimensions, cuts, floors, cell id string format (`trades:200+\|rating:4.5+\|age:24m+`), K-anonymity merge rule. | Open decisions 1-3 closed and written down. |
+| 0.2 | protocol | Reputation band grid as a protocol constant: the three dimensions, cuts, floors, cell id string format (`reviews:200+\|rating:4.5+\|age:24m+`), K-anonymity merge rule. | Open decisions 1-3 closed and written down. |
 | 0.3 | protocol | Issuer keyset event: kind number, `d` tag, `epoch` tag, content schema, accepted-epochs rule. | Kind number reserved. |
 | 0.4 | protocol | Actions `export-reputation`, `export-reputation-response`, `import-reputation`, `reputation-imported`; payload schemas; new `cant-do` reasons; the redemption checks in section 5.3 as normative text. | Spec merged. |
-| 0.5 | protocol | Test vectors: keyset, `B_`/`C_`/`C` for a fixed `r` and `k`, DLEQ, a valid token, and a table of invalid tokens (wrong cell, wrong identity, expired epoch). | Vectors file committed; every implementation below tests against it. |
+| 0.5 | protocol | Test vectors: keyset; a full clause-blind-Schnorr transcript (`x_cell`, `k_0`, `k_1`, `α_i`, `β_i`, `R_i`, `c'_i`, `b`, `s'_b`, `s`) for fixed randomness; a valid token; and a table of invalid tokens (wrong cell key, wrong identity, expired epoch, mauled `s`, mauled `R`). | Vectors file committed; every implementation below tests against it. |
 
 ### Phase 1: `since` rollout
 
@@ -326,9 +410,9 @@ Independent of the migration and worth shipping first.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 2.1 | mostro-core | Module `reputation::bands`: `TradesBand`, `RatingBand`, `AgeBand` enums with cuts and floors, `Cell { trades, rating, age }`, `Cell::from_stats(trades, avg_rating, since, now)`, `Cell::id()` / `parse()`. Pure, exhaustively tested against 0.2. | Round-trips every cell id. |
-| 2.2 | mostro-core | `ReputationKeyset` (parse/build the event from 0.3, epoch handling) and `ReputationToken { issuer, epoch, cell, secret, c }` with serde and shape validation. No crypto. | Parses the 0.5 vectors. |
-| 2.3 | mostro-core | `src/message.rs`: `Action` variants `ExportReputation`, `ReputationExported`, `ImportReputation`, `ReputationImported` (past participle for daemon replies, matching `Released` / `Canceled`); `Payload` variants `BlindedReputationRequest(BlindedReputationRequest)`, `BlindedReputationResponse(BlindedReputationResponse)`, `ReputationToken(ReputationToken)`. `src/error.rs`: `CantDoReason` variants `UntrustedReputationIssuer`, `InvalidReputationToken`, `ReputationAlreadyRedeemed`, `ReputationIdentityMismatch`, `ExpiredReputationKeyset`, `NotEligibleForReputationExport`, `ReputationAlreadyExported`, inserted before `Unknown`. `src/prelude.rs`: `NOSTR_REPUTATION_KEYSET_KIND`. Serde round-trip tests; decide whether `PROTOCOL_VER` bumps (open decision 7). | Part of the **minor** release. |
+| 2.1 | mostro-core | Module `reputation::bands`: `ReviewsBand`, `RatingBand`, `AgeBand` enums with half-open cuts and floors, `Cell { reviews, rating, age }`, `Cell::from_stats(total_reviews, avg_rating, since, now)`, `Cell::id()` / `parse()`. Pure, exhaustively tested against 0.2 including every boundary value. | Round-trips every cell id; boundary values land in exactly one band. |
+| 2.2 | mostro-core | `ReputationKeyset` (parse/build the event from 0.3, epoch handling) and `ReputationToken { issuer, epoch, cell, m, r_point, s }` with serde and shape validation. No crypto. | Parses the 0.5 vectors. |
+| 2.3 | mostro-core | `src/message.rs`: `Action` variants `ExportReputation`, `ReputationExported`, `ImportReputation`, `ReputationImported` (past participle for daemon replies, matching `Released` / `Canceled`); `Payload` variants `BlindedReputationRequest(BlindedReputationRequest)`, `BlindedReputationResponse(BlindedReputationResponse)`, `ReputationToken(ReputationToken)`. `src/error.rs`: `CantDoReason` variants `UntrustedReputationIssuer`, `InvalidReputationToken`, `ReputationAlreadyRedeemed`, `ReputationIdentityMismatch`, `ExpiredReputationKeyset`, `NotEligibleForReputationExport`, `ReputationAlreadyExported`, inserted before `Unknown`. `src/prelude.rs`: `NOSTR_REPUTATION_KEYSET_KIND`. Serde round-trip tests, plus a test asserting an old client never receives these variants (`PROTOCOL_VER` stays 2, see the compatibility note above). | Part of the **minor** release. |
 | 2.4 | mostro-core | `src/user.rs`: `User` gains `seeded_reviews: i64`, `seeded_rating_sum: f64`, `reputation_exported_at: Option<i64>`, each with `#[sqlx(default)]` and `#[serde(default)]` so a daemon on an un-migrated database still deserialises `SELECT *`. `User::new` initialises them. | First use of `sqlx(default)` in core; test with a row that lacks the columns. |
 | 2.5 | mostro-core | `src/user.rs`: `User::apply_reputation_seed(&mut self, cell: &Cell, now: i64)` implementing section 6 next to `update_rating`, plus `User::native_stats(&self) -> (reviews, rating, since)` that subtracts the seeded part. Property tests: never decreases `total_reviews`, never moves `created_at` forward, idempotent per issuer. | No I/O; released as **0.15.0** together with 2.1-2.4. |
 
@@ -338,7 +422,7 @@ Independent of the migration and worth shipping first.
 |---|---|---|---|
 | 3.1 | mostro | Settings section `[reputation_import]` (`enabled`, `issuers`, `accepted_epochs`) with parsing, defaults and validation. No behaviour. | Bad config is rejected at startup with a clear error. |
 | 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(secret_hash PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
-| 3.3 | mostro | Crypto module `reputation::verify`: `hash_to_curve`, unblinded-signature verification and DLEQ verification on top of `cdk`. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
+| 3.3 | mostro | Crypto module `reputation::verify` over `k256` (new dependency): challenge hash and the `s·G == R + H(R‖m)·P_cell` check. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
 | 3.4 | mostro | Keyset fetcher: fetch and cache the issuer keyset event per trusted issuer, refresh on epoch change, reject unknown epochs. Tested with the `local-relay` feature. | Cache survives a relay outage. |
 | 3.5 | mostro | Handler `src/app/import_reputation.rs`: routing in `app.rs`, checks 1-5 of section 5.3 in one transaction, calls `User::apply_reputation_seed` from core, persists through a new `update_user_reputation_seed` in `db.rs`, replies `reputation-imported` or `cant-do`. Integration test end to end with a fixture issuer. | A second redemption of the same token is rejected. |
 | 3.6 | mostro | Publish the updated kind 38384 rating event after a successful import, reusing `update_user_rating_event`. | Event visible on the local relay. |
@@ -349,20 +433,19 @@ Independent of the migration and worth shipping first.
 |---|---|---|---|
 | 4.1 | mostro | Settings `[reputation_export]` (`enabled`, `epoch_length`); per-cell key derivation from the daemon key and epoch (HKDF, deterministic, never stored). Unit tests: same inputs, same keys. | No publication yet. |
 | 4.2 | mostro | Publish the keyset event at startup and on epoch rollover, with the K-anonymity merge from section 4 using cell populations from the database. | Event validates against 2.2. |
-| 4.3 | mostro | Native trade count: `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` (full-privacy orders carry no master pubkey and are simply not counted). Combined with `User::native_stats` from core into the export cell. Tested. | Seeded values are excluded. |
-| 4.4 | mostro | Handler `export_reputation_action`: eligibility, once-only flag, blind signature with `cdk`, DLEQ, reply; sets `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons. |
+| 4.3 | mostro | Native stats for the export cell come from `User::native_stats` in core (reviews and rating minus the seeded part, `created_at` for age). `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` feeds eligibility only (full-privacy orders carry no master pubkey and are simply not counted). Tested. | Seeded values are excluded from the cell. |
+| 4.4 | mostro | Handler `export_reputation_action`: the two-round-trip clause protocol (open session with `R'_0`/`R'_1`, then answer one clause), session store with expiry, eligibility, once-only flag, `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons; an abandoned session expires without consuming the flag. |
 
 ### Phase 5: mobile (app 1.x, `mobile`)
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 5.1 | mobile | BDHKE client primitives in Dart: `hashToCurve`, blind, unblind, DLEQ verify, over secp256k1. Tested against the 0.5 vectors. | No UI, no services. |
+| 5.1 | mobile | Blind Schnorr client primitives in Dart over secp256k1: blinding factors, challenge, unblinding and signature verification. Tested against the 0.5 vectors. | No UI, no services. |
 | 5.2 | mobile | Models: keyset event parser, `ReputationToken`, band cell; `MostroMessage` support for the new actions and payloads. | Serde round-trip tests. |
-| 5.3 | mobile | Storage: Sembast repository for tokens and for in-flight blinding state (`r`, `secret`, issuer) so an interrupted flow resumes. | Survives app restart in a test. |
+| 5.3 | mobile | Storage: Sembast repository for tokens and for in-flight session state (the open clauses, `α_i`, `β_i`, `m`, issuer) so an interrupted flow resumes. | Survives app restart in a test. |
 | 5.4 | mobile | `MostroService` + notifier: `exportReputation(issuer)` and `importReputation(token)` flows against a Mostro issuer, with the random redemption delay. | Integration test against a local daemon from 4.4. |
-| 5.5 | mobile | Telegram transport: open `t.me/lnp2pbot?start=migrate_<B_>`, receive the response through the app's deep link scheme, verify DLEQ, store token. | Manual test with the bot from phase 6. |
+| 5.5 | mobile | Telegram transport: the two deep-link round trips with the bot, cell validation against the user's own stats, signature verification, store token. | Manual test with the bot from phase 6. |
 | 5.6 | mobile | Settings screen "Import reputation": issuer list from the selected node's trust list, status per issuer, localized strings in every `intl_*.arb`. | `flutter analyze` clean, gen-l10n reports no untranslated keys. |
-| 5.7 | mobile | Optional: "use a new identity on this instance" when importing. | Separate PR, can slip. |
 
 ### Phase 5b: app 2.x (`app`)
 
@@ -370,21 +453,20 @@ Runs in parallel with phase 5; shares the UI copy and the localized strings.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 5b.1 | app | Rust core: bump mostro-core to 0.15.0 so `Cell`, `ReputationKeyset`, `ReputationToken`, the new `Action` / `Payload` / `CantDoReason` variants come from core. Add `rust/src/mostro/reputation.rs` with blind, unblind and DLEQ verify over `cdk`'s BDHKE (no new dependency). Tested against the 0.5 vectors. | No bridge, no UI. |
+| 5b.1 | app | Rust core: bump mostro-core to 0.15.0 so `Cell`, `ReputationKeyset`, `ReputationToken`, the new `Action` / `Payload` / `CantDoReason` variants come from core. Add `rust/src/mostro/reputation.rs` with the blind Schnorr client side over `k256`, already a dependency. Tested against the 0.5 vectors. | No bridge, no UI. |
 | 5b.2 | app | Rust core: token and in-flight blinding state persisted in the existing SQLite (native) / IndexedDB (web) layer, so an interrupted flow resumes on every platform. | Survives restart in a test on native and WASM. |
 | 5b.3 | app | Rust core: `export_reputation(issuer)` and `import_reputation(token)` flows against a Mostro issuer through the existing message queue, with the random redemption delay; keyset fetch and cache per trusted issuer. Bridge functions exposed through flutter_rust_bridge (generated, never hand-written). | Integration test against the local daemon from 4.4. |
-| 5b.4 | app | Telegram transport: open `t.me/lnp2pbot?start=migrate_<B_>` from Dart, receive the response through the app's deep link scheme on mobile and through a paste field on desktop and web, hand it to the Rust core for DLEQ verification. | Manual test with the bot from phase 6. |
+| 5b.4 | app | Telegram transport: the two round trips from Dart, through the deep link scheme on mobile and a paste field on desktop and web, handing each response to the Rust core for cell validation and signature verification. | Manual test with the bot from phase 6. |
 | 5b.5 | app | Dart UI: settings screen "Import reputation" reusing the 1.x copy, localized in every ARB under `lib/l10n/`. | `flutter analyze` clean, no untranslated keys. |
-| 5b.6 | app | Optional: "use a new identity on this instance" when importing. | Separate PR, can slip. |
 
 ### Phase 6: lnp2pBot as issuer
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation; per-cell key derivation (same HKDF scheme as 4.1); `@cashu/crypto` dependency. Unit tests on derivation. | No command yet. |
+| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation; per-cell key derivation (same HKDF scheme as 4.1); `@noble/curves` dependency for secp256k1 arithmetic. Unit tests on derivation. | No command yet. |
 | 6.2 | bot | Publish the keyset event through the existing `nostr` module at startup, with the K-anonymity merge computed from Mongo. | Event validates against 2.2. |
-| 6.3 | bot | `User.reputation_exported_at`; `computeCell(user)` and `isEligible(user)` in `util/` using `trades_completed`, `total_rating`, `disputes`, `banned`, `created_at`. Tests on band edges. | Pure functions only. |
-| 6.4 | bot | `/start migrate_<B_>` handler: parse, eligibility, once-only, blind sign, DLEQ, reply with the app deep link; error messages in every locale YAML. Tests with a mocked user. | Round trip with 5.5. |
+| 6.3 | bot | `User.reputation_exported_at`; `computeCell(user)` and `isEligible(user)` in `util/`, the cell from `total_reviews`, `total_rating` and `created_at`, eligibility from `trades_completed`, `disputes` and `banned`. Tests on band edges. | Pure functions only. |
+| 6.4 | bot | `/start migrate_...` handler: the two round trips (open session, then answer one clause), session store with expiry, eligibility, once-only, reply with the app deep link; error messages in every locale YAML. Tests with a mocked user. | Round trip with 5.5. |
 
 ### Phase 7: rollout
 
@@ -398,8 +480,19 @@ Runs in parallel with phase 5; shares the UI copy and the localized strings.
 
 1. Band cuts for the three dimensions (section 4).
 2. `K` minimum cell population (default 50).
-3. Eligibility minimums (default 10 trades, disputes lost < 10%).
+3. Eligibility minimums (default 10 completed trades, 1 rating, disputes lost < 10%).
 4. Keyset event kind number and epoch length (default yearly).
 5. Admin override for re-issuance: yes or no.
 6. Length of the `days` deprecation window before PR 1.4 (default one minor release).
-7. ~~Whether the new actions bump `PROTOCOL_VER`~~ Closed: they do not. New actions ride on the unknown-variant tolerance already in the protocol; `PROTOCOL_VER` stays at 2.
+7. Width of the random redemption delay window (default 24h, section 3).
+
+Closed during review:
+
+- **Signature scheme.** Blind Schnorr on secp256k1, clause variant. BDHKE was
+  ruled out because the destination cannot verify a BDHKE token without the
+  issuer's private key.
+- **`PROTOCOL_VER`.** Stays at 2; the new actions do not gate on it (section 9).
+- **Trades vs reviews.** The first band dimension counts ratings received;
+  completed trades decide eligibility only.
+- **Fresh identity per instance.** Dropped, as incompatible with Sybil
+  resistance (section 7).

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -151,7 +151,23 @@ identity mismatch, expired epoch).
 
 ## 6. Merging on the destination
 
-Seeds are added to the user's existing values; nothing is overwritten.
+Each dimension has its own merge rule, because they measure different things:
+
+- **Completed trades add up.** A trade on A and a trade on B are distinct
+  trades, so the seed is added to the local count.
+- **Rating is a weighted average**, weighted by review count per origin. It is
+  never summed and never maxed.
+- **Account age is a maximum, never a sum.** "Days operating" answers "since
+  when does this person trade?", and that is a single date, the oldest one that
+  can be proven. Time passes in parallel on every venue, so adding day counts
+  would count the same month twice. A user who opened orders on A and B on the
+  same 10 August has 30 days on both a month later; importing A into B leaves
+  B at `max(30, 30) = 30`, not 60. With the default bands the import does not
+  even move the date: 30 days falls in `<6m`, whose floor is 0. Only a user who
+  proves 6+ months elsewhere moves `created_at`, and only when the local date
+  is more recent than that floor.
+
+Seeds are applied to the user's existing values; nothing is overwritten.
 
 | `users` column | Effect |
 |---|---|

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -56,13 +56,13 @@ migrations per day, a colluding pair can match "issued at 14:02" with
 solved, and it is bounded rather than eliminated:
 
 - The client waits a random delay before redeeming, drawn from a window wide
-  enough that many issuances fall inside it (*open decision* 8, default 24h).
+  enough that many issuances fall inside it (*open decision* 7, default 24h).
   The effective anonymity set is the number of migrations from the same
   issuer within that window, which is small on day one and grows with
   adoption.
-- Issuers store no issuance timestamp finer than the per-user flag in
-  section 6, so the correlation must be done live; it cannot be reconstructed
-  later from the database alone.
+- Issuers store no issuance timestamp finer than the day-truncated per-user
+  flag in section 5.3, so the correlation must be done live; it cannot be
+  reconstructed later from the database alone.
 - Nothing here helps the very first migrant. Anyone for whom this matters
   should wait until the issuer has processed a meaningful number of exports.
 
@@ -75,17 +75,22 @@ band means.
 
 All intervals are **half-open**, `[low, high)`, so every value falls in
 exactly one band and two implementations cannot disagree on a boundary. A
-"month" is exactly 30 days of 86400 seconds; ages are computed from
-`day_truncate(created_at)` (section 6.1) so the band does not flip mid-day.
+"month" is exactly 30 days of 86400 seconds; ages are computed from the
+day-truncated creation date (section 6.1) so the band does not flip mid-day —
+on a Mostro issuer that date is `native_created_at`, never the backdated
+`created_at` (section 7).
 
-| Dimension | Bands (*open decision*) | Floor | Seeds on the destination |
-|---|---|---|---|
-| Ratings received | `[1,10)`, `[10,50)`, `[50,200)`, `[200,∞)` | 1 / 10 / 50 / 200 | `total_reviews` += floor |
-| Average rating | `[0,4.0)`, `[4.0,4.5)`, `[4.5,5.0]` | 0.0 / 4.0 / 4.5 | `total_rating` weighted with floor |
-| Account age | `[0,6m)`, `[6m,24m)`, `[24m,∞)` | 0d / 180d / 720d | `created_at` moved back by floor |
+| Dimension (cell-id key) | Bands (*open decision*) | Cell-id labels | Floor | Seeds on the destination |
+|---|---|---|---|---|
+| Ratings received (`reviews`) | `[1,10)`, `[10,50)`, `[50,200)`, `[200,∞)` | `1-10`, `10-50`, `50-200`, `200+` | 1 / 10 / 50 / 200 | `total_reviews` += floor |
+| Average rating (`rating`) | `[0,4.0)`, `[4.0,4.5)`, `[4.5,5.0]` | `0-4.0`, `4.0-4.5`, `4.5+` | 0.0 / 4.0 / 4.5 | `total_rating` weighted with floor |
+| Account age (`age`) | `[0,6m)`, `[6m,24m)`, `[24m,∞)` | `0-6m`, `6m-24m`, `24m+` | 0d / 180d / 720d | `created_at` moved back by floor |
 
 The top rating band is closed at 5.0 because that is the maximum a rating can
-take; every other band is half-open.
+take; every other band is half-open. The cell-id labels are the exact strings
+used in keyset events and token `cell` fields (section 5.1); a label always
+names the band's low bound and, except for the open-ended top band, its high
+bound.
 
 Rules:
 
@@ -101,7 +106,7 @@ Rules:
   any cell holding fewer than `K` users (*open decision*, default 50) into an
   adjacent lower cell before publishing, so every cell is a real crowd. The
   merge is **deterministic and published**: a sparse cell steps down one band,
-  trying dimensions in the fixed order ratings, age, rating, and repeats until
+  trying dimensions in the fixed order `reviews`, `age`, `rating`, and repeats until
   the absorbing cell holds at least `K` or no lower band exists in any
   dimension, in which case it merges into the nearest non-empty lower cell.
   The resulting raw→effective map ships in the keyset, so a client can apply
@@ -149,7 +154,7 @@ without extra framing.
 | Challenge | `c = int(H_"mostro/reputation/challenge/v1"(R ‖ m)) mod n`, `R` compressed |
 | `m` | `"repv1:"` (6 ASCII bytes) ‖ 32-byte x-only destination identity pubkey ‖ 32-byte random nonce — 70 bytes exactly |
 | Token id | `H_"mostro/reputation/token/v1"(m)`, the primary key in `redeemed_reputation_tokens` |
-| Cell id | UTF-8 `reviews:<band>\|rating:<band>\|age:<band>`, no spaces, bands spelled as in section 4 |
+| Cell id | UTF-8 `reviews:<label>\|rating:<label>\|age:<label>`, no spaces, labels from the section 4 table |
 
 Points are compressed rather than x-only, and the challenge is a plain tagged
 hash rather than BIP-340's: BIP-340 normalises `R` to even Y, and the client's
@@ -186,19 +191,26 @@ destination lists as a trusted issuer, and it is the `issuer` field of every
 token. For lnp2pBot that key is `REPUTATION_ISSUER_SK`, kept separate from the
 bot's existing `NOSTR_SK` so reputation issuance can be rotated or revoked
 without disturbing the bot's other Nostr activity. A Mostro uses its daemon
-key. Keysets are rotated by **epoch** (yearly); a destination accepts
-the current and previous epoch only, so stale reputation cannot be imported
-years later and an issuer can retire keys.
+key. How an issuer derives or stores its `x_cell` scalars is its own business
+and not part of the protocol; only the `P_cell` points are.
+
+Keysets are rotated by **epoch**. The epoch label is a protocol constant, not
+an issuer choice — the UTC calendar year by default (*open decision* 4) — so
+that "current and previous epoch" means the same thing to every destination
+regardless of which issuer minted the token. A destination accepts the current
+and previous epoch only, so stale reputation cannot be imported years later
+and an issuer can retire keys.
 
 ### 5.3 Issuance (export)
 
 The blinding runs on the user's device; the issuer never sees the message it
 signs. Writing `m` for that message and `H` for the challenge hash:
 
-1. Client builds `m = "repv1:" || destination_identity_pubkey || nonce`.
+1. Client builds `m = "repv1:" ‖ destination_identity_pubkey ‖ nonce` (section 5.1).
 2. Issuer looks up the user, checks eligibility and the once-only flag, picks
-   the cell, and opens the session by sending the cell id and two nonce
-   points `R'_0 = k_0·G`, `R'_1 = k_1·G`.
+   the effective cell (raw cell folded through its own published `merges`),
+   and opens the session by sending that cell id and two nonce points
+   `R'_0 = k_0·G`, `R'_1 = k_1·G`.
 3. **Client validates the cell against its own statistics.** The user knows
    their own review count, rating and account age, so the client computes the
    raw cell, applies the keyset's published `merges` map transitively, and
@@ -284,7 +296,7 @@ Each dimension has its own merge rule, because they measure different things:
   would count the same month twice. A user who opened orders on A and B on the
   same 10 August has 30 days on both a month later; importing A into B leaves
   B at `max(30, 30) = 30`, not 60. With the default bands the import does not
-  even move the date: 30 days falls in `<6m`, whose floor is 0. Only a user who
+  even move the date: 30 days falls in `[0,6m)`, whose floor is 0. Only a user who
   proves 6+ months elsewhere moves `created_at`, and only when the local date
   is more recent than that floor.
 
@@ -327,7 +339,7 @@ eligibility:
 |---|---|---|
 | `total_reviews` | 2 | 202 |
 | `total_rating` | 4.5 | 4.5 |
-| `since` | 10 days ago | 730 days ago |
+| `since` | 10 days ago | 720 days ago |
 
 Counterparties see "4.5 · 202 reviews · trading for 2 years".
 
@@ -475,7 +487,7 @@ Independent of the migration and worth shipping first.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 2.1 | mostro-core | Module `reputation::bands`: `ReviewsBand`, `RatingBand`, `AgeBand` enums with half-open cuts and floors, `Cell { reviews, rating, age }`, `Cell::from_stats(total_reviews, avg_rating, since, now)`, `Cell::id()` / `parse()`, and `apply_merges(&MergeMap)` implementing the transitive fold. Pure, exhaustively tested against 0.2 including every boundary value. | Round-trips every cell id; boundary values land in exactly one band; the fold terminates on a cyclic map instead of looping. |
+| 2.1 | mostro-core | Module `reputation::bands`: `ReviewsBand`, `RatingBand`, `AgeBand` enums with half-open cuts and floors, `Cell { reviews, rating, age }`, `Cell::from_stats(total_reviews, avg_rating, created_at, now)` (callers pass `native_created_at` on a Mostro issuer), `Cell::id()` / `parse()`, and `apply_merges(&MergeMap)` implementing the transitive fold. Pure, exhaustively tested against 0.2 including every boundary value. | Round-trips every cell id; boundary values land in exactly one band; the fold terminates on a cyclic map instead of looping. |
 | 2.2 | mostro-core | `ReputationKeyset` (parse/build the event from 0.3, epoch handling, `cells` **and** `merges`) and `ReputationToken { issuer, epoch, cell, m, r_point, s }` with serde and shape validation. Plus `reputation::encoding`: tagged hashes, point/scalar codecs, `m` builder and parser, token id — the section 5.1 contract, no signing. | Parses the 0.5 vectors byte for byte. |
 | 2.3 | mostro-core | `src/message.rs`: `Action` variants `ExportReputation`, `ReputationExported`, `ImportReputation`, `ReputationImported` (past participle for daemon replies, matching `Released` / `Canceled`); `Payload` variants `BlindedReputationRequest(BlindedReputationRequest)`, `BlindedReputationResponse(BlindedReputationResponse)`, `ReputationToken(ReputationToken)`. `src/error.rs`: `CantDoReason` variants `UntrustedReputationIssuer`, `InvalidReputationToken`, `ReputationAlreadyRedeemed`, `ReputationIdentityMismatch`, `ExpiredReputationKeyset`, `NotEligibleForReputationExport`, `ReputationAlreadyExported`, inserted before `Unknown`. `src/prelude.rs`: `NOSTR_REPUTATION_KEYSET_KIND`. Serde round-trip tests, plus a test asserting an old client never receives these variants (`PROTOCOL_VER` stays 2, see the compatibility note above). | Part of the **minor** release. |
 | 2.4 | mostro-core | `src/user.rs`: `User` gains `seeded_reviews: i64`, `seeded_rating_sum: f64`, `native_created_at: i64`, `reputation_exported_at: Option<i64>` (day-truncated), each with `#[sqlx(default)]` and `#[serde(default)]` so a daemon on an un-migrated database still deserialises `SELECT *`. `User::new` initialises `native_created_at` to `created_at`. | First use of `sqlx(default)` in core; test with a row that lacks the columns; existing rows backfill `native_created_at` from `created_at`. |
@@ -489,14 +501,14 @@ Independent of the migration and worth shipping first.
 | 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `native_created_at` (backfilled from `created_at`) and `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(token_id PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
 | 3.3 | mostro | Crypto module `reputation::verify` over `k256` (new dependency), using `reputation::encoding` from core so the byte contract is shared: challenge hash and the `s·G == R + H(R‖m)·P_cell` check. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
 | 3.4 | mostro | Keyset fetcher: fetch and cache the issuer keyset event per trusted issuer, refresh on epoch change, reject unknown epochs. Tested with the `local-relay` feature. | Cache survives a relay outage. |
-| 3.5 | mostro | Handler `src/app/import_reputation.rs`: routing in `app.rs`, checks 1-5 of section 5.3 in one transaction, calls `User::apply_reputation_seed` from core, persists through a new `update_user_reputation_seed` in `db.rs`, replies `reputation-imported` or `cant-do`. Integration test end to end with a fixture issuer. | A second redemption of the same token is rejected. |
+| 3.5 | mostro | Handler `src/app/import_reputation.rs`: routing in `app.rs`, checks 1-5 of section 5.4 in one transaction, calls `User::apply_reputation_seed` from core, persists through a new `update_user_reputation_seed` in `db.rs`, replies `reputation-imported` or `cant-do`. Integration test end to end with a fixture issuer. | A second redemption of the same token is rejected. |
 | 3.6 | mostro | Publish the updated kind 38384 rating event after a successful import, reusing `update_user_rating_event`. | Event visible on the local relay. |
 
 ### Phase 4: mostrod as issuer (export)
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 4.1 | mostro | Settings `[reputation_export]` (`enabled`, `epoch_length`); per-cell key derivation from the daemon key and epoch (HKDF, deterministic, never stored). Unit tests: same inputs, same keys. | No publication yet. |
+| 4.1 | mostro | Settings `[reputation_export]` (`enabled`); per-cell key derivation from the daemon key and the protocol-constant epoch label (HKDF, deterministic, never stored). Unit tests: same inputs, same keys; a different epoch label yields different keys. | No publication yet. |
 | 4.2 | mostro | Publish the keyset event at startup and on epoch rollover: cell populations from the database, the deterministic merge from section 4, and both `cells` and the raw→effective `merges` map. | Event validates against 2.2; a client applying `merges` reproduces the issuer's assignment for every raw cell. |
 | 4.3 | mostro | Native stats for the export cell come from `User::native_stats` in core (reviews and rating minus the seeded part, `native_created_at` for age). `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` feeds eligibility only (full-privacy orders carry no master pubkey and are simply not counted). Tested. | Seeded values are excluded from the cell. |
 | 4.4 | mostro | Handler `export_reputation_action`: the two-round-trip clause protocol (open session with `R'_0`/`R'_1`, then answer one clause), session store with expiry, eligibility, once-only flag, `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons; an abandoned session expires without consuming the flag. |
@@ -535,7 +547,7 @@ Runs in parallel with phase 5; shares the UI copy and the localized strings.
 
 ### Phase 7: rollout
 
-1. Deploy 1.2 and 1.3 first; wait one release before 1.4.
+1. Deploy 1.2, then ship 1.3 and 1.3b; wait one release before 1.4.
 2. Deploy phase 3 on the reference instance with an empty issuer list.
 3. Deploy phase 6 on the bot and phase 4 on the reference instance; add both keys to the trust list.
 4. Ship the 1.x app with phases 5.1-5.6 and the 2.x app with phases 5b.1-5b.5.

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -263,29 +263,96 @@ issuers = [
   issuer signs a pubkey it does not see. It is bounded by eligibility, by the
   one-token rule, and by being equivalent to selling the account.
 
-## 9. Work breakdown
+## 9. Implementation plan
 
-**Protocol** (first, the others depend on it): actions `export-reputation`,
-`import-reputation`, `reputation-imported`; token payload; keyset event kind
-and schema; the band grid as a protocol constant; error reasons.
+Ordered by dependency. Each item is one pull request, small enough to be
+reviewed in full by a human and by the automated reviewers (CodeRabbit,
+Codex). A PR never mixes a protocol type change with behaviour, nor a
+migration with a handler. Every PR carries its own tests and lands green on
+its own; nothing in a later phase starts until the release it depends on is
+published.
 
-**lnp2pBot**: module `bot/modules/reputation` with the `/migrate` deep-link
-handler, issuer key from a new `REPUTATION_ISSUER_SK`, keyset publication via
-the existing `nostr` module, eligibility rules, `reputation_exported_at` on
-`User`, cell population check for `K`-anonymity before publishing.
+Repositories: `protocol` (spec), `mostro-core` (shared types, crates.io),
+`mostro` (daemon), `mobile` (app), `lnp2pbot/bot`.
 
-**Mostro**: `[reputation_import]` settings; keyset fetch and cache per
-issuer; BDHKE verify with `cdk`; migration adding `seeded_reviews`,
-`seeded_rating_sum`, `reputation_exported_at` to `users` and the table
-`redeemed_reputation_tokens(secret_hash, issuer, identity_pubkey, cell,
-redeemed_at)`; issuer side (`export-reputation`) with its own keyset and DLEQ.
+### Phase 0: specification
 
-**Mobile**: settings screen "Import reputation" listing available issuers;
-blinding, DLEQ verification and unblinding; Telegram deep-link round trip for
-the bot; random redemption delay; persisting the blinding state in Sembast so
-an interrupted flow can resume; optional "new identity on this instance"; the
-order-book rating filter already reads `total_rating`, so merged values pass
-through it unchanged.
+| PR | Repo | Scope | Done when |
+|---|---|---|---|
+| 0.1 | protocol | Add `since` to the `rating` tag and to the kind 38384 event, day-truncated Unix timestamp. Mark `days` deprecated with a removal version. | Spec merged, example events updated. |
+| 0.2 | protocol | Reputation band grid as a protocol constant: the three dimensions, cuts, floors, cell id string format (`trades:200+\|rating:4.5+\|age:24m+`), K-anonymity merge rule. | Open decisions 1-3 closed and written down. |
+| 0.3 | protocol | Issuer keyset event: kind number, `d` tag, `epoch` tag, content schema, accepted-epochs rule. | Kind number reserved. |
+| 0.4 | protocol | Actions `export-reputation`, `export-reputation-response`, `import-reputation`, `reputation-imported`; payload schemas; new `cant-do` reasons; the redemption checks in section 5.3 as normative text. | Spec merged. |
+| 0.5 | protocol | Test vectors: keyset, `B_`/`C_`/`C` for a fixed `r` and `k`, DLEQ, a valid token, and a table of invalid tokens (wrong cell, wrong identity, expired epoch). | Vectors file committed; every implementation below tests against it. |
+
+### Phase 1: `since` rollout
+
+Independent of the migration and worth shipping first.
+
+| PR | Repo | Scope | Done when |
+|---|---|---|---|
+| 1.1 | mostro-core | `Rating` gains `since: Option<u64>`; `to_tags()` emits `since` when set. Pure type change with unit tests. | Released as a patch version. |
+| 1.2 | mostro | Bump core. `create_rating_tag` emits `days` **and** `since`; `rate_user` pushes a `since` tag next to `days`; one shared `day_truncate(created_at)` helper. Unit tests on both emitters. | Both events carry both fields on a local relay. |
+| 1.3 | mobile | `Rating` model parses `since`, falls back to `days` when absent; age is computed at display time from `since`. Tests for both shapes. | Old and new daemons render the same age. |
+| 1.4 | mostro | Remove `days` after the deprecation window (open decision: one minor release). | Removed with a changelog entry. |
+
+### Phase 2: shared types in mostro-core
+
+| PR | Repo | Scope | Done when |
+|---|---|---|---|
+| 2.1 | mostro-core | Module `reputation::bands`: `TradesBand`, `RatingBand`, `AgeBand` enums with cuts and floors, `Cell { trades, rating, age }`, `Cell::from_stats(trades, avg_rating, since, now)`, `Cell::id()` / `parse()`. Pure, exhaustively tested against 0.2. | Round-trips every cell id. |
+| 2.2 | mostro-core | `ReputationKeyset` (parse/build the event from 0.3, epoch handling) and `ReputationToken { issuer, epoch, cell, secret, c }` with serde and shape validation. No crypto. | Parses the 0.5 vectors. |
+| 2.3 | mostro-core | `Action` variants `ExportReputation`, `ExportReputationResponse`, `ImportReputation`, `ReputationImported`; `Payload` variants `BlindedReputationRequest { b }`, `BlindedReputationResponse { c, cell, dleq }`, `ReputationToken`; `CantDoReason` variants `UntrustedIssuer`, `InvalidReputationToken`, `ReputationAlreadyRedeemed`, `ReputationIdentityMismatch`, `ExpiredKeysetEpoch`, `NotEligibleForExport`, `ReputationAlreadyExported`. Serde round-trip tests. | Released as a minor version. |
+
+### Phase 3: mostrod as destination (import)
+
+| PR | Repo | Scope | Done when |
+|---|---|---|---|
+| 3.1 | mostro | Settings section `[reputation_import]` (`enabled`, `issuers`, `accepted_epochs`) with parsing, defaults and validation. No behaviour. | Bad config is rejected at startup with a clear error. |
+| 3.2 | mostro | Migration: `users` gains `seeded_reviews`, `seeded_rating_sum`, `reputation_exported_at`; new table `redeemed_reputation_tokens(secret_hash PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database. |
+| 3.3 | mostro | Crypto module `reputation::verify`: `hash_to_curve`, unblinded-signature verification and DLEQ verification on top of `cdk`. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
+| 3.4 | mostro | Keyset fetcher: fetch and cache the issuer keyset event per trusted issuer, refresh on epoch change, reject unknown epochs. Tested with the `local-relay` feature. | Cache survives a relay outage. |
+| 3.5 | mostro | Pure merge: `apply_seed(&mut User, &Cell, now)` implementing section 6 (trades add, weighted rating, `since` min, seeded counters). Property tests: never decreases `total_reviews`, never moves `created_at` forward, idempotent per issuer. | No I/O in the function. |
+| 3.6 | mostro | Handler `import_reputation_action`: routing in `app.rs`, checks 1-5 of section 5.3 in one transaction, reply `reputation-imported` or `cant-do`. Integration test end to end with a fixture issuer. | A second redemption of the same token is rejected. |
+| 3.7 | mostro | Publish the updated kind 38384 rating event after a successful import. | Event visible on the local relay. |
+
+### Phase 4: mostrod as issuer (export)
+
+| PR | Repo | Scope | Done when |
+|---|---|---|---|
+| 4.1 | mostro | Settings `[reputation_export]` (`enabled`, `epoch_length`); per-cell key derivation from the daemon key and epoch (HKDF, deterministic, never stored). Unit tests: same inputs, same keys. | No publication yet. |
+| 4.2 | mostro | Publish the keyset event at startup and on epoch rollover, with the K-anonymity merge from section 4 using cell populations from the database. | Event validates against 2.2. |
+| 4.3 | mostro | Native stats: `native_stats(identity)` = completed orders for the identity, native rating from `seeded_rating_sum`, `since` from `created_at`. Query plus pure function, tested. | Seeded values are excluded. |
+| 4.4 | mostro | Handler `export_reputation_action`: eligibility, once-only flag, blind signature with `cdk`, DLEQ, reply; sets `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons. |
+
+### Phase 5: mobile
+
+| PR | Repo | Scope | Done when |
+|---|---|---|---|
+| 5.1 | mobile | BDHKE client primitives in Dart: `hashToCurve`, blind, unblind, DLEQ verify, over secp256k1. Tested against the 0.5 vectors. | No UI, no services. |
+| 5.2 | mobile | Models: keyset event parser, `ReputationToken`, band cell; `MostroMessage` support for the new actions and payloads. | Serde round-trip tests. |
+| 5.3 | mobile | Storage: Sembast repository for tokens and for in-flight blinding state (`r`, `secret`, issuer) so an interrupted flow resumes. | Survives app restart in a test. |
+| 5.4 | mobile | `MostroService` + notifier: `exportReputation(issuer)` and `importReputation(token)` flows against a Mostro issuer, with the random redemption delay. | Integration test against a local daemon from 4.4. |
+| 5.5 | mobile | Telegram transport: open `t.me/lnp2pbot?start=migrate_<B_>`, receive the response through the app's deep link scheme, verify DLEQ, store token. | Manual test with the bot from phase 6. |
+| 5.6 | mobile | Settings screen "Import reputation": issuer list from the selected node's trust list, status per issuer, localized strings in every `intl_*.arb`. | `flutter analyze` clean, gen-l10n reports no untranslated keys. |
+| 5.7 | mobile | Optional: "use a new identity on this instance" when importing. | Separate PR, can slip. |
+
+### Phase 6: lnp2pBot as issuer
+
+| PR | Repo | Scope | Done when |
+|---|---|---|---|
+| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation; per-cell key derivation (same HKDF scheme as 4.1); `@cashu/crypto` dependency. Unit tests on derivation. | No command yet. |
+| 6.2 | bot | Publish the keyset event through the existing `nostr` module at startup, with the K-anonymity merge computed from Mongo. | Event validates against 2.2. |
+| 6.3 | bot | `User.reputation_exported_at`; `computeCell(user)` and `isEligible(user)` in `util/` using `trades_completed`, `total_rating`, `disputes`, `banned`, `created_at`. Tests on band edges. | Pure functions only. |
+| 6.4 | bot | `/start migrate_<B_>` handler: parse, eligibility, once-only, blind sign, DLEQ, reply with the app deep link; error messages in every locale YAML. Tests with a mocked user. | Round trip with 5.5. |
+
+### Phase 7: rollout
+
+1. Deploy 1.2 and 1.3 first; wait one release before 1.4.
+2. Deploy phase 3 on the reference instance with an empty issuer list.
+3. Deploy phase 6 on the bot and phase 4 on the reference instance; add both keys to the trust list.
+4. Ship the app with phases 5.1-5.6.
+5. Document the operator side (`docs/REPUTATION_PORTABILITY.md`, settings template) and the user side (mobile in-app help).
 
 ## 10. Open decisions
 
@@ -294,3 +361,4 @@ through it unchanged.
 3. Eligibility minimums (default 10 trades, disputes lost < 10%).
 4. Keyset event kind number and epoch length (default yearly).
 5. Admin override for re-issuance: yes or no.
+6. Length of the `days` deprecation window before PR 1.4 (default one minor release).

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -99,7 +99,13 @@ Rules:
   earned; the destination shows a conservative lower bound.
 - Cells are the leaves of the issuer keyset (section 5). An issuer must merge
   any cell holding fewer than `K` users (*open decision*, default 50) into an
-  adjacent lower cell before publishing, so every cell is a real crowd.
+  adjacent lower cell before publishing, so every cell is a real crowd. The
+  merge is **deterministic and published**: a sparse cell steps down one band,
+  trying dimensions in the fixed order ratings, age, rating, and repeats until
+  the absorbing cell holds at least `K` or no lower band exists in any
+  dimension, in which case it merges into the nearest non-empty lower cell.
+  The resulting raw→effective map ships in the keyset, so a client can apply
+  the same map and check the issuer followed it.
 - Eligibility (*open decision*): at least 10 completed trades **and** at least
   1 rating received, not banned, and disputes lost below 10% of completed
   trades. Below eligibility the issuer refuses and there is nothing to
@@ -128,7 +134,29 @@ Implementations need scalar and point arithmetic on secp256k1, not a Cashu
 library: `k256` in mostro and in the 2.x app's Rust core, `@noble/curves` in
 the bot, and a small Dart implementation in the 1.x app.
 
-### 5.1 Issuer keyset
+### 5.1 Canonical encoding
+
+Everything hashed or transmitted has exactly one byte encoding, so the Rust,
+JavaScript and Dart implementations cannot derive different challenges for the
+same token. Every field is fixed length, which makes concatenation unambiguous
+without extra framing.
+
+| Element | Encoding |
+|---|---|
+| Curve points | 33-byte compressed SEC1 (`0x02`/`0x03` prefix) |
+| Scalars | 32-byte big-endian, reduced mod `n`, rejected if zero |
+| Tagged hash | `H_tag(x) = SHA256(SHA256(tag) ‖ SHA256(tag) ‖ x)`, as in BIP-340 |
+| Challenge | `c = int(H_"mostro/reputation/challenge/v1"(R ‖ m)) mod n`, `R` compressed |
+| `m` | `"repv1:"` (6 ASCII bytes) ‖ 32-byte x-only destination identity pubkey ‖ 32-byte random nonce — 70 bytes exactly |
+| Token id | `H_"mostro/reputation/token/v1"(m)`, the primary key in `redeemed_reputation_tokens` |
+| Cell id | UTF-8 `reviews:<band>\|rating:<band>\|age:<band>`, no spaces, bands spelled as in section 4 |
+
+Points are compressed rather than x-only, and the challenge is a plain tagged
+hash rather than BIP-340's: BIP-340 normalises `R` to even Y, and the client's
+blinded `R_i = R'_i + α_i·G + β_i·P_cell` has unpredictable parity that the
+signer cannot compensate for, so x-only encoding would break the blinding.
+
+### 5.2 Issuer keyset
 
 An issuer holds one secret scalar `x_cell` per grid cell and publishes the
 public points `P_cell = x_cell·G` as a parameterised replaceable Nostr event
@@ -137,20 +165,32 @@ signed with the issuer's own key:
 ```text
 kind: 30xxx (open decision)
 tags: ["d", "reputation-keyset:2026"], ["epoch", "2026"]
-content: {"cells": {"reviews:200+|rating:4.5+|age:24m+": "<hex P>", ...}}
+content: {
+  "cells":  {"reviews:200+|rating:4.5+|age:24m+": "<hex compressed P>", ...},
+  "merges": {"reviews:200+|rating:0-4.0|age:24m+": "reviews:50-200|rating:0-4.0|age:24m+", ...}
+}
 ```
+
+`cells` holds only the **effective** cells, the ones that actually have a key.
+`merges` is the published map from every raw cell that was folded away to the
+cell that absorbed it, so the client can reproduce the issuer's choice instead
+of having to trust it (section 5.3, step 3).
 
 The epoch is part of the `d` tag, not only a separate tag. Addressable events
 replace on `(kind, pubkey, d)`, so a fixed `d` would make each rotation
 **delete the previous keyset** from relays and leave the destination unable to
 verify tokens from the epoch it still accepts.
 
-lnp2pBot publishes with its existing `NOSTR_SK`. A Mostro publishes with its
-daemon key. Keysets are rotated by **epoch** (yearly); a destination accepts
+The issuer's identity is **one key**: it signs the keyset event, it is what a
+destination lists as a trusted issuer, and it is the `issuer` field of every
+token. For lnp2pBot that key is `REPUTATION_ISSUER_SK`, kept separate from the
+bot's existing `NOSTR_SK` so reputation issuance can be rotated or revoked
+without disturbing the bot's other Nostr activity. A Mostro uses its daemon
+key. Keysets are rotated by **epoch** (yearly); a destination accepts
 the current and previous epoch only, so stale reputation cannot be imported
 years later and an issuer can retire keys.
 
-### 5.2 Issuance (export)
+### 5.3 Issuance (export)
 
 The blinding runs on the user's device; the issuer never sees the message it
 signs. Writing `m` for that message and `H` for the challenge hash:
@@ -160,11 +200,15 @@ signs. Writing `m` for that message and `H` for the challenge hash:
    the cell, and opens the session by sending the cell id and two nonce
    points `R'_0 = k_0·G`, `R'_1 = k_1·G`.
 3. **Client validates the cell against its own statistics.** The user knows
-   their own review count, rating and account age, so the client recomputes
-   the cell and aborts if the issuer named a different one. Without this
-   check an adversarial issuer could tag a user by assigning a deliberately
-   rare cell and recognise it at redemption; no proof about the signature
-   itself would catch that, because the signature would be perfectly valid.
+   their own review count, rating and account age, so the client computes the
+   raw cell, applies the keyset's published `merges` map transitively, and
+   aborts if the result differs from the cell the issuer named. Applying the
+   map is what makes this compatible with K-anonymity merging: a user whose
+   raw cell was folded away still validates, because the client folds it the
+   same way. Without this check an adversarial issuer could tag a user by
+   assigning a deliberately rare cell and recognise it at redemption; no
+   proof about the signature itself would catch that, because the signature
+   would be perfectly valid.
 4. Client picks random `α_i`, `β_i` for each clause, computes
    `R_i = R'_i + α_i·G + β_i·P_cell` and `c'_i = H(R_i ‖ m) + β_i`, and sends
    both `c'_i`.
@@ -192,7 +236,14 @@ The session is stateful across the two round trips, so both the issuer and the
 client persist it; an abandoned session expires and does not consume the
 once-only flag.
 
-### 5.3 Redemption (import)
+`reputation_exported_at` is stored **day-truncated**, with the same
+`day_truncate` helper as `since` (section 6.1). It exists only to enforce the
+once-only rule, and a second-precision value would hand a leaked source
+database exactly the timestamp needed to correlate an export with a redemption
+— the correlation section 3 tries to bound. Session state, which is
+necessarily fine-grained, is deleted when the session completes or expires.
+
+### 5.4 Redemption (import)
 
 A new action `import-reputation` carrying the token, sent over the daemon's
 ordinary protocol transport. The destination daemon:
@@ -207,8 +258,9 @@ ordinary protocol transport. The destination daemon:
    to the trade pubkey authoring the event, so it cannot be grafted from
    another sender. This binds the token to one identity; selling it means
    handing over the key, which is the same risk as selling the account today.
-4. Checks `hash(m)` is not in `redeemed_reputation_tokens`, and that this
-   `(issuer, identity)` pair has not been redeemed before.
+4. Checks the token id `H_"mostro/reputation/token/v1"(m)` (section 5.1) is
+   not in `redeemed_reputation_tokens`, and that this `(issuer, identity)`
+   pair has not been redeemed before.
 5. Inserts the redemption and seeds the user row (section 6) in the same
    transaction.
 
@@ -247,10 +299,18 @@ effect.
 |---|---|
 | `total_reviews` | `+= reviews_floor` |
 | `total_rating` | recomputed as the weighted average of the existing average and the seed floor |
-| `created_at` | `= min(created_at, now - age_floor)` |
+| `created_at` | `= min(created_at, now - age_floor)` — the displayed age |
+| `native_created_at` (new) | **unchanged**; the account's own creation date, never backdated |
 | `min_rating`, `max_rating`, `last_rating` | unchanged if non-zero, otherwise set to `round(rating_floor)` |
 | `seeded_reviews` (new) | `+= reviews_floor`, internal only |
 | `seeded_rating_sum` (new) | `+= reviews_floor * rating_floor`, internal only |
+
+`native_created_at` is set once, when the row is created, and no import ever
+moves it. Without it the age dimension would leak across hops: A→B backdates
+B's `created_at`, and B exporting to C would then present A's age as its own
+native age, so a seed would travel twice. Reviews and rating are protected the
+same way by `seeded_reviews` and `seeded_rating_sum`; age needs its own field
+because the merge is a minimum rather than a subtraction.
 
 The public `rating` tag on order events keeps its three-field shape:
 `{"total_reviews", "total_rating", "since"}` (see 6.1). No `legacy` marker is published.
@@ -306,8 +366,9 @@ new peers interoperate during the window.
 ## 7. Mostro-to-Mostro specifics
 
 - **Only native reputation is exportable.** When a Mostro acts as issuer it
-  computes the cell from `total_reviews - seeded_reviews` and the native
-  rating derived from `seeded_rating_sum`. Seeds never travel twice, which
+  computes the cell from `total_reviews - seeded_reviews`, the native rating
+  derived from `seeded_rating_sum`, and `native_created_at` rather than the
+  backdated `created_at`. Seeds never travel twice, which
   rules out A→B→A doubling and A→B→C chains. A user who wants A and C on B
   redeems one token from each; the destination records each issuer once per
   identity.
@@ -393,10 +454,10 @@ reasoning.
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
 | 0.1 | protocol | Add `since` to the `rating` tag and to the kind 38384 event, day-truncated Unix timestamp. Mark `days` deprecated with a removal version. | Spec merged, example events updated. |
-| 0.2 | protocol | Reputation band grid as a protocol constant: the three dimensions, cuts, floors, cell id string format (`reviews:200+\|rating:4.5+\|age:24m+`), K-anonymity merge rule. | Open decisions 1-3 closed and written down. |
+| 0.2 | protocol | Reputation band grid as a protocol constant: the three dimensions, cuts, floors, cell id string format (`reviews:200+\|rating:4.5+\|age:24m+`), the deterministic K-anonymity merge rule and its raw→effective map. | Open decisions 1-3 closed and written down. |
 | 0.3 | protocol | Issuer keyset event: kind number, `d` tag, `epoch` tag, content schema, accepted-epochs rule. | Kind number reserved. |
-| 0.4 | protocol | Actions `export-reputation`, `export-reputation-response`, `import-reputation`, `reputation-imported`; payload schemas; new `cant-do` reasons; the redemption checks in section 5.3 as normative text. | Spec merged. |
-| 0.5 | protocol | Test vectors: keyset; a full clause-blind-Schnorr transcript (`x_cell`, `k_0`, `k_1`, `α_i`, `β_i`, `R_i`, `c'_i`, `b`, `s'_b`, `s`) for fixed randomness; a valid token; and a table of invalid tokens (wrong cell key, wrong identity, expired epoch, mauled `s`, mauled `R`). | Vectors file committed; every implementation below tests against it. |
+| 0.4 | protocol | Actions `export-reputation`, `reputation-exported`, `import-reputation`, `reputation-imported` — those four kebab-case strings are the wire discriminators, used verbatim in the schema, the core enum serialization, the compatibility note and the vectors. Payload schemas; new `cant-do` reasons; the redemption checks in section 5.4 as normative text. | Spec merged; one name per action across every document. |
+| 0.5 | protocol | Test vectors for the section 5.1 encoding (tagged hashes, point and scalar bytes, a canonical `m`, a cell id and a token id); keyset with a `merges` map; a full clause-blind-Schnorr transcript (`x_cell`, `k_0`, `k_1`, `α_i`, `β_i`, `R_i`, `c'_i`, `b`, `s'_b`, `s`) for fixed randomness; a valid token; and a table of invalid tokens (wrong cell key, wrong identity, expired epoch, mauled `s`, mauled `R`). | Vectors file committed; every implementation below tests against it. |
 
 ### Phase 1: `since` rollout
 
@@ -414,19 +475,19 @@ Independent of the migration and worth shipping first.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 2.1 | mostro-core | Module `reputation::bands`: `ReviewsBand`, `RatingBand`, `AgeBand` enums with half-open cuts and floors, `Cell { reviews, rating, age }`, `Cell::from_stats(total_reviews, avg_rating, since, now)`, `Cell::id()` / `parse()`. Pure, exhaustively tested against 0.2 including every boundary value. | Round-trips every cell id; boundary values land in exactly one band. |
-| 2.2 | mostro-core | `ReputationKeyset` (parse/build the event from 0.3, epoch handling) and `ReputationToken { issuer, epoch, cell, m, r_point, s }` with serde and shape validation. No crypto. | Parses the 0.5 vectors. |
+| 2.1 | mostro-core | Module `reputation::bands`: `ReviewsBand`, `RatingBand`, `AgeBand` enums with half-open cuts and floors, `Cell { reviews, rating, age }`, `Cell::from_stats(total_reviews, avg_rating, since, now)`, `Cell::id()` / `parse()`, and `apply_merges(&MergeMap)` implementing the transitive fold. Pure, exhaustively tested against 0.2 including every boundary value. | Round-trips every cell id; boundary values land in exactly one band; the fold terminates on a cyclic map instead of looping. |
+| 2.2 | mostro-core | `ReputationKeyset` (parse/build the event from 0.3, epoch handling, `cells` **and** `merges`) and `ReputationToken { issuer, epoch, cell, m, r_point, s }` with serde and shape validation. Plus `reputation::encoding`: tagged hashes, point/scalar codecs, `m` builder and parser, token id — the section 5.1 contract, no signing. | Parses the 0.5 vectors byte for byte. |
 | 2.3 | mostro-core | `src/message.rs`: `Action` variants `ExportReputation`, `ReputationExported`, `ImportReputation`, `ReputationImported` (past participle for daemon replies, matching `Released` / `Canceled`); `Payload` variants `BlindedReputationRequest(BlindedReputationRequest)`, `BlindedReputationResponse(BlindedReputationResponse)`, `ReputationToken(ReputationToken)`. `src/error.rs`: `CantDoReason` variants `UntrustedReputationIssuer`, `InvalidReputationToken`, `ReputationAlreadyRedeemed`, `ReputationIdentityMismatch`, `ExpiredReputationKeyset`, `NotEligibleForReputationExport`, `ReputationAlreadyExported`, inserted before `Unknown`. `src/prelude.rs`: `NOSTR_REPUTATION_KEYSET_KIND`. Serde round-trip tests, plus a test asserting an old client never receives these variants (`PROTOCOL_VER` stays 2, see the compatibility note above). | Part of the **minor** release. |
-| 2.4 | mostro-core | `src/user.rs`: `User` gains `seeded_reviews: i64`, `seeded_rating_sum: f64`, `reputation_exported_at: Option<i64>`, each with `#[sqlx(default)]` and `#[serde(default)]` so a daemon on an un-migrated database still deserialises `SELECT *`. `User::new` initialises them. | First use of `sqlx(default)` in core; test with a row that lacks the columns. |
-| 2.5 | mostro-core | `src/user.rs`: `User::apply_reputation_seed(&mut self, cell: &Cell, now: i64)` implementing section 6 next to `update_rating`, plus `User::native_stats(&self) -> (reviews, rating, since)` that subtracts the seeded part. Property tests: never decreases `total_reviews`, never moves `created_at` forward, idempotent per issuer. | No I/O; released as **0.15.0** together with 2.1-2.4. |
+| 2.4 | mostro-core | `src/user.rs`: `User` gains `seeded_reviews: i64`, `seeded_rating_sum: f64`, `native_created_at: i64`, `reputation_exported_at: Option<i64>` (day-truncated), each with `#[sqlx(default)]` and `#[serde(default)]` so a daemon on an un-migrated database still deserialises `SELECT *`. `User::new` initialises `native_created_at` to `created_at`. | First use of `sqlx(default)` in core; test with a row that lacks the columns; existing rows backfill `native_created_at` from `created_at`. |
+| 2.5 | mostro-core | `src/user.rs`: `User::apply_reputation_seed(&mut self, cell: &Cell, now: i64)` implementing section 6 next to `update_rating`, plus `User::native_stats(&self) -> (reviews, rating, since)` that subtracts the seeded part and reads `native_created_at`, never `created_at`. Property tests: never decreases `total_reviews`, never moves `created_at` forward, never touches `native_created_at`, and an A→B→C chain exports the same native stats B had before importing from A. | No I/O; released as **0.15.0** together with 2.1-2.4. |
 
 ### Phase 3: mostrod as destination (import)
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
 | 3.1 | mostro | Settings section `[reputation_import]` (`enabled`, `issuers`, `accepted_epochs`) with parsing, defaults and validation. No behaviour. | Bad config is rejected at startup with a clear error. |
-| 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(secret_hash PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
-| 3.3 | mostro | Crypto module `reputation::verify` over `k256` (new dependency): challenge hash and the `s·G == R + H(R‖m)·P_cell` check. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
+| 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `native_created_at` (backfilled from `created_at`) and `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(token_id PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
+| 3.3 | mostro | Crypto module `reputation::verify` over `k256` (new dependency), using `reputation::encoding` from core so the byte contract is shared: challenge hash and the `s·G == R + H(R‖m)·P_cell` check. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
 | 3.4 | mostro | Keyset fetcher: fetch and cache the issuer keyset event per trusted issuer, refresh on epoch change, reject unknown epochs. Tested with the `local-relay` feature. | Cache survives a relay outage. |
 | 3.5 | mostro | Handler `src/app/import_reputation.rs`: routing in `app.rs`, checks 1-5 of section 5.3 in one transaction, calls `User::apply_reputation_seed` from core, persists through a new `update_user_reputation_seed` in `db.rs`, replies `reputation-imported` or `cant-do`. Integration test end to end with a fixture issuer. | A second redemption of the same token is rejected. |
 | 3.6 | mostro | Publish the updated kind 38384 rating event after a successful import, reusing `update_user_rating_event`. | Event visible on the local relay. |
@@ -436,8 +497,8 @@ Independent of the migration and worth shipping first.
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
 | 4.1 | mostro | Settings `[reputation_export]` (`enabled`, `epoch_length`); per-cell key derivation from the daemon key and epoch (HKDF, deterministic, never stored). Unit tests: same inputs, same keys. | No publication yet. |
-| 4.2 | mostro | Publish the keyset event at startup and on epoch rollover, with the K-anonymity merge from section 4 using cell populations from the database. | Event validates against 2.2. |
-| 4.3 | mostro | Native stats for the export cell come from `User::native_stats` in core (reviews and rating minus the seeded part, `created_at` for age). `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` feeds eligibility only (full-privacy orders carry no master pubkey and are simply not counted). Tested. | Seeded values are excluded from the cell. |
+| 4.2 | mostro | Publish the keyset event at startup and on epoch rollover: cell populations from the database, the deterministic merge from section 4, and both `cells` and the raw→effective `merges` map. | Event validates against 2.2; a client applying `merges` reproduces the issuer's assignment for every raw cell. |
+| 4.3 | mostro | Native stats for the export cell come from `User::native_stats` in core (reviews and rating minus the seeded part, `native_created_at` for age). `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` feeds eligibility only (full-privacy orders carry no master pubkey and are simply not counted). Tested. | Seeded values are excluded from the cell. |
 | 4.4 | mostro | Handler `export_reputation_action`: the two-round-trip clause protocol (open session with `R'_0`/`R'_1`, then answer one clause), session store with expiry, eligibility, once-only flag, `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons; an abandoned session expires without consuming the flag. |
 
 ### Phase 5: mobile (app 1.x, `mobile`)
@@ -467,9 +528,9 @@ Runs in parallel with phase 5; shares the UI copy and the localized strings.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation; per-cell key derivation (same HKDF scheme as 4.1); `@noble/curves` dependency for secp256k1 arithmetic. Unit tests on derivation. | No command yet. |
-| 6.2 | bot | Publish the keyset event through the existing `nostr` module at startup, with the K-anonymity merge computed from Mongo. | Event validates against 2.2. |
-| 6.3 | bot | `User.reputation_exported_at`; `computeCell(user)` and `isEligible(user)` in `util/`, the cell from `total_reviews`, `total_rating` and `created_at`, eligibility from `trades_completed`, `disputes` and `banned`. Tests on band edges. | Pure functions only. |
+| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation — this is the bot's issuer identity: it signs the keyset, appears in trusted lists and fills the token `issuer` field, and is deliberately not `NOSTR_SK`. Per-cell key derivation from it (same HKDF scheme as 4.1); `@noble/curves` dependency for secp256k1 arithmetic. Unit tests on derivation. | No command yet; the derived pubkey matches what 6.2 publishes. |
+| 6.2 | bot | Publish the keyset event through the existing `nostr` module at startup, signed with `REPUTATION_ISSUER_SK`, with the deterministic merge and its `merges` map computed from Mongo. | Event validates against 2.2. |
+| 6.3 | bot | `User.reputation_exported_at` (day-truncated); `computeCell(user)` and `isEligible(user)` in `util/`, the cell from `total_reviews`, `total_rating` and `created_at`, eligibility from `trades_completed`, `disputes` and `banned`. Tests on band edges. | Pure functions only. |
 | 6.4 | bot | `/start migrate_...` handler: the two round trips (open session, then answer one clause), session store with expiry, eligibility, once-only, reply with the app deep link; error messages in every locale YAML. Tests with a mocked user. | Round trip with 5.5. |
 
 ### Phase 7: rollout
@@ -500,3 +561,15 @@ Closed during review:
   completed trades decide eligibility only.
 - **Fresh identity per instance.** Dropped, as incompatible with Sybil
   resistance (section 7).
+- **Canonical encoding.** Fixed in section 5.1: compressed points, big-endian
+  scalars, BIP-340-style tagged hashes, a fixed-length 70-byte `m`. Points are
+  not x-only because even-Y normalisation would break the blinding.
+- **K-anonymity vs client validation.** The merge is deterministic and its
+  raw→effective map ships in the keyset, so the client folds its own cell the
+  same way instead of aborting.
+- **Native account age.** `native_created_at` is never backdated, so an
+  imported age cannot be re-exported as native.
+- **Issuer identity.** One key per issuer; for the bot that is
+  `REPUTATION_ISSUER_SK`, not `NOSTR_SK`.
+- **Action naming.** `reputation-exported` is the wire name for the export
+  response, everywhere.

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -179,7 +179,7 @@ Seeds are applied to the user's existing values; nothing is overwritten.
 | `seeded_rating_sum` (new) | `+= trades_floor * rating_floor`, internal only |
 
 The public `rating` tag on order events is unchanged in shape:
-`{"total_reviews", "total_rating", "days"}`. No `legacy` marker is published.
+`{"total_reviews", "total_rating", "since"}` (see 6.1). No `legacy` marker is published.
 The seeded review count acts as an anchor, so new ratings move the average
 slowly, exactly as they would for a long-standing Mostro user.
 
@@ -190,9 +190,30 @@ lnp2pBot where they have 347 trades, 4.87 average, 3 years:
 |---|---|---|
 | `total_reviews` | 2 | 202 |
 | `total_rating` | 4.5 | 4.5 |
-| `days` | 10 | 730 |
+| `since` | 10 days ago | 730 days ago |
 
-Counterparties see "4.5 · 202 reviews · 2 years".
+Counterparties see "4.5 · 202 reviews · trading for 2 years".
+
+### 6.1 Publish `since` instead of `days`
+
+`days` is derived at publish time, so it is stale on any event that lives on
+relays for a while, and it is awkward to merge. The underlying datum is a
+date, so the public field should be one:
+
+```json
+{"total_reviews": 202, "total_rating": 4.5, "since": 1693526400}
+```
+
+`since` is a Unix timestamp **truncated to the start of its UTC day**
+(`created_at - created_at % 86400`). Second precision would be a unique
+fingerprint for the user, and the rating tag already travels on every order
+of the same user, so it would make trade pubkeys perfectly correlatable.
+Day precision carries exactly the information `days` carries today.
+
+Clients compute the age at display time. The merge rule in section 6 becomes
+`since = min(since_local, since_seed)`. The daemon publishes both `days` and
+`since` for one deprecation window, in the order rating tag and in the
+kind 38384 rating event, then drops `days`.
 
 ## 7. Mostro-to-Mostro specifics
 

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -290,7 +290,15 @@ its own; nothing in a later phase starts until the release it depends on is
 published.
 
 Repositories: `protocol` (spec), `mostro-core` (shared types, crates.io),
-`mostro` (daemon), `mobile` (app), `lnp2pbot/bot`.
+`mostro` (daemon), `mobile` (app 1.x, pure Dart), `app` (app 2.x, Flutter UI
+over a Rust core through flutter_rust_bridge, already on mostro-core, nostr-sdk
+0.45 and cdk), `lnp2pbot/bot`.
+
+Both apps must support the migration. They differ in where the work lands:
+the 1.x app needs its own Dart implementation of everything (BDHKE, models,
+parsing), while the 2.x app gets the types from mostro-core and the BDHKE
+primitives from cdk inside its Rust core, and only adds bridge functions and
+UI on the Dart side.
 
 ### Phase 0: specification
 
@@ -311,6 +319,7 @@ Independent of the migration and worth shipping first.
 | 1.1 | mostro-core | `src/rating.rs`: `Rating` gains `since: Option<u64>` (serde default); `to_tags()` emits a `since` tag when set, `from_tags()` parses it; `Rating::new` keeps its signature and a `with_since(u64)` builder is added so no caller breaks. `src/user.rs`: `UserInfo` gains `since: Option<u64>` (serde default). Unit tests for both round trips. | Released as a **patch** (0.14.7): additive, no signature changes. |
 | 1.2 | mostro | Bump core. One helper `day_truncate(created_at) -> u64` in `util.rs`. `create_rating_tag` (`nip33.rs`) emits `days` **and** `since`; `rate_user.rs` builds the `Rating` with `.with_since()` and keeps pushing the `days` tag; the `UserInfo` built in `util.rs` fills `since`. Unit tests on the three emitters. | All three sites carry both fields on a local relay. |
 | 1.3 | mobile | `data/models/rating.dart` parses `since` and falls back to `days`; `data/models/user_info.dart` parses `since` and falls back to `operating_days`; age is computed at display time. Tests for both shapes. | Old and new daemons render the same age. |
+| 1.3b | app | Rust core: `nostr/order_events.rs::parse_rating_tag` reads `since` and falls back to `days`; `mostro/status.rs` maps `UserInfo.since` with fallback to `operating_days`; bump mostro-core to 0.14.7. Bridge exposes `since` and the Dart side (`peer_reputation_card.dart`, trade detail) computes the age at display time. Tests for both shapes. | Old and new daemons render the same age. |
 | 1.4 | mostro | Remove `days` and `operating_days` emission after the deprecation window (open decision 6). `UserInfo.operating_days` removal in core is a **minor** bump and goes with PR 2.3. | Removed with a changelog entry. |
 
 ### Phase 2: shared types in mostro-core
@@ -343,7 +352,7 @@ Independent of the migration and worth shipping first.
 | 4.3 | mostro | Native trade count: `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` (full-privacy orders carry no master pubkey and are simply not counted). Combined with `User::native_stats` from core into the export cell. Tested. | Seeded values are excluded. |
 | 4.4 | mostro | Handler `export_reputation_action`: eligibility, once-only flag, blind signature with `cdk`, DLEQ, reply; sets `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons. |
 
-### Phase 5: mobile
+### Phase 5: mobile (app 1.x, `mobile`)
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
@@ -354,6 +363,19 @@ Independent of the migration and worth shipping first.
 | 5.5 | mobile | Telegram transport: open `t.me/lnp2pbot?start=migrate_<B_>`, receive the response through the app's deep link scheme, verify DLEQ, store token. | Manual test with the bot from phase 6. |
 | 5.6 | mobile | Settings screen "Import reputation": issuer list from the selected node's trust list, status per issuer, localized strings in every `intl_*.arb`. | `flutter analyze` clean, gen-l10n reports no untranslated keys. |
 | 5.7 | mobile | Optional: "use a new identity on this instance" when importing. | Separate PR, can slip. |
+
+### Phase 5b: app 2.x (`app`)
+
+Runs in parallel with phase 5; shares the UI copy and the localized strings.
+
+| PR | Repo | Scope | Done when |
+|---|---|---|---|
+| 5b.1 | app | Rust core: bump mostro-core to 0.15.0 so `Cell`, `ReputationKeyset`, `ReputationToken`, the new `Action` / `Payload` / `CantDoReason` variants come from core. Add `rust/src/mostro/reputation.rs` with blind, unblind and DLEQ verify over `cdk`'s BDHKE (no new dependency). Tested against the 0.5 vectors. | No bridge, no UI. |
+| 5b.2 | app | Rust core: token and in-flight blinding state persisted in the existing SQLite (native) / IndexedDB (web) layer, so an interrupted flow resumes on every platform. | Survives restart in a test on native and WASM. |
+| 5b.3 | app | Rust core: `export_reputation(issuer)` and `import_reputation(token)` flows against a Mostro issuer through the existing message queue, with the random redemption delay; keyset fetch and cache per trusted issuer. Bridge functions exposed through flutter_rust_bridge (generated, never hand-written). | Integration test against the local daemon from 4.4. |
+| 5b.4 | app | Telegram transport: open `t.me/lnp2pbot?start=migrate_<B_>` from Dart, receive the response through the app's deep link scheme on mobile and through a paste field on desktop and web, hand it to the Rust core for DLEQ verification. | Manual test with the bot from phase 6. |
+| 5b.5 | app | Dart UI: settings screen "Import reputation" reusing the 1.x copy, localized in every ARB under `lib/l10n/`. | `flutter analyze` clean, no untranslated keys. |
+| 5b.6 | app | Optional: "use a new identity on this instance" when importing. | Separate PR, can slip. |
 
 ### Phase 6: lnp2pBot as issuer
 
@@ -369,7 +391,7 @@ Independent of the migration and worth shipping first.
 1. Deploy 1.2 and 1.3 first; wait one release before 1.4.
 2. Deploy phase 3 on the reference instance with an empty issuer list.
 3. Deploy phase 6 on the bot and phase 4 on the reference instance; add both keys to the trust list.
-4. Ship the app with phases 5.1-5.6.
+4. Ship the 1.x app with phases 5.1-5.6 and the 2.x app with phases 5b.1-5b.5.
 5. Document the operator side (`docs/REPUTATION_PORTABILITY.md`, settings template) and the user side (mobile in-app help).
 
 ## 10. Open decisions
@@ -380,4 +402,4 @@ Independent of the migration and worth shipping first.
 4. Keyset event kind number and epoch length (default yearly).
 5. Admin override for re-issuance: yes or no.
 6. Length of the `days` deprecation window before PR 1.4 (default one minor release).
-7. Whether the new actions bump `PROTOCOL_VER` (currently 2) or ride on the `Unknown` / ignore-unknown tolerance already in core.
+7. ~~Whether the new actions bump `PROTOCOL_VER`~~ Closed: they do not. New actions ride on the unknown-variant tolerance already in the protocol; `PROTOCOL_VER` stays at 2.

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -178,7 +178,7 @@ Seeds are applied to the user's existing values; nothing is overwritten.
 | `seeded_reviews` (new) | `+= trades_floor`, internal only |
 | `seeded_rating_sum` (new) | `+= trades_floor * rating_floor`, internal only |
 
-The public `rating` tag on order events is unchanged in shape:
+The public `rating` tag on order events keeps its three-field shape:
 `{"total_reviews", "total_rating", "since"}` (see 6.1). No `legacy` marker is published.
 The seeded review count acts as an anchor, so new ratings move the average
 slowly, exactly as they would for a long-standing Mostro user.

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -183,9 +183,10 @@ Transport differs per issuer:
   (`t.me/lnp2pbot?start=migrate_...`), the bot answering into the app's deep
   link scheme. The bot sets `reputation_exported_at` on the user and stores
   nothing else.
-- **Mostro**: gift-wrapped `export-reputation` messages signed with the source
-  identity key, one per round trip. The daemon sets `reputation_exported_at`
-  in `users`.
+- **Mostro**: `export-reputation` messages over the daemon's ordinary
+  protocol transport (v2: NIP-44 `kind: 14`, authored by a trade key with the
+  identity proof inside the ciphertext), one per round trip. The daemon sets
+  `reputation_exported_at` in `users`.
 
 The session is stateful across the two round trips, so both the issuer and the
 client persist it; an abandoned session expires and does not consume the
@@ -193,16 +194,19 @@ once-only flag.
 
 ### 5.3 Redemption (import)
 
-A new gift-wrapped action `import-reputation`, signed with the **destination
-identity key**, carrying the token. The destination daemon:
+A new action `import-reputation` carrying the token, sent over the daemon's
+ordinary protocol transport. The destination daemon:
 
 1. Checks the issuer is in its trusted list and the epoch is accepted.
 2. Verifies `s·G == R + H(R ‖ m)·P_cell` with the `P_cell` published for the
    token's cell and epoch. This needs only public data, which is the whole
    reason for blind Schnorr; the cell whose key verifies is the band.
-3. Checks the pubkey embedded in `m` equals the identity that signed the
-   message. This binds the token to one identity; selling it means handing
-   over the key, which is the same risk as selling the account today.
+3. Checks the pubkey embedded in `m` equals `UnwrappedMessage.identity` —
+   the identity the transport *proved*, not one the sender claims. On
+   protocol v2 that proof is `identity_sig`, a domain-tagged signature bound
+   to the trade pubkey authoring the event, so it cannot be grafted from
+   another sender. This binds the token to one identity; selling it means
+   handing over the key, which is the same risk as selling the account today.
 4. Checks `hash(m)` is not in `redeemed_reputation_tokens`, and that this
    `(issuer, identity)` pair has not been redeemed before.
 5. Inserts the redemption and seeds the user row (section 6) in the same
@@ -378,7 +382,7 @@ functions and UI on the Dart side.
 not gate on it. In core 0.14.6 only `CantDoReason` carries `#[serde(other)]`;
 `Action` and `Payload` would fail to deserialise an unknown variant. That is
 safe here because these messages are strictly request/response over targeted
-gift wraps: `export-reputation` and `import-reputation` are only ever sent by
+encrypted direct messages: `export-reputation` and `import-reputation` are only ever sent by
 a client that implements them, and `reputation-exported` / `reputation-imported`
 only ever come back to the client that asked. No new variant is broadcast, so
 no old client is ever handed one. PR 2.3 carries a test that pins this

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -156,6 +156,28 @@ without extra framing.
 | Token id | `H_"mostro/reputation/token/v1"(m)`, the primary key in `redeemed_reputation_tokens` |
 | Cell id | UTF-8 `reviews:<label>\|rating:<label>\|age:<label>`, no spaces, labels from the section 4 table |
 
+The token travels as the `ReputationToken` payload of `import-reputation`
+(PR 0.4 owns the normative schema; this is the byte contract it must state).
+Binary fields are lowercase hex, and a parser rejects the token before any
+curve arithmetic when a field is missing, duplicated, of the wrong length,
+not lowercase hex, or when a point does not decode onto the curve or a scalar
+is zero or not below `n`:
+
+| Field | Type | Bytes | Meaning |
+|---|---|---|---|
+| `issuer` | hex | 32 | x-only pubkey of the issuer's identity key, the one that signed the keyset |
+| `epoch` | string | – | epoch label, must match the keyset's `epoch` tag |
+| `cell` | string | – | effective cell id, must be a key of the keyset's `cells` |
+| `m` | hex | 70 | the message above, prefix checked before use |
+| `r_point` | hex | 33 | compressed `R_b` |
+| `s` | hex | 32 | the unblinded scalar |
+
+Field order in JSON is not significant and nothing is hashed over the JSON;
+the token id and the challenge are computed from the decoded bytes only, so
+the same token serialised by Rust, JavaScript or Dart verifies identically.
+The 0.5 vectors include one complete serialised token together with its
+decoded bytes and its token id.
+
 Points are compressed rather than x-only, and the challenge is a plain tagged
 hash rather than BIP-340's: BIP-340 normalises `R` to even Y, and the client's
 blinded `R_i = R'_i + α_i·G + β_i·P_cell` has unpredictable parity that the
@@ -193,6 +215,17 @@ bot's existing `NOSTR_SK` so reputation issuance can be rotated or revoked
 without disturbing the bot's other Nostr activity. A Mostro uses its daemon
 key. How an issuer derives or stores its `x_cell` scalars is its own business
 and not part of the protocol; only the `P_cell` points are.
+
+A keyset is **immutable within its epoch**. The merge depends on cell
+populations, and populations move, so an issuer that recomputed the merge on
+every restart would replace the epoch's event with one whose `cells` no longer
+carries the `P_cell` of a cell folded away since — and every token minted
+against that cell would become unverifiable while its epoch is still
+accepted. The issuer therefore computes the merge once, when the epoch opens,
+persists the raw→effective map, and republishes exactly the same content on
+every later startup; population changes only shape the next epoch's keyset.
+A client compares a freshly fetched keyset with its cached one and treats a
+changed `cells` or `merges` under the same `d` as an issuer fault.
 
 Keysets are rotated by **epoch**. The epoch label is a protocol constant, not
 an issuer choice — the UTC calendar year by default (*open decision* 4) — so
@@ -316,6 +349,7 @@ effect.
 | `min_rating`, `max_rating`, `last_rating` | unchanged if non-zero, otherwise set to `round(rating_floor)` |
 | `seeded_reviews` (new) | `+= reviews_floor`, internal only |
 | `seeded_rating_sum` (new) | `+= reviews_floor * rating_floor`, internal only |
+| `native_rating_sum` (new) | **unchanged**; incremented by `update_rating` on native reviews only, internal only |
 
 `native_created_at` is set once, when the row is created, and no import ever
 moves it. Without it the age dimension would leak across hops: A→B backdates
@@ -378,9 +412,24 @@ new peers interoperate during the window.
 ## 7. Mostro-to-Mostro specifics
 
 - **Only native reputation is exportable.** When a Mostro acts as issuer it
-  computes the cell from `total_reviews - seeded_reviews`, the native rating
-  derived from `seeded_rating_sum`, and `native_created_at` rather than the
-  backdated `created_at`. Seeds never travel twice, which
+  computes the cell from `User::native_stats`, which reads
+  `native_created_at` rather than the backdated `created_at` and undoes the
+  seed arithmetic of section 6 exactly:
+
+  ```text
+  native_reviews = total_reviews - seeded_reviews
+  native_rating  = 0                                     if native_reviews == 0
+                 = native_rating_sum / native_reviews    otherwise
+  ```
+
+  where `native_rating_sum` is a new `users` column that `update_rating`
+  increments by the raw rating on every native review, and that
+  `apply_reputation_seed` never touches. Reversing `total_rating` instead is
+  not exact: the running mean is stored in `f64`, and the first-vote 1/2
+  weighting means `total_rating × total_reviews` is not the sum of ratings
+  for a user with a single native review. The accumulator keeps the export
+  cell independent of how many seeds arrived and in which order. The
+  displayed `total_rating` is unaffected. Seeds never travel twice, which
   rules out A→B→A doubling and A→B→C chains. A user who wants A and C on B
   redeems one token from each; the destination records each issuer once per
   identity.
@@ -490,27 +539,27 @@ Independent of the migration and worth shipping first.
 | 2.1 | mostro-core | Module `reputation::bands`: `ReviewsBand`, `RatingBand`, `AgeBand` enums with half-open cuts and floors, `Cell { reviews, rating, age }`, `Cell::from_stats(total_reviews, avg_rating, created_at, now)` (callers pass `native_created_at` on a Mostro issuer), `Cell::id()` / `parse()`, and `apply_merges(&MergeMap)` implementing the transitive fold. Pure, exhaustively tested against 0.2 including every boundary value. | Round-trips every cell id; boundary values land in exactly one band; the fold terminates on a cyclic map instead of looping. |
 | 2.2 | mostro-core | `ReputationKeyset` (parse/build the event from 0.3, epoch handling, `cells` **and** `merges`) and `ReputationToken { issuer, epoch, cell, m, r_point, s }` with serde and shape validation. Plus `reputation::encoding`: tagged hashes, point/scalar codecs, `m` builder and parser, token id — the section 5.1 contract, no signing. | Parses the 0.5 vectors byte for byte. |
 | 2.3 | mostro-core | `src/message.rs`: `Action` variants `ExportReputation`, `ReputationExported`, `ImportReputation`, `ReputationImported` (past participle for daemon replies, matching `Released` / `Canceled`); `Payload` variants `BlindedReputationRequest(BlindedReputationRequest)`, `BlindedReputationResponse(BlindedReputationResponse)`, `ReputationToken(ReputationToken)`. `src/error.rs`: `CantDoReason` variants `UntrustedReputationIssuer`, `InvalidReputationToken`, `ReputationAlreadyRedeemed`, `ReputationIdentityMismatch`, `ExpiredReputationKeyset`, `NotEligibleForReputationExport`, `ReputationAlreadyExported`, inserted before `Unknown`. `src/prelude.rs`: `NOSTR_REPUTATION_KEYSET_KIND`. Serde round-trip tests, plus a test asserting an old client never receives these variants (`PROTOCOL_VER` stays 2, see the compatibility note above). | Part of the **minor** release. |
-| 2.4 | mostro-core | `src/user.rs`: `User` gains `seeded_reviews: i64`, `seeded_rating_sum: f64`, `native_created_at: i64`, `reputation_exported_at: Option<i64>` (day-truncated), each with `#[sqlx(default)]` and `#[serde(default)]` so a daemon on an un-migrated database still deserialises `SELECT *`. `User::new` initialises `native_created_at` to `created_at`. | First use of `sqlx(default)` in core; test with a row that lacks the columns; existing rows backfill `native_created_at` from `created_at`. |
-| 2.5 | mostro-core | `src/user.rs`: `User::apply_reputation_seed(&mut self, cell: &Cell, now: i64)` implementing section 6 next to `update_rating`, plus `User::native_stats(&self) -> (reviews, rating, since)` that subtracts the seeded part and reads `native_created_at`, never `created_at`. Property tests: never decreases `total_reviews`, never moves `created_at` forward, never touches `native_created_at`, and an A→B→C chain exports the same native stats B had before importing from A. | No I/O; released as **0.15.0** together with 2.1-2.4. |
+| 2.4 | mostro-core | `src/user.rs`: `User` gains `seeded_reviews: i64`, `seeded_rating_sum: f64`, `native_rating_sum: f64`, `native_created_at: Option<i64>`, `reputation_exported_at: Option<i64>` (day-truncated), each with `#[sqlx(default)]` and `#[serde(default)]` so a daemon on an un-migrated database still deserialises `SELECT *`. `native_created_at` is an `Option` on purpose: `#[sqlx(default)]` on a plain `i64` would read a missing column as `0`, and `native_stats` would then place every legacy user in 1970. `User::new` sets it to `Some(created_at)`; every reader goes through `User::native_created_at()`, which falls back to `created_at` when the column is absent. | First use of `sqlx(default)` in core; test with a row that lacks the columns and assert the fallback equals `created_at`, never `0`; existing rows backfill `native_created_at` from `created_at`. |
+| 2.5 | mostro-core | `src/user.rs`: `User::apply_reputation_seed(&mut self, cell: &Cell, now: i64)` implementing section 6 next to `update_rating`, plus `User::native_stats(&self) -> (reviews, rating, since)` implementing the section 7 formula: `native_reviews = total_reviews - seeded_reviews`, `native_rating = native_rating_sum / native_reviews` (0 when there are no native reviews), `since` from `native_created_at()`. `update_rating` gains `native_rating_sum += rating`; `apply_reputation_seed` leaves it alone. Unit tests: one native review (rating 5 → native rating 5.0 even though `total_rating` is 2.5 by the first-vote rule); several native reviews match the plain mean of their ratings; one seed then native reviews; several seeds from different issuers; native reviews before and after a seed. Property tests: never decreases `total_reviews`, never moves `created_at` forward, never touches `native_created_at` or `native_rating_sum`, and an A→B→C chain exports the same native stats B had before importing from A. | No I/O; released as **0.15.0** together with 2.1-2.4. |
 
 ### Phase 3: mostrod as destination (import)
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
 | 3.1 | mostro | Settings section `[reputation_import]` (`enabled`, `issuers`, `accepted_epochs`) with parsing, defaults and validation. No behaviour. | Bad config is rejected at startup with a clear error. |
-| 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `native_created_at` (backfilled from `created_at`) and `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(token_id PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
+| 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `native_rating_sum` (backfilled as `total_rating * total_reviews`, the best available estimate for legacy rows), `native_created_at` (backfilled from `created_at`) and `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(token_id PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
 | 3.3 | mostro | Crypto module `reputation::verify` over `k256` (new dependency), using `reputation::encoding` from core so the byte contract is shared: challenge hash and the `s·G == R + H(R‖m)·P_cell` check. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
 | 3.4 | mostro | Keyset fetcher: fetch and cache the issuer keyset event per trusted issuer, refresh on epoch change, reject unknown epochs. Tested with the `local-relay` feature. | Cache survives a relay outage. |
-| 3.5 | mostro | Handler `src/app/import_reputation.rs`: routing in `app.rs`, checks 1-5 of section 5.4 in one transaction, calls `User::apply_reputation_seed` from core, persists through a new `update_user_reputation_seed` in `db.rs`, replies `reputation-imported` or `cant-do`. Integration test end to end with a fixture issuer. | A second redemption of the same token is rejected. |
+| 3.5 | mostro | Handler `src/app/import_reputation.rs`: routing in `app.rs`, checks 1-5 of section 5.4 in one transaction, calls `User::apply_reputation_seed` from core, persists through a new `update_user_reputation_seed` in `db.rs`, replies `reputation-imported` or `cant-do`. Integration test end-to-end with a fixture issuer. | A second redemption of the same token is rejected. |
 | 3.6 | mostro | Publish the updated kind 38384 rating event after a successful import, reusing `update_user_rating_event`. | Event visible on the local relay. |
 
 ### Phase 4: mostrod as issuer (export)
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 4.1 | mostro | Settings `[reputation_export]` (`enabled`); per-cell key derivation from the daemon key and the protocol-constant epoch label (HKDF, deterministic, never stored). Unit tests: same inputs, same keys; a different epoch label yields different keys. | No publication yet. |
-| 4.2 | mostro | Publish the keyset event at startup and on epoch rollover: cell populations from the database, the deterministic merge from section 4, and both `cells` and the raw→effective `merges` map. | Event validates against 2.2; a client applying `merges` reproduces the issuer's assignment for every raw cell. |
-| 4.3 | mostro | Native stats for the export cell come from `User::native_stats` in core (reviews and rating minus the seeded part, `native_created_at` for age). `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` feeds eligibility only (full-privacy orders carry no master pubkey and are simply not counted). Tested. | Seeded values are excluded from the cell. |
+| 4.1 | mostro | Settings `[reputation_export]` (`enabled`); per-cell key derivation `x_cell = HKDF(ikm = daemon secret key, salt = "mostro/reputation/keyset/v1", info = epoch label ‖ 0x00 ‖ cell id)` (deterministic, never stored), the cell id being the canonical section 5.1 string so each cell gets its own scalar. Unit tests: same inputs, same keys; a different epoch label yields different keys; a different cell id yields different keys; the derived `P_cell` set has no duplicates across the grid. | No publication yet. |
+| 4.2 | mostro | Publish the keyset event at startup and on epoch rollover. The merge is computed **once per epoch**: on first publication the daemon takes cell populations from the database, runs the deterministic merge from section 4, and persists the resulting raw→effective map in a new `reputation_keysets(epoch PK, merges JSON, published_at)` table. Every later startup within the same epoch republishes byte-identical `cells` and `merges` from that row, never from a fresh count, so the event replacing on `(kind, pubkey, d)` is always the same keyset. | Event validates against 2.2; a client applying `merges` reproduces the issuer's assignment for every raw cell; a restart after the population changes republishes the stored keyset unchanged. |
+| 4.3 | mostro | Native stats for the export cell come from `User::native_stats` in core (`total_reviews - seeded_reviews`, `native_rating_sum / native_reviews`, `native_created_at` for age, per section 7). `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` feeds eligibility only (full-privacy orders carry no master pubkey and are simply not counted). Tested. | Seeded values are excluded from the cell. |
 | 4.4 | mostro | Handler `export_reputation_action`: the two-round-trip clause protocol (open session with `R'_0`/`R'_1`, then answer one clause), session store with expiry, eligibility, once-only flag, `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons; an abandoned session expires without consuming the flag. |
 
 ### Phase 5: mobile (app 1.x, `mobile`)
@@ -540,8 +589,8 @@ Runs in parallel with phase 5; shares the UI copy and the localized strings.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation — this is the bot's issuer identity: it signs the keyset, appears in trusted lists and fills the token `issuer` field, and is deliberately not `NOSTR_SK`. Per-cell key derivation from it (same HKDF scheme as 4.1); `@noble/curves` dependency for secp256k1 arithmetic. Unit tests on derivation. | No command yet; the derived pubkey matches what 6.2 publishes. |
-| 6.2 | bot | Publish the keyset event through the existing `nostr` module at startup, signed with `REPUTATION_ISSUER_SK`, with the deterministic merge and its `merges` map computed from Mongo. | Event validates against 2.2. |
+| 6.1 | bot | `REPUTATION_ISSUER_SK` in `.env-sample` and config validation — this is the bot's issuer identity: it signs the keyset, appears in trusted lists and fills the token `issuer` field, and is deliberately not `NOSTR_SK`. Per-cell key derivation from it (same HKDF scheme as 4.1, epoch label and cell id in `info`); `@noble/curves` dependency for secp256k1 arithmetic. Unit tests on derivation. | No command yet; the derived pubkey matches what 6.2 publishes. |
+| 6.2 | bot | Publish the keyset event through the existing `nostr` module at startup, signed with `REPUTATION_ISSUER_SK`. As in 4.2 the merge is computed from Mongo once per epoch and stored in a `reputation_keysets` collection; later startups republish the stored `cells` and `merges` unchanged. | Event validates against 2.2; a restart republishes the stored keyset unchanged. |
 | 6.3 | bot | `User.reputation_exported_at` (day-truncated); `computeCell(user)` and `isEligible(user)` in `util/`, the cell from `total_reviews`, `total_rating` and `created_at`, eligibility from `trades_completed`, `disputes` and `banned`. Tests on band edges. | Pure functions only. |
 | 6.4 | bot | `/start migrate_...` handler: the two round trips (open session, then answer one clause), session store with expiry, eligibility, once-only, reply with the app deep link; error messages in every locale YAML. Tests with a mocked user. | Round trip with 5.5. |
 

--- a/docs/REPUTATION_PORTABILITY.md
+++ b/docs/REPUTATION_PORTABILITY.md
@@ -145,9 +145,10 @@ identity key**, carrying the token. The destination daemon:
 5. Inserts the redemption and seeds the user row (section 6) in the same
    transaction.
 
-Replies: `reputation-imported` on success; existing error payload with a new
-reason on failure (untrusted issuer, bad signature, already redeemed,
-identity mismatch, expired epoch).
+Replies: `reputation-imported` on success; `cant-do` with one of the new
+`CantDoReason` variants on failure (section 9, PR 2.3). Older clients map
+unknown reasons to the `Unknown` catch-all that core 0.14.6 introduced, so
+the new variants do not break them.
 
 ## 6. Merging on the destination
 
@@ -168,6 +169,11 @@ Each dimension has its own merge rule, because they measure different things:
   is more recent than that floor.
 
 Seeds are applied to the user's existing values; nothing is overwritten.
+The math lives next to `User::update_rating` in mostro-core, which already
+owns the running-average formula (first vote weighted 1/2, then incremental
+mean). A seeded user has `total_reviews > 1` from the start, so the
+first-vote damping no longer applies to them; that is the intended anchor
+effect.
 
 | `users` column | Effect |
 |---|---|
@@ -211,9 +217,20 @@ of the same user, so it would make trade pubkeys perfectly correlatable.
 Day precision carries exactly the information `days` carries today.
 
 Clients compute the age at display time. The merge rule in section 6 becomes
-`since = min(since_local, since_seed)`. The daemon publishes both `days` and
-`since` for one deprecation window, in the order rating tag and in the
-kind 38384 rating event, then drops `days`.
+`since = min(since_local, since_seed)`.
+
+The day count is exposed in **three** places today, and all three change:
+
+| Site | Today | Owner |
+|---|---|---|
+| `rating` tag on order events | `days` inside the JSON built by `create_rating_tag` | mostro |
+| kind 38384 rating event | `days` tag pushed by `rate_user` next to `Rating::to_tags()` | mostro; `Rating` itself has no date field |
+| `Peer` payload sent to the counterparty | `UserInfo.operating_days`, filled in `util.rs` | mostro-core type, mostro fills it |
+
+The daemon publishes both `days` and `since` for one deprecation window at
+all three sites, then drops `days`. `Rating::from_tags` ignores unknown keys
+and `UserInfo` gains the field as `Option` with a serde default, so old and
+new peers interoperate during the window.
 
 ## 7. Mostro-to-Mostro specifics
 
@@ -291,10 +308,10 @@ Independent of the migration and worth shipping first.
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
-| 1.1 | mostro-core | `Rating` gains `since: Option<u64>`; `to_tags()` emits `since` when set. Pure type change with unit tests. | Released as a patch version. |
-| 1.2 | mostro | Bump core. `create_rating_tag` emits `days` **and** `since`; `rate_user` pushes a `since` tag next to `days`; one shared `day_truncate(created_at)` helper. Unit tests on both emitters. | Both events carry both fields on a local relay. |
-| 1.3 | mobile | `Rating` model parses `since`, falls back to `days` when absent; age is computed at display time from `since`. Tests for both shapes. | Old and new daemons render the same age. |
-| 1.4 | mostro | Remove `days` after the deprecation window (open decision: one minor release). | Removed with a changelog entry. |
+| 1.1 | mostro-core | `src/rating.rs`: `Rating` gains `since: Option<u64>` (serde default); `to_tags()` emits a `since` tag when set, `from_tags()` parses it; `Rating::new` keeps its signature and a `with_since(u64)` builder is added so no caller breaks. `src/user.rs`: `UserInfo` gains `since: Option<u64>` (serde default). Unit tests for both round trips. | Released as a **patch** (0.14.7): additive, no signature changes. |
+| 1.2 | mostro | Bump core. One helper `day_truncate(created_at) -> u64` in `util.rs`. `create_rating_tag` (`nip33.rs`) emits `days` **and** `since`; `rate_user.rs` builds the `Rating` with `.with_since()` and keeps pushing the `days` tag; the `UserInfo` built in `util.rs` fills `since`. Unit tests on the three emitters. | All three sites carry both fields on a local relay. |
+| 1.3 | mobile | `data/models/rating.dart` parses `since` and falls back to `days`; `data/models/user_info.dart` parses `since` and falls back to `operating_days`; age is computed at display time. Tests for both shapes. | Old and new daemons render the same age. |
+| 1.4 | mostro | Remove `days` and `operating_days` emission after the deprecation window (open decision 6). `UserInfo.operating_days` removal in core is a **minor** bump and goes with PR 2.3. | Removed with a changelog entry. |
 
 ### Phase 2: shared types in mostro-core
 
@@ -302,19 +319,20 @@ Independent of the migration and worth shipping first.
 |---|---|---|---|
 | 2.1 | mostro-core | Module `reputation::bands`: `TradesBand`, `RatingBand`, `AgeBand` enums with cuts and floors, `Cell { trades, rating, age }`, `Cell::from_stats(trades, avg_rating, since, now)`, `Cell::id()` / `parse()`. Pure, exhaustively tested against 0.2. | Round-trips every cell id. |
 | 2.2 | mostro-core | `ReputationKeyset` (parse/build the event from 0.3, epoch handling) and `ReputationToken { issuer, epoch, cell, secret, c }` with serde and shape validation. No crypto. | Parses the 0.5 vectors. |
-| 2.3 | mostro-core | `Action` variants `ExportReputation`, `ExportReputationResponse`, `ImportReputation`, `ReputationImported`; `Payload` variants `BlindedReputationRequest { b }`, `BlindedReputationResponse { c, cell, dleq }`, `ReputationToken`; `CantDoReason` variants `UntrustedIssuer`, `InvalidReputationToken`, `ReputationAlreadyRedeemed`, `ReputationIdentityMismatch`, `ExpiredKeysetEpoch`, `NotEligibleForExport`, `ReputationAlreadyExported`. Serde round-trip tests. | Released as a minor version. |
+| 2.3 | mostro-core | `src/message.rs`: `Action` variants `ExportReputation`, `ReputationExported`, `ImportReputation`, `ReputationImported` (past participle for daemon replies, matching `Released` / `Canceled`); `Payload` variants `BlindedReputationRequest(BlindedReputationRequest)`, `BlindedReputationResponse(BlindedReputationResponse)`, `ReputationToken(ReputationToken)`. `src/error.rs`: `CantDoReason` variants `UntrustedReputationIssuer`, `InvalidReputationToken`, `ReputationAlreadyRedeemed`, `ReputationIdentityMismatch`, `ExpiredReputationKeyset`, `NotEligibleForReputationExport`, `ReputationAlreadyExported`, inserted before `Unknown`. `src/prelude.rs`: `NOSTR_REPUTATION_KEYSET_KIND`. Serde round-trip tests; decide whether `PROTOCOL_VER` bumps (open decision 7). | Part of the **minor** release. |
+| 2.4 | mostro-core | `src/user.rs`: `User` gains `seeded_reviews: i64`, `seeded_rating_sum: f64`, `reputation_exported_at: Option<i64>`, each with `#[sqlx(default)]` and `#[serde(default)]` so a daemon on an un-migrated database still deserialises `SELECT *`. `User::new` initialises them. | First use of `sqlx(default)` in core; test with a row that lacks the columns. |
+| 2.5 | mostro-core | `src/user.rs`: `User::apply_reputation_seed(&mut self, cell: &Cell, now: i64)` implementing section 6 next to `update_rating`, plus `User::native_stats(&self) -> (reviews, rating, since)` that subtracts the seeded part. Property tests: never decreases `total_reviews`, never moves `created_at` forward, idempotent per issuer. | No I/O; released as **0.15.0** together with 2.1-2.4. |
 
 ### Phase 3: mostrod as destination (import)
 
 | PR | Repo | Scope | Done when |
 |---|---|---|---|
 | 3.1 | mostro | Settings section `[reputation_import]` (`enabled`, `issuers`, `accepted_epochs`) with parsing, defaults and validation. No behaviour. | Bad config is rejected at startup with a clear error. |
-| 3.2 | mostro | Migration: `users` gains `seeded_reviews`, `seeded_rating_sum`, `reputation_exported_at`; new table `redeemed_reputation_tokens(secret_hash PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database. |
+| 3.2 | mostro | Bump core to 0.15.0. Migration `users` gains `seeded_reviews`, `seeded_rating_sum`, `reputation_exported_at` (matching PR 2.4 exactly, `SELECT *` + `FromRow` requires it); new table `redeemed_reputation_tokens(secret_hash PK, issuer, identity_pubkey, cell, redeemed_at)` with a unique index on `(issuer, identity_pubkey)`. `db.rs` accessors with tests. | Migration applies on an existing database; the `users` insert in `db.rs` binds the new columns. |
 | 3.3 | mostro | Crypto module `reputation::verify`: `hash_to_curve`, unblinded-signature verification and DLEQ verification on top of `cdk`. Tested against the 0.5 vectors, including every invalid case. | No daemon wiring yet. |
 | 3.4 | mostro | Keyset fetcher: fetch and cache the issuer keyset event per trusted issuer, refresh on epoch change, reject unknown epochs. Tested with the `local-relay` feature. | Cache survives a relay outage. |
-| 3.5 | mostro | Pure merge: `apply_seed(&mut User, &Cell, now)` implementing section 6 (trades add, weighted rating, `since` min, seeded counters). Property tests: never decreases `total_reviews`, never moves `created_at` forward, idempotent per issuer. | No I/O in the function. |
-| 3.6 | mostro | Handler `import_reputation_action`: routing in `app.rs`, checks 1-5 of section 5.3 in one transaction, reply `reputation-imported` or `cant-do`. Integration test end to end with a fixture issuer. | A second redemption of the same token is rejected. |
-| 3.7 | mostro | Publish the updated kind 38384 rating event after a successful import. | Event visible on the local relay. |
+| 3.5 | mostro | Handler `src/app/import_reputation.rs`: routing in `app.rs`, checks 1-5 of section 5.3 in one transaction, calls `User::apply_reputation_seed` from core, persists through a new `update_user_reputation_seed` in `db.rs`, replies `reputation-imported` or `cant-do`. Integration test end to end with a fixture issuer. | A second redemption of the same token is rejected. |
+| 3.6 | mostro | Publish the updated kind 38384 rating event after a successful import, reusing `update_user_rating_event`. | Event visible on the local relay. |
 
 ### Phase 4: mostrod as issuer (export)
 
@@ -322,7 +340,7 @@ Independent of the migration and worth shipping first.
 |---|---|---|---|
 | 4.1 | mostro | Settings `[reputation_export]` (`enabled`, `epoch_length`); per-cell key derivation from the daemon key and epoch (HKDF, deterministic, never stored). Unit tests: same inputs, same keys. | No publication yet. |
 | 4.2 | mostro | Publish the keyset event at startup and on epoch rollover, with the K-anonymity merge from section 4 using cell populations from the database. | Event validates against 2.2. |
-| 4.3 | mostro | Native stats: `native_stats(identity)` = completed orders for the identity, native rating from `seeded_rating_sum`, `since` from `created_at`. Query plus pure function, tested. | Seeded values are excluded. |
+| 4.3 | mostro | Native trade count: `count_completed_orders_for_identity` in `db.rs` over `orders.master_buyer_pubkey` / `master_seller_pubkey` with status `success` (full-privacy orders carry no master pubkey and are simply not counted). Combined with `User::native_stats` from core into the export cell. Tested. | Seeded values are excluded. |
 | 4.4 | mostro | Handler `export_reputation_action`: eligibility, once-only flag, blind signature with `cdk`, DLEQ, reply; sets `reputation_exported_at`. Integration test: export from instance A, import on instance B, both in-process. | Round trip passes on two local daemons. |
 
 ### Phase 5: mobile
@@ -362,3 +380,4 @@ Independent of the migration and worth shipping first.
 4. Keyset event kind number and epoch length (default yearly).
 5. Admin override for re-issuance: yes or no.
 6. Length of the `days` deprecation window before PR 1.4 (default one minor release).
+7. Whether the new actions bump `PROTOCOL_VER` (currently 2) or ride on the `Unknown` / ignore-unknown tolerance already in core.


### PR DESCRIPTION
## Summary

Design proposal for letting a user carry reputation earned on lnp2pBot, or on another Mostro instance, into a Mostro instance without giving any operator, or anyone reading relays, a way to link the two identities. Documentation only, no code changes.

`docs/REPUTATION_PORTABILITY.md` covers:

- **Threat model.** Source and destination operators, collusion or a leaked source database, relay observers. Two attacks drive the design: fingerprinting by exact values, and an issuer recognising what it signed.
- **Reputation bands.** A three-dimensional grid (completed trades, average rating, account age) as a protocol constant, seeded on the destination at the band floor, with a K-anonymity merge rule for sparse cells.
- **Blind signatures per band.** BDHKE as used by Cashu, one issuer key per grid cell, DLEQ proofs against a published keyset, epoch rotation. Mostro already depends on `cdk`, the bot can use `@cashu/crypto`, the 1.x app needs a small Dart implementation, the 2.x app gets it from `cdk` in its Rust core.
- **Merging on the destination.** Trades add up, rating is a weighted average, account age is a maximum and never a sum. Imported reputation lands in the ordinary fields so counterparties see one rating, one review count and one age.
- **`since` instead of `days`.** A day-truncated Unix timestamp replaces the derived day count at the three sites where it is exposed today (order `rating` tag, kind 38384 event, `UserInfo` in the `Peer` payload), with a deprecation window.
- **Mostro-to-Mostro.** Only native reputation is exportable, one token per issuer and destination identity, per-instance trust list of issuers.
- **Implementation plan.** Seven dependency-ordered phases across `protocol`, `mostro-core`, `mostro`, `mobile` (1.x), `app` (2.x) and `lnp2pbot/bot`, one PR per row with scope and acceptance criteria, aligned with mostro-core 0.14.6 (`Rating` has no date field, `User` derives `FromRow` over `SELECT *`, seed math belongs next to `User::update_rating`).
- **Open decisions.** Band cuts, K, eligibility, keyset event kind, re-issuance override, deprecation window length.

## Scope Declaration

- **Event domains affected:** none in this PR (documentation only). The proposal itself touches the order `rating` tag, the kind 38384 rating event and the `Peer` payload; those changes land in later PRs listed in section 9.
- **Cross-kind change:** no
- **External compatibility impact:** none from this PR. The proposed `since` field is additive during the deprecation window; `Rating::from_tags` ignores unknown keys and `UserInfo` would gain it as an optional field.

## Review focus

Concept review is what this PR needs: the threat model in section 3, the band grid in section 4, the merge rules in section 6 and the open decisions in section 10. The PR plan in section 9 is meant to be adjusted as decisions close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AataUN5L9RNdyyMZYm9jC9

---
_Generated by [Claude Code](https://claude.ai/code/session_01AataUN5L9RNdyyMZYm9jC9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a design proposal for portable reputation between trading venues.
  - Documents privacy guarantees, threat models, reputation bands, and blind-signature workflows.
  - Defines encrypted export/import exchanges, identity validation, merge rules, timestamp handling, and cross-venue behavior.
  - Specifies canonical token encoding, validation rules, issuer keysets, replay protection, native account age, and reputation export timestamps.
  - Documents immutable keysets within each epoch and exact native reputation statistics.
  - Covers Sybil resistance, re-issuance constraints, phased implementation plans, and resolved design decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->