### PR TITLE
chore: bump fedimint-tonic-lnd to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,9 +1300,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fedimint-tonic-lnd"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d7b804191264442b33656b9d1e2800c38f8431c64644bb0f4419f3c7be4bc"
+checksum = "544e07140e0b295035d28068a66ed752ada57762571ddbb3ac54124c3d9cc892"
 dependencies = [
  "hex",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ sqlx = { version = "0.9.0", features = [
   "uuid",
 ] }
 tokio = { version = "1.47.1", features = ["full"] }
-fedimint-tonic-lnd = "0.3.0"
+fedimint-tonic-lnd = "0.4.0"
 uuid = { version = "1.17.0", features = [
   "v4",
   "fast-rng",

--- a/src/app/bond/payout.rs
+++ b/src/app/bond/payout.rs
@@ -594,7 +594,10 @@ async fn pay_counterparty(
                     )
                     .await;
                 }
-                Ok(Some(PaymentStatus::InFlight)) => {
+                // `Initiated` (LND >= 0.17): the payment is registered but no
+                // HTLC has been attempted yet. Not terminal, so treat it like
+                // an in-flight payment and never re-send on top of it.
+                Ok(Some(PaymentStatus::InFlight)) | Ok(Some(PaymentStatus::Initiated)) => {
                     info!(
                         bond_id = %bond.id,
                         order_id = %bond.order_id,

--- a/src/app/dev_fee.rs
+++ b/src/app/dev_fee.rs
@@ -856,7 +856,7 @@ async fn check_dev_fee_payment_status(
     {
         Ok(Ok(Some(status))) => match status {
             PaymentStatus::Succeeded => DevFeePaymentState::Succeeded,
-            PaymentStatus::InFlight => DevFeePaymentState::InFlight,
+            PaymentStatus::InFlight | PaymentStatus::Initiated => DevFeePaymentState::InFlight,
             PaymentStatus::Failed => DevFeePaymentState::Failed,
             _ => DevFeePaymentState::Unknown,
         },

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -1142,7 +1142,7 @@ enum DispatchVerdict {
 ///   to its CLTV). Re-arming against it risks a double payout; kept, the
 ///   payout is delayed by at most the reconciler cadence, never lost.
 /// - An RPC-level send failure resolves the claim by what LND reports for
-///   the hash: in flight / settled / lookup error → KEEP (the payment may
+///   the hash: initiated / in flight / settled / lookup error → KEEP (the payment may
 ///   still settle); failed / unknown / no record / unusable hash → re-arm
 ///   retry now (and notify the buyer) instead of waiting for the
 ///   grace-delayed reconciliation job.
@@ -1157,9 +1157,13 @@ fn classify_dispatch(
             PAYOUT_SEND_PAYMENT_TIMEOUT.as_secs()
         )),
         Ok(Err(send_err)) => match lookup {
-            Some(Ok(Some(PaymentStatus::InFlight))) | Some(Ok(Some(PaymentStatus::Succeeded))) => {
+            // `Initiated` counts as pending: LND registered the payment and
+            // may still attempt HTLCs even though the send RPC errored.
+            Some(Ok(Some(PaymentStatus::InFlight)))
+            | Some(Ok(Some(PaymentStatus::Initiated)))
+            | Some(Ok(Some(PaymentStatus::Succeeded))) => {
                 DispatchVerdict::KeepMarker(format!(
-                    "send errored ({send_err}) but LND reports the payment in flight or settled"
+                    "send errored ({send_err}) but LND reports the payment pending or settled"
                 ))
             }
             Some(Err(lookup_err)) => DispatchVerdict::KeepMarker(format!(
@@ -2626,6 +2630,20 @@ mod tests {
             classify_dispatch(
                 Ok(Err(send_err())),
                 Some(Ok(Some(PaymentStatus::Succeeded)))
+            ),
+            DispatchVerdict::KeepMarker(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispatch_rpc_error_with_initiated_payment_keeps_the_marker() {
+        // `Initiated`: LND registered the payment but attempted no HTLC
+        // yet. It may still go in flight and settle, so re-arming would
+        // risk a double payout.
+        assert!(matches!(
+            classify_dispatch(
+                Ok(Err(send_err())),
+                Some(Ok(Some(PaymentStatus::Initiated)))
             ),
             DispatchVerdict::KeepMarker(_)
         ));

--- a/src/app/release.rs
+++ b/src/app/release.rs
@@ -1375,8 +1375,9 @@ pub async fn reconcile_inflight_payout(
                 }
             }
         }
-        Ok(Some(PaymentStatus::InFlight)) => {
-            // Still pending — do not re-dispatch; a later tick will reconcile.
+        Ok(Some(PaymentStatus::InFlight)) | Ok(Some(PaymentStatus::Initiated)) => {
+            // Still pending (`Initiated` = registered by LND, no HTLC attempted
+            // yet) — do not re-dispatch; a later tick will reconcile.
         }
         Err(e) => {
             warn!("Order {order_id}: payout reconciliation lookup failed: {e}");

--- a/src/lightning/mod.rs
+++ b/src/lightning/mod.rs
@@ -623,6 +623,7 @@ impl LndConnector {
         .await
         {
             Ok(Ok(Some(payment::PaymentStatus::InFlight)))
+            | Ok(Ok(Some(payment::PaymentStatus::Initiated)))
             | Ok(Ok(Some(payment::PaymentStatus::Succeeded))) => {
                 info!(
                     "Aborting payment for hash {}: already in flight or settled",
@@ -795,9 +796,13 @@ impl LndConnector {
         let mut total: u32 = 0;
         let mut to_destination: u32 = 0;
         for payment in response.into_inner().payments {
-            let in_flight =
-                fedimint_tonic_lnd::lnrpc::payment::PaymentStatus::try_from(payment.status)
-                    == Ok(fedimint_tonic_lnd::lnrpc::payment::PaymentStatus::InFlight);
+            // `Initiated` payments are about to dispatch HTLCs; count them
+            // toward the slot ceiling so the gate cannot be raced.
+            let in_flight = matches!(
+                fedimint_tonic_lnd::lnrpc::payment::PaymentStatus::try_from(payment.status),
+                Ok(fedimint_tonic_lnd::lnrpc::payment::PaymentStatus::InFlight)
+                    | Ok(fedimint_tonic_lnd::lnrpc::payment::PaymentStatus::Initiated)
+            );
             if !in_flight {
                 continue;
             }
@@ -949,7 +954,9 @@ impl LnStatus {
             node_pubkey: info.identity_pubkey,
             commit_hash: info.commit_hash,
             node_alias: info.alias,
-            chains: info.chains.iter().map(|c| c.chain.to_string()).collect(),
+            // `Chain::chain` is deprecated since LND 0.17: the chain is
+            // always bitcoin, so report that for every entry.
+            chains: info.chains.iter().map(|_| "bitcoin".to_string()).collect(),
             networks: info.chains.iter().map(|c| c.network.to_string()).collect(),
             uris: info.uris.iter().map(|u| u.to_string()).collect(),
         }
@@ -1511,8 +1518,8 @@ mod offline_connector_tests {
             commit_hash: "deadbeef".to_string(),
             alias: "test-node".to_string(),
             chains: vec![fedimint_tonic_lnd::lnrpc::Chain {
-                chain: "bitcoin".to_string(),
                 network: "regtest".to_string(),
+                ..Default::default()
             }],
             uris: vec!["02abc@127.0.0.1:9735".to_string()],
             ..Default::default()


### PR DESCRIPTION
## Summary

Bumps `fedimint-tonic-lnd` from 0.3.x to 0.4.0 and adapts the code to the LND 0.17+ protos it ships.

Two proto changes broke the build (and CI's `clippy -D warnings`):

- **New `PaymentStatus::Initiated` variant** — the payment is registered by LND but no HTLC has been attempted yet. Two exhaustive `match` sites stopped compiling.
- **`Chain::chain` is deprecated** — LND now assumes the chain is always bitcoin.

## Changes

`Initiated` is non-terminal, so it is handled exactly like `InFlight` everywhere: never re-dispatch on top of it, never count it as a failure or as unknown.

- `src/app/bond/payout.rs` — bond payout reconciliation defers to the next tick instead of re-sending.
- `src/app/release.rs` — buyer payout reconciliation does not re-arm the retry.
- `src/app/dev_fee.rs` — previously fell into the `_ => Unknown` arm; now maps to `InFlight`.
- `src/lightning/mod.rs` — the duplicate-send guard also aborts on `Initiated`, and the payout slot counter includes it so the gate cannot be raced.
- `src/lightning/mod.rs` — `LnStatus::chains` reports a constant `"bitcoin"` per entry instead of reading the deprecated field; the unit test builds `Chain` via `..Default::default()`. The `lnd_chains` info-event tag is unchanged.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test` — 1338 passed, 0 failed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cHB1V15sfjRdoRkd5uzk8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment reconciliation for payments that have started but have not yet attempted delivery.
  * Prevented duplicate payment dispatches and ensured newly initiated payments count toward in-flight payment limits.
  * Improved recovery, timeout, and payout handling for initiated payments, preventing premature retries.
  * Corrected network status reporting to consistently identify the Bitcoin network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->