### PR TITLE
fix(admin-settle): claim status before settling (#809)

### DIFF
--- a/src/app/admin_settle.rs
+++ b/src/app/admin_settle.rs
@@ -1,8 +1,8 @@
 use crate::app::bond::{self, BondSlashReason};
 use crate::app::context::AppContext;
 use crate::db::{
-    ensure_dispute_finalize_permission, find_dispute_by_order_id, is_assigned_solver,
-    is_dispute_taken_by_admin,
+    claim_order_status, ensure_dispute_finalize_permission, find_dispute_by_order_id,
+    is_assigned_solver, is_dispute_taken_by_admin,
 };
 use crate::lightning::LndConnector;
 use crate::nip33::{create_dispute_event_tags, new_dispute_event};
@@ -113,33 +113,51 @@ pub async fn admin_settle_action(
         }
     };
 
+    // #809: claim `Dispute → SettledHoldInvoice` before the settle, so a
+    // losing concurrent handler never reaches LND; a miss means another path
+    // owns the transition, so return `Ok`. The helper's `cashu_escrow_locked_at
+    // IS NULL` predicate never excludes an order here: `dispatch_cashu` refuses
+    // `AdminSettle`, and the admin RPC server and the escrow-deadline job (the
+    // other writer of `Dispute`) are Lightning-only.
+    if !claim_order_status(pool, order.id, Status::Dispute, Status::SettledHoldInvoice).await? {
+        tracing::warn!(
+            order_id = %order.id,
+            "admin_settle: order transitioned out of dispute concurrently; escrow untouched"
+        );
+        return Ok(());
+    }
+
     // Settle seller hold invoice
-    settle_seller_hold_invoice(event, ln_client, Action::AdminSettled, true, &order)
-        .await
-        .map_err(|e| MostroInternalErr(ServiceError::LnNodeError(e.to_string())))?;
-    // Update order event
+    if let Err(e) =
+        settle_seller_hold_invoice(event, ln_client, Action::AdminSettled, true, &order).await
+    {
+        // The claim is standing and the `Dispute` guard blocks a retry, so
+        // release it, only if the status is still ours. Best effort: the
+        // settle's error is what the caller needs.
+        if let Err(release) =
+            claim_order_status(pool, order.id, Status::SettledHoldInvoice, Status::Dispute).await
+        {
+            error!(
+                order_id = %order.id,
+                "admin_settle: could not release the settle claim after a failed settle; the order \
+                 stays settled-hold-invoice with its escrow unsettled: {release}"
+            );
+        }
+        return Err(MostroInternalErr(ServiceError::LnNodeError(e.to_string())));
+    }
+
+    // The claim already persisted the status; patch only the republished
+    // `event_id` rather than writing back a pre-claim snapshot.
     let order_updated = update_order_event(my_keys, Status::SettledHoldInvoice, &order)
         .await
         .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
-    // Persist the status change to DB before calling do_payment (same reason as release_action)
-    let result =
-        sqlx::query("UPDATE orders SET status = ?, event_id = ? WHERE id = ? AND status = ?")
-            .bind(&order_updated.status)
-            .bind(&order_updated.event_id)
-            .bind(order_updated.id)
-            .bind(Status::Dispute.to_string())
-            .execute(pool)
-            .await
-            .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
-
-    if result.rows_affected() == 0 {
-        tracing::warn!(
-            "Order {} not transitioned to settled-hold-invoice: status changed concurrently",
-            order_updated.id
-        );
-        return Ok(());
-    }
+    sqlx::query("UPDATE orders SET event_id = ? WHERE id = ?")
+        .bind(&order_updated.event_id)
+        .bind(order_updated.id)
+        .execute(pool)
+        .await
+        .map_err(|e| MostroInternalErr(ServiceError::DbAccessError(e.to_string())))?;
 
     // we check if there is a dispute
     let dispute = find_dispute_by_order_id(pool, order.id).await;
@@ -617,6 +635,107 @@ mod handler_tests {
             result,
             Err(MostroInternalErr(ServiceError::LnNodeError(_)))
         ));
+    }
+
+    /// The two transitions `admin_settle_action` drives through
+    /// `claim_order_status`: the claim, and its release on a failed settle.
+    async fn claim_settle(pool: &SqlitePool, order_id: uuid::Uuid) -> bool {
+        claim_order_status(pool, order_id, Status::Dispute, Status::SettledHoldInvoice)
+            .await
+            .unwrap()
+    }
+
+    async fn release_settle(pool: &SqlitePool, order_id: uuid::Uuid) -> bool {
+        claim_order_status(pool, order_id, Status::SettledHoldInvoice, Status::Dispute)
+            .await
+            .unwrap()
+    }
+
+    /// #809: exactly one caller can win `Dispute → SettledHoldInvoice`. The
+    /// race itself is not deterministically testable; this exclusivity is.
+    #[tokio::test]
+    async fn settle_claim_admits_exactly_one_winner() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let order = dispute_order(seller, buyer)
+            .create(ctx.pool())
+            .await
+            .unwrap();
+
+        assert!(
+            claim_settle(ctx.pool(), order.id).await,
+            "the first claim against a disputed order must win it"
+        );
+        assert!(
+            !claim_settle(ctx.pool(), order.id).await,
+            "the second claim must miss — the row has left dispute"
+        );
+
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, Status::SettledHoldInvoice.to_string());
+    }
+
+    /// The release is conditional on the status this handler wrote, so a
+    /// release racing a later transition must not drag the order backwards.
+    #[tokio::test]
+    async fn releasing_a_settle_claim_leaves_other_statuses_alone() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.status = Status::CanceledByAdmin.to_string();
+        let order = order.create(ctx.pool()).await.unwrap();
+
+        assert!(
+            !release_settle(ctx.pool(), order.id).await,
+            "a release against a status this handler does not own must miss"
+        );
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(stored.status, Status::CanceledByAdmin.to_string());
+    }
+
+    /// #809: a failed settle must surface and hand the order back to
+    /// `Dispute`; the `Dispute` guard would otherwise block any retry.
+    #[tokio::test]
+    async fn failed_settle_releases_the_claim() {
+        let pool = setup_pool().await;
+        let ctx = build_ctx(pool.clone());
+        let mut ln = dead_lnd().await;
+        let admin = Keys::generate();
+        let seller = Keys::generate().public_key();
+        let buyer = Keys::generate().public_key();
+
+        let mut order = dispute_order(seller, buyer);
+        order.seller_dispute = true;
+        order.preimage = None; // settle short-circuits with InvalidInvoice
+        let order = order.create(ctx.pool()).await.unwrap();
+        assign_solver(ctx.pool(), order.id, &admin.public_key()).await;
+
+        let result = admin_settle_action(
+            &ctx,
+            settle_msg(order.id),
+            &admin_event(admin.public_key()),
+            &admin,
+            &mut ln,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(MostroInternalErr(ServiceError::LnNodeError(_)))),
+            "the failed settle must surface, got {result:?}"
+        );
+
+        let stored = Order::by_id(ctx.pool(), order.id).await.unwrap().unwrap();
+        assert_eq!(
+            stored.status,
+            Status::Dispute.to_string(),
+            "a failed settle must release the claim so the solver can retry"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #809. `admin_settle` guarded its `Dispute → SettledHoldInvoice` transition with a compare-and-swap that ran **after** `settle_seller_hold_invoice`. The guard meant to serialize concurrent handlers sat behind the irreversible effect it was guarding: two near-simultaneous settle events both passed the `Dispute` read, both settled the escrow, and only then contended on the status write, the loser having already moved money.

This claims the transition **before** the settle, so a losing caller never reaches LND.

**The two callers are real.** The admin RPC server runs in its own task with its own mutex over a clone of the LND client, while the event loop drives the other one, so an RPC settle and a Nostr settle or cancel on the same dispute can interleave. Two RPC calls cannot: the service holds that mutex across the whole handler. Thanks @Matobi98 for asking for this to be stated.

**Scope.** `src/app/admin_settle.rs` only. `release.rs`, also named in #809, is out per @grunch on #810 (*"let's keep the release.rs change to do it in a new issue/PR after this is tested and merged"*), and becomes its own issue once this lands. One PR per issue, as asked on #809 and #855: #810 (the same defect in `admin_cancel`) follows separately. This was written on top of #825, which hoists the rejecting checks above the settle; it waited for #825 to merge and is rebased onto it.

## What changed

- **Claim first.** `claim_order_status(pool, order.id, Dispute, SettledHoldInvoice)` runs before `settle_seller_hold_invoice`. A miss means another path already moved the order, so the handler logs and refuses with `CantDo(InvalidOrderStatus)` without touching the escrow — the reason this handler already answers when its status guard sees the same condition. It returned `Ok(())` until @Matobi98 pointed out that this has the gRPC surface report a settle that never happened.
- **Release on a failed settle.** Claiming before an irreversible effect adds a failure mode the old ordering did not have: a failed settle would leave the order `SettledHoldInvoice` with its escrow unsettled, and the `Dispute` guard rejects a second admin settle, so there would be no retry path at all. The claim is released with the same helper, `(SettledHoldInvoice → Dispute)`, which is conditional on the status this handler wrote, so a release racing a later transition cannot drag the order backwards. The release is best effort: the settle's error is what gets returned, and a failed release is logged.
- **Nothing aborts past the settle.** Once the escrow has moved, the `Dispute` guard rejects a retry, so an early return has no path back: it strands every `Locked` bond and skips the buyer's payout. Four `?`s could do that — the order-event republish, its `event_id` patch, the dispute row update and the dispute event build — and so could an unparseable counterparty pubkey in the notification fan-out. All are logged and stepped over now. The dispute close is `close_dispute_after_user_resolution`, the helper `release_action` and `cancel.rs` already use, which publishes only when the row actually moved.
- **`event_id`-only patch afterwards.** The status is already persisted by the claim before `do_payment` (the reason the write lived there originally), so only the republished `event_id` is written. The old code wrote status and `event_id` back from a snapshot read before the settle.

### Why `claim_order_status`, and its extra predicate

It is the helper #830 added and the take flow already uses (`Pending → WaitingPayment`). Its `WHERE` also requires `cashu_escrow_locked_at IS NULL`. That never excludes an order on this path, because nothing in Cashu mode reaches this handler: `dispatch_cashu` refuses `AdminSettle`, the admin RPC server is not started in Cashu mode, and `enforce_escrow_deadline`, the other writer of `Dispute`, only runs in Lightning mode. Track D (#771, as currently written) settles Cashu disputes through its own `cashu_admin_settle`. This is stated at the call site.

The one way to meet the predicate is a Cashu order carried across a switch to Lightning mode and then disputed there — nothing ever clears that lock, which `find_locked_cashu_orders_includes_terminal_status_orders` pins as a deliberate CF-4 contract. The claim misses and the handler now refuses, so such an order can never be admin-settled. It is unreachable today and there was no claim to miss before this PR, so it arrives with the change; TD-3 ends it either way, since Track D §5C makes a locked escrow the buyer-wins path here rather than something to refuse. **Both cases want a CAS of their own rather than this helper** — flagged the same way on #810. The reasoning is at the call site.

#810 will reuse the same helper for `Dispute → CanceledByAdmin`, so the two PRs don't carry near-identical private claims.

## Residuals, not changed here

`/code-review` found three edge cases. The first two behave the same as, or no worse than, before this change; the third is new but narrow:

- **A settle that errors but went through** (e.g. a timeout after LND settled). The claim is released and the order returns to `Dispute` with the escrow already settled; a retry then fails at the node. Nothing is paid twice. The old ordering ended the same way, since its `?` returned before the status write.
- **A failure after the settle** (publishing the order event, or the `event_id` write) no longer aborts the handler, so the bond resolution and the payout still run. What remains is that `do_payment`'s own early returns leave no retry marker, so a payout that never starts is invisible to the retry job and the buyer waits for an operator. That is the reconcile-by-payment-hash gap already discussed on this PR, and it predates the change.
- **A seller rating inside the claim window.** `rate_user` accepts a seller rating in `SettledHoldInvoice`, and the claim now sets that status one LND round-trip before the escrow is actually settled. If the seller rates in that window and the settle then fails, the claim is released but the rating stays. This one is new, and the window is a single settle call.

## Tests

The race itself needs two handlers interleaving between the read and the write, which is not deterministically testable here. Two of these fail against a broken fix — the claim-miss test against both of @Matobi98's mutations, and the release test against the release removed — and two fail against nothing: they pin the exclusivity the fix relies on rather than the old ordering. I'd rather say which is which than let all four read as regression tests.

| Test | Fails against | What it pins |
|---|---|---|
| `settle_claim_admits_exactly_one_winner` | nothing — asserts the claim this handler uses | exactly one caller can own the transition, which is what makes the loser bail before LND |
| `releasing_a_settle_claim_leaves_other_statuses_alone` | nothing | the release only undoes this handler's own write: against an order `admin_cancel` already moved, it misses and leaves the row alone |
| `a_lost_claim_refuses_before_the_settle` | the claim moved after the settle, and the refusal removed — both verified: the settle is reached and the test gets `LnNodeError` | a lost claim refuses **before** the escrow moves, injected with a trigger that makes the claim's own write match no row |
| `failed_settle_releases_the_claim` | the release removed — verified on this base: `left: "settled-hold-invoice", right: "dispute"` | a failed settle surfaces the error **and** hands the order back to `Dispute` so the solver can retry |

## Test plan

Based on `main` @ `e5ea779` (0.18.7, #825 included).

- `cargo fmt --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo test --bin mostrod` — **1342 passed**, 0 failed, 2 ignored

Local only: `ci.yml` does not build pull requests (#929).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dispute settlement reliability when multiple handlers process the same order concurrently.
  * Prevented duplicate settlement attempts from reaching the payment node.
  * Failed settlement attempts now return the order to its prior dispute state, allowing safe retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
